### PR TITLE
OP-113: relation registry + two-way issue linking (#95)

### DIFF
--- a/plugins/op-obsidian/manifest.json
+++ b/plugins/op-obsidian/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "op-obsidian",
   "name": "Obsidian Projects (op)",
-  "version": "0.36.0",
+  "version": "0.37.0",
   "minAppVersion": "1.5.0",
   "description": "Jira-lite issue tracker for Obsidian vaults — deterministic commands backing the op workflow.",
   "author": "Eugene Archibald",

--- a/plugins/op-obsidian/package-lock.json
+++ b/plugins/op-obsidian/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "op-obsidian",
-  "version": "0.25.6",
+  "version": "0.36.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "op-obsidian",
-      "version": "0.25.6",
+      "version": "0.36.0",
       "license": "MIT",
       "dependencies": {
         "protobufjs": "^8.0.1"

--- a/plugins/op-obsidian/package.json
+++ b/plugins/op-obsidian/package.json
@@ -1,6 +1,6 @@
 {
   "name": "op-obsidian",
-  "version": "0.36.0",
+  "version": "0.37.0",
   "description": "Obsidian plugin that owns the deterministic half of the op workflow.",
   "main": "main.js",
   "scripts": {

--- a/plugins/op-obsidian/src/cliHandlers.ts
+++ b/plugins/op-obsidian/src/cliHandlers.ts
@@ -136,3 +136,43 @@ export function parseScaffoldParams(
   if (!prefix) return { ok: false, error: "--prefix is required" };
   return { ok: true, value: { slug, prefix } };
 }
+
+export function parseSetLinkParams(
+  params: Record<string, string>,
+): ParamsResult<{ srcId: string; dstId: string; relation: string }> {
+  const srcId = params.issue ?? params.id ?? params.src;
+  const dstId = params.target ?? params.dst;
+  const relation = params.relation;
+  if (!srcId || !dstId || !relation) {
+    return {
+      ok: false,
+      error:
+        "op-set-link failed: --issue, --relation, --target all required",
+    };
+  }
+  return { ok: true, value: { srcId, dstId, relation } };
+}
+
+export function parseRemoveLinkParams(
+  params: Record<string, string>,
+): ParamsResult<{ srcId: string; dstId: string; relation: string }> {
+  const srcId = params.issue ?? params.id ?? params.src;
+  const dstId = params.target ?? params.dst;
+  const relation = params.relation;
+  if (!srcId || !dstId || !relation) {
+    return {
+      ok: false,
+      error:
+        "op-remove-link failed: --issue, --relation, --target all required",
+    };
+  }
+  return { ok: true, value: { srcId, dstId, relation } };
+}
+
+export function parseLinkCheckParams(
+  params: Record<string, string>,
+): ParamsResult<{ repair: boolean }> {
+  const raw = params.repair;
+  const repair = raw === "1" || raw === "true";
+  return { ok: true, value: { repair } };
+}

--- a/plugins/op-obsidian/src/links.ts
+++ b/plugins/op-obsidian/src/links.ts
@@ -1,0 +1,332 @@
+import { App, TFile } from "obsidian";
+import type { IssueStore } from "./issueStore";
+import type { IssueEntry } from "./types";
+import {
+  computeApply,
+  computeMigrate,
+  computeRemove,
+  scanDrift,
+  validateLinkArgs,
+  type Cleanup,
+  type DriftEntry,
+  type RelationName,
+  RELATIONS,
+  RELATION_NAMES,
+} from "./relations";
+
+// Obsidian-bound glue for the two-way linking verbs. Each public function
+// resolves the issue ids via the IssueStore (covers ISSUES/ + RESOLVED ISSUES/
+// uniformly), reads frontmatter snapshots from the metadata cache, hands off
+// to the pure functions in `relations.ts`, then applies the resulting delta
+// via `app.fileManager.processFrontMatter` (per-file serialization, same
+// path as the rest of the plugin's frontmatter writes).
+//
+// Concurrency: a single applyLink call awaits each side's processFrontMatter
+// sequentially, so a competing call on either file blocks naturally on the
+// per-file lock obsidian provides. No new locking is introduced here.
+
+export interface LinkArgs {
+  srcId: string;
+  dstId: string;
+  relation: string;
+}
+
+export interface ApplyLinkResult {
+  ok: true;
+  command: "op-set-link" | "op-remove-link";
+  srcId: string;
+  dstId: string;
+  relation: RelationName;
+  srcPath: string;
+  dstPath: string;
+  changed: boolean;
+  /** Issue ids whose inverse list was trimmed because of a many-to-one reparent. */
+  cleaned: string[];
+}
+
+export async function applyLink(
+  app: App,
+  store: IssueStore,
+  args: LinkArgs,
+): Promise<ApplyLinkResult> {
+  const { srcId, dstId, relation } = validateLinkArgs(args);
+  const srcEntry = resolveOrThrow(store, srcId);
+  const dstEntry = resolveOrThrow(store, dstId);
+  const srcFile = requireFile(app, srcEntry.path);
+  const dstFile = requireFile(app, dstEntry.path);
+
+  const srcFmSnap = readFm(app, srcFile);
+  const dstFmSnap = readFm(app, dstFile);
+  const planned = computeApply({
+    srcFm: srcFmSnap,
+    dstFm: dstFmSnap,
+    srcId,
+    dstId,
+    relation: relation.name,
+  });
+
+  // Apply src/dst writes even when changed=false but cleanups exist (won't
+  // happen in practice for a fresh apply, but treat the two flags
+  // independently so future relations don't trip on it).
+  if (planned.changed) {
+    await writeFmDelta(app, srcFile, srcFmSnap, planned.srcFmNext);
+    await writeFmDelta(app, dstFile, dstFmSnap, planned.dstFmNext);
+  }
+
+  const cleaned: string[] = [];
+  for (const c of planned.cleanups) {
+    const ok = await applyCleanup(app, store, c);
+    if (ok) cleaned.push(c.holderId);
+  }
+
+  return {
+    ok: true,
+    command: "op-set-link",
+    srcId,
+    dstId,
+    relation: relation.name,
+    srcPath: srcEntry.path,
+    dstPath: dstEntry.path,
+    changed: planned.changed || cleaned.length > 0,
+    cleaned,
+  };
+}
+
+export async function removeLink(
+  app: App,
+  store: IssueStore,
+  args: LinkArgs,
+): Promise<ApplyLinkResult> {
+  const { srcId, dstId, relation } = validateLinkArgs(args);
+  const srcEntry = resolveOrThrow(store, srcId);
+  const dstEntry = resolveOrThrow(store, dstId);
+  const srcFile = requireFile(app, srcEntry.path);
+  const dstFile = requireFile(app, dstEntry.path);
+
+  const srcFmSnap = readFm(app, srcFile);
+  const dstFmSnap = readFm(app, dstFile);
+  const planned = computeRemove({
+    srcFm: srcFmSnap,
+    dstFm: dstFmSnap,
+    srcId,
+    dstId,
+    relation: relation.name,
+  });
+
+  if (planned.changed) {
+    await writeFmDelta(app, srcFile, srcFmSnap, planned.srcFmNext);
+    await writeFmDelta(app, dstFile, dstFmSnap, planned.dstFmNext);
+  }
+
+  return {
+    ok: true,
+    command: "op-remove-link",
+    srcId,
+    dstId,
+    relation: relation.name,
+    srcPath: srcEntry.path,
+    dstPath: dstEntry.path,
+    changed: planned.changed,
+    cleaned: [],
+  };
+}
+
+export interface LinkCheckResult {
+  ok: true;
+  command: "op-link-check";
+  scanned: number;
+  drift: DriftEntry[];
+  /** Drift entries that were repaired (only populated when repair=true). */
+  repaired: DriftEntry[];
+  /** Drift entries that could not be repaired (e.g. dangling-target). */
+  unrepaired: DriftEntry[];
+}
+
+export async function linkCheck(
+  app: App,
+  store: IssueStore,
+  opts: { repair?: boolean } = {},
+): Promise<LinkCheckResult> {
+  const issues = store.issues();
+  const snapshot = new Map<string, Record<string, unknown>>();
+  for (const e of issues) {
+    const file = app.vault.getAbstractFileByPath(e.path);
+    if (file instanceof TFile) {
+      snapshot.set(e.id, readFm(app, file));
+    }
+  }
+
+  const drift = scanDrift(snapshot);
+
+  if (!opts.repair || drift.length === 0) {
+    return {
+      ok: true,
+      command: "op-link-check",
+      scanned: issues.length,
+      drift,
+      repaired: [],
+      unrepaired: drift.filter((d) => d.problem === "dangling-target"),
+    };
+  }
+
+  const repaired: DriftEntry[] = [];
+  const unrepaired: DriftEntry[] = [];
+  // Re-scan after each repair: applyLink only touches two files, so an O(n^2)
+  // worst case is bounded by the drift count, not the issue count. In the
+  // overwhelming common case repair count is tiny.
+  for (const d of drift) {
+    if (d.problem === "dangling-target") {
+      unrepaired.push(d);
+      continue;
+    }
+    try {
+      await applyLink(app, store, {
+        srcId: d.issueId,
+        dstId: d.target,
+        relation: d.relation,
+      });
+      repaired.push(d);
+    } catch (err) {
+      console.warn("[op-obsidian] link-check repair failed", d, err);
+      unrepaired.push(d);
+    }
+  }
+
+  return {
+    ok: true,
+    command: "op-link-check",
+    scanned: issues.length,
+    drift,
+    repaired,
+    unrepaired,
+  };
+}
+
+export interface MigrateLinksResult {
+  ok: true;
+  command: "op-migrate-links";
+  scanned: number;
+  rewrites: Array<{ issueId: string; path: string; diff: string[] }>;
+}
+
+export async function migrateLinks(
+  app: App,
+  store: IssueStore,
+): Promise<MigrateLinksResult> {
+  const issues = store.issues();
+  const rewrites: MigrateLinksResult["rewrites"] = [];
+  for (const e of issues) {
+    const file = app.vault.getAbstractFileByPath(e.path);
+    if (!(file instanceof TFile)) continue;
+    const fm = readFm(app, file);
+    const result = computeMigrate(fm);
+    if (!result.changed) continue;
+
+    await app.fileManager.processFrontMatter(file, (live) => {
+      if ("parent_issue" in live) delete live.parent_issue;
+      if ("subissues" in live) delete live.subissues;
+      if ("parent" in result.fmNext) live.parent = result.fmNext.parent;
+      if ("children" in result.fmNext) live.children = result.fmNext.children;
+    });
+    rewrites.push({ issueId: e.id, path: e.path, diff: result.diff });
+  }
+
+  return { ok: true, command: "op-migrate-links", scanned: issues.length, rewrites };
+}
+
+// ---------- internal helpers ----------
+
+function resolveOrThrow(store: IssueStore, id: string): IssueEntry {
+  const entry = store.byId(id);
+  if (!entry) {
+    throw new Error(
+      `Issue not found: ${id}. Both ISSUES/ and RESOLVED ISSUES/ are searched — check the id.`,
+    );
+  }
+  if (entry.type !== "issue") {
+    throw new Error(`Expected issue, got ${entry.type}: ${id}`);
+  }
+  return entry;
+}
+
+function requireFile(app: App, path: string): TFile {
+  const f = app.vault.getAbstractFileByPath(path);
+  if (!(f instanceof TFile)) throw new Error(`Issue file not found on disk: ${path}`);
+  return f;
+}
+
+function readFm(app: App, file: TFile): Record<string, unknown> {
+  const fm = app.metadataCache.getFileCache(file)?.frontmatter;
+  return fm ? { ...fm } : {};
+}
+
+/**
+ * Apply the difference between `before` and `after` to the live fm under
+ * `processFrontMatter`. Only the keys that actually differ are touched; keys
+ * present in `before` but missing from `after` are deleted.
+ */
+async function writeFmDelta(
+  app: App,
+  file: TFile,
+  before: Record<string, unknown>,
+  after: Record<string, unknown>,
+): Promise<void> {
+  const setKeys: string[] = [];
+  const deleteKeys: string[] = [];
+  for (const k of Object.keys(after)) {
+    if (!fmValueEquals(before[k], after[k])) setKeys.push(k);
+  }
+  for (const k of Object.keys(before)) {
+    if (!(k in after)) deleteKeys.push(k);
+  }
+  if (setKeys.length === 0 && deleteKeys.length === 0) return;
+  await app.fileManager.processFrontMatter(file, (live) => {
+    for (const k of setKeys) live[k] = after[k];
+    for (const k of deleteKeys) delete live[k];
+  });
+}
+
+async function applyCleanup(
+  app: App,
+  store: IssueStore,
+  c: Cleanup,
+): Promise<boolean> {
+  const entry = store.byId(c.holderId);
+  if (!entry || entry.type !== "issue") {
+    console.warn("[op-obsidian] applyCleanup: holder not found", c);
+    return false;
+  }
+  const file = app.vault.getAbstractFileByPath(entry.path);
+  if (!(file instanceof TFile)) return false;
+  let didChange = false;
+  await app.fileManager.processFrontMatter(file, (fm) => {
+    const v = fm[c.field];
+    if (!Array.isArray(v)) return;
+    const next = v.filter(
+      (x: unknown) => !(typeof x === "string" && x === c.remove),
+    );
+    if (next.length === v.length) return;
+    if (next.length === 0) {
+      delete fm[c.field];
+    } else {
+      fm[c.field] = next;
+    }
+    didChange = true;
+  });
+  return didChange;
+}
+
+function fmValueEquals(a: unknown, b: unknown): boolean {
+  if (a === b) return true;
+  if (Array.isArray(a) && Array.isArray(b)) {
+    if (a.length !== b.length) return false;
+    for (let i = 0; i < a.length; i++) {
+      if (a[i] !== b[i]) return false;
+    }
+    return true;
+  }
+  return false;
+}
+
+export { RELATIONS, RELATION_NAMES };
+export type { RelationName } from "./relations";

--- a/plugins/op-obsidian/src/main.ts
+++ b/plugins/op-obsidian/src/main.ts
@@ -22,6 +22,8 @@ import { appendCommit, setPr } from "./commits";
 import { setScope } from "./setScope";
 import { setEvaluation } from "./setEvaluation";
 import { setFlow, type Complexity, type Flow } from "./setFlow";
+import { applyLink, removeLink, linkCheck, migrateLinks } from "./links";
+import { RELATION_NAMES } from "./relations";
 import { runEvaluatorFlow } from "./evaluator";
 import { launchHeadless } from "./launchHeadless";
 import {
@@ -48,6 +50,10 @@ import {
   handleOpSetScopeUri as handleOpSetScopeUriPure,
   handleOpSetEvaluationUri as handleOpSetEvaluationUriPure,
   handleOpSetFlowUri as handleOpSetFlowUriPure,
+  handleOpSetLinkUri as handleOpSetLinkUriPure,
+  handleOpRemoveLinkUri as handleOpRemoveLinkUriPure,
+  handleOpLinkCheckUri as handleOpLinkCheckUriPure,
+  handleOpMigrateLinksUri as handleOpMigrateLinksUriPure,
   type UriHandlerDeps,
 } from "./uriHandlers";
 import {
@@ -58,6 +64,9 @@ import {
   parseSetEvaluationParams,
   parseSetFlowParams,
   parseNewParams,
+  parseSetLinkParams,
+  parseRemoveLinkParams,
+  parseLinkCheckParams,
 } from "./cliHandlers";
 import type { IssueEntry, LifecycleEvent } from "./types";
 import { DEFAULT_SETTINGS, mergeSettings, OpSettingsTab, type OpSettings } from "./settings";
@@ -395,6 +404,24 @@ export default class OpPlugin extends Plugin {
     });
 
     this.addCommand({
+      id: "op-link-check",
+      name: "op: check issue link drift",
+      callback: () => void this.runLinkCheckCommand(false),
+    });
+
+    this.addCommand({
+      id: "op-link-check-repair",
+      name: "op: check issue link drift (repair)",
+      callback: () => void this.runLinkCheckCommand(true),
+    });
+
+    this.addCommand({
+      id: "op-migrate-links",
+      name: "op: migrate legacy parent_issue/subissues to parent/children",
+      callback: () => void this.runMigrateLinksCommand(),
+    });
+
+    this.addCommand({
       id: "op-debug-agent-launch",
       name: "op-dev: open agent to debug agent launch",
       callback: () => void this.runDebugAgentLaunch(),
@@ -461,6 +488,30 @@ export default class OpPlugin extends Plugin {
 
     this.registerObsidianProtocolHandler("op-set-flow", (params) => {
       this.runUri("op-set-flow", normalizeUriParams(params), (p) => this.handleOpSetFlowUri(p));
+    });
+
+    this.registerObsidianProtocolHandler("op-set-link", (params) => {
+      this.runUri("op-set-link", normalizeUriParams(params), (p) =>
+        handleOpSetLinkUriPure(this.uriDeps(), p),
+      );
+    });
+
+    this.registerObsidianProtocolHandler("op-remove-link", (params) => {
+      this.runUri("op-remove-link", normalizeUriParams(params), (p) =>
+        handleOpRemoveLinkUriPure(this.uriDeps(), p),
+      );
+    });
+
+    this.registerObsidianProtocolHandler("op-link-check", (params) => {
+      this.runUri("op-link-check", normalizeUriParams(params), (p) =>
+        handleOpLinkCheckUriPure(this.uriDeps(), p),
+      );
+    });
+
+    this.registerObsidianProtocolHandler("op-migrate-links", (params) => {
+      this.runUri("op-migrate-links", normalizeUriParams(params), (p) =>
+        handleOpMigrateLinksUriPure(this.uriDeps(), p),
+      );
     });
 
     this.registerObsidianProtocolHandler("op-resolve", (params) => {
@@ -634,6 +685,48 @@ export default class OpPlugin extends Plugin {
         issue: { value: "<id>", description: "Issue id (e.g. OP-34)" },
       },
       (params) => this.handleOpResetFlowCli(params),
+    );
+
+    const linkRelationsHelp = `Relation name (one of: ${RELATION_NAMES.join("|")})`;
+    this.registerCliHandler(
+      "op-set-link",
+      "Set a two-way issue link. Plugin writes both sides atomically.",
+      {
+        issue: { value: "<id>", description: "Source issue id (e.g. OP-34)" },
+        relation: { value: "<rel>", description: linkRelationsHelp },
+        target: { value: "<id>", description: "Target issue id" },
+      },
+      (params) => this.handleOpSetLinkCli(params),
+    );
+
+    this.registerCliHandler(
+      "op-remove-link",
+      "Remove a two-way issue link. Plugin updates both sides atomically.",
+      {
+        issue: { value: "<id>", description: "Source issue id (e.g. OP-34)" },
+        relation: { value: "<rel>", description: linkRelationsHelp },
+        target: { value: "<id>", description: "Target issue id" },
+      },
+      (params) => this.handleOpRemoveLinkCli(params),
+    );
+
+    this.registerCliHandler(
+      "op-link-check",
+      "Walk every issue and report any one-sided link drift across the vault.",
+      {
+        repair: {
+          description:
+            "Pass repair=true to reconcile drift by re-applying links (dangling targets are reported, not fixed).",
+        },
+      },
+      (params) => this.handleOpLinkCheckCli(params),
+    );
+
+    this.registerCliHandler(
+      "op-migrate-links",
+      "Rewrite legacy parent_issue/subissues to canonical parent/children. Idempotent.",
+      {},
+      (params) => this.handleOpMigrateLinksCli(params),
     );
 
     this.registerCliHandler(
@@ -1014,6 +1107,10 @@ export default class OpPlugin extends Plugin {
       setScope: (entry, scope, options) => setScope(this.app, entry, scope, options),
       setEvaluation: (entry, evaluation) => setEvaluation(this.app, entry, evaluation),
       setFlow: (entry, input) => setFlow(this.app, entry, input),
+      applyLink: (args) => applyLink(this.app, this.store, args),
+      removeLink: (args) => removeLink(this.app, this.store, args),
+      linkCheck: (opts) => linkCheck(this.app, this.store, opts),
+      migrateLinks: () => migrateLinks(this.app, this.store),
     };
   }
 
@@ -1395,6 +1492,112 @@ export default class OpPlugin extends Plugin {
       console.error("[op-obsidian]", command, err);
       await writeUriResponse(this.app, { ok: false, command, error: msg });
       return `${command} failed: ${msg}`;
+    }
+  }
+
+  private async handleOpSetLinkCli(params: Record<string, string>): Promise<string> {
+    const command = "op-set-link";
+    try {
+      const parsed = parseSetLinkParams(params);
+      if (!parsed.ok) return parsed.error;
+      const { srcId, dstId, relation } = parsed.value;
+      const res = await applyLink(this.app, this.store, { srcId, dstId, relation });
+      await writeUriResponse(this.app, { ...res });
+      const cleanedNote =
+        res.cleaned.length > 0 ? ` · cleaned ${res.cleaned.join(", ")}` : "";
+      const changedNote = res.changed ? "linked" : "already linked";
+      return `${command}: ${res.srcId} ${res.relation}=${res.dstId} (${changedNote})${cleanedNote}`;
+    } catch (err: any) {
+      const msg = err?.message ?? String(err);
+      console.error("[op-obsidian]", command, err);
+      await writeUriResponse(this.app, { ok: false, command, error: msg });
+      return `${command} failed: ${msg}`;
+    }
+  }
+
+  private async handleOpRemoveLinkCli(params: Record<string, string>): Promise<string> {
+    const command = "op-remove-link";
+    try {
+      const parsed = parseRemoveLinkParams(params);
+      if (!parsed.ok) return parsed.error;
+      const { srcId, dstId, relation } = parsed.value;
+      const res = await removeLink(this.app, this.store, { srcId, dstId, relation });
+      await writeUriResponse(this.app, { ...res });
+      const changedNote = res.changed ? "removed" : "no-op";
+      return `${command}: ${res.srcId} ${res.relation}=${res.dstId} (${changedNote})`;
+    } catch (err: any) {
+      const msg = err?.message ?? String(err);
+      console.error("[op-obsidian]", command, err);
+      await writeUriResponse(this.app, { ok: false, command, error: msg });
+      return `${command} failed: ${msg}`;
+    }
+  }
+
+  private async handleOpLinkCheckCli(params: Record<string, string>): Promise<string> {
+    const command = "op-link-check";
+    try {
+      const parsed = parseLinkCheckParams(params);
+      if (!parsed.ok) return parsed.error;
+      const res = await linkCheck(this.app, this.store, { repair: parsed.value.repair });
+      await writeUriResponse(this.app, { ...res });
+      const driftCount = res.drift.length;
+      const repairedCount = res.repaired.length;
+      const danglingCount = res.unrepaired.filter(
+        (d) => d.problem === "dangling-target",
+      ).length;
+      const parts = [`scanned ${res.scanned}`, `drift ${driftCount}`];
+      if (parsed.value.repair) parts.push(`repaired ${repairedCount}`);
+      if (danglingCount > 0) parts.push(`dangling ${danglingCount}`);
+      return `${command}: ${parts.join(" · ")}`;
+    } catch (err: any) {
+      const msg = err?.message ?? String(err);
+      console.error("[op-obsidian]", command, err);
+      await writeUriResponse(this.app, { ok: false, command, error: msg });
+      return `${command} failed: ${msg}`;
+    }
+  }
+
+  private async handleOpMigrateLinksCli(_params: Record<string, string>): Promise<string> {
+    const command = "op-migrate-links";
+    try {
+      const res = await migrateLinks(this.app, this.store);
+      await writeUriResponse(this.app, { ...res });
+      return `${command}: scanned ${res.scanned} · rewrote ${res.rewrites.length}`;
+    } catch (err: any) {
+      const msg = err?.message ?? String(err);
+      console.error("[op-obsidian]", command, err);
+      await writeUriResponse(this.app, { ok: false, command, error: msg });
+      return `${command} failed: ${msg}`;
+    }
+  }
+
+  private async runLinkCheckCommand(repair: boolean): Promise<void> {
+    try {
+      const res = await linkCheck(this.app, this.store, { repair });
+      await writeUriResponse(this.app, { ...res });
+      const dangling = res.unrepaired.filter(
+        (d) => d.problem === "dangling-target",
+      ).length;
+      const parts = [`drift ${res.drift.length}`];
+      if (repair) parts.push(`repaired ${res.repaired.length}`);
+      if (dangling > 0) parts.push(`dangling ${dangling}`);
+      new Notice(`op-link-check: scanned ${res.scanned} · ${parts.join(" · ")}`);
+    } catch (err: any) {
+      console.error("[op-obsidian] op-link-check failed", err);
+      new Notice(`op-link-check failed: ${err?.message ?? err}`);
+    }
+  }
+
+  private async runMigrateLinksCommand(): Promise<void> {
+    try {
+      const res = await migrateLinks(this.app, this.store);
+      await writeUriResponse(this.app, { ...res });
+      new Notice(
+        `op-migrate-links: scanned ${res.scanned} · rewrote ${res.rewrites.length}`,
+      );
+    } catch (err: any) {
+      console.error("[op-obsidian] op-migrate-links failed", err);
+      new Notice(`op-migrate-links failed: ${err?.message ?? err}`);
     }
   }
 

--- a/plugins/op-obsidian/src/relations.test.ts
+++ b/plugins/op-obsidian/src/relations.test.ts
@@ -1,0 +1,480 @@
+import { describe, it, expect } from "vitest";
+import {
+  RELATIONS,
+  RELATION_NAMES,
+  computeApply,
+  computeRemove,
+  computeMigrate,
+  scanDrift,
+  validateLinkArgs,
+  isRelationName,
+} from "./relations";
+
+describe("RELATIONS registry", () => {
+  it("declares an inverse for every relation that itself resolves", () => {
+    for (const name of RELATION_NAMES) {
+      const def = RELATIONS[name];
+      expect(RELATIONS[def.inverse]).toBeDefined();
+    }
+  });
+
+  it("inverse-of-inverse returns to the original (or self for symmetric)", () => {
+    for (const name of RELATION_NAMES) {
+      const def = RELATIONS[name];
+      const inverseDef = RELATIONS[def.inverse];
+      expect(inverseDef.inverse).toBe(name);
+    }
+  });
+
+  it("isList/inverseIsList shapes match between the pair", () => {
+    for (const name of RELATION_NAMES) {
+      const def = RELATIONS[name];
+      const inv = RELATIONS[def.inverse];
+      expect(def.inverseIsList).toBe(inv.isList);
+      expect(def.isList).toBe(inv.inverseIsList);
+    }
+  });
+
+  it("isRelationName is a strict guard", () => {
+    expect(isRelationName("parent")).toBe(true);
+    expect(isRelationName("not_a_relation")).toBe(false);
+    expect(isRelationName(undefined)).toBe(false);
+    expect(isRelationName(42)).toBe(false);
+  });
+});
+
+describe("validateLinkArgs", () => {
+  it("rejects self-links", () => {
+    expect(() =>
+      validateLinkArgs({ srcId: "OP-1", dstId: "OP-1", relation: "parent" }),
+    ).toThrow(/itself/);
+  });
+
+  it("rejects unknown relations", () => {
+    expect(() =>
+      validateLinkArgs({ srcId: "OP-1", dstId: "OP-2", relation: "blocks" }),
+    ).toThrow(/Unknown relation/);
+  });
+
+  it("requires non-empty src and dst", () => {
+    expect(() =>
+      validateLinkArgs({ srcId: "", dstId: "OP-2", relation: "parent" }),
+    ).toThrow(/srcId/);
+    expect(() =>
+      validateLinkArgs({ srcId: "OP-1", dstId: "", relation: "parent" }),
+    ).toThrow(/dstId/);
+  });
+});
+
+describe("computeApply — many-to-one (parent ↔ children)", () => {
+  it("sets parent on src and appends to children on dst", () => {
+    const res = computeApply({
+      srcFm: {},
+      dstFm: {},
+      srcId: "OP-10",
+      dstId: "OP-2",
+      relation: "parent",
+    });
+    expect(res.changed).toBe(true);
+    expect(res.srcFmNext.parent).toBe("OP-2");
+    expect(res.dstFmNext.children).toEqual(["OP-10"]);
+    expect(res.cleanups).toEqual([]);
+  });
+
+  it("relation=children mirrors relation=parent (just from the other side)", () => {
+    const res = computeApply({
+      srcFm: {},
+      dstFm: {},
+      srcId: "OP-2",
+      dstId: "OP-10",
+      relation: "children",
+    });
+    expect(res.changed).toBe(true);
+    expect(res.srcFmNext.children).toEqual(["OP-10"]);
+    expect(res.dstFmNext.parent).toBe("OP-2");
+    expect(res.cleanups).toEqual([]);
+  });
+
+  it("idempotent: re-applying an existing parent link is a no-op", () => {
+    const res = computeApply({
+      srcFm: { parent: "OP-2" },
+      dstFm: { children: ["OP-10"] },
+      srcId: "OP-10",
+      dstId: "OP-2",
+      relation: "parent",
+    });
+    expect(res.changed).toBe(false);
+    expect(res.cleanups).toEqual([]);
+  });
+
+  it("appends to existing children list without duplicating", () => {
+    const res = computeApply({
+      srcFm: {},
+      dstFm: { children: ["OP-9"] },
+      srcId: "OP-10",
+      dstId: "OP-2",
+      relation: "parent",
+    });
+    expect(res.dstFmNext.children).toEqual(["OP-9", "OP-10"]);
+  });
+
+  it("reparenting emits a cleanup directive for the old parent", () => {
+    const res = computeApply({
+      srcFm: { parent: "OP-A" },
+      dstFm: {},
+      srcId: "OP-10",
+      dstId: "OP-B",
+      relation: "parent",
+    });
+    expect(res.changed).toBe(true);
+    expect(res.srcFmNext.parent).toBe("OP-B");
+    expect(res.dstFmNext.children).toEqual(["OP-10"]);
+    expect(res.cleanups).toEqual([
+      { holderId: "OP-A", field: "children", remove: "OP-10" },
+    ]);
+  });
+
+  it("reparenting via relation=children emits cleanup for the dst's old parent", () => {
+    // op-set-link issue=OP-X relation=children target=OP-Y where OP-Y already
+    // had parent=OP-Z. Cleanup: drop OP-Y from OP-Z.children.
+    const res = computeApply({
+      srcFm: {},
+      dstFm: { parent: "OP-Z" },
+      srcId: "OP-X",
+      dstId: "OP-Y",
+      relation: "children",
+    });
+    expect(res.changed).toBe(true);
+    expect(res.dstFmNext.parent).toBe("OP-X");
+    expect(res.cleanups).toEqual([
+      { holderId: "OP-Z", field: "children", remove: "OP-Y" },
+    ]);
+  });
+});
+
+describe("computeApply — many-to-many (depends_on ↔ depended_on_by)", () => {
+  it("appends to both sides", () => {
+    const res = computeApply({
+      srcFm: {},
+      dstFm: {},
+      srcId: "OP-1",
+      dstId: "OP-2",
+      relation: "depends_on",
+    });
+    expect(res.srcFmNext.depends_on).toEqual(["OP-2"]);
+    expect(res.dstFmNext.depended_on_by).toEqual(["OP-1"]);
+  });
+
+  it("idempotent for already-linked", () => {
+    const res = computeApply({
+      srcFm: { depends_on: ["OP-2"] },
+      dstFm: { depended_on_by: ["OP-1"] },
+      srcId: "OP-1",
+      dstId: "OP-2",
+      relation: "depends_on",
+    });
+    expect(res.changed).toBe(false);
+  });
+});
+
+describe("computeApply — symmetric (related_to ↔ related_to)", () => {
+  it("appends to both sides without double-write", () => {
+    const res = computeApply({
+      srcFm: {},
+      dstFm: {},
+      srcId: "OP-1",
+      dstId: "OP-2",
+      relation: "related_to",
+    });
+    expect(res.srcFmNext.related_to).toEqual(["OP-2"]);
+    expect(res.dstFmNext.related_to).toEqual(["OP-1"]);
+    expect(res.changed).toBe(true);
+  });
+
+  it("idempotent when both sides already list the partner", () => {
+    const res = computeApply({
+      srcFm: { related_to: ["OP-2"] },
+      dstFm: { related_to: ["OP-1"] },
+      srcId: "OP-1",
+      dstId: "OP-2",
+      relation: "related_to",
+    });
+    expect(res.changed).toBe(false);
+  });
+
+  it("repairs a one-sided related_to without oscillating: adding the missing side and re-running is a no-op", () => {
+    // X.related_to=[Y] but Y.related_to=[]. Apply src=X dst=Y rel=related_to.
+    // Should add X to Y.related_to without removing Y from X.related_to.
+    const first = computeApply({
+      srcFm: { related_to: ["OP-Y"] },
+      dstFm: {},
+      srcId: "OP-X",
+      dstId: "OP-Y",
+      relation: "related_to",
+    });
+    expect(first.srcFmNext.related_to).toEqual(["OP-Y"]);
+    expect(first.dstFmNext.related_to).toEqual(["OP-X"]);
+
+    // Re-running should report no change.
+    const second = computeApply({
+      srcFm: first.srcFmNext,
+      dstFm: first.dstFmNext,
+      srcId: "OP-X",
+      dstId: "OP-Y",
+      relation: "related_to",
+    });
+    expect(second.changed).toBe(false);
+  });
+});
+
+describe("computeRemove", () => {
+  it("removes the scalar parent and the entry from children, idempotently", () => {
+    const res = computeRemove({
+      srcFm: { parent: "OP-2" },
+      dstFm: { children: ["OP-10", "OP-11"] },
+      srcId: "OP-10",
+      dstId: "OP-2",
+      relation: "parent",
+    });
+    expect(res.changed).toBe(true);
+    expect(res.srcFmNext.parent).toBeUndefined();
+    expect(res.dstFmNext.children).toEqual(["OP-11"]);
+  });
+
+  it("deletes the children key when emptied", () => {
+    const res = computeRemove({
+      srcFm: { parent: "OP-2" },
+      dstFm: { children: ["OP-10"] },
+      srcId: "OP-10",
+      dstId: "OP-2",
+      relation: "parent",
+    });
+    expect("children" in res.dstFmNext).toBe(false);
+  });
+
+  it("no-op when the link wasn't present", () => {
+    const res = computeRemove({
+      srcFm: {},
+      dstFm: {},
+      srcId: "OP-1",
+      dstId: "OP-2",
+      relation: "depends_on",
+    });
+    expect(res.changed).toBe(false);
+  });
+
+  it("removes both sides for symmetric related_to", () => {
+    const res = computeRemove({
+      srcFm: { related_to: ["OP-2", "OP-3"] },
+      dstFm: { related_to: ["OP-1"] },
+      srcId: "OP-1",
+      dstId: "OP-2",
+      relation: "related_to",
+    });
+    expect(res.srcFmNext.related_to).toEqual(["OP-3"]);
+    expect("related_to" in res.dstFmNext).toBe(false);
+  });
+
+  it("rejects self-links", () => {
+    expect(() =>
+      computeRemove({
+        srcFm: {},
+        dstFm: {},
+        srcId: "OP-1",
+        dstId: "OP-1",
+        relation: "parent",
+      }),
+    ).toThrow(/itself/);
+  });
+});
+
+describe("scanDrift", () => {
+  it("returns no drift for fully-mirrored data", () => {
+    const issues = new Map<string, Record<string, unknown>>([
+      ["OP-1", { parent: "OP-2" }],
+      ["OP-2", { children: ["OP-1"] }],
+      ["OP-3", { related_to: ["OP-4"] }],
+      ["OP-4", { related_to: ["OP-3"] }],
+    ]);
+    expect(scanDrift(issues)).toEqual([]);
+  });
+
+  it("flags missing-inverse on parent → children", () => {
+    const issues = new Map<string, Record<string, unknown>>([
+      ["OP-1", { parent: "OP-2" }],
+      ["OP-2", {}],
+    ]);
+    expect(scanDrift(issues)).toEqual([
+      {
+        issueId: "OP-1",
+        relation: "parent",
+        target: "OP-2",
+        problem: "missing-inverse",
+      },
+    ]);
+  });
+
+  it("flags missing-inverse on children → parent", () => {
+    const issues = new Map<string, Record<string, unknown>>([
+      ["OP-1", {}],
+      ["OP-2", { children: ["OP-1"] }],
+    ]);
+    expect(scanDrift(issues)).toEqual([
+      {
+        issueId: "OP-2",
+        relation: "children",
+        target: "OP-1",
+        problem: "missing-inverse",
+      },
+    ]);
+  });
+
+  it("flags missing-inverse on symmetric related_to (one-sided)", () => {
+    const issues = new Map<string, Record<string, unknown>>([
+      ["OP-1", { related_to: ["OP-2"] }],
+      ["OP-2", {}],
+    ]);
+    expect(scanDrift(issues)).toEqual([
+      {
+        issueId: "OP-1",
+        relation: "related_to",
+        target: "OP-2",
+        problem: "missing-inverse",
+      },
+    ]);
+  });
+
+  it("flags dangling-target when the referenced issue isn't in the snapshot", () => {
+    const issues = new Map<string, Record<string, unknown>>([
+      ["OP-1", { depends_on: ["OP-99"] }],
+    ]);
+    expect(scanDrift(issues)).toEqual([
+      {
+        issueId: "OP-1",
+        relation: "depends_on",
+        target: "OP-99",
+        problem: "dangling-target",
+      },
+    ]);
+  });
+
+  it("includes resolved-folder issues — a parent→child link must remain valid after the child resolves", () => {
+    // Caller is expected to populate the snapshot with both folders. scanDrift
+    // doesn't care about location — only about id presence — so resolved
+    // issues round-trip naturally.
+    const issues = new Map<string, Record<string, unknown>>([
+      ["OP-1", { parent: "OP-92" }],
+      ["OP-92", { children: ["OP-1"] }],
+    ]);
+    expect(scanDrift(issues)).toEqual([]);
+  });
+});
+
+describe("computeMigrate", () => {
+  it("rewrites parent_issue → parent and removes the old key", () => {
+    const res = computeMigrate({ parent_issue: "OP-92" });
+    expect(res.changed).toBe(true);
+    expect(res.fmNext).toEqual({ parent: "OP-92" });
+    expect(res.diff).toContain("parent_issue → parent (OP-92)");
+  });
+
+  it("rewrites subissues → children and removes the old key", () => {
+    const res = computeMigrate({ subissues: ["OP-95", "OP-97"] });
+    expect(res.changed).toBe(true);
+    expect(res.fmNext).toEqual({ children: ["OP-95", "OP-97"] });
+  });
+
+  it("handles both keys at once", () => {
+    const res = computeMigrate({
+      parent_issue: "OP-92",
+      subissues: ["OP-95"],
+      other: "untouched",
+    });
+    expect(res.fmNext).toEqual({
+      parent: "OP-92",
+      children: ["OP-95"],
+      other: "untouched",
+    });
+  });
+
+  it("idempotent: a fm without interim keys returns changed: false", () => {
+    const res = computeMigrate({ parent: "OP-92", children: ["OP-95"] });
+    expect(res.changed).toBe(false);
+    expect(res.diff).toEqual([]);
+  });
+
+  it("re-running on already-migrated fm is a no-op", () => {
+    const first = computeMigrate({
+      parent_issue: "OP-92",
+      subissues: ["OP-95"],
+    });
+    const second = computeMigrate(first.fmNext);
+    expect(second.changed).toBe(false);
+    expect(second.fmNext).toEqual(first.fmNext);
+  });
+
+  it("conflict: keeps canonical parent when both keys are set", () => {
+    const res = computeMigrate({
+      parent_issue: "OP-OLD",
+      parent: "OP-NEW",
+    });
+    expect(res.fmNext.parent).toBe("OP-NEW");
+    expect("parent_issue" in res.fmNext).toBe(false);
+    expect(res.diff[0]).toMatch(/parent already set/);
+  });
+
+  it("conflict: union-merges children when both keys overlap", () => {
+    const res = computeMigrate({
+      subissues: ["OP-95", "OP-97"],
+      children: ["OP-95", "OP-99"],
+    });
+    expect(res.fmNext.children).toEqual(["OP-95", "OP-99", "OP-97"]);
+    expect("subissues" in res.fmNext).toBe(false);
+  });
+
+  it("does not mutate the input fm", () => {
+    const input = { parent_issue: "OP-92", subissues: ["OP-95"] };
+    const snapshot = JSON.parse(JSON.stringify(input));
+    computeMigrate(input);
+    expect(input).toEqual(snapshot);
+  });
+});
+
+describe("computeApply round-trip", () => {
+  it("apply then remove returns to the original state", () => {
+    const srcFm = {};
+    const dstFm = {};
+    const applied = computeApply({
+      srcFm,
+      dstFm,
+      srcId: "OP-1",
+      dstId: "OP-2",
+      relation: "depends_on",
+    });
+    const removed = computeRemove({
+      srcFm: applied.srcFmNext,
+      dstFm: applied.dstFmNext,
+      srcId: "OP-1",
+      dstId: "OP-2",
+      relation: "depends_on",
+    });
+    expect(removed.srcFmNext).toEqual({});
+    expect(removed.dstFmNext).toEqual({});
+  });
+
+  it("does not mutate input frontmatter records", () => {
+    const srcFm = { other: "x" };
+    const dstFm = { other: "y", children: ["OP-9"] };
+    const srcSnapshot = JSON.parse(JSON.stringify(srcFm));
+    const dstSnapshot = JSON.parse(JSON.stringify(dstFm));
+    computeApply({
+      srcFm,
+      dstFm,
+      srcId: "OP-10",
+      dstId: "OP-2",
+      relation: "parent",
+    });
+    expect(srcFm).toEqual(srcSnapshot);
+    expect(dstFm).toEqual(dstSnapshot);
+  });
+});

--- a/plugins/op-obsidian/src/relations.ts
+++ b/plugins/op-obsidian/src/relations.ts
@@ -1,0 +1,462 @@
+// Pure relation registry + frontmatter mutators for two-way issue linking.
+//
+// No `obsidian` imports — operates on plain `Record<string, unknown>` copies of
+// frontmatter so the logic can be unit-tested without a vault. The
+// obsidian-bound `applyLink`/`removeLink`/`linkCheck`/`migrateLinks` glue in
+// `links.ts` calls these and turns the returned deltas into
+// `app.fileManager.processFrontMatter` writes.
+//
+// Adding a new relation is a config-only change: append an entry to
+// `RELATIONS` and wire it into the schema doc. The verb surface (`op-set-link`,
+// etc.) takes the relation name as a parameter and consults the registry, so
+// no command-side code needs to change.
+
+export type RelationName =
+  | "parent"
+  | "children"
+  | "depends_on"
+  | "depended_on_by"
+  | "related_to";
+
+export type Cardinality = "many-to-one" | "many-to-many";
+
+export interface RelationDef {
+  /** Canonical field name on the source issue. */
+  name: RelationName;
+  /** Field name on the target issue that mirrors this relation. */
+  inverse: RelationName;
+  /**
+   * Pair-level cardinality. `many-to-one` means there is a scalar side
+   * (`parent`) and a list side (`children`) — exactly one inverse slot, with
+   * cleanup-of-old-holder semantics on reassignment. `many-to-many` means both
+   * sides are lists with idempotent append/remove.
+   */
+  cardinality: Cardinality;
+  /** Is this field stored as a list (`children`) or scalar (`parent`)? */
+  isList: boolean;
+  /** Is the inverse field stored as a list? */
+  inverseIsList: boolean;
+}
+
+export const RELATIONS: Record<RelationName, RelationDef> = {
+  parent: {
+    name: "parent",
+    inverse: "children",
+    cardinality: "many-to-one",
+    isList: false,
+    inverseIsList: true,
+  },
+  children: {
+    name: "children",
+    inverse: "parent",
+    cardinality: "many-to-one",
+    isList: true,
+    inverseIsList: false,
+  },
+  depends_on: {
+    name: "depends_on",
+    inverse: "depended_on_by",
+    cardinality: "many-to-many",
+    isList: true,
+    inverseIsList: true,
+  },
+  depended_on_by: {
+    name: "depended_on_by",
+    inverse: "depends_on",
+    cardinality: "many-to-many",
+    isList: true,
+    inverseIsList: true,
+  },
+  related_to: {
+    name: "related_to",
+    inverse: "related_to",
+    cardinality: "many-to-many",
+    isList: true,
+    inverseIsList: true,
+  },
+};
+
+export const RELATION_NAMES: RelationName[] = Object.keys(RELATIONS) as RelationName[];
+
+export function isRelationName(v: unknown): v is RelationName {
+  return typeof v === "string" && Object.prototype.hasOwnProperty.call(RELATIONS, v);
+}
+
+export function getRelation(name: string): RelationDef {
+  if (!isRelationName(name)) {
+    throw new Error(
+      `Unknown relation "${name}". Known: ${RELATION_NAMES.join(", ")}`,
+    );
+  }
+  return RELATIONS[name];
+}
+
+export interface ValidateLinkInput {
+  srcId: string;
+  dstId: string;
+  relation: string;
+}
+
+export function validateLinkArgs(input: ValidateLinkInput): {
+  srcId: string;
+  dstId: string;
+  relation: RelationDef;
+} {
+  const srcId = input.srcId?.trim();
+  const dstId = input.dstId?.trim();
+  if (!srcId) throw new Error("srcId is required");
+  if (!dstId) throw new Error("dstId is required");
+  if (srcId === dstId) {
+    throw new Error(`Cannot link issue to itself: ${srcId}`);
+  }
+  const relation = getRelation(input.relation);
+  return { srcId, dstId, relation };
+}
+
+/**
+ * Cleanup directive returned by `computeApply` when a many-to-one reassignment
+ * orphans a previous holder. The obsidian-bound caller looks up the holder
+ * issue, opens its frontmatter, and removes `remove` from its `field` list.
+ */
+export interface Cleanup {
+  /** Issue id whose frontmatter needs the cleanup write. */
+  holderId: string;
+  /** List field on the holder to remove from (always the inverse list). */
+  field: RelationName;
+  /** Id to remove from that list. */
+  remove: string;
+}
+
+export interface ApplyResult {
+  srcFmNext: Record<string, unknown>;
+  dstFmNext: Record<string, unknown>;
+  /** True when either fm changed; false on a fully idempotent re-apply. */
+  changed: boolean;
+  cleanups: Cleanup[];
+}
+
+/**
+ * Compute the two-sided delta for `op-set-link srcId relation→dstId`.
+ *
+ * Returns the next frontmatter for both files plus any cleanup directives the
+ * caller must apply (used when a many-to-one reassignment orphans a previous
+ * holder). The function does not mutate its inputs.
+ *
+ * Symmetric relations (`related_to ↔ related_to`) are handled without
+ * double-writing: `srcFmNext` and `dstFmNext` are independent copies even
+ * though they carry the same field name, so each side gets exactly one append
+ * of the other's id.
+ */
+export function computeApply(input: {
+  srcFm: Record<string, unknown>;
+  dstFm: Record<string, unknown>;
+  srcId: string;
+  dstId: string;
+  relation: string;
+}): ApplyResult {
+  const { srcId, dstId, relation } = validateLinkArgs(input);
+  const srcFmNext = shallowClone(input.srcFm);
+  const dstFmNext = shallowClone(input.dstFm);
+  const cleanups: Cleanup[] = [];
+  let changed = false;
+
+  // Source side: srcId.<relation.name> ← dstId
+  if (relation.isList) {
+    if (addToList(srcFmNext, relation.name, dstId)) changed = true;
+  } else {
+    const before = readScalar(srcFmNext, relation.name);
+    if (before !== dstId) {
+      if (before && before !== dstId) {
+        // Reparent: the old holder of the scalar relationship needs its
+        // inverse list trimmed of srcId. (e.g. set parent=Y_NEW on X — X used
+        // to have parent=Y_OLD, so Y_OLD.children must drop X.)
+        cleanups.push({ holderId: before, field: relation.inverse, remove: srcId });
+      }
+      srcFmNext[relation.name] = dstId;
+      changed = true;
+    }
+  }
+
+  // Target side: dstId.<relation.inverse> ← srcId
+  if (relation.inverseIsList) {
+    if (addToList(dstFmNext, relation.inverse, srcId)) changed = true;
+  } else {
+    const before = readScalar(dstFmNext, relation.inverse);
+    if (before !== srcId) {
+      if (before && before !== srcId) {
+        cleanups.push({ holderId: before, field: relation.name, remove: dstId });
+      }
+      dstFmNext[relation.inverse] = srcId;
+      changed = true;
+    }
+  }
+
+  return { srcFmNext, dstFmNext, changed, cleanups };
+}
+
+export interface RemoveResult {
+  srcFmNext: Record<string, unknown>;
+  dstFmNext: Record<string, unknown>;
+  /** True when either fm changed; false on a no-op (link wasn't present). */
+  changed: boolean;
+}
+
+/**
+ * Compute the two-sided delta for `op-remove-link srcId relation→dstId`.
+ *
+ * Idempotent: removing a link that isn't there returns `changed: false` and
+ * the original fms unchanged. Cleanup of orphans is not applicable here — the
+ * caller is removing a known pair, and its inverse on the other file is the
+ * only other write.
+ */
+export function computeRemove(input: {
+  srcFm: Record<string, unknown>;
+  dstFm: Record<string, unknown>;
+  srcId: string;
+  dstId: string;
+  relation: string;
+}): RemoveResult {
+  const { srcId, dstId, relation } = validateLinkArgs(input);
+  const srcFmNext = shallowClone(input.srcFm);
+  const dstFmNext = shallowClone(input.dstFm);
+  let changed = false;
+
+  if (relation.isList) {
+    if (removeFromList(srcFmNext, relation.name, dstId)) changed = true;
+  } else {
+    if (readScalar(srcFmNext, relation.name) === dstId) {
+      delete srcFmNext[relation.name];
+      changed = true;
+    }
+  }
+
+  if (relation.inverseIsList) {
+    if (removeFromList(dstFmNext, relation.inverse, srcId)) changed = true;
+  } else {
+    if (readScalar(dstFmNext, relation.inverse) === srcId) {
+      delete dstFmNext[relation.inverse];
+      changed = true;
+    }
+  }
+
+  return { srcFmNext, dstFmNext, changed };
+}
+
+export interface DriftEntry {
+  issueId: string;
+  relation: RelationName;
+  target: string;
+  /**
+   * `missing-inverse`: target exists, but its inverse field doesn't list
+   * `issueId`. Repairable by re-applying the link.
+   * `dangling-target`: target id doesn't resolve to any known issue. Not
+   * auto-repairable — surfaced so the user can fix it manually.
+   */
+  problem: "missing-inverse" | "dangling-target";
+}
+
+/**
+ * Walk every issue's link fields and report any one-sided drift.
+ *
+ * `issuesById` is a snapshot keyed by canonical id (`OP-12` etc.); the value
+ * is the issue's frontmatter. Both `ISSUES/` and `RESOLVED ISSUES/` should be
+ * included by the caller — a child can resolve before its parent and the
+ * parent→child link must remain valid.
+ */
+export function scanDrift(
+  issuesById: Map<string, Record<string, unknown>>,
+): DriftEntry[] {
+  const drift: DriftEntry[] = [];
+  for (const [id, fm] of issuesById.entries()) {
+    for (const relName of RELATION_NAMES) {
+      const def = RELATIONS[relName];
+      const targets = readField(fm, relName, def.isList);
+      for (const target of targets) {
+        if (target === id) {
+          // Self-link in stored data — treat as drift on the stored side. The
+          // inverse direction would also report it; dedupe at the caller if
+          // needed.
+          drift.push({
+            issueId: id,
+            relation: relName,
+            target,
+            problem: "dangling-target",
+          });
+          continue;
+        }
+        const targetFm = issuesById.get(target);
+        if (!targetFm) {
+          drift.push({
+            issueId: id,
+            relation: relName,
+            target,
+            problem: "dangling-target",
+          });
+          continue;
+        }
+        const inverseTargets = readField(targetFm, def.inverse, def.inverseIsList);
+        if (!inverseTargets.includes(id)) {
+          drift.push({
+            issueId: id,
+            relation: relName,
+            target,
+            problem: "missing-inverse",
+          });
+        }
+      }
+    }
+  }
+  return drift;
+}
+
+export interface MigrateResult {
+  fmNext: Record<string, unknown>;
+  /** True when the fm was rewritten (including pure key removal). */
+  changed: boolean;
+  /** Human-readable per-key notes for the caller's report. */
+  diff: string[];
+}
+
+/**
+ * Rewrite the interim `parent_issue` / `subissues` keys to the canonical
+ * `parent` / `children`. Idempotent: an fm with no interim keys returns
+ * `changed: false` and no diff.
+ *
+ * Conflict resolution: if both interim and canonical keys are present, the
+ * canonical key wins for scalars and is union-merged for lists. Either way
+ * the interim key is removed.
+ */
+export function computeMigrate(fm: Record<string, unknown>): MigrateResult {
+  const fmNext = shallowClone(fm);
+  const diff: string[] = [];
+  let changed = false;
+
+  if ("parent_issue" in fmNext) {
+    const v = fmNext.parent_issue;
+    if (typeof v === "string" && v.length > 0) {
+      const existing = readScalar(fmNext, "parent");
+      if (!existing) {
+        fmNext.parent = v;
+        diff.push(`parent_issue → parent (${v})`);
+      } else if (existing === v) {
+        diff.push(`parent_issue=${v} dropped (parent already canonical)`);
+      } else {
+        diff.push(
+          `parent_issue=${v} dropped (parent already set to ${existing} — kept canonical)`,
+        );
+      }
+    }
+    delete fmNext.parent_issue;
+    changed = true;
+  }
+
+  if ("subissues" in fmNext) {
+    const v = fmNext.subissues;
+    const items = Array.isArray(v)
+      ? v.filter((x): x is string => typeof x === "string" && x.length > 0)
+      : [];
+    if (items.length > 0) {
+      const existing = readField(fmNext, "children", true);
+      const merged = uniq([...existing, ...items]);
+      if (existing.length === 0) {
+        fmNext.children = merged;
+        diff.push(`subissues → children (${items.join(", ")})`);
+      } else {
+        const added = items.filter((i) => !existing.includes(i));
+        if (added.length > 0) {
+          fmNext.children = merged;
+          diff.push(`subissues merged into children: +${added.join(", ")}`);
+        } else {
+          diff.push(
+            `subissues=[${items.join(", ")}] dropped (children already covers all)`,
+          );
+        }
+      }
+    }
+    delete fmNext.subissues;
+    changed = true;
+  }
+
+  return { fmNext, changed, diff };
+}
+
+// ---------- internal helpers ----------
+
+function shallowClone(fm: Record<string, unknown>): Record<string, unknown> {
+  const next: Record<string, unknown> = {};
+  for (const [k, v] of Object.entries(fm)) {
+    next[k] = Array.isArray(v) ? [...v] : v;
+  }
+  return next;
+}
+
+function readScalar(fm: Record<string, unknown>, key: string): string | undefined {
+  const v = fm[key];
+  return typeof v === "string" && v.length > 0 ? v : undefined;
+}
+
+function readField(
+  fm: Record<string, unknown>,
+  name: string,
+  isList: boolean,
+): string[] {
+  const v = fm[name];
+  if (isList) {
+    if (!Array.isArray(v)) return [];
+    return v.filter((x): x is string => typeof x === "string" && x.length > 0);
+  }
+  if (typeof v === "string" && v.length > 0) return [v];
+  return [];
+}
+
+function addToList(
+  fm: Record<string, unknown>,
+  key: string,
+  value: string,
+): boolean {
+  const current = Array.isArray(fm[key])
+    ? (fm[key] as unknown[]).filter((x): x is string => typeof x === "string" && x.length > 0)
+    : [];
+  if (current.includes(value)) {
+    // Normalize: if the underlying value wasn't already a clean string list,
+    // rewrite to the cleaned form so subsequent reads are deterministic.
+    if (!Array.isArray(fm[key]) || (fm[key] as unknown[]).length !== current.length) {
+      fm[key] = current;
+      return true;
+    }
+    return false;
+  }
+  fm[key] = [...current, value];
+  return true;
+}
+
+function removeFromList(
+  fm: Record<string, unknown>,
+  key: string,
+  value: string,
+): boolean {
+  const current = Array.isArray(fm[key])
+    ? (fm[key] as unknown[]).filter((x): x is string => typeof x === "string" && x.length > 0)
+    : [];
+  const idx = current.indexOf(value);
+  if (idx === -1) return false;
+  const next = current.filter((x) => x !== value);
+  if (next.length === 0) {
+    delete fm[key];
+  } else {
+    fm[key] = next;
+  }
+  return true;
+}
+
+function uniq<T>(xs: T[]): T[] {
+  const seen = new Set<T>();
+  const out: T[] = [];
+  for (const x of xs) {
+    if (!seen.has(x)) {
+      seen.add(x);
+      out.push(x);
+    }
+  }
+  return out;
+}

--- a/plugins/op-obsidian/src/uriHandlers.ts
+++ b/plugins/op-obsidian/src/uriHandlers.ts
@@ -13,6 +13,7 @@ import type { SetScopeResult } from "./setScope";
 import type { SetEvaluationResult } from "./setEvaluation";
 import type { SetFlowResult, Flow, Complexity } from "./setFlow";
 import type { ResolveArgs, ResolveStatus } from "./resolve";
+import type { ApplyLinkResult, LinkCheckResult, MigrateLinksResult } from "./links";
 
 export interface UriHandlerDeps {
   store: { issues(): IssueEntry[] };
@@ -29,6 +30,18 @@ export interface UriHandlerDeps {
     entry: IssueEntry,
     input: { flow?: Flow | null; complexity?: Complexity | null },
   ) => Promise<SetFlowResult>;
+  applyLink?: (args: {
+    srcId: string;
+    dstId: string;
+    relation: string;
+  }) => Promise<ApplyLinkResult>;
+  removeLink?: (args: {
+    srcId: string;
+    dstId: string;
+    relation: string;
+  }) => Promise<ApplyLinkResult>;
+  linkCheck?: (opts: { repair?: boolean }) => Promise<LinkCheckResult>;
+  migrateLinks?: () => Promise<MigrateLinksResult>;
 }
 
 export function findIssueById(store: { issues(): IssueEntry[] }, id: string): IssueEntry {
@@ -180,6 +193,55 @@ export async function handleOpSetFlowUri(
     flow: res.flow ?? undefined,
     complexity: res.complexity ?? undefined,
   };
+}
+
+export async function handleOpSetLinkUri(
+  deps: UriHandlerDeps,
+  params: Record<string, string>,
+): Promise<UriResponsePayload> {
+  if (!deps.applyLink) throw new Error("op-set-link not wired");
+  const srcId = params.issue ?? params.id ?? params.src;
+  const dstId = params.target ?? params.dst;
+  const relation = params.relation;
+  if (!srcId || !dstId || !relation) {
+    throw new Error("op-set-link URI requires issue, relation, target");
+  }
+  const res = await deps.applyLink({ srcId, dstId, relation });
+  return { ...res };
+}
+
+export async function handleOpRemoveLinkUri(
+  deps: UriHandlerDeps,
+  params: Record<string, string>,
+): Promise<UriResponsePayload> {
+  if (!deps.removeLink) throw new Error("op-remove-link not wired");
+  const srcId = params.issue ?? params.id ?? params.src;
+  const dstId = params.target ?? params.dst;
+  const relation = params.relation;
+  if (!srcId || !dstId || !relation) {
+    throw new Error("op-remove-link URI requires issue, relation, target");
+  }
+  const res = await deps.removeLink({ srcId, dstId, relation });
+  return { ...res };
+}
+
+export async function handleOpLinkCheckUri(
+  deps: UriHandlerDeps,
+  params: Record<string, string>,
+): Promise<UriResponsePayload> {
+  if (!deps.linkCheck) throw new Error("op-link-check not wired");
+  const repair = params.repair === "1" || params.repair === "true";
+  const res = await deps.linkCheck({ repair });
+  return { ...res };
+}
+
+export async function handleOpMigrateLinksUri(
+  deps: UriHandlerDeps,
+  _params: Record<string, string>,
+): Promise<UriResponsePayload> {
+  if (!deps.migrateLinks) throw new Error("op-migrate-links not wired");
+  const res = await deps.migrateLinks();
+  return { ...res };
 }
 
 export async function handleOpSetScopeUri(

--- a/plugins/op/.claude-plugin/plugin.json
+++ b/plugins/op/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "op",
   "description": "Obsidian Projects workflow — schema, slash commands, and agent skill for running a Jira-lite issue tracker inside an Obsidian vault.",
-  "version": "0.36.0",
+  "version": "0.37.0",
   "author": {
     "name": "Eugene Archibald"
   },

--- a/plugins/op/skills/op/SKILL.md
+++ b/plugins/op/skills/op/SKILL.md
@@ -56,6 +56,10 @@ All `op-*` commands take `key=value` arguments (not `--flag`). Each prints a one
 | `op-append-commit` | `issue`, `sha`, `subject` | — | idempotent append to issue's `commits:` list |
 | `op-set-pr` | `issue`, `url` | — | sets scalar `pr:` |
 | `op-set-scope` | `issue`, `scope` | `mode=scope\|body` | default `mode=scope` replaces the issue body's `## Scope` section (appends it if missing); payload is markdown without H2 headings. `mode=body` replaces the entire body content after the optional `# Title` heading; payload may include H2s. This is the one mutation the plan-mode agent is allowed, so it can persist a refined plan back to the issue note. |
+| `op-set-link` | `issue`, `relation`, `target` | — | writes both sides of an inter-issue link atomically. Plugin owns the inverse — agents MUST NOT touch link frontmatter directly. Relations: `parent` / `children` (many-to-one), `depends_on` / `depended_on_by` (many-to-many), `related_to` (symmetric). |
+| `op-remove-link` | `issue`, `relation`, `target` | — | removes both sides of a link. Idempotent. |
+| `op-link-check` | — | `repair=true` | walks every issue, reports any one-sided link drift (`missing-inverse` / `dangling-target`); with `repair=true` reconciles drift by re-applying links. |
+| `op-migrate-links` | — | — | one-shot rewrite of legacy `parent_issue` / `subissues` to canonical `parent` / `children`. Idempotent. |
 | `op-resolve` (or `op-close-current-issue`) | `issue` (or `path`) | `status=wontfix` | sets `status: resolved`, writes `resolved: <today>`, moves into `RESOLVED ISSUES/`, trashes linked TASKS — atomically. When `closeGithubIssueOnResolve` is on and the issue has a `github_issue:` URL, also runs `gh issue close` on it; the JSON response reports `githubClosed` / `githubCloseError` |
 
 `scope` is a single value containing newline-separated bullets.
@@ -143,7 +147,36 @@ Skip both for meta-only projects with no git repo.
 - Missing or unknown issue id (the caller didn't pass one, or the id doesn't resolve to a file) → stop and ask the user for the `<PREFIX>-<N>`. Never append to a guessed issue — the `commits:` trail is a permanent record and wrong attribution is worse than a missing entry.
 - `obsidian op-append-commit` returns an error (vault unreachable, plugin disabled, issue file moved mid-session) → re-probe the plugin (`app.plugins.enabledPlugins.has("op-obsidian")`) and re-resolve the issue path. If it still fails, record the `<sha7> <subject>` pair in the session (or a scratch note) and batch-append at resolve time; don't block the commit cadence on vault health.
 
-### GitHub issue linkage
+### Linking issues
+
+Issue-to-issue links live as plugin-managed frontmatter fields. **Never write `parent`, `children`, `depends_on`, `depended_on_by`, or `related_to` directly** — call `op-set-link` / `op-remove-link` and let the plugin maintain both sides. Direct frontmatter edits are tolerated for human convenience but `op-link-check` will flag the drift.
+
+Canonical relations and call shape:
+
+```bash
+# X is a child of umbrella Y (many-to-one)
+obsidian op-set-link issue=OP-95 relation=parent target=OP-92
+
+# Equivalent from the umbrella side (same effect — plugin writes both)
+obsidian op-set-link issue=OP-92 relation=children target=OP-95
+
+# X blocks on Y (many-to-many)
+obsidian op-set-link issue=OP-X relation=depends_on target=OP-Y
+
+# X and Y are related (symmetric)
+obsidian op-set-link issue=OP-X relation=related_to target=OP-Y
+
+# Remove a link (idempotent)
+obsidian op-remove-link issue=OP-95 relation=parent target=OP-92
+
+# Audit the entire vault for one-sided drift
+obsidian op-link-check                # report-only
+obsidian op-link-check repair=true    # reconcile drift in place
+```
+
+Resolved-folder issues are valid link targets — a parent→child link must remain valid after the child resolves and moves into `RESOLVED ISSUES/`. The plugin's resolver looks at both folders.
+
+When you discover a parent/child relationship mid-session, set the link with `op-set-link` and append a one-line note in the issue's `## Notes` block — don't paste a bare wikilink.
 
 If the issue has a `github_issue:` frontmatter field, it mirrors a GitHub issue. The URL may have been populated automatically at `op-new` time (when `autoCreateGithubIssue` is on) or set later via the plugin's "Set GitHub issue URL" command. While working, treat it as a one-way mirror: you may comment on, label, or reference the GH issue, but do **not** close it manually — the plugin closes it atomically during `op-resolve` (see below). If the user asks "is the GitHub issue still open?", check live state with `gh issue view <url>` rather than inferring from the op status.
 

--- a/plugins/op/skills/op/reference/schema.md
+++ b/plugins/op/skills/op/reference/schema.md
@@ -44,8 +44,14 @@ github_issue:            # optional; direct mapping to a GitHub issue URL
 version:                 # optional; semver string of the release that shipped this issue, set at resolve
 flow:                    # optional; current stage of the multi-mode workflow (evaluate → planning → implementation → review → finalization → done)
 complexity:              # optional; simple | complex — simple issues may skip evaluate/review modes
-parent_issue:            # optional, interim; <PARENT-ID> when this issue is a child of a tracking umbrella (see "Tracking-umbrella linking")
-subissues:               # optional, interim; list of child <ISSUE-ID>s when this issue is itself a tracking umbrella
+parent:                  # optional; <PARENT-ID> for many-to-one tracking-umbrella linking (see "Issue links")
+children:                # optional; list of child <ISSUE-ID>s when this issue is a tracking umbrella
+  - <ISSUE-ID>
+depends_on:              # optional; list of <ISSUE-ID>s this issue blocks on
+  - <ISSUE-ID>
+depended_on_by:          # optional; inverse of depends_on, plugin-managed
+  - <ISSUE-ID>
+related_to:              # optional; symmetric soft link, plugin-managed
   - <ISSUE-ID>
 tags:
   - project/<slug>
@@ -66,7 +72,23 @@ Why: keeps the project key visible in file lists and makes wikilinks from TASKS 
 
 **Version.** `version:` records the semver release that shipped the issue (e.g. `0.1.7`). Set at resolve time, in the same commit that bumps the project's version file (`plugin.json` / `manifest.json` / `package.json`). One bump per issue; classify as patch (fixes, docs, internal), minor (new user-facing behavior, additive schema), or major (breaking schema change). See the `op` skill's "Semver bumping" section for the full rules. Optional — meta-only projects without a version file leave it unset.
 
-**Tracking-umbrella linking (interim).** `parent_issue:` and `subissues:` are interim linking fields for the case where an umbrella issue is too large to ship as one PR and gets split into children. The umbrella lists its children in `subissues:`; each child carries `parent_issue: <UMBRELLA-ID>`. They are unenforced by tooling — purely for human/agent navigation between related issues. Treat them as a stopgap pending a first-class tracking concept; revisit and migrate once that feature lands. Originated with OP-92's split into OP-95/97/98/99/100.
+**Issue links.** Issues form a graph via plugin-managed link fields. The `op-obsidian` plugin owns both sides of every link — agents MUST use `op-set-link` / `op-remove-link` and never write the link frontmatter directly. Direct edits are tolerated for human convenience, but `op-link-check` will flag any drift across the vault and `op-link-check repair=true` will reconcile it.
+
+Canonical relations (config-only addition surface — extend `RELATIONS` in `plugins/op-obsidian/src/relations.ts` to ship more):
+
+| Relation | Cardinality | Inverse | Shape |
+| :--- | :--- | :--- | :--- |
+| `parent` ↔ `children` | many-to-one | each other | scalar ↔ list |
+| `depends_on` ↔ `depended_on_by` | many-to-many | each other | list ↔ list |
+| `related_to` ↔ `related_to` | many-to-many (symmetric) | self | list ↔ list |
+
+Field values are **bare ids** (e.g. `OP-92`), not wikilinks — ids are stable across renames; the plugin can resolve to a wikilink at read time if a UI ever needs it. Resolved-folder issues are valid link targets; a parent→child link must remain valid after the child resolves and moves into `RESOLVED ISSUES/`.
+
+**Verbs:**
+- `op-set-link issue=<src> relation=<rel> target=<dst>` — write both sides atomically. Self-links and unknown relations are rejected. For many-to-one (`parent` / `children`), reassigning the scalar side cleans up the previous holder's inverse list.
+- `op-remove-link issue=<src> relation=<rel> target=<dst>` — remove both sides. Idempotent.
+- `op-link-check [repair=true]` — scan every issue's link fields for drift; report `missing-inverse` and `dangling-target` entries; with `repair=true`, re-apply links to fix any one-sided drift (dangling targets are reported, not auto-fixed).
+- `op-migrate-links` — one-shot rewrite of the legacy `parent_issue` / `subissues` interim fields (introduced by OP-92, replaced here) to canonical `parent` / `children`. Idempotent.
 
 ---
 


### PR DESCRIPTION
## Summary

Ships first-class issue linking in `op-obsidian` (0.37.0), replacing the interim `parent_issue` / `subissues` fields introduced by OP-92.

- **Relation registry** in `plugins/op-obsidian/src/relations.ts` — every link declares its inverse; adding a new relation is a config-only change.
  - `parent ↔ children` (many-to-one, scalar ↔ list; reassigning cleans up the old holder's `children` list)
  - `depends_on ↔ depended_on_by` (many-to-many)
  - `related_to ↔ related_to` (symmetric — `inverse === self`, no double-write, no oscillation under repair)
- **Verbs** (palette + URI + obsidian CLI):
  - `op-set-link issue=<src> relation=<rel> target=<dst>` — atomic two-sided write.
  - `op-remove-link issue=<src> relation=<rel> target=<dst>` — idempotent.
  - `op-link-check [repair=true]` — vault-wide drift audit (`missing-inverse` and `dangling-target`).
  - `op-migrate-links` — one-shot rewrite of legacy `parent_issue` / `subissues` to canonical `parent` / `children`. Idempotent.
- **Schema doc + skill doc** updated. ISSUES yaml drops `parent_issue`/`subissues`, adds `parent`, `children`, `depends_on`, `depended_on_by`, `related_to`. Schema gains a canonical "Issue links" section; skill gains a "Linking issues" subsection under the work verb instructing agents to never write link frontmatter directly.
- **Migration run on the vault** — rewrote OP-92 (`subissues → children`) plus OP-95/97/98/99/100 (`parent_issue → parent`).

## Breaking change

The frontmatter rename from `parent_issue` / `subissues` → `parent` / `children` is technically breaking. Mitigated by:
- `op-migrate-links` runs once on the vault and is idempotent on re-run.
- `op-link-check` will surface anything missed.
- No `.base` file or plugin code referenced the old fields outside the schema doc itself.

Pre-1.0 → minor bump per project rule.

## Test plan

- [x] 39 new pure-logic unit tests in `relations.test.ts` (inverse computation, symmetric edge case, cardinality enforcement, reparent cleanup from both directions, self-link rejection, idempotent apply/remove, dangling-target detection, migration round-trip, input-immutability).
- [x] Full vitest suite green (367 tests).
- [x] Plugin built + synced + reloaded; `op-link-check` registered, `version=0.37.0`.
- [x] Vault migration run: 6 issues rewritten as expected.
- [x] Smoke: `op-set-link` writes both sides; `op-link-check` clean; `op-remove-link` clears both sides; self-link rejected; re-running migrate is a no-op.
- [x] `obsidian dev:console` empty during smoke run — no plugin errors.

Closes #95