### PR TITLE
OP-137: op-new fire-and-forget gh issue create

### DIFF
--- a/plugins/op-obsidian/manifest.json
+++ b/plugins/op-obsidian/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "op-obsidian",
   "name": "Obsidian Projects (op)",
-  "version": "0.39.0",
+  "version": "0.39.1",
   "minAppVersion": "1.5.0",
   "description": "Jira-lite issue tracker for Obsidian vaults — deterministic commands backing the op workflow.",
   "author": "Eugene Archibald",

--- a/plugins/op-obsidian/package.json
+++ b/plugins/op-obsidian/package.json
@@ -1,6 +1,6 @@
 {
   "name": "op-obsidian",
-  "version": "0.39.0",
+  "version": "0.39.1",
   "description": "Obsidian plugin that owns the deterministic half of the op workflow.",
   "main": "main.js",
   "scripts": {

--- a/plugins/op-obsidian/src/main.ts
+++ b/plugins/op-obsidian/src/main.ts
@@ -1324,8 +1324,21 @@ export default class OpPlugin extends Plugin {
         scope,
         scopeBody,
       });
+      // Persist the scratch payload + return the stdout one-liner BEFORE
+      // kicking off `gh issue create`. The gh call takes ~5s, which blew past
+      // the obsidian-cli stdout-bridge wait window (OP-137, same shape as
+      // OP-121). `autoCreateGithubIssueFor` writes the resulting URL to the
+      // issue's `github_issue:` frontmatter via `setGithubIssue` once gh
+      // returns, so async URL landing is preserved — callers needing the URL
+      // synchronously must re-read the issue file after a short delay.
+      await writeUriResponse(this.app, {
+        ok: true,
+        command,
+        issueId: res.id,
+        path: res.path,
+      });
       if (this.settings.github.autoCreateGithubIssue) {
-        await this.autoCreateGithubIssueFor(res.path, res.id, {
+        void this.autoCreateGithubIssueFor(res.path, res.id, {
           slug,
           title,
           priority,
@@ -1335,12 +1348,6 @@ export default class OpPlugin extends Plugin {
           (err) => console.error("[op-obsidian] cli auto-create github issue failed", err),
         );
       }
-      await writeUriResponse(this.app, {
-        ok: true,
-        command,
-        issueId: res.id,
-        path: res.path,
-      });
       return `${command}: created ${res.id} at ${res.path}`;
     } catch (err: any) {
       const msg = err?.message ?? String(err);
@@ -2032,8 +2039,13 @@ export default class OpPlugin extends Plugin {
       githubIssue,
     });
     new Notice(`Created ${res.id}`);
+    const file = this.app.vault.getAbstractFileByPath(res.path);
+    if (file instanceof TFile) {
+      await this.app.workspace.getLeaf(false).openFile(file);
+    }
+    // Fire-and-forget gh create — see OP-137 / handleOpNewCli for context.
     if (!githubIssue && this.settings.github.autoCreateGithubIssue) {
-      await this.autoCreateGithubIssueFor(res.path, res.id, {
+      void this.autoCreateGithubIssueFor(res.path, res.id, {
         slug,
         title,
         priority,
@@ -2042,10 +2054,6 @@ export default class OpPlugin extends Plugin {
       }).catch(
         (err) => console.error("[op-obsidian] uri auto-create failed", err),
       );
-    }
-    const file = this.app.vault.getAbstractFileByPath(res.path);
-    if (file instanceof TFile) {
-      await this.app.workspace.getLeaf(false).openFile(file);
     }
   }
 }

--- a/plugins/op/.claude-plugin/plugin.json
+++ b/plugins/op/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "op",
   "description": "Obsidian Projects workflow — schema, slash commands, and agent skill for running a Jira-lite issue tracker inside an Obsidian vault.",
-  "version": "0.39.0",
+  "version": "0.39.1",
   "author": {
     "name": "Eugene Archibald"
   },


### PR DESCRIPTION
## Summary

- `obsidian op-new` was returning empty stdout under `autoCreateGithubIssue: true` because `handleOpNewCli` awaited `autoCreateGithubIssueFor` (~5s `gh issue create`) before emitting the one-liner — the obsidian-cli stdout bridge gave up listening.
- Same shape as OP-121: persist the `_scratch` payload, return the one-liner, then fire-and-forget the gh-create. `setGithubIssue` inside `autoCreateGithubIssueFor` still writes `github_issue:` to the new note's frontmatter when gh returns, so async URL landing is preserved.
- Mirrored the change in `handleOpNewUri` and reordered `openFile` to precede the gh kick-off there.
- Bumped to `0.39.1` (patch — bug fix).

Closes #126.

## Test plan

- [x] `npm test` — 386 / 386 green
- [x] Built + synced + reloaded `0.39.1` against the live vault
- [x] Smoke: `time obsidian op-new project=obsidian-projects title="…" priority=low scope="…"` → returned `op-new: created OP-140 at …` in **184 ms** (vs 5+ second hang prior)
- [x] `github_issue: https://…/issues/130` written to OP-140 frontmatter ~5 s later by the async path
- [x] Cleaned up: resolved OP-140, gh #130 closed via the OP-121 bus listener, smoke note trashed

🤖 Generated with [Claude Code](https://claude.com/claude-code)