### PR TITLE
OP-112: drag-reorder projects in command pickers; bump to 0.37.0

### DIFF
--- a/plugins/op-obsidian/manifest.json
+++ b/plugins/op-obsidian/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "op-obsidian",
   "name": "Obsidian Projects (op)",
-  "version": "0.36.0",
+  "version": "0.37.0",
   "minAppVersion": "1.5.0",
   "description": "Jira-lite issue tracker for Obsidian vaults — deterministic commands backing the op workflow.",
   "author": "Eugene Archibald",

--- a/plugins/op-obsidian/package.json
+++ b/plugins/op-obsidian/package.json
@@ -1,6 +1,6 @@
 {
   "name": "op-obsidian",
-  "version": "0.36.0",
+  "version": "0.37.0",
   "description": "Obsidian plugin that owns the deterministic half of the op workflow.",
   "main": "main.js",
   "scripts": {

--- a/plugins/op-obsidian/src/main.ts
+++ b/plugins/op-obsidian/src/main.ts
@@ -5,7 +5,7 @@ import { EventBus } from "./eventBus";
 import { IssueStore } from "./issueStore";
 import { createIssue, type CreateIssueInput, type Priority } from "./createIssue";
 import { findIssue } from "./findIssue";
-import { listProjects } from "./projects";
+import { applyProjectOrder, listProjects } from "./projects";
 import {
   AppendCommitModal,
   FindIssueModal,
@@ -751,7 +751,7 @@ export default class OpPlugin extends Plugin {
   }
 
   private runNewIssueCommand(): void {
-    const projects = listProjects(this.app);
+    const projects = applyProjectOrder(listProjects(this.app), this.settings.projectOrder);
     if (projects.length === 0) {
       new Notice("No projects found under Projects/");
       return;

--- a/plugins/op-obsidian/src/projects.test.ts
+++ b/plugins/op-obsidian/src/projects.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect } from "vitest";
+import { applyProjectOrder, type ProjectInfo } from "./projects";
+
+const p = (slug: string): ProjectInfo => ({ slug, statusPath: `Projects/${slug}/STATUS.md` });
+
+describe("applyProjectOrder", () => {
+  it("sorts lexically when order is empty", () => {
+    expect(applyProjectOrder([p("c"), p("a"), p("b")], []).map((x) => x.slug)).toEqual([
+      "a",
+      "b",
+      "c",
+    ]);
+  });
+
+  it("places ordered slugs first, in the given order", () => {
+    expect(
+      applyProjectOrder([p("a"), p("b"), p("c")], ["c", "a"]).map((x) => x.slug),
+    ).toEqual(["c", "a", "b"]);
+  });
+
+  it("appends unordered slugs lexically at the tail", () => {
+    expect(
+      applyProjectOrder([p("z"), p("y"), p("x")], ["x"]).map((x) => x.slug),
+    ).toEqual(["x", "y", "z"]);
+  });
+
+  it("ignores order entries that don't match any project", () => {
+    expect(
+      applyProjectOrder([p("a"), p("b")], ["ghost", "b", "phantom"]).map((x) => x.slug),
+    ).toEqual(["b", "a"]);
+  });
+
+  it("falls back to lexical when no order entry matches", () => {
+    expect(
+      applyProjectOrder([p("c"), p("a"), p("b")], ["ghost"]).map((x) => x.slug),
+    ).toEqual(["a", "b", "c"]);
+  });
+
+  it("does not mutate the input arrays", () => {
+    const projects = [p("c"), p("a"), p("b")];
+    const order = ["a"];
+    const before = projects.map((x) => x.slug);
+    const orderBefore = [...order];
+    applyProjectOrder(projects, order);
+    expect(projects.map((x) => x.slug)).toEqual(before);
+    expect(order).toEqual(orderBefore);
+  });
+
+  it("handles duplicate order entries by keeping the first rank", () => {
+    expect(
+      applyProjectOrder([p("a"), p("b"), p("c")], ["b", "a", "b"]).map((x) => x.slug),
+    ).toEqual(["b", "a", "c"]);
+  });
+});

--- a/plugins/op-obsidian/src/projects.ts
+++ b/plugins/op-obsidian/src/projects.ts
@@ -23,6 +23,30 @@ export function listProjects(app: App): ProjectInfo[] {
   return out.sort((a, b) => a.slug.localeCompare(b.slug));
 }
 
+// Reorder a list of projects by a user-curated slug order. Slugs in `order`
+// come first, in the given order; the remaining projects (newly discovered or
+// never reordered) follow in lexical slug order. `order` is treated as a
+// preference, not a filter — projects whose slug is absent are still returned.
+export function applyProjectOrder(
+  projects: ProjectInfo[],
+  order: readonly string[],
+): ProjectInfo[] {
+  if (!order.length) return [...projects].sort((a, b) => a.slug.localeCompare(b.slug));
+  const rank = new Map<string, number>();
+  order.forEach((slug, i) => {
+    if (!rank.has(slug)) rank.set(slug, i);
+  });
+  const ordered: ProjectInfo[] = [];
+  const tail: ProjectInfo[] = [];
+  for (const p of projects) {
+    if (rank.has(p.slug)) ordered.push(p);
+    else tail.push(p);
+  }
+  ordered.sort((a, b) => (rank.get(a.slug) ?? 0) - (rank.get(b.slug) ?? 0));
+  tail.sort((a, b) => a.slug.localeCompare(b.slug));
+  return [...ordered, ...tail];
+}
+
 export function findProjectByPrefix(app: App, prefix: string): ProjectInfo | undefined {
   return listProjects(app).find((p) => p.prefix === prefix);
 }

--- a/plugins/op-obsidian/src/settings.test.ts
+++ b/plugins/op-obsidian/src/settings.test.ts
@@ -151,4 +151,20 @@ describe("mergeSettings", () => {
     expect(mergeSettings({}).orchestratorState).toEqual(emptyRegistry());
     expect(mergeSettings({ orchestratorState: "garbage" }).orchestratorState).toEqual(emptyRegistry());
   });
+
+  it("projectOrder defaults to [] and accepts a sanitised string array", () => {
+    expect(mergeSettings({}).projectOrder).toEqual([]);
+    expect(mergeSettings({ projectOrder: ["foo", "bar"] }).projectOrder).toEqual(["foo", "bar"]);
+  });
+
+  it("projectOrder rejects non-array, drops non-string / blank / duplicate entries", () => {
+    expect(mergeSettings({ projectOrder: "foo" as unknown as string[] }).projectOrder).toEqual([]);
+    expect(mergeSettings({ projectOrder: { 0: "foo" } as unknown as string[] }).projectOrder).toEqual([]);
+    expect(
+      mergeSettings({
+        projectOrder: ["foo", 42 as unknown as string, "", "  ", "bar", "foo"],
+      }).projectOrder,
+    ).toEqual(["foo", "bar"]);
+    expect(mergeSettings({ projectOrder: ["  baz  "] }).projectOrder).toEqual(["baz"]);
+  });
 });

--- a/plugins/op-obsidian/src/settings.ts
+++ b/plugins/op-obsidian/src/settings.ts
@@ -2,6 +2,7 @@ import { App, PluginSettingTab, Setting, Notice } from "obsidian";
 import { existsSync } from "fs";
 import * as path from "path";
 import type OpPlugin from "./main";
+import { applyProjectOrder, listProjects } from "./projects";
 import { AGENT_IDS, type AgentId } from "./agentProfiles";
 import type { ITermPlacement } from "./terminalLaunch";
 import { LAYOUT_IDS, type LayoutId } from "./layout/layouts";
@@ -36,6 +37,113 @@ export type {
 export class OpSettingsTab extends PluginSettingTab {
   constructor(app: App, private plugin: OpPlugin) {
     super(app, plugin);
+  }
+
+  private renderProjectOrder(containerEl: HTMLElement): void {
+    const s = this.plugin.settings;
+    const projects = applyProjectOrder(listProjects(this.app), s.projectOrder);
+
+    if (projects.length === 0) {
+      containerEl.createEl("p", {
+        text: "No projects discovered yet. Scaffold one with /op:scaffold.",
+        cls: "op-project-order__empty",
+      });
+      return;
+    }
+
+    const list = containerEl.createEl("ul", { cls: "op-project-order__list" });
+    let dragSlug: string | null = null;
+
+    const persistFromDom = async (): Promise<void> => {
+      const next: string[] = [];
+      list.querySelectorAll<HTMLLIElement>(".op-project-order__item").forEach((li) => {
+        const slug = li.dataset.slug;
+        if (slug) next.push(slug);
+      });
+      // Preserve any slugs the user has ordered for projects that aren't
+      // currently discovered (e.g. STATUS.md temporarily missing) so a
+      // transient absence doesn't wipe their curated position.
+      const visible = new Set(next);
+      for (const slug of s.projectOrder) {
+        if (!visible.has(slug)) next.push(slug);
+      }
+      s.projectOrder = next;
+      await this.plugin.saveSettings();
+    };
+
+    const clearDropAffordance = (): void => {
+      list.querySelectorAll(".is-drop-before, .is-drop-after").forEach((el) => {
+        el.classList.remove("is-drop-before", "is-drop-after");
+      });
+    };
+
+    for (const p of projects) {
+      const li = list.createEl("li", { cls: "op-project-order__item" });
+      li.dataset.slug = p.slug;
+      li.draggable = true;
+      li.createEl("span", { cls: "op-project-order__handle", text: "⋮⋮" });
+      li.createEl("span", { cls: "op-project-order__slug", text: p.slug });
+      if (p.prefix) {
+        li.createEl("span", { cls: "op-project-order__prefix", text: p.prefix });
+      }
+
+      li.addEventListener("dragstart", (ev) => {
+        dragSlug = p.slug;
+        li.classList.add("is-dragging");
+        if (ev.dataTransfer) {
+          ev.dataTransfer.effectAllowed = "move";
+          ev.dataTransfer.setData("text/plain", p.slug);
+        }
+      });
+      li.addEventListener("dragend", () => {
+        dragSlug = null;
+        li.classList.remove("is-dragging");
+        clearDropAffordance();
+      });
+      li.addEventListener("dragover", (ev) => {
+        if (!dragSlug || dragSlug === p.slug) return;
+        ev.preventDefault();
+        if (ev.dataTransfer) ev.dataTransfer.dropEffect = "move";
+        const rect = li.getBoundingClientRect();
+        const before = ev.clientY < rect.top + rect.height / 2;
+        clearDropAffordance();
+        li.classList.add(before ? "is-drop-before" : "is-drop-after");
+      });
+      li.addEventListener("dragleave", () => {
+        li.classList.remove("is-drop-before", "is-drop-after");
+      });
+      li.addEventListener("drop", async (ev) => {
+        ev.preventDefault();
+        if (!dragSlug || dragSlug === p.slug) {
+          clearDropAffordance();
+          return;
+        }
+        const src = list.querySelector<HTMLLIElement>(
+          `.op-project-order__item[data-slug="${CSS.escape(dragSlug)}"]`,
+        );
+        if (!src) {
+          clearDropAffordance();
+          return;
+        }
+        const rect = li.getBoundingClientRect();
+        const before = ev.clientY < rect.top + rect.height / 2;
+        if (before) list.insertBefore(src, li);
+        else list.insertBefore(src, li.nextSibling);
+        clearDropAffordance();
+        await persistFromDom();
+      });
+    }
+
+    new Setting(containerEl)
+      .setName("Reset to alphabetical")
+      .setDesc("Clears your custom order so projects sort alphabetically again.")
+      .addButton((b) =>
+        b.setButtonText("Reset").onClick(async () => {
+          s.projectOrder = [];
+          await this.plugin.saveSettings();
+          this.display();
+        }),
+      );
   }
 
   display(): void {
@@ -337,6 +445,13 @@ export class OpSettingsTab extends PluginSettingTab {
           this.display();
         });
       });
+
+    containerEl.createEl("h2", { text: "Project order" });
+    containerEl.createEl("p", {
+      text: "Drag to reorder how projects appear in command pickers (e.g. “op: New issue”). Newly-discovered projects sort alphabetically below the curated list. Reset to alphabetical clears your custom order.",
+      cls: "setting-item-description",
+    });
+    this.renderProjectOrder(containerEl);
 
     containerEl.createEl("h2", { text: "Terminal" });
     new Setting(containerEl)

--- a/plugins/op-obsidian/src/settingsPure.ts
+++ b/plugins/op-obsidian/src/settingsPure.ts
@@ -61,6 +61,10 @@ export interface OpSettings {
   flow: FlowSettings;
   orchestrator: OrchestratorSettings;
   orchestratorState: RegistryData;
+  // User-curated display order for project pickers, by slug. Slugs not in this
+  // list (e.g. newly-discovered projects) sort lexically at the tail. Empty
+  // array ⇒ pure lexical sort (the historical default).
+  projectOrder: string[];
 }
 
 export const DEFAULT_SETTINGS: OpSettings = {
@@ -102,6 +106,7 @@ export const DEFAULT_SETTINGS: OpSettings = {
     preferred: "2x2",
   },
   orchestratorState: emptyRegistry(),
+  projectOrder: [],
 };
 
 const SIDEBAR_TABS: ReadonlySet<SidebarTab> = new Set(["issues", "in-flight", "resolved"]);
@@ -166,6 +171,18 @@ export function mergeSettings(loaded: unknown): OpSettings {
     if (typeof a.enforceWorktree === "boolean") {
       base.agents.enforceWorktree = a.enforceWorktree;
     }
+  }
+  if (Array.isArray((l as { projectOrder?: unknown }).projectOrder)) {
+    const seen = new Set<string>();
+    const out: string[] = [];
+    for (const v of (l as { projectOrder: unknown[] }).projectOrder) {
+      if (typeof v !== "string") continue;
+      const trimmed = v.trim();
+      if (!trimmed || seen.has(trimmed)) continue;
+      seen.add(trimmed);
+      out.push(trimmed);
+    }
+    base.projectOrder = out;
   }
   if (l.flow && typeof l.flow === "object") {
     const f = l.flow as Partial<FlowSettings>;

--- a/plugins/op-obsidian/styles.css
+++ b/plugins/op-obsidian/styles.css
@@ -164,3 +164,67 @@ a.op-sidebar__agent:hover {
   color: var(--text-accent);
   text-decoration: underline;
 }
+
+.op-project-order__list {
+  list-style: none;
+  margin: 0.5rem 0;
+  padding: 0;
+  border: 1px solid var(--background-modifier-border);
+  border-radius: 4px;
+  background: var(--background-secondary);
+}
+
+.op-project-order__item {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.4rem 0.6rem;
+  border-bottom: 1px solid var(--background-modifier-border);
+  cursor: grab;
+  user-select: none;
+}
+
+.op-project-order__item:last-child {
+  border-bottom: none;
+}
+
+.op-project-order__item.is-dragging {
+  opacity: 0.4;
+  cursor: grabbing;
+}
+
+.op-project-order__item.is-drop-before {
+  box-shadow: inset 0 2px 0 0 var(--interactive-accent);
+}
+
+.op-project-order__item.is-drop-after {
+  box-shadow: inset 0 -2px 0 0 var(--interactive-accent);
+}
+
+.op-project-order__handle {
+  color: var(--text-muted);
+  font-family: var(--font-monospace, monospace);
+  font-size: 1rem;
+  line-height: 1;
+}
+
+.op-project-order__slug {
+  flex: 1;
+  min-width: 0;
+  font-weight: 500;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.op-project-order__prefix {
+  color: var(--text-muted);
+  font-family: var(--font-monospace, monospace);
+  font-size: var(--font-ui-smaller, 0.75rem);
+}
+
+.op-project-order__empty {
+  color: var(--text-faint);
+  font-style: italic;
+  padding: 0.5rem;
+}

--- a/plugins/op/.claude-plugin/plugin.json
+++ b/plugins/op/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "op",
   "description": "Obsidian Projects workflow — schema, slash commands, and agent skill for running a Jira-lite issue tracker inside an Obsidian vault.",
-  "version": "0.36.0",
+  "version": "0.37.0",
   "author": {
     "name": "Eugene Archibald"
   },


### PR DESCRIPTION
## Summary

- Adds `projectOrder: string[]` setting (default `[]`) and pure helper `applyProjectOrder()` that places curated slugs first by their index, then appends unknown slugs lexically at the tail. Empty order preserves the legacy lexical sort.
- New "Project order" section in Settings → op with HTML5 drag-and-drop rows and a "Reset to alphabetical" button. Wired only into `runNewIssueCommand` — internal `listProjects` callers (find/resolve keyed lookups) untouched.
- `mergeSettings` sanitises the persisted order: array-only, drops non-string / blank / duplicate entries, trims values.

## Test plan

- [x] `vitest` — 318 passing, including 7 new `applyProjectOrder` cases and 2 new `mergeSettings.projectOrder` cases.
- [x] Live smoke (synced + reloaded into Agent-Vault):
  - Saved `projectOrder = ["statusline-plugin", "obsidian-projects"]`; "op: New issue" picker showed those two first, remaining 8 lexical.
  - Reset cleared the order; picker returned to pure alphabetical.
  - Settings tab rendered 10 draggable `.op-project-order__item` rows with prefix badges.
  - `obsidian dev:console` clean across the sequence.