### PR TITLE
OP-124: validate op-new scope; add scope_mode=body opt-in

### DIFF
--- a/plugins/op-obsidian/manifest.json
+++ b/plugins/op-obsidian/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "op-obsidian",
   "name": "Obsidian Projects (op)",
-  "version": "0.37.0",
+  "version": "0.38.0",
   "minAppVersion": "1.5.0",
   "description": "Jira-lite issue tracker for Obsidian vaults — deterministic commands backing the op workflow.",
   "author": "Eugene Archibald",

--- a/plugins/op-obsidian/package.json
+++ b/plugins/op-obsidian/package.json
@@ -1,6 +1,6 @@
 {
   "name": "op-obsidian",
-  "version": "0.37.0",
+  "version": "0.38.0",
   "description": "Obsidian plugin that owns the deterministic half of the op workflow.",
   "main": "main.js",
   "scripts": {

--- a/plugins/op-obsidian/src/createIssue.test.ts
+++ b/plugins/op-obsidian/src/createIssue.test.ts
@@ -87,6 +87,26 @@ describe("renderIssueNote", () => {
     );
   });
 
+  it("scopeBody renders verbatim under ## Scope (no - [ ] wrapping)", () => {
+    const out = render({
+      scope: [],
+      // @ts-expect-error — exercise the new field
+      scopeBody: "Para one.\n\n- a sub-bullet\n- another",
+    });
+    expect(out).toContain("\n## Scope\n\nPara one.\n\n- a sub-bullet\n- another\n");
+    expect(out).not.toContain("- [ ] Para one");
+  });
+
+  it("scopeBody takes precedence over bullets when both supplied", () => {
+    const out = render({
+      scope: ["bullet"],
+      // @ts-expect-error — exercise the new field
+      scopeBody: "verbatim text",
+    });
+    expect(out).toContain("\n## Scope\n\nverbatim text\n");
+    expect(out).not.toContain("- [ ] bullet");
+  });
+
   it("Plan/Initial Evaluation/Notes/Summary appear even when no scope is supplied", () => {
     const out = render({ scope: [] });
     const planIdx = out.indexOf("## Plan");

--- a/plugins/op-obsidian/src/createIssue.ts
+++ b/plugins/op-obsidian/src/createIssue.ts
@@ -19,6 +19,9 @@ export interface CreateIssueInput {
   title: string;
   priority?: Priority;
   scope?: string[];
+  // When set, the renderer writes this verbatim under `## Scope` instead of
+  // wrapping `scope` bullets. Use for multi-paragraph / structured scope.
+  scopeBody?: string;
   assignee?: string;
   githubIssue?: string;
 }
@@ -75,6 +78,7 @@ export async function createIssue(
     title: input.title,
     priority: input.priority ?? "med",
     scope: input.scope ?? [],
+    scopeBody: input.scopeBody,
     assignee: input.assignee ?? "earchibald",
     githubIssue: input.githubIssue?.trim() || undefined,
   });

--- a/plugins/op-obsidian/src/issueTemplate.ts
+++ b/plugins/op-obsidian/src/issueTemplate.ts
@@ -15,6 +15,9 @@ export interface RenderInput {
   title: string;
   priority: Priority;
   scope: string[];
+  // When set, written verbatim under `## Scope` instead of bullets. Mutually
+  // exclusive with `scope` — if both are present, `scopeBody` wins.
+  scopeBody?: string;
   assignee: string;
   githubIssue?: string;
 }
@@ -37,7 +40,9 @@ export function renderIssueNote(i: RenderInput): string {
 
   const body: string[] = [`# ${i.title}`, ""];
   body.push("## Scope", "");
-  if (i.scope.length > 0) {
+  if (i.scopeBody && i.scopeBody.trim().length > 0) {
+    body.push(i.scopeBody.replace(/\s+$/g, ""));
+  } else if (i.scope.length > 0) {
     for (const bullet of i.scope) {
       body.push(`- [ ] ${bullet.trim()}`);
     }

--- a/plugins/op-obsidian/src/main.ts
+++ b/plugins/op-obsidian/src/main.ts
@@ -20,6 +20,7 @@ import { scaffoldProject, type ScaffoldProjectResult } from "./scaffoldProject";
 import { workIssue } from "./workIssue";
 import { appendCommit, setPr } from "./commits";
 import { setScope } from "./setScope";
+import { parseNewScopePayload, type NewScopeMode } from "./setScopePure";
 import { setEvaluation } from "./setEvaluation";
 import { setFlow, type Complexity, type Flow } from "./setFlow";
 import { applyLink, removeLink, linkCheck, migrateLinks } from "./links";
@@ -1296,7 +1297,7 @@ export default class OpPlugin extends Plugin {
     const seedPriority = seedTitle
       ? ((params.priority as Priority | undefined) ?? "med")
       : undefined;
-    const seedScope = seedTitle ? collectRepeated(params, "scope") : undefined;
+    const seedScopeShape = seedTitle ? resolveScopeParams(params) : {};
     const repoPath = params.repo_path?.trim() || undefined;
     return scaffoldProject(this.app, this.store, {
       slug,
@@ -1304,7 +1305,8 @@ export default class OpPlugin extends Plugin {
       repoPath,
       seedTitle,
       seedPriority,
-      seedScope,
+      seedScope: seedScopeShape.scope,
+      seedScopeBody: seedScopeShape.scopeBody,
     });
   }
 
@@ -1314,10 +1316,22 @@ export default class OpPlugin extends Plugin {
       const parsed = parseNewParams(params);
       if (!parsed.ok) return parsed.error;
       const { slug, title, priority } = parsed.value;
-      const scope = collectRepeated(params, "scope");
-      const res = await createIssue(this.app, this.store, { slug, title, priority, scope });
+      const { scope, scopeBody } = resolveScopeParams(params);
+      const res = await createIssue(this.app, this.store, {
+        slug,
+        title,
+        priority,
+        scope,
+        scopeBody,
+      });
       if (this.settings.github.autoCreateGithubIssue) {
-        await this.autoCreateGithubIssueFor(res.path, res.id, { slug, title, priority, scope }).catch(
+        await this.autoCreateGithubIssueFor(res.path, res.id, {
+          slug,
+          title,
+          priority,
+          scope,
+          scopeBody,
+        }).catch(
           (err) => console.error("[op-obsidian] cli auto-create github issue failed", err),
         );
       }
@@ -2007,18 +2021,25 @@ export default class OpPlugin extends Plugin {
       throw new Error("op-new URI requires project and title");
     }
     const priority = (params.priority as Priority | undefined) ?? "med";
-    const scope = collectRepeated(params, "scope");
+    const { scope, scopeBody } = resolveScopeParams(params);
     const githubIssue = params.github_issue?.trim() || undefined;
     const res = await createIssue(this.app, this.store, {
       slug,
       title,
       priority,
       scope,
+      scopeBody,
       githubIssue,
     });
     new Notice(`Created ${res.id}`);
     if (!githubIssue && this.settings.github.autoCreateGithubIssue) {
-      await this.autoCreateGithubIssueFor(res.path, res.id, { slug, title, priority, scope }).catch(
+      await this.autoCreateGithubIssueFor(res.path, res.id, {
+        slug,
+        title,
+        priority,
+        scope,
+        scopeBody,
+      }).catch(
         (err) => console.error("[op-obsidian] uri auto-create failed", err),
       );
     }
@@ -2042,10 +2063,34 @@ function defaultBinaryFor(id: AgentId): string {
 
 function buildGithubBody(id: string, input: CreateIssueInput): string {
   const lines = [`Tracked as op issue **${id}**.`, ""];
-  if (input.scope && input.scope.length > 0) {
+  if (input.scopeBody && input.scopeBody.trim().length > 0) {
+    lines.push("## Scope", "", input.scopeBody.replace(/\s+$/g, ""));
+  } else if (input.scope && input.scope.length > 0) {
     lines.push("## Scope", "");
     for (const b of input.scope) lines.push(`- [ ] ${b}`);
   }
   return lines.join("\n").trim();
+}
+
+// Resolve the raw `scope=` / `scope_mode=` params into either bullets or a
+// verbatim body. Reject H2/code-fence payloads in bullets mode (OP-124).
+// Returns an empty object when no scope was supplied.
+function resolveScopeParams(
+  params: Record<string, string>,
+): { scope?: string[]; scopeBody?: string } {
+  const raw = params.scope;
+  if (typeof raw !== "string" || raw.trim() === "") return {};
+  const rawMode = params.scope_mode;
+  let mode: NewScopeMode = "bullets";
+  if (rawMode !== undefined && rawMode !== "") {
+    if (rawMode !== "bullets" && rawMode !== "body") {
+      throw new Error("scope_mode must be 'bullets' or 'body'");
+    }
+    mode = rawMode;
+  }
+  const parsed = parseNewScopePayload(raw, mode);
+  return parsed.kind === "bullets"
+    ? { scope: parsed.bullets }
+    : { scopeBody: parsed.body };
 }
 

--- a/plugins/op-obsidian/src/scaffoldProject.ts
+++ b/plugins/op-obsidian/src/scaffoldProject.ts
@@ -9,6 +9,7 @@ export interface ScaffoldProjectInput {
   seedTitle?: string;
   seedPriority?: Priority;
   seedScope?: string[];
+  seedScopeBody?: string;
 }
 
 export interface ScaffoldProjectResult {
@@ -78,6 +79,7 @@ export async function scaffoldProject(
       title: seedTitle,
       priority: input.seedPriority ?? "med",
       scope: input.seedScope ?? [],
+      scopeBody: input.seedScopeBody,
     });
   }
 
@@ -87,7 +89,13 @@ export async function scaffoldProject(
 async function retryCreateSeed(
   app: App,
   store: IssueStore,
-  input: { slug: string; title: string; priority: Priority; scope: string[] },
+  input: {
+    slug: string;
+    title: string;
+    priority: Priority;
+    scope: string[];
+    scopeBody?: string;
+  },
 ): Promise<CreateIssueResult> {
   const deadline = Date.now() + 2000;
   let lastErr: unknown;

--- a/plugins/op-obsidian/src/setScope.test.ts
+++ b/plugins/op-obsidian/src/setScope.test.ts
@@ -4,6 +4,7 @@ import {
   normalizeScopePayload,
   rewriteFullBody,
   normalizeBodyPayload,
+  parseNewScopePayload,
 } from "./setScopePure";
 
 const FM = `---
@@ -98,6 +99,53 @@ old plan
 
   it("body mode rejects empty payload", () => {
     expect(() => normalizeBodyPayload("   \n")).toThrow(/empty/);
+  });
+
+  it("parseNewScopePayload bullets mode splits on newlines into trimmed bullets", () => {
+    const out = parseNewScopePayload("first bullet\n  second bullet  \n\nthird", "bullets");
+    expect(out).toEqual({
+      kind: "bullets",
+      bullets: ["first bullet", "second bullet", "third"],
+    });
+  });
+
+  it("parseNewScopePayload bullets mode also splits on commas (legacy URI delimiter)", () => {
+    const out = parseNewScopePayload("a, b, c", "bullets");
+    expect(out).toEqual({ kind: "bullets", bullets: ["a", "b", "c"] });
+  });
+
+  it("parseNewScopePayload bullets mode rejects payload containing an H2", () => {
+    expect(() =>
+      parseNewScopePayload("intro\n## Deliverables\nfoo", "bullets"),
+    ).toThrow(/H2|scope_mode=body/);
+  });
+
+  it("parseNewScopePayload bullets mode rejects payload containing a code fence", () => {
+    expect(() =>
+      parseNewScopePayload("intro\n```yaml\nkey: val\n```", "bullets"),
+    ).toThrow(/code fence|scope_mode=body/);
+  });
+
+  it("parseNewScopePayload body mode returns the trimmed payload verbatim", () => {
+    const out = parseNewScopePayload("Para one.\n\n- a\n- b\n", "body");
+    expect(out).toEqual({ kind: "body", body: "Para one.\n\n- a\n- b" });
+  });
+
+  it("parseNewScopePayload body mode allows code fences", () => {
+    const raw = "Spec:\n```yaml\nkey: val\n```";
+    const out = parseNewScopePayload(raw, "body");
+    expect(out).toEqual({ kind: "body", body: raw });
+  });
+
+  it("parseNewScopePayload body mode rejects H2 (would terminate ## Scope section)", () => {
+    expect(() =>
+      parseNewScopePayload("Intro\n## Deliverables\nfoo", "body"),
+    ).toThrow(/H2/);
+  });
+
+  it("parseNewScopePayload rejects empty payload in either mode", () => {
+    expect(() => parseNewScopePayload("", "bullets")).toThrow(/empty/);
+    expect(() => parseNewScopePayload("   \n\n", "body")).toThrow(/empty/);
   });
 
   it("handles ## Scope at end of file (no trailing section)", () => {

--- a/plugins/op-obsidian/src/setScopePure.ts
+++ b/plugins/op-obsidian/src/setScopePure.ts
@@ -1,3 +1,45 @@
+export type NewScopeMode = "bullets" | "body";
+
+export type ParsedNewScope =
+  | { kind: "bullets"; bullets: string[] }
+  | { kind: "body"; body: string };
+
+// Validate and shape the raw `scope=` value passed to op-new (and the
+// op-scaffold seed path). Bullets mode is the default — it splits the payload
+// into trimmed bullets that the renderer wraps as `- [ ]`. We reject H2s and
+// code-fence lines there because the renderer would flatten them into bullets
+// (see OP-124). Body mode writes the payload verbatim under `## Scope` and
+// only rejects H2s, which would terminate the section.
+export function parseNewScopePayload(raw: string, mode: NewScopeMode): ParsedNewScope {
+  if (typeof raw !== "string") throw new Error("scope payload must be a string");
+  const trimmed = raw.replace(/\r\n/g, "\n").replace(/\s+$/g, "");
+  if (!trimmed.trim()) throw new Error("scope payload is empty");
+  if (/^##\s+/m.test(trimmed)) {
+    if (mode === "body") {
+      throw new Error(
+        "scope payload must not contain H2 headings (`## ...`) — they would terminate the Scope section",
+      );
+    }
+    throw new Error(
+      "scope payload contains an H2 heading (`## ...`). H2s would be flattened into `- [ ]` bullets. Pass `scope_mode=body` to write the payload verbatim under `## Scope`, or use `op-set-scope mode=body` after creation.",
+    );
+  }
+  if (mode === "body") {
+    return { kind: "body", body: trimmed };
+  }
+  if (/^```/m.test(trimmed)) {
+    throw new Error(
+      "scope payload contains a code fence (```), which would be flattened into `- [ ]` bullets. Pass `scope_mode=body` to write the payload verbatim under `## Scope`.",
+    );
+  }
+  const bullets = trimmed
+    .split(/[\n,]/)
+    .map((l) => l.trim())
+    .filter(Boolean);
+  if (bullets.length === 0) throw new Error("scope payload is empty");
+  return { kind: "bullets", bullets };
+}
+
 export function normalizeScopePayload(raw: string): string {
   if (typeof raw !== "string") throw new Error("scope payload must be a string");
   const trimmed = raw.replace(/\r\n/g, "\n").replace(/\s+$/g, "");

--- a/plugins/op/.claude-plugin/plugin.json
+++ b/plugins/op/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "op",
   "description": "Obsidian Projects workflow — schema, slash commands, and agent skill for running a Jira-lite issue tracker inside an Obsidian vault.",
-  "version": "0.37.0",
+  "version": "0.38.0",
   "author": {
     "name": "Eugene Archibald"
   },

--- a/plugins/op/skills/op/SKILL.md
+++ b/plugins/op/skills/op/SKILL.md
@@ -50,8 +50,8 @@ All `op-*` commands take `key=value` arguments (not `--flag`). Each prints a one
 
 | Command | Required | Optional | Effect |
 | :--- | :--- | :--- | :--- |
-| `op-scaffold` | `slug`, `prefix` | `repo_path`, `title`, `priority`, `scope` | creates `Projects/<slug>/<slug>.base` + `STATUS.md`; writes `repo_path:` (absolute path only) if given; seeds `<PREFIX>-1` if `title` given |
-| `op-new` | `project`, `title` | `priority`, `scope`, `github_issue` | creates next-N issue with sanitized filename and schema-conformant frontmatter; when the plugin's `autoCreateGithubIssue` setting is on and no `github_issue` is passed, also runs `gh issue create` in the project's `repo_path` and writes the URL to `github_issue:` |
+| `op-scaffold` | `slug`, `prefix` | `repo_path`, `title`, `priority`, `scope`, `scope_mode` | creates `Projects/<slug>/<slug>.base` + `STATUS.md`; writes `repo_path:` (absolute path only) if given; seeds `<PREFIX>-1` if `title` given. `scope_mode=bullets\|body` matches `op-new` semantics |
+| `op-new` | `project`, `title` | `priority`, `scope`, `scope_mode`, `github_issue` | creates next-N issue with sanitized filename and schema-conformant frontmatter. Default `scope_mode=bullets` splits `scope=` on newlines and wraps each line as `- [ ]`; rejects payloads containing `## ` H2s or code fences (would be flattened). Pass `scope_mode=body` to write `scope=` verbatim under `## Scope` (bullets, paragraphs, code fences allowed; H2s still rejected since they would terminate the section). When the plugin's `autoCreateGithubIssue` setting is on and no `github_issue` is passed, also runs `gh issue create` in the project's `repo_path` and writes the URL to `github_issue:` |
 | `op-work` | `issue` | — | sets `status: in-progress`; creates the initial TASKS note |
 | `op-append-commit` | `issue`, `sha`, `subject` | — | idempotent append to issue's `commits:` list |
 | `op-set-pr` | `issue`, `url` | — | sets scalar `pr:` |
@@ -62,7 +62,7 @@ All `op-*` commands take `key=value` arguments (not `--flag`). Each prints a one
 | `op-migrate-links` | — | — | one-shot rewrite of legacy `parent_issue` / `subissues` to canonical `parent` / `children`. Idempotent. |
 | `op-resolve` (or `op-close-current-issue`) | `issue` (or `path`) | `status=wontfix` | sets `status: resolved`, writes `resolved: <today>`, moves into `RESOLVED ISSUES/`, trashes linked TASKS — atomically. When `closeGithubIssueOnResolve` is on and the issue has a `github_issue:` URL, also runs `gh issue close` on it; the JSON response reports `githubClosed` / `githubCloseError` |
 
-`scope` is a single value containing newline-separated bullets.
+`scope` is a single value containing newline-separated bullets. To pass richer markdown (paragraphs, sub-bullets, code fences) for the issue's `## Scope` section, set `scope_mode=body` and the payload is written verbatim. H2 headings (`## ...`) are rejected in either mode because they would terminate the Scope section.
 
 **URI senders (`obsidian://op-new?…`):** Obsidian's protocol parser is `Record<string, string>` and last-wins, so repeated `scope=a&scope=b` keys collapse to only the last value. Pack multi-value lists into a single `scope=` param using `%0A` (newline) or `,` as the delimiter; the plugin's `collectRepeated` helper splits on either. Spaces and `+`: the parser uses `decodeURIComponent`, which leaves `+` untouched — but the plugin normalizes `+` → space at the dispatch boundary to match `URLSearchParams.toString()` semantics. To preserve a literal `+`, encode it as `%2B`.
 
@@ -92,7 +92,7 @@ Prefix → slug is **not** a plugin command — scan `Projects/*/STATUS.md` dire
    - **Detailed** (> 140 chars, or multi-line regardless of length) → propose title, priority, summary paragraph + checklist; preserve any explicit acceptance criteria verbatim; confirm.
    - **If unsure** (borderline length, ambiguous structure) → treat as detailed and surface the ambiguity in the confirm step rather than guessing silently.
 3. **Always pause for explicit user confirmation before mutating vault or repo** — even in auto mode. Issue creation is a commitment artifact.
-4. Run `obsidian op-new project=<slug> title="<title>" priority=<low|med|high> [scope="bullet 1\nbullet 2"]`.
+4. Run `obsidian op-new project=<slug> title="<title>" priority=<low|med|high> [scope="bullet 1\nbullet 2"]`. For multi-paragraph scope or scope with code fences/sub-bullets, add `scope_mode=body` so the payload is written verbatim under `## Scope` instead of being wrapped per-line as `- [ ]`. Bullets-mode payloads must not contain `## ` H2s or code fences — the plugin rejects them rather than mangle the body.
 5. Report the new id and path, and include the `obsidian://` link for the new issue note so the user can open it in one click; suggest `/op:issue <PREFIX>-<N>`.
 
 ---


### PR DESCRIPTION
## Summary

- `op-new` (and `op-scaffold` seed path) now validates the raw `scope=` payload before splitting. Bullets mode (default) rejects payloads containing `## ` H2 headings or code-fence lines with an actionable error pointing at `scope_mode=body` or post-creation `op-set-scope`.
- New `scope_mode=body` writes the payload verbatim under `## Scope` for richer markdown (paragraphs, sub-bullets, code fences). H2s still rejected — they would terminate the section.
- Renderer extended with `scopeBody`; `buildGithubBody` mirrors the body branch so the GH-mirror keeps verbatim shape.

Fixes the bug behind OP-113..117 shipping with mangled bodies (every H2 / code-fence line flattened into a `- [ ]`). 0.37.1 → 0.38.0 (minor — additive `scope_mode=`).

## Test plan

- [x] 367/367 unit tests green; `tsc --noEmit` clean
- [x] Smoke (deployed v0.38.0): all four rejection paths surface the expected error without creating any issue file
  - `scope=$'intro\n## Deliverables\nfoo'` → H2 rejection
  - `scope=$'intro\n```yaml\nx: 1\n```'` → code-fence rejection
  - `scope=$'intro\n## H' scope_mode=body` → H2-in-body rejection
  - `scope_mode=lol` → invalid-mode rejection
- [ ] (Not run live) body-mode happy path end-to-end — every project in the test vault has `repo_path` + `autoCreateGithubIssue=true`, and toggling settings mid-work was out of scope. Render-branch unit tests cover the path; dispatch wiring is shared with the rejection smokes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)