### PR TITLE
OP-122: bump-version.mjs detect parallel-bump collision against origin/main

### DIFF
--- a/plugins/op-obsidian/manifest.json
+++ b/plugins/op-obsidian/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "op-obsidian",
   "name": "Obsidian Projects (op)",
-  "version": "0.38.0",
+  "version": "0.39.0",
   "minAppVersion": "1.5.0",
   "description": "Jira-lite issue tracker for Obsidian vaults — deterministic commands backing the op workflow.",
   "author": "Eugene Archibald",

--- a/plugins/op-obsidian/package.json
+++ b/plugins/op-obsidian/package.json
@@ -1,6 +1,6 @@
 {
   "name": "op-obsidian",
-  "version": "0.38.0",
+  "version": "0.39.0",
   "description": "Obsidian plugin that owns the deterministic half of the op workflow.",
   "main": "main.js",
   "scripts": {

--- a/plugins/op/.claude-plugin/plugin.json
+++ b/plugins/op/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "op",
   "description": "Obsidian Projects workflow — schema, slash commands, and agent skill for running a Jira-lite issue tracker inside an Obsidian vault.",
-  "version": "0.38.0",
+  "version": "0.39.0",
   "author": {
     "name": "Eugene Archibald"
   },

--- a/scripts/bump-version.mjs
+++ b/scripts/bump-version.mjs
@@ -30,6 +30,11 @@ const targets = [
   join(root, "plugins/op/.claude-plugin/plugin.json"),
 ];
 
+// Parallel-bump collision guard (OP-122) reads the manifest at this path on
+// origin/main. Keep this in sync with `targets[0]` above — if the manifest
+// moves, update both.
+const ORIGIN_MANIFEST_REF = "origin/main:plugins/op-obsidian/manifest.json";
+
 const SEMVER = /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$/;
 
 function readJSON(p) {
@@ -55,6 +60,38 @@ function writeJSON(p, obj) {
   writeFileSync(p, JSON.stringify(obj, null, 2) + "\n");
 }
 
+function cmpSemver(a, b) {
+  const pa = a.split(".").map(Number);
+  const pb = b.split(".").map(Number);
+  for (let i = 0; i < 3; i++) {
+    if (pa[i] !== pb[i]) return pa[i] - pb[i];
+  }
+  return 0;
+}
+
+function tryFetchOriginMain() {
+  const r = spawnSync("git", ["fetch", "--quiet", "origin", "main"], {
+    cwd: root,
+    stdio: ["ignore", "ignore", "pipe"],
+    timeout: 15000,
+  });
+  return r.status === 0;
+}
+
+function readOriginMainManifestVersion() {
+  const r = spawnSync("git", ["show", ORIGIN_MANIFEST_REF], {
+    cwd: root,
+    encoding: "utf8",
+  });
+  if (r.status !== 0) return null;
+  try {
+    const v = JSON.parse(r.stdout).version;
+    return SEMVER.test(v) ? v : null;
+  } catch {
+    return null;
+  }
+}
+
 function bump(current, kind) {
   if (!SEMVER.test(current)) {
     throw new Error(`current version ${JSON.stringify(current)} is not strict semver (x.y.z)`);
@@ -75,6 +112,25 @@ if (!arg) {
 
 const manifest = readJSON(targets[0]);
 const next = process.env.npm_package_version ?? bump(manifest.version, arg);
+
+// OP-122: refuse if origin/main already shows a version >= what we'd write.
+// Catches the OP-112/OP-113 footgun: two branches forked from the same base,
+// each bumped to the same target in isolation, collided at squash-merge.
+if (tryFetchOriginMain()) {
+  const originVersion = readOriginMainManifestVersion();
+  if (originVersion && cmpSemver(next, originVersion) <= 0) {
+    console.error(
+      `bump-version: origin/main is at ${originVersion}, but local bump would land at ${next}. ` +
+        `Another branch likely already shipped this version. ` +
+        `Rebase onto origin/main first, or pass an explicit higher target version.`,
+    );
+    process.exit(1);
+  }
+} else {
+  console.warn(
+    "bump-version: could not fetch origin/main (offline or no remote?) — skipping parallel-bump collision check.",
+  );
+}
 
 for (const path of targets) {
   const obj = readJSON(path);


### PR DESCRIPTION
## Summary

- Adds a guard in `scripts/bump-version.mjs` that fetches `origin/main` and refuses to bump if the local target version is `<=` `origin/main:plugins/op-obsidian/manifest.json`.
- Catches the OP-112/OP-113 footgun where two branches forked from the same base each bumped to the same target in isolation and squash-merged with the same version label.
- Offline / no-remote: warn once and continue (per the trade-off in the issue's scope).
- Bumps to 0.39.0.

The guard fired live during this issue's own bump: branch was created from `main@673ba90` (0.37.1), but mid-session OP-124 (#112) shipped 0.38.0; the first `bump minor` correctly refused (`local would land at 0.38.0` matching origin). After `git rebase origin/main`, the bump produced 0.39.0 cleanly.

Resolves #106.

## Test plan

- [x] `node scripts/bump-version.mjs 0.37.1` (collision: equal) → exits 1, no files modified
- [x] `node scripts/bump-version.mjs 0.30.0` (collision: below) → exits 1, no files modified
- [x] `node scripts/bump-version.mjs minor` from stale branch → exits 1 with actionable message
- [x] `node scripts/bump-version.mjs minor` after rebase → succeeds, build runs, `main.js` mtime gate passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)