### PR TITLE
OP-115: document gh pr merge --delete-branch failure mode under sibling-worktree delegation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,6 +40,16 @@ Always, in order:
    ```
    Also spot-check the plugin instance: `obsidian eval code='app.plugins.plugins["op-obsidian"]'` should return a live object with your commands registered.
 
+5. **Smoke-test Settings UIs.** When the change touches the op-obsidian Settings tab — Project order, working dirs, agent overlays, flow chaining, GitHub integration — `executeCommandById` won't reach it. Use `app.setting.openTabById` to render the tab synchronously and assert against the live DOM:
+
+   ```bash
+   obsidian eval code='(()=>{ app.setting.open(); app.setting.openTabById("op-obsidian"); return document.querySelectorAll(".op-project-order__item").length; })()'
+   ```
+
+   Returns synchronously — no `await` needed. Use it to verify drag-row count, `draggable=true` flags, prefix badges, reset-button presence, etc. without touching the GUI. Worked example: after a change to the "Project order" section, the count above should equal the number of discovered projects (one `.op-project-order__item` per project). Swap the selector for the section you actually changed.
+
+   Cross-reference: OPD-8 captures the generic obsidian-plugin-creator skill update for this recipe (also covers the async-modal-probe hang). The snippet here is the OP-side mirror so agents working op tasks aren't blocked on the OPD skill being updated first.
+
 Never skip these steps, even for "trivial" changes — untested plugin builds ship silently broken.
 
 ## Merging a PR from a delegated worktree

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,3 +36,30 @@ Always, in order:
    Also spot-check the plugin instance: `obsidian eval code='app.plugins.plugins["op-obsidian"]'` should return a live object with your commands registered.
 
 Never skip these steps, even for "trivial" changes — untested plugin builds ship silently broken.
+
+## Merging a PR from a delegated worktree
+
+When you ran `EnterWorktree` (or otherwise work in `.claude/worktrees/<name>/`) and another checkout — typically the delegating agent — still holds `main`, `gh pr merge <#> --squash --delete-branch` will **fail locally** with:
+
+```
+failed to run git: fatal: 'main' is already used by worktree at '/Users/.../obsidian-projects'
+```
+
+This is not a bug in `gh` or in op. It's an interaction with git's invariant that a branch can only be checked out in one worktree. After the squash lands on origin, `gh` tries to fast-forward your local `main` and aborts because `main` is held elsewhere; `--delete-branch` is gated on that step, so the remote branch is also left alive. Net result: **PR is merged on GitHub, but the local fast-forward is skipped and the remote/local branches are still alive.** Every worktree-per-issue flow with a delegating agent on main will hit this.
+
+**Recognize and recover.** Don't re-merge or panic — verify, then clean up:
+
+1. **Verify the merge actually landed.**
+   ```bash
+   gh pr view <#> --json state,mergedAt,mergeCommit
+   ```
+   Expect `"state": "MERGED"` with a non-null `mergedAt` and `mergeCommit.oid`. If state is still `OPEN`, the merge genuinely failed — investigate before retrying.
+
+2. **Delete the remote branch manually.**
+   ```bash
+   git push origin --delete <branch-name>
+   ```
+
+3. **Tear down the local worktree.** Use `ExitWorktree action=remove discard_changes=true`. Safe even though the worktree's tip differs from `main` after the squash — origin's squash commit is content-equivalent to the worktree's pre-squash work.
+
+**Avoiding the failure entirely.** `gh pr merge --auto` and `--merge-queue` defer the actual merge to GitHub server-side and skip local cleanup at invocation time, so they likely sidestep this failure — not verified in this repo, but worth trying first if you have permission to enable auto-merge on the PR. The delegating agent (the one holding `main`) can always run `gh pr merge --delete-branch` cleanly because its checkout *is* `main`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,6 +10,11 @@ Always, in order:
 
 1. **Semver bump + build.** Run `node scripts/bump-version.mjs <patch|minor|major>` so `plugins/op-obsidian/manifest.json`, `plugins/op-obsidian/package.json`, and `plugins/op/.claude-plugin/plugin.json` move in lockstep. Pick the bump level by judgment (patch = fix, minor = additive, major = breaking). The script then runs `npm run build` in `plugins/op-obsidian/` and asserts `main.js` is fresher than `manifest.json` — a green run guarantees the artifact matches the source you just bumped (OP-105 guardrail). If `node_modules/` is missing, the script aborts with an actionable error; install deps (`npm ci` when `package-lock.json` exists, else `npm install`) in `plugins/op-obsidian/` and re-run.
 
+   **Fresh-worktree fixup mode.** In a freshly created worktree (`EnterWorktree` / `git worktree add`), `plugins/op-obsidian/node_modules/` does not exist. The script writes the new version into all three JSON files **before** the `npm run build` step fails with `Cannot find package 'esbuild'` — so the bump is already on disk when you see the error. Recovery:
+
+   1. `cd plugins/op-obsidian && npm ci` (or `npm install` if no lockfile — but op-obsidian has one).
+   2. Re-run with the **literal version** that's now in the JSON files, e.g. `node scripts/bump-version.mjs 0.37.3` — **not** `patch`/`minor`/`major`, which would compound the bump. The script idempotently re-runs the build step against the version already on disk.
+
 2. **Sync into the active vault.**
    ```bash
    VAULT=$(obsidian vault | awk -F'\t' '/^path\t/{print $2}')

--- a/plugins/op/skills/op/reference/cli-gotchas.md
+++ b/plugins/op/skills/op/reference/cli-gotchas.md
@@ -20,6 +20,10 @@ Full form: `obsidian move path=<src> to=<dst>`.
 
 `obsidian <subcommand> --help` creates `Untitled N.md` — the CLI treats `--help` as content. Use `obsidian help` at the top level only.
 
+## There is no `property:get` — use `property:read`
+
+To read a frontmatter field, use `obsidian property:read name=<key> path=<vault-relative-path>`. Typing `property:get` fails with `Did you mean: property:set, property:read?` — the read verb is `:read`, not `:get`.
+
 ## There is no `property:add` / `property:append`
 
 The CLI exposes only `property:read`, `property:set`, and `property:remove`. To append to a list-valued property (e.g. `commits:`) without the plugin, you have to read → append-in-memory → rewrite:


### PR DESCRIPTION
## Summary

- Adds a `## Merging a PR from a delegated worktree` section to project `CLAUDE.md` so future agents recognize the `'main' is already used by worktree at …` failure as expected and follow the documented verify-and-cleanup recipe instead of re-investigating from scratch.
- Documents: failure mode + mechanism (git's one-worktree-per-branch invariant), the verification one-liner (`gh pr view <#> --json state,mergedAt,mergeCommit`), the manual cleanup (`git push origin --delete <branch>` + `ExitWorktree action=remove discard_changes=true`), and an advisory that `gh pr merge --auto` / `--merge-queue` likely sidestep the failure (not verified here).
- **Bundles OP-117**: documents the fresh-worktree fixup mode for `bump-version.mjs` — when `node_modules/` is missing, the version files are still written to disk before the build step fails, so recovery is `npm ci` + re-run with the **literal** version (not `patch`/`minor`/`major`, which double-bumps).
- **Bundles OP-114**: adds step 5 "Smoke-test Settings UIs" to the post-change checklist — the synchronous `app.setting.open()` + `app.setting.openTabById("op-obsidian")` + `querySelectorAll` one-liner from OP-112, with the Project-order worked example and a cross-link to OPD-8 for the generic skill update.
- **Bundles OP-126**: adds a `property:read` (not `property:get`) gotcha section to `plugins/op/skills/op/reference/cli-gotchas.md` — paired with the existing `property:add` / `property:append` gotcha, includes the literal `Did you mean: property:set, property:read?` error string so future agents can grep their own terminal output and land on the note.

Closes #98 (OP-115).
Closes #101 (OP-117).
Closes #97 (OP-114).
Closes #110 (OP-126).

## Test plan

- [x] Section renders cleanly when reading `CLAUDE.md` end-to-end (no broken markdown, all code fences close).
- [ ] Future PR-finalize from a delegated worktree references the new section instead of re-investigating.
- [ ] Future agent hitting `Cannot find package 'esbuild'` in a fresh worktree follows the literal-version recovery and avoids the double-bump.
- [ ] Future agent touching the op-obsidian Settings tab finds the `openTabById` recipe in CLAUDE.md without having to discover it via experimentation.
- [ ] Future agent typing `property:get` finds the cli-gotchas.md note before re-investigating.

🤖 Generated with [Claude Code](https://claude.com/claude-code)