### PR TITLE
OP-136: close GH issue as NOT_PLANNED when op status is wontfix

### DIFF
--- a/plugins/op-obsidian/manifest.json
+++ b/plugins/op-obsidian/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "op-obsidian",
   "name": "Obsidian Projects (op)",
-  "version": "0.40.0",
+  "version": "0.40.1",
   "minAppVersion": "1.5.0",
   "description": "Jira-lite issue tracker for Obsidian vaults — deterministic commands backing the op workflow.",
   "author": "Eugene Archibald",

--- a/plugins/op-obsidian/package.json
+++ b/plugins/op-obsidian/package.json
@@ -1,6 +1,6 @@
 {
   "name": "op-obsidian",
-  "version": "0.40.0",
+  "version": "0.40.1",
   "description": "Obsidian plugin that owns the deterministic half of the op workflow.",
   "main": "main.js",
   "scripts": {

--- a/plugins/op-obsidian/src/github.test.ts
+++ b/plugins/op-obsidian/src/github.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { extractIssueUrl, isAlreadyClosedError } from "./githubPure";
+import { closeReasonForStatus, extractIssueUrl, isAlreadyClosedError } from "./githubPure";
 
 describe("extractIssueUrl", () => {
   it("extracts issue URL from gh output", () => {
@@ -30,5 +30,20 @@ describe("isAlreadyClosedError", () => {
   it("does not match unrelated errors", () => {
     expect(isAlreadyClosedError("HTTP 401: Bad credentials")).toBe(false);
     expect(isAlreadyClosedError("")).toBe(false);
+  });
+});
+
+describe("closeReasonForStatus", () => {
+  it("maps resolved to completed", () => {
+    expect(closeReasonForStatus("resolved")).toBe("completed");
+  });
+
+  it("maps wontfix to not planned", () => {
+    expect(closeReasonForStatus("wontfix")).toBe("not planned");
+  });
+
+  it("falls back to completed for unexpected statuses", () => {
+    expect(closeReasonForStatus("in-progress")).toBe("completed");
+    expect(closeReasonForStatus("")).toBe("completed");
   });
 });

--- a/plugins/op-obsidian/src/github.ts
+++ b/plugins/op-obsidian/src/github.ts
@@ -2,7 +2,7 @@ import { App, TFile } from "obsidian";
 import { execFile } from "child_process";
 import { promisify } from "util";
 import type { IssueEntry } from "./types";
-import { extractIssueUrl, isAlreadyClosedError } from "./githubPure";
+import { extractIssueUrl, isAlreadyClosedError, type GithubCloseReason } from "./githubPure";
 
 const pExecFile = promisify(execFile);
 
@@ -53,11 +53,15 @@ export async function getIssueState(repoPath: string, url: string): Promise<Gith
 //   2. tolerate that specific error as a no-op race — re-query state and
 //      swallow if CLOSED, else re-throw.
 // Real failures (auth, network, repo not found) still throw.
-export async function closeGithubIssue(repoPath: string, url: string): Promise<void> {
+export async function closeGithubIssue(
+  repoPath: string,
+  url: string,
+  reason: GithubCloseReason,
+): Promise<void> {
   if ((await getIssueState(repoPath, url)) === "CLOSED") return;
   const env = augmentedPathEnv();
   try {
-    await pExecFile("gh", ["issue", "close", url], { cwd: repoPath, env });
+    await pExecFile("gh", ["issue", "close", url, "--reason", reason], { cwd: repoPath, env });
   } catch (err: any) {
     const stderr = typeof err?.stderr === "string" ? err.stderr.trim() : "";
     if (isAlreadyClosedError(stderr)) {

--- a/plugins/op-obsidian/src/githubPure.ts
+++ b/plugins/op-obsidian/src/githubPure.ts
@@ -9,3 +9,14 @@ export function extractIssueUrl(stdout: string): string | undefined {
 export function isAlreadyClosedError(stderr: string): boolean {
   return /Could not close the issue/i.test(stderr);
 }
+
+// Mirrors GitHub's two state-reason values for closed issues:
+//   - "completed"   — work shipped (op status `resolved`)
+//   - "not planned" — won't ship (op status `wontfix`)
+// Anything else falls back to "completed" so a future op status doesn't
+// silently lose the reason; callers should pass `resolved` or `wontfix`.
+export type GithubCloseReason = "completed" | "not planned";
+
+export function closeReasonForStatus(status: string): GithubCloseReason {
+  return status === "wontfix" ? "not planned" : "completed";
+}

--- a/plugins/op-obsidian/src/main.ts
+++ b/plugins/op-obsidian/src/main.ts
@@ -38,6 +38,7 @@ import {
   createGithubIssue,
   setGithubIssue,
 } from "./github";
+import { closeReasonForStatus } from "./githubPure";
 import { resolveRepoPath } from "./repoPath";
 import { writeUriResponse, type UriResponsePayload } from "./uriResponse";
 import { normalizeUriParams, collectRepeated } from "./uriParams";
@@ -215,7 +216,11 @@ export default class OpPlugin extends Plugin {
         new Notice(`op: no repo_path for ${entry.project} — skipping gh issue close`);
         return;
       }
-      return closeGithubIssue(repoPath, entry.githubIssue).catch((err: any) => {
+      return closeGithubIssue(
+        repoPath,
+        entry.githubIssue,
+        closeReasonForStatus(entry.status),
+      ).catch((err: any) => {
         const msg = err?.message ?? String(err);
         console.error("[op-obsidian] gh issue close failed", msg);
         new Notice(`op: gh issue close failed — ${msg}`);
@@ -1223,7 +1228,7 @@ export default class OpPlugin extends Plugin {
           new Notice(`op: no repo_path for ${entry.project} — skipping gh issue close`);
           return;
         }
-        await closeGithubIssue(repoPath, entry.githubIssue);
+        await closeGithubIssue(repoPath, entry.githubIssue, closeReasonForStatus(entry.status));
       },
     };
   }

--- a/plugins/op/.claude-plugin/plugin.json
+++ b/plugins/op/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "op",
   "description": "Obsidian Projects workflow — schema, slash commands, and agent skill for running a Jira-lite issue tracker inside an Obsidian vault.",
-  "version": "0.40.0",
+  "version": "0.40.1",
   "author": {
     "name": "Eugene Archibald"
   },


### PR DESCRIPTION
## Summary

- `closeGithubIssue` now requires a `reason: "completed" | "not planned"` and forwards it as `gh issue close --reason <reason>`.
- New `closeReasonForStatus(status)` helper maps `wontfix → "not planned"` and everything else → `"completed"`. Both call sites (`issue:status-changed` bus listener and `withGhCloseHook.onAfterMove`) pass `closeReasonForStatus(entry.status)`, so wontfix resolves now land as NOT_PLANNED on GitHub instead of COMPLETED.
- Bumped to 0.39.1 (patch / behavior fix).

Signal 2 (synchronous JSON payload missing `githubClosed`/`githubCloseError`) stays wontfix-by-design — that's the OP-121 contract.

## Test plan

- [x] `npx vitest run` (370 pass) — covers `closeReasonForStatus` mapping.
- [x] Bundle grep confirms `"--reason"` and `"not planned"` are embedded in `main.js`.
- [x] Plugin reloaded clean in the active vault at 0.39.1; `op-resolve` command registered, `closeGithubIssueOnResolve` setting still on.
- [ ] Live smoke (post-merge): resolve a real op issue with `status=wontfix` and verify the linked GH issue closes with `state_reason: not_planned`.