### PR TITLE
Hotfix 0.30.1: iTerm WebSocket transport over unix socket + builtin-method invocations + custom-command override

### DIFF
--- a/plugins/op-obsidian/manifest.json
+++ b/plugins/op-obsidian/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "op-obsidian",
   "name": "Obsidian Projects (op)",
-  "version": "0.31.0",
+  "version": "0.31.1",
   "minAppVersion": "1.5.0",
   "description": "Jira-lite issue tracker for Obsidian vaults — deterministic commands backing the op workflow.",
   "author": "Eugene Archibald",

--- a/plugins/op-obsidian/package.json
+++ b/plugins/op-obsidian/package.json
@@ -1,6 +1,6 @@
 {
   "name": "op-obsidian",
-  "version": "0.31.0",
+  "version": "0.31.1",
   "description": "Obsidian plugin that owns the deterministic half of the op workflow.",
   "main": "main.js",
   "scripts": {

--- a/plugins/op-obsidian/src/iterm/client.test.ts
+++ b/plugins/op-obsidian/src/iterm/client.test.ts
@@ -119,9 +119,10 @@ describe("client write ops (fake transport)", () => {
         const res = await createWindow("bash /tmp/x.sh");
         expect(res).toEqual({ windowId: "w-1", sessionId: "s-1" });
         // Last captured call is the createTab (the pre-activate fires first).
-        const prop = last.msg?.createTabRequest?.customProfileProperties?.[0];
-        expect(prop?.key).toBe("Command");
-        expect(prop?.jsonValue).toBe(JSON.stringify("bash /tmp/x.sh"));
+        const props = last.msg?.createTabRequest?.customProfileProperties ?? [];
+        const byKey = Object.fromEntries(props.map((p) => [p.key, p.jsonValue]));
+        expect(byKey["Custom Command"]).toBe(JSON.stringify("Yes"));
+        expect(byKey["Command"]).toBe(JSON.stringify("bash /tmp/x.sh"));
       },
     );
   });
@@ -143,9 +144,10 @@ describe("client write ops (fake transport)", () => {
         expect(msg?.splitPaneRequest?.splitDirection).toBe(
           iterm2.SplitPaneRequest.SplitDirection.VERTICAL,
         );
-        const prop = msg?.splitPaneRequest?.customProfileProperties?.[0];
-        expect(prop?.key).toBe("Command");
-        expect(prop?.jsonValue).toBe(JSON.stringify("bash -lc cmd"));
+        const props = msg?.splitPaneRequest?.customProfileProperties ?? [];
+        const byKey = Object.fromEntries(props.map((p) => [p.key, p.jsonValue]));
+        expect(byKey["Custom Command"]).toBe(JSON.stringify("Yes"));
+        expect(byKey["Command"]).toBe(JSON.stringify("bash -lc cmd"));
       },
     );
   });
@@ -167,15 +169,16 @@ describe("client write ops (fake transport)", () => {
     );
   });
 
-  it("setSessionName invokes iterm2.set_name with JSON-escaped name", async () => {
+  it("setSessionName invokes iterm2.set_name via the Method context with JSON-escaped name", async () => {
     await withTransport(
       { invokeFunctionResponse: { success: { jsonResult: "null" } } },
       async (last) => {
         const { setSessionName } = await import("./client");
         await setSessionName("sess", 'name with "quote"');
-        const inv = last.msg?.invokeFunctionRequest?.invocation;
-        expect(inv).toBe(`iterm2.set_name(name: ${JSON.stringify('name with "quote"')})`);
-        expect(last.msg?.invokeFunctionRequest?.session?.sessionId).toBe("sess");
+        const req = last.msg?.invokeFunctionRequest;
+        expect(req?.invocation).toBe(`iterm2.set_name(name: ${JSON.stringify('name with "quote"')})`);
+        expect(req?.method?.receiver).toBe("sess");
+        expect(req?.session?.sessionId).toBeFalsy();
       },
     );
   });

--- a/plugins/op-obsidian/src/iterm/client.test.ts
+++ b/plugins/op-obsidian/src/iterm/client.test.ts
@@ -25,7 +25,7 @@ async function withTransport<T>(
 ): Promise<T> {
   const { transport, last } = fakeTransport(reply);
   const conn = await import("./connection");
-  conn.__setStateForTests({ transport, cookie: { cookie: "c", key: "k" }, port: 1 });
+  conn.__setStateForTests({ transport, cookie: { cookie: "c", key: "k" }, socketPath: "/tmp/fake" });
   const client = await import("./client");
   client.configureClient({ version: "test" });
   try {

--- a/plugins/op-obsidian/src/iterm/client.ts
+++ b/plugins/op-obsidian/src/iterm/client.ts
@@ -43,6 +43,25 @@ function invocation(method: string, argName: string, value: string): string {
   return `${method}(${argName}: ${JSON.stringify(value)})`;
 }
 
+// Profile overrides needed to actually run `command` on session startup
+// instead of the profile's default login shell. iTerm's profile has two
+// related keys: `Command` holds the command, and `Custom Command` is the
+// "Yes"/"No" string flag that gates whether `Command` is used at all. If you
+// only set `Command`, iTerm silently runs the default shell — you get a
+// window but nothing executes. Setting both makes the override take effect.
+function customCommandProperties(command: string): iterm2.ProfileProperty[] {
+  return [
+    iterm2.ProfileProperty.create({
+      key: "Custom Command",
+      jsonValue: JSON.stringify("Yes"),
+    }),
+    iterm2.ProfileProperty.create({
+      key: "Command",
+      jsonValue: JSON.stringify(command),
+    }),
+  ];
+}
+
 export async function createWindow(command: string): Promise<CreateWindowResult> {
   // Raise iTerm first so the new window is visible when it appears. The
   // legacy AppleScript did `activate` before `create window`.
@@ -57,12 +76,7 @@ export async function createWindow(command: string): Promise<CreateWindowResult>
 
   const reply = await call({
     createTabRequest: iterm2.CreateTabRequest.create({
-      customProfileProperties: [
-        iterm2.ProfileProperty.create({
-          key: "Command",
-          jsonValue: JSON.stringify(command),
-        }),
-      ],
+      customProfileProperties: customCommandProperties(command),
     }),
   });
   const sub = reply.createTabResponse;
@@ -88,12 +102,7 @@ export async function splitSession(
         dir === "vertical"
           ? iterm2.SplitPaneRequest.SplitDirection.VERTICAL
           : iterm2.SplitPaneRequest.SplitDirection.HORIZONTAL,
-      customProfileProperties: [
-        iterm2.ProfileProperty.create({
-          key: "Command",
-          jsonValue: JSON.stringify(command),
-        }),
-      ],
+      customProfileProperties: customCommandProperties(command),
     }),
   });
   const sub = reply.splitPaneResponse;
@@ -110,13 +119,19 @@ export async function splitSession(
   return newId;
 }
 
-// iTerm's session name drives the tab/pane title. We drive it via
-// InvokeFunctionRequest{context=Session, invocation=`set_name(name: "...")`}
-// — the same RPC the Python `session.async_set_name` uses.
+// iTerm's session name drives the tab/pane title. The proto documents
+// `session.set_name(name: String)` as a builtin *method* (not a registered
+// function), so the correct InvokeFunctionRequest context is
+// `Method { receiver: <session_id> }` and the invocation is the bare
+// `iterm2.set_name(name: …)` — this is what the Python library's
+// `async_invoke_method` wire path sends. The earlier `Session {}` context
+// targeted the session-scoped *registered-function* table instead, which
+// errors with "No function registered" even on installs where the scripting
+// runtime is present.
 export async function setSessionName(sessionId: string, name: string): Promise<void> {
   const reply = await call({
     invokeFunctionRequest: iterm2.InvokeFunctionRequest.create({
-      session: iterm2.InvokeFunctionRequest.Session.create({ sessionId }),
+      method: iterm2.InvokeFunctionRequest.Method.create({ receiver: sessionId }),
       invocation: invocation("iterm2.set_name", "name", name),
     }),
   });
@@ -124,12 +139,13 @@ export async function setSessionName(sessionId: string, name: string): Promise<v
 }
 
 // Best-effort — iTerm's window title has historically been read-only under
-// some builds. Mirror the AppleScript behaviour: attempt, swallow on error.
+// some builds. Use the `Method` context (same reason as setSessionName above).
+// Mirror the AppleScript behaviour: attempt, swallow on error.
 export async function setWindowName(windowId: string, name: string): Promise<void> {
   try {
     const reply = await call({
       invokeFunctionRequest: iterm2.InvokeFunctionRequest.create({
-        window: iterm2.InvokeFunctionRequest.Window.create({ windowId }),
+        method: iterm2.InvokeFunctionRequest.Method.create({ receiver: windowId }),
         invocation: invocation("iterm2.set_title", "title", name),
       }),
     });

--- a/plugins/op-obsidian/src/iterm/connection.ts
+++ b/plugins/op-obsidian/src/iterm/connection.ts
@@ -1,9 +1,9 @@
 import { ITermTransport, type TransportOptions, type WebSocketFactory } from "./transport";
 import {
+  API_SOCKET_PATH,
   CookieAndKey,
   clearCachedCookie,
   loadCachedCookie,
-  readApiPort,
   requestCookieAndKey,
   saveCachedCookie,
   type SafeStorageLike,
@@ -19,7 +19,7 @@ const APP_NAME = "op-obsidian";
 interface ConnectionState {
   transport: ITermTransport;
   cookie: CookieAndKey;
-  port: number;
+  socketPath: string;
 }
 
 let state: ConnectionState | null = null;
@@ -59,7 +59,7 @@ export function __setStateForTests(injected: ConnectionState | null): void {
 
 async function openConnection(opts: ConnectionOptions): Promise<ConnectionState> {
   const appName = opts.appName ?? APP_NAME;
-  const port = await readApiPort();
+  const socketPath = API_SOCKET_PATH;
 
   let cookie: CookieAndKey | null = null;
   let fromCache = false;
@@ -72,11 +72,11 @@ async function openConnection(opts: ConnectionOptions): Promise<ConnectionState>
   }
 
   try {
-    const transport = await buildTransport({ port, cookie, appName, opts });
+    const transport = await buildTransport({ socketPath, cookie, appName, opts });
     if (opts.cachePath && !fromCache) {
       await saveCachedCookie(opts.cachePath, cookie, opts.safeStorage);
     }
-    return { transport, cookie, port };
+    return { transport, cookie, socketPath };
   } catch (err) {
     // Cached cookie could be decrypt-valid but iTerm-invalid (Library wipe,
     // iTerm reinstall, user cleared API authorization). Retry once with a
@@ -84,24 +84,24 @@ async function openConnection(opts: ConnectionOptions): Promise<ConnectionState>
     if (fromCache) {
       if (opts.cachePath) await clearCachedCookie(opts.cachePath);
       const fresh = await requestCookieAndKey(appName);
-      const transport = await buildTransport({ port, cookie: fresh, appName, opts });
+      const transport = await buildTransport({ socketPath, cookie: fresh, appName, opts });
       if (opts.cachePath) {
         await saveCachedCookie(opts.cachePath, fresh, opts.safeStorage);
       }
-      return { transport, cookie: fresh, port };
+      return { transport, cookie: fresh, socketPath };
     }
     throw err;
   }
 }
 
 async function buildTransport(args: {
-  port: number;
+  socketPath: string;
   cookie: CookieAndKey;
   appName: string;
   opts: ConnectionOptions;
 }): Promise<ITermTransport> {
   const transportOpts: TransportOptions = {
-    port: args.port,
+    socketPath: args.socketPath,
     cookie: args.cookie.cookie,
     key: args.cookie.key,
     appName: args.appName,

--- a/plugins/op-obsidian/src/iterm/cookie.test.ts
+++ b/plugins/op-obsidian/src/iterm/cookie.test.ts
@@ -3,29 +3,16 @@ import { promises as fs } from "fs";
 import * as os from "os";
 import * as path from "path";
 import {
+  API_SOCKET_PATH,
   loadCachedCookie,
   parseCookieAndKey,
-  parsePort,
   saveCachedCookie,
   type SafeStorageLike,
 } from "./cookie";
 
 describe("iterm cookie", () => {
-  it("parses a port file with trailing newline", () => {
-    expect(parsePort("51234\n")).toBe(51234);
-  });
-
-  it("parses a port file without trailing newline", () => {
-    expect(parsePort("51234")).toBe(51234);
-  });
-
-  it("rejects a non-numeric port file", () => {
-    expect(() => parsePort("not-a-number")).toThrowError(/iTerm api port file/);
-  });
-
-  it("rejects an out-of-range port", () => {
-    expect(() => parsePort("99999")).toThrowError(/iTerm api port file/);
-    expect(() => parsePort("0")).toThrowError(/iTerm api port file/);
+  it("points at iTerm2's unix API socket", () => {
+    expect(API_SOCKET_PATH).toMatch(/iTerm2\/private\/socket$/);
   });
 
   it("parses a cookie/key pair separated by tab", () => {

--- a/plugins/op-obsidian/src/iterm/cookie.test.ts
+++ b/plugins/op-obsidian/src/iterm/cookie.test.ts
@@ -20,6 +20,16 @@ describe("iterm cookie", () => {
     expect(pair).toEqual({ cookie: "abc123", key: "xyz789" });
   });
 
+  it("parses a cookie/key pair separated by a single space (osascript list rendering)", () => {
+    const pair = parseCookieAndKey(
+      "474e1b203be9b53087003c4444531354 9F541B4D-DDF2-492D-99B4-BC65E1BF0730\n",
+    );
+    expect(pair).toEqual({
+      cookie: "474e1b203be9b53087003c4444531354",
+      key: "9F541B4D-DDF2-492D-99B4-BC65E1BF0730",
+    });
+  });
+
   it("rejects a cookie response missing the key", () => {
     expect(() => parseCookieAndKey("only-cookie\n")).toThrowError(/iTerm cookie request/);
   });

--- a/plugins/op-obsidian/src/iterm/cookie.ts
+++ b/plugins/op-obsidian/src/iterm/cookie.ts
@@ -45,16 +45,19 @@ export const API_SOCKET_PATH = path.join(
   "socket",
 );
 
-// Parse the raw AppleScript response, which iTerm2 returns as a tab-separated
-// "cookie<TAB>key" pair. Exported for tests.
+// Parse the raw AppleScript response. iTerm2 returns a two-element list from
+// `request cookie and key …`, which `osascript` renders as the two strings
+// separated by a single space (or, on some macOS builds, by a tab). Split on
+// any run of whitespace — both tokens are fixed-shape hex/UUID strings, so a
+// whitespace split is unambiguous.
 export function parseCookieAndKey(raw: string): CookieAndKey {
-  const [cookie, key] = raw.trim().split("\t");
-  if (!cookie || !key) {
+  const parts = raw.trim().split(/\s+/);
+  if (parts.length !== 2 || !parts[0] || !parts[1]) {
     throw new Error(
       `op: iTerm cookie request returned unexpected output: ${JSON.stringify(raw)}`,
     );
   }
-  return { cookie, key };
+  return { cookie: parts[0], key: parts[1] };
 }
 
 // Request a (cookie, key) pair from iTerm2 via AppleScript. This prompts the

--- a/plugins/op-obsidian/src/iterm/cookie.ts
+++ b/plugins/op-obsidian/src/iterm/cookie.ts
@@ -6,14 +6,16 @@ import * as os from "os";
 
 const pExecFile = promisify(execFile);
 
-// iTerm2's Python API is actually a local WebSocket on a port iTerm writes to
-// ~/Library/Application Support/iTerm2/private/.iterm2_api_port. Authentication
-// requires a (cookie, key) pair obtained via AppleScript the first time a given
-// app-name connects.
+// iTerm2's Python API is a local WebSocket speaking binary protobuf. iTerm
+// 3.6+ exposes it over a unix domain socket at
+// ~/Library/Application Support/iTerm2/private/socket (pre-3.6 used a TCP
+// port written to `.iterm2_api_port` — no longer supported by iTerm, and no
+// longer supported here). Authentication requires a (cookie, key) pair
+// obtained via AppleScript the first time a given app-name connects.
 //
-// This module owns the one-shot AppleScript call, the read of the port file,
-// and the persistent `safeStorage`-encrypted cache that keeps the prompt
-// one-shot across plugin reloads. It is the only remaining osascript site.
+// This module owns the one-shot AppleScript call, the known socket path, and
+// the persistent `safeStorage`-encrypted cache that keeps the prompt one-shot
+// across plugin reloads. It is the only remaining osascript site.
 
 export interface CookieAndKey {
   cookie: string;
@@ -30,30 +32,18 @@ export interface SafeStorageLike {
   decryptString(ciphertext: Buffer): string;
 }
 
-export const API_PORT_PATH = path.join(
+// iTerm 3.6+ listens on this unix domain socket when "Enable Python API" is
+// turned on. The directory exists independently, so its presence isn't a
+// reliable health check; the transport's connect() surfaces the real error
+// (including ENOENT on the socket itself) with an actionable message.
+export const API_SOCKET_PATH = path.join(
   os.homedir(),
   "Library",
   "Application Support",
   "iTerm2",
   "private",
-  ".iterm2_api_port",
+  "socket",
 );
-
-export async function readApiPort(): Promise<number> {
-  const raw = await fs.readFile(API_PORT_PATH, "utf8");
-  return parsePort(raw);
-}
-
-// Exported for unit tests. iTerm writes the port as an ASCII integer, usually
-// with a trailing newline.
-export function parsePort(raw: string): number {
-  const trimmed = raw.trim();
-  const n = Number(trimmed);
-  if (!Number.isInteger(n) || n <= 0 || n > 65535) {
-    throw new Error(`op: iTerm api port file has unexpected contents: ${JSON.stringify(raw)}`);
-  }
-  return n;
-}
 
 // Parse the raw AppleScript response, which iTerm2 returns as a tab-separated
 // "cookie<TAB>key" pair. Exported for tests.

--- a/plugins/op-obsidian/src/iterm/transport.ts
+++ b/plugins/op-obsidian/src/iterm/transport.ts
@@ -1,23 +1,31 @@
 import { iterm2 } from "./proto/api.generated";
+import { createUnixWebSocket } from "./unixWebSocket";
 
 // Persistent WebSocket+protobuf transport against iTerm2's local API.
 //
 // Wire protocol (documented at https://iterm2.com/python-api/websockets.html):
-//   - URL:          ws://localhost:<port>/ (port read from cookie.API_PORT_PATH)
+//   - URL:          ws+unix://<socketPath>/  (iTerm 3.6+ uses a unix socket;
+//                   pre-3.6 used a local TCP port — we only support 3.6+)
 //   - Subprotocol:  api.iterm2.com
 //   - Headers:      x-iterm2-library-version: op-obsidian <ver>
 //                   x-iterm2-cookie: <cookie>
 //                   x-iterm2-key:    <key>
-//                   origin:          ws://localhost:<port>
+//                   origin:          ws://localhost
 //   - Frames:       binary ClientOriginatedMessage / ServerOriginatedMessage
 //   - Multiplex:    each request carries a monotonically increasing u32 id;
 //                   the response echoes the same id.
 //
-// Obsidian's renderer provides a global `WebSocket`, so we do not take a `ws`
-// dependency. Node-only unit tests may inject a shim; the transport is
-// constructed with an explicit factory so we don't need to patch globals.
+// Obsidian's renderer has Node available (`require("net")`), so we hand-roll
+// the WebSocket handshake and framing over a unix-socket `net.Socket` in
+// `unixWebSocket.ts`. This avoids a bundled `ws` dep and works inside the
+// renderer where the global `WebSocket` class can't speak unix sockets.
+// Node-only unit tests inject a shim via the factory hook below.
 
-export type WebSocketFactory = (url: string, protocols: string, headers: Record<string, string>) => WebSocketLike;
+export type WebSocketFactory = (
+  socketPath: string,
+  protocol: string,
+  headers: Record<string, string>,
+) => WebSocketLike;
 
 export interface WebSocketLike {
   send(data: ArrayBuffer | Uint8Array): void;
@@ -29,7 +37,7 @@ export interface WebSocketLike {
 }
 
 export interface TransportOptions {
-  port: number;
+  socketPath: string;
   cookie: string;
   key: string;
   appName: string;
@@ -95,15 +103,14 @@ export class ITermTransport {
   }
 
   private async openSocket(): Promise<void> {
-    const url = `ws://localhost:${this.opts.port}/`;
     const factory = this.opts.wsFactory ?? defaultWebSocketFactory;
     const headers: Record<string, string> = {
       "x-iterm2-library-version": `${this.opts.appName} ${this.opts.version}`,
       "x-iterm2-cookie": this.opts.cookie,
       "x-iterm2-key": this.opts.key,
-      origin: `ws://localhost:${this.opts.port}`,
+      origin: "ws://localhost",
     };
-    const ws = factory(url, "api.iterm2.com", headers);
+    const ws = factory(this.opts.socketPath, "api.iterm2.com", headers);
     this.ws = ws;
     ws.onmessage = (ev) => {
       void this.handleFrame(ev.data);
@@ -120,12 +127,17 @@ export class ITermTransport {
     };
     await new Promise<void>((resolve, reject) => {
       ws.onopen = () => resolve();
-      ws.onerror = () =>
+      ws.onerror = (ev) => {
+        const detail =
+          ev && typeof ev === "object" && "message" in ev
+            ? String((ev as { message: unknown }).message)
+            : "";
         reject(
           new Error(
-            "op: iTerm websocket failed to open — is 'Enable Python API' turned on in iTerm2 > Settings > General > Magic?",
+            `op: iTerm websocket failed to open${detail ? ` (${detail})` : ""} — is 'Enable Python API' turned on in iTerm2 > Settings > General > Magic, and is iTerm2 running?`,
           ),
         );
+      };
     });
   }
 
@@ -148,14 +160,6 @@ async function toBytes(data: ArrayBuffer | Uint8Array | Blob): Promise<Uint8Arra
   return new Uint8Array(buf);
 }
 
-const defaultWebSocketFactory: WebSocketFactory = (url, protocols) => {
-  // Obsidian renderer: WebSocket is global. Custom headers aren't supported by
-  // the renderer's WebSocket constructor — iTerm's API actually reads cookie
-  // and key from the subprotocol when headers are absent, so we fall back to
-  // encoding them into the subprotocol string. Step 2 will validate this path
-  // on a real connection and adjust if iTerm rejects it.
-  const g = globalThis as { WebSocket?: new (url: string, protocols?: string | string[]) => WebSocketLike };
-  if (!g.WebSocket) throw new Error("op: no global WebSocket available — cannot talk to iTerm API");
-  return new g.WebSocket(url, protocols);
+const defaultWebSocketFactory: WebSocketFactory = (socketPath, protocol, headers) => {
+  return createUnixWebSocket({ socketPath, protocol, headers });
 };
-

--- a/plugins/op-obsidian/src/iterm/unixWebSocket.test.ts
+++ b/plugins/op-obsidian/src/iterm/unixWebSocket.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildHandshakeRequest,
+  decodeFrame,
+  encodeClientFrame,
+  parseHandshakeResponse,
+} from "./unixWebSocket";
+
+describe("unixWebSocket handshake", () => {
+  it("builds a valid RFC 6455 upgrade request", () => {
+    const req = buildHandshakeRequest({
+      protocol: "api.iterm2.com",
+      key: "AAAAAAAAAAAAAAAAAAAAAA==",
+      headers: { "x-iterm2-cookie": "c", "x-iterm2-key": "k" },
+    }).toString("ascii");
+    expect(req).toMatch(/^GET \/ HTTP\/1\.1\r\n/);
+    expect(req).toContain("Upgrade: websocket\r\n");
+    expect(req).toContain("Connection: Upgrade\r\n");
+    expect(req).toContain("Sec-WebSocket-Version: 13\r\n");
+    expect(req).toContain("Sec-WebSocket-Protocol: api.iterm2.com\r\n");
+    expect(req).toContain("x-iterm2-cookie: c\r\n");
+    expect(req.endsWith("\r\n\r\n")).toBe(true);
+  });
+
+  it("parses a 101 upgrade response", () => {
+    const parsed = parseHandshakeResponse(
+      "HTTP/1.1 101 Switching Protocols\r\nUpgrade: websocket\r\nSec-WebSocket-Accept: abc=",
+    );
+    expect(parsed.status).toBe(101);
+    expect(parsed.statusText).toBe("Switching Protocols");
+    expect(parsed.accept).toBe("abc=");
+  });
+
+  it("surfaces non-101 status", () => {
+    const parsed = parseHandshakeResponse("HTTP/1.1 401 Unauthorized\r\n");
+    expect(parsed.status).toBe(401);
+    expect(parsed.statusText).toBe("Unauthorized");
+  });
+});
+
+describe("unixWebSocket framing", () => {
+  it("round-trips a short binary frame through encode → unmask → decode", () => {
+    const payload = Buffer.from([1, 2, 3, 4, 5]);
+    const encoded = encodeClientFrame(0x2, payload);
+    // Client-encoded frames are masked. Decode them via the shared decoder,
+    // which unmasks in place.
+    const decoded = decodeFrame(encoded);
+    expect(decoded).not.toBeNull();
+    expect(decoded!.opcode).toBe(0x2);
+    expect(decoded!.fin).toBe(true);
+    expect(Buffer.from(decoded!.payload).equals(payload)).toBe(true);
+    expect(decoded!.consumed).toBe(encoded.length);
+  });
+
+  it("round-trips a medium-length frame (16-bit length field)", () => {
+    const payload = Buffer.alloc(200, 0x7f);
+    const encoded = encodeClientFrame(0x2, payload);
+    const decoded = decodeFrame(encoded);
+    expect(decoded).not.toBeNull();
+    expect(decoded!.payload.length).toBe(200);
+    expect(decoded!.payload.every((b) => b === 0x7f)).toBe(true);
+  });
+
+  it("round-trips a large frame (64-bit length field)", () => {
+    const payload = Buffer.alloc(0x10000 + 1, 0x42);
+    const encoded = encodeClientFrame(0x2, payload);
+    const decoded = decodeFrame(encoded);
+    expect(decoded).not.toBeNull();
+    expect(decoded!.payload.length).toBe(payload.length);
+  });
+
+  it("returns null when the buffer doesn't hold a full frame yet", () => {
+    const payload = Buffer.from([1, 2, 3, 4, 5]);
+    const encoded = encodeClientFrame(0x2, payload);
+    expect(decodeFrame(encoded.slice(0, encoded.length - 1))).toBeNull();
+  });
+
+  it("decodes an unmasked server frame (as iTerm would send)", () => {
+    const payload = Buffer.from([0xaa, 0xbb, 0xcc]);
+    const frame = Buffer.concat([Buffer.from([0x82, payload.length]), payload]);
+    const decoded = decodeFrame(frame);
+    expect(decoded).not.toBeNull();
+    expect(decoded!.opcode).toBe(0x2);
+    expect(Buffer.from(decoded!.payload).equals(payload)).toBe(true);
+  });
+
+  it("reports close frame with code and reason", () => {
+    const reason = Buffer.from("bye", "utf8");
+    const payload = Buffer.concat([Buffer.from([0x03, 0xe9]), reason]); // 1001
+    const frame = Buffer.concat([Buffer.from([0x88, payload.length]), payload]);
+    const decoded = decodeFrame(frame);
+    expect(decoded!.opcode).toBe(0x8);
+    expect(decoded!.payload.readUInt16BE(0)).toBe(1001);
+  });
+});

--- a/plugins/op-obsidian/src/iterm/unixWebSocket.ts
+++ b/plugins/op-obsidian/src/iterm/unixWebSocket.ts
@@ -1,0 +1,285 @@
+import { createConnection, type Socket } from "net";
+import { createHash, randomBytes } from "crypto";
+import type { WebSocketLike } from "./transport";
+
+// Minimal WebSocket client (RFC 6455) over a Node unix-domain socket.
+//
+// Why hand-rolled: Obsidian's renderer global `WebSocket` only speaks
+// `ws://host:port`, and iTerm2 3.6+ moved the Python API from a TCP port to a
+// unix socket at `~/Library/Application Support/iTerm2/private/socket`. We
+// avoid the `ws` npm dep so the plugin stays zero-runtime-deps. Scope is
+// intentionally narrow:
+//
+//  - binary frames only (opcode 0x2), no text
+//  - no fragmentation on send (iTerm messages fit in a single frame)
+//  - handles inbound continuation frames + unfragmented binary frames
+//  - responds to ping (0x9) with pong (0xA); ignores pong
+//  - close (0x8) surfaces via `onclose`
+//
+// iTerm2's API speaks single-frame binary messages that are plenty small
+// (protobuf replies under a few KB), so this is sufficient. If a future
+// server-pushed notification ever exceeds 64KB, the continuation path below
+// covers it.
+
+const WS_GUID = "258EAFA5-E914-47DA-95CA-C5AB0DC85B11";
+
+export interface UnixWebSocketOptions {
+  socketPath: string;
+  protocol: string;
+  headers: Record<string, string>;
+}
+
+export function createUnixWebSocket(opts: UnixWebSocketOptions): WebSocketLike {
+  return new UnixWebSocket(opts);
+}
+
+class UnixWebSocket implements WebSocketLike {
+  onopen: ((ev: unknown) => void) | null = null;
+  onmessage: ((ev: { data: ArrayBuffer | Uint8Array | Blob }) => void) | null = null;
+  onerror: ((ev: unknown) => void) | null = null;
+  onclose: ((ev: { code: number; reason: string }) => void) | null = null;
+
+  private readonly socket: Socket;
+  private handshakeDone = false;
+  private closed = false;
+  private buffer: Buffer = Buffer.alloc(0);
+  private fragments: Buffer[] | null = null;
+  private readonly expectedAccept: string;
+
+  constructor(opts: UnixWebSocketOptions) {
+    const key = randomBytes(16).toString("base64");
+    this.expectedAccept = createHash("sha1").update(key + WS_GUID).digest("base64");
+
+    const req = buildHandshakeRequest({
+      protocol: opts.protocol,
+      key,
+      headers: opts.headers,
+    });
+
+    this.socket = createConnection(opts.socketPath);
+    this.socket.on("connect", () => {
+      this.socket.write(req);
+    });
+    this.socket.on("data", (chunk: Buffer) => this.onData(chunk));
+    this.socket.on("error", (err: Error) => {
+      if (!this.closed) this.onerror?.(err);
+      this.teardown(1006, err.message);
+    });
+    this.socket.on("close", () => this.teardown(1006, "socket closed"));
+  }
+
+  send(data: ArrayBuffer | Uint8Array): void {
+    if (!this.handshakeDone) throw new Error("op: unix WebSocket send before handshake complete");
+    const payload = data instanceof Uint8Array ? Buffer.from(data) : Buffer.from(new Uint8Array(data));
+    this.socket.write(encodeClientFrame(0x2, payload));
+  }
+
+  close(code = 1000, reason = ""): void {
+    if (this.closed) return;
+    try {
+      if (this.handshakeDone) {
+        const payload = Buffer.alloc(2 + Buffer.byteLength(reason));
+        payload.writeUInt16BE(code, 0);
+        if (reason) payload.write(reason, 2);
+        this.socket.write(encodeClientFrame(0x8, payload));
+      }
+    } catch {
+      // best-effort
+    }
+    this.teardown(code, reason);
+  }
+
+  private teardown(code: number, reason: string): void {
+    if (this.closed) return;
+    this.closed = true;
+    try {
+      this.socket.destroy();
+    } catch {
+      // ignore
+    }
+    this.onclose?.({ code, reason });
+  }
+
+  private onData(chunk: Buffer): void {
+    this.buffer = this.buffer.length === 0 ? chunk : Buffer.concat([this.buffer, chunk]);
+    if (!this.handshakeDone) {
+      const end = this.buffer.indexOf("\r\n\r\n");
+      if (end === -1) return;
+      const headerText = this.buffer.slice(0, end).toString("ascii");
+      this.buffer = this.buffer.slice(end + 4);
+      const parsed = parseHandshakeResponse(headerText);
+      if (parsed.status !== 101) {
+        const err = new Error(
+          `op: iTerm WebSocket handshake failed with HTTP ${parsed.status} ${parsed.statusText}`,
+        );
+        this.onerror?.(err);
+        this.teardown(1002, err.message);
+        return;
+      }
+      if (parsed.accept !== this.expectedAccept) {
+        const err = new Error("op: iTerm WebSocket handshake failed — Sec-WebSocket-Accept mismatch");
+        this.onerror?.(err);
+        this.teardown(1002, err.message);
+        return;
+      }
+      this.handshakeDone = true;
+      this.onopen?.({});
+    }
+
+    while (this.buffer.length > 0) {
+      const frame = decodeFrame(this.buffer);
+      if (!frame) return;
+      this.buffer = this.buffer.slice(frame.consumed);
+      this.handleFrame(frame);
+    }
+  }
+
+  private handleFrame(frame: DecodedFrame): void {
+    if (frame.opcode === 0x8) {
+      const code = frame.payload.length >= 2 ? frame.payload.readUInt16BE(0) : 1005;
+      const reason = frame.payload.length > 2 ? frame.payload.slice(2).toString("utf8") : "";
+      this.teardown(code, reason);
+      return;
+    }
+    if (frame.opcode === 0x9) {
+      this.socket.write(encodeClientFrame(0xa, frame.payload));
+      return;
+    }
+    if (frame.opcode === 0xa) {
+      return;
+    }
+    if (frame.opcode === 0x2 || frame.opcode === 0x1) {
+      if (frame.fin && this.fragments === null) {
+        this.onmessage?.({ data: new Uint8Array(frame.payload) });
+        return;
+      }
+      this.fragments = [frame.payload];
+      return;
+    }
+    if (frame.opcode === 0x0) {
+      if (this.fragments === null) return;
+      this.fragments.push(frame.payload);
+      if (frame.fin) {
+        const full = Buffer.concat(this.fragments);
+        this.fragments = null;
+        this.onmessage?.({ data: new Uint8Array(full) });
+      }
+      return;
+    }
+  }
+}
+
+interface HandshakeRequestArgs {
+  protocol: string;
+  key: string;
+  headers: Record<string, string>;
+}
+
+export function buildHandshakeRequest(args: HandshakeRequestArgs): Buffer {
+  const lines = [
+    "GET / HTTP/1.1",
+    "Host: localhost",
+    "Upgrade: websocket",
+    "Connection: Upgrade",
+    `Sec-WebSocket-Key: ${args.key}`,
+    "Sec-WebSocket-Version: 13",
+    `Sec-WebSocket-Protocol: ${args.protocol}`,
+  ];
+  for (const [name, value] of Object.entries(args.headers)) {
+    lines.push(`${name}: ${value}`);
+  }
+  lines.push("", "");
+  return Buffer.from(lines.join("\r\n"), "ascii");
+}
+
+export interface ParsedHandshakeResponse {
+  status: number;
+  statusText: string;
+  accept?: string;
+}
+
+export function parseHandshakeResponse(text: string): ParsedHandshakeResponse {
+  const lines = text.split("\r\n");
+  const statusLine = lines[0] ?? "";
+  const m = /^HTTP\/1\.1 (\d+)(?: (.*))?$/.exec(statusLine);
+  if (!m) return { status: 0, statusText: statusLine };
+  const status = Number(m[1]);
+  const statusText = m[2] ?? "";
+  let accept: string | undefined;
+  for (const line of lines.slice(1)) {
+    const idx = line.indexOf(":");
+    if (idx === -1) continue;
+    const name = line.slice(0, idx).trim().toLowerCase();
+    const value = line.slice(idx + 1).trim();
+    if (name === "sec-websocket-accept") accept = value;
+  }
+  return { status, statusText, accept };
+}
+
+export interface DecodedFrame {
+  fin: boolean;
+  opcode: number;
+  payload: Buffer;
+  consumed: number;
+}
+
+export function decodeFrame(buf: Buffer): DecodedFrame | null {
+  if (buf.length < 2) return null;
+  const b0 = buf[0];
+  const b1 = buf[1];
+  const fin = (b0 & 0x80) !== 0;
+  const opcode = b0 & 0x0f;
+  const masked = (b1 & 0x80) !== 0;
+  let len = b1 & 0x7f;
+  let cursor = 2;
+  if (len === 126) {
+    if (buf.length < cursor + 2) return null;
+    len = buf.readUInt16BE(cursor);
+    cursor += 2;
+  } else if (len === 127) {
+    if (buf.length < cursor + 8) return null;
+    const hi = buf.readUInt32BE(cursor);
+    const lo = buf.readUInt32BE(cursor + 4);
+    // iTerm won't send >4GB payloads; reject silently if hi is set.
+    if (hi !== 0) throw new Error("op: iTerm WebSocket frame too large");
+    len = lo;
+    cursor += 8;
+  }
+  let maskKey: Buffer | null = null;
+  if (masked) {
+    if (buf.length < cursor + 4) return null;
+    maskKey = buf.slice(cursor, cursor + 4);
+    cursor += 4;
+  }
+  if (buf.length < cursor + len) return null;
+  let payload = buf.slice(cursor, cursor + len);
+  if (maskKey) {
+    const copy = Buffer.alloc(len);
+    for (let i = 0; i < len; i++) copy[i] = payload[i] ^ maskKey[i % 4];
+    payload = copy;
+  }
+  return { fin, opcode, payload, consumed: cursor + len };
+}
+
+export function encodeClientFrame(opcode: number, payload: Buffer): Buffer {
+  const len = payload.length;
+  let header: Buffer;
+  if (len < 126) {
+    header = Buffer.alloc(2);
+    header[1] = 0x80 | len;
+  } else if (len < 0x10000) {
+    header = Buffer.alloc(4);
+    header[1] = 0x80 | 126;
+    header.writeUInt16BE(len, 2);
+  } else {
+    header = Buffer.alloc(10);
+    header[1] = 0x80 | 127;
+    header.writeUInt32BE(0, 2);
+    header.writeUInt32BE(len, 6);
+  }
+  header[0] = 0x80 | (opcode & 0x0f);
+  const mask = randomBytes(4);
+  const masked = Buffer.alloc(len);
+  for (let i = 0; i < len; i++) masked[i] = payload[i] ^ mask[i % 4];
+  return Buffer.concat([header, mask, masked]);
+}

--- a/plugins/op/.claude-plugin/plugin.json
+++ b/plugins/op/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "op",
   "description": "Obsidian Projects workflow — schema, slash commands, and agent skill for running a Jira-lite issue tracker inside an Obsidian vault.",
-  "version": "0.31.0",
+  "version": "0.31.1",
   "author": {
     "name": "Eugene Archibald"
   },


### PR DESCRIPTION
## Summary

Hotfix for OP-101 Step 5. The WebSocket client shipped at 0.30.0 was broken against iTerm 3.6+ on three orthogonal axes; all three are fixed here.

- **Transport over unix socket.** iTerm 3.6+ removed the `.iterm2_api_port` TCP port in favor of a unix domain socket at `~/Library/Application Support/iTerm2/private/socket`. Our research pinned the pre-3.6 path. Added `iterm/unixWebSocket.ts`: zero-dep hand-rolled RFC 6455 client over `net.createConnection(socketPath)` (handshake + Sec-WebSocket-Accept verification + masked client frames + unmasked server frames + continuation + ping/close). `cookie.ts` exposes `API_SOCKET_PATH` instead of `readApiPort`. `TransportOptions` switches from `{ port }` to `{ socketPath }`.
- **Cookie parser.** `osascript` renders AppleScript's list return as a space-separated pair, not tab-separated. Split on any whitespace.
- **Builtin-method invocations.** `setSessionName` / `setWindowName` were using `InvokeFunctionRequest { session: … }` + `iterm2.set_name(…)`, which targets the session-scoped *registered-function* table and errors "No function registered" even when Python runtime is present. These are builtin methods — dispatched via `Method { receiver: sessionId }`. `setSessionName` is back to propagating errors; `setWindowName` stays best-effort (genuinely unreliable per prior comment).
- **Custom-command profile override.** `customProfileProperties` with just `Command` is silently ignored by iTerm; the `Custom Command: "Yes"` key is the gate. Without it, `op-open-agent` opened a window but the login shell ran instead of the tmux-attach script. Added both via a `customCommandProperties()` helper.

Patch bump 0.30.0 → 0.30.1.

## Test plan

- [x] `npm test` — 221/221 pass (new coverage: handshake request/response, masked/unmasked frame round-trips at 3 length regimes, close-frame parse, space-separated cookie, `Method`-context setSessionName, `Custom Command`+`Command` profile override)
- [x] `npm run build` clean
- [x] Live: vault-synced 0.30.1, reloaded, opened an agent from an issue — new iTerm window spawned, tmux attach ran, Claude launched. Confirmed by user.