### PR TITLE
OP-118: bump to 0.37.1 to disambiguate OP-113 from OP-112 in version trail

### DIFF
--- a/plugins/op-obsidian/manifest.json
+++ b/plugins/op-obsidian/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "op-obsidian",
   "name": "Obsidian Projects (op)",
-  "version": "0.37.0",
+  "version": "0.37.1",
   "minAppVersion": "1.5.0",
   "description": "Jira-lite issue tracker for Obsidian vaults — deterministic commands backing the op workflow.",
   "author": "Eugene Archibald",

--- a/plugins/op-obsidian/package.json
+++ b/plugins/op-obsidian/package.json
@@ -1,6 +1,6 @@
 {
   "name": "op-obsidian",
-  "version": "0.37.0",
+  "version": "0.37.1",
   "description": "Obsidian plugin that owns the deterministic half of the op workflow.",
   "main": "main.js",
   "scripts": {

--- a/plugins/op/.claude-plugin/plugin.json
+++ b/plugins/op/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "op",
   "description": "Obsidian Projects workflow — schema, slash commands, and agent skill for running a Jira-lite issue tracker inside an Obsidian vault.",
-  "version": "0.37.0",
+  "version": "0.37.1",
   "author": {
     "name": "Eugene Archibald"
   },


### PR DESCRIPTION
## Summary

- Patch bump 0.37.0 → 0.37.1 across `plugins/op-obsidian/manifest.json`, `plugins/op-obsidian/package.json`, and `plugins/op/.claude-plugin/plugin.json` via `scripts/bump-version.mjs patch`.
- OP-112 (#96) and OP-113 (#100) both squash-merged stamped 0.37.0 because OP-113 was forked before OP-112 landed and independently bumped 0.36.0 → 0.37.0. This patch records OP-113 as the second shipped change in the version trail.
- No code change.

Closes #102.

## Test plan

- [x] `node scripts/bump-version.mjs patch` — three version files in lockstep at 0.37.1
- [x] `npm run build` — `main.js` rebuilt, OP-105 freshness guard satisfied
- [x] Vault sync + `obsidian plugin:reload id=op-obsidian` — plugin reports `version: 0.37.1`
- [x] Smoke: `op-new` command registered, `dev:console` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)