### PR TITLE
OP-125: op-set-section verb for Plan/Notes/Summary body sections

### DIFF
--- a/plugins/op-obsidian/manifest.json
+++ b/plugins/op-obsidian/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "op-obsidian",
   "name": "Obsidian Projects (op)",
-  "version": "0.39.0",
+  "version": "0.40.0",
   "minAppVersion": "1.5.0",
   "description": "Jira-lite issue tracker for Obsidian vaults — deterministic commands backing the op workflow.",
   "author": "Eugene Archibald",

--- a/plugins/op-obsidian/package.json
+++ b/plugins/op-obsidian/package.json
@@ -1,6 +1,6 @@
 {
   "name": "op-obsidian",
-  "version": "0.39.0",
+  "version": "0.40.0",
   "description": "Obsidian plugin that owns the deterministic half of the op workflow.",
   "main": "main.js",
   "scripts": {

--- a/plugins/op-obsidian/src/cliHandlers.test.ts
+++ b/plugins/op-obsidian/src/cliHandlers.test.ts
@@ -4,6 +4,7 @@ import {
   parseAppendCommitParams,
   parseSetPrParams,
   parseSetScopeParams,
+  parseSetSectionParams,
   parseSetEvaluationParams,
   parseSetFlowParams,
   parseNewParams,
@@ -62,6 +63,31 @@ describe("parseSetScopeParams", () => {
   it("rejects unknown mode", () => {
     const r = parseSetScopeParams({ id: "OP-1", scope: "x", mode: "wat" });
     expect(r.ok).toBe(false);
+  });
+});
+
+describe("parseSetSectionParams", () => {
+  it("requires id, name, content", () => {
+    expect(parseSetSectionParams({}).ok).toBe(false);
+    expect(parseSetSectionParams({ id: "OP-1" }).ok).toBe(false);
+    expect(parseSetSectionParams({ id: "OP-1", name: "Plan" }).ok).toBe(false);
+  });
+  it("happy path defaults append=false", () => {
+    const r = parseSetSectionParams({ id: "OP-1", name: "Plan", content: "body" });
+    expect(r.ok && r.value).toEqual({ id: "OP-1", name: "Plan", content: "body", append: false });
+  });
+  it("accepts empty content (caller handles empty-payload rejection)", () => {
+    const r = parseSetSectionParams({ id: "OP-1", name: "Notes", content: "" });
+    expect(r.ok).toBe(true);
+  });
+  it("forwards append=true", () => {
+    const r = parseSetSectionParams({ id: "OP-1", name: "Notes", content: "x", append: "true" });
+    expect(r.ok && r.value.append).toBe(true);
+  });
+  it("rejects name outside Plan|Notes|Summary", () => {
+    const r = parseSetSectionParams({ id: "OP-1", name: "Scope", content: "x" });
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.error).toMatch(/Plan\|Notes\|Summary/);
   });
 });
 

--- a/plugins/op-obsidian/src/cliHandlers.ts
+++ b/plugins/op-obsidian/src/cliHandlers.ts
@@ -97,6 +97,29 @@ export function parseSetFlowParams(
   return { ok: true, value: out };
 }
 
+export function parseSetSectionParams(
+  params: Record<string, string>,
+): ParamsResult<{ id: string; name: "Plan" | "Notes" | "Summary"; content: string; append: boolean }> {
+  const id = params.issue ?? params.id;
+  const name = params.name;
+  const content = params.content;
+  if (!id || typeof name !== "string" || typeof content !== "string") {
+    return {
+      ok: false,
+      error: "op-set-section failed: --issue, --name, --content all required",
+    };
+  }
+  if (name !== "Plan" && name !== "Notes" && name !== "Summary") {
+    return {
+      ok: false,
+      error: `op-set-section failed: --name must be one of Plan|Notes|Summary (got ${JSON.stringify(name)})`,
+    };
+  }
+  const rawAppend = params.append;
+  const append = rawAppend === "1" || rawAppend === "true";
+  return { ok: true, value: { id, name, content, append } };
+}
+
 export function parseSetScopeParams(
   params: Record<string, string>,
 ): ParamsResult<{ id: string; scope: string; mode: "scope" | "body" }> {

--- a/plugins/op-obsidian/src/main.ts
+++ b/plugins/op-obsidian/src/main.ts
@@ -22,6 +22,7 @@ import { appendCommit, setPr } from "./commits";
 import { setScope } from "./setScope";
 import { parseNewScopePayload, type NewScopeMode } from "./setScopePure";
 import { setEvaluation } from "./setEvaluation";
+import { setSection } from "./setSection";
 import { setFlow, type Complexity, type Flow } from "./setFlow";
 import { applyLink, removeLink, linkCheck, migrateLinks } from "./links";
 import { RELATION_NAMES } from "./relations";
@@ -50,6 +51,7 @@ import {
   handleOpSetPrUri as handleOpSetPrUriPure,
   handleOpSetScopeUri as handleOpSetScopeUriPure,
   handleOpSetEvaluationUri as handleOpSetEvaluationUriPure,
+  handleOpSetSectionUri as handleOpSetSectionUriPure,
   handleOpSetFlowUri as handleOpSetFlowUriPure,
   handleOpSetLinkUri as handleOpSetLinkUriPure,
   handleOpRemoveLinkUri as handleOpRemoveLinkUriPure,
@@ -63,6 +65,7 @@ import {
   parseSetPrParams,
   parseSetScopeParams,
   parseSetEvaluationParams,
+  parseSetSectionParams,
   parseSetFlowParams,
   parseNewParams,
   parseSetLinkParams,
@@ -487,6 +490,12 @@ export default class OpPlugin extends Plugin {
       );
     });
 
+    this.registerObsidianProtocolHandler("op-set-section", (params) => {
+      this.runUri("op-set-section", normalizeUriParams(params), (p) =>
+        this.handleOpSetSectionUri(p),
+      );
+    });
+
     this.registerObsidianProtocolHandler("op-set-flow", (params) => {
       this.runUri("op-set-flow", normalizeUriParams(params), (p) => this.handleOpSetFlowUri(p));
     });
@@ -668,6 +677,27 @@ export default class OpPlugin extends Plugin {
         },
       },
       (params) => this.handleOpSetEvaluationCli(params),
+    );
+
+    this.registerCliHandler(
+      "op-set-section",
+      "Replace (or append to) a body section on an issue. Restricted to Plan|Notes|Summary.",
+      {
+        issue: { value: "<id>", description: "Issue id (e.g. OP-34)" },
+        name: {
+          value: "<Plan|Notes|Summary>",
+          description: "Section heading to target.",
+        },
+        content: {
+          value: "<markdown>",
+          description: "New section body. Must not contain H2 headings (`## ...`).",
+        },
+        append: {
+          description:
+            "Pass append=true to append to the existing section (with blank-line separator) instead of replacing.",
+        },
+      },
+      (params) => this.handleOpSetSectionCli(params),
     );
 
     this.registerCliHandler(
@@ -1107,6 +1137,8 @@ export default class OpPlugin extends Plugin {
       setPr: (entry, url) => setPr(this.app, entry, url),
       setScope: (entry, scope, options) => setScope(this.app, entry, scope, options),
       setEvaluation: (entry, evaluation) => setEvaluation(this.app, entry, evaluation),
+      setSection: (entry, name, content, options) =>
+        setSection(this.app, entry, name, content, options),
       setFlow: (entry, input) => setFlow(this.app, entry, input),
       applyLink: (args) => applyLink(this.app, this.store, args),
       removeLink: (args) => removeLink(this.app, this.store, args),
@@ -1159,6 +1191,12 @@ export default class OpPlugin extends Plugin {
     params: Record<string, string>,
   ): Promise<UriResponsePayload> {
     return handleOpSetEvaluationUriPure(this.uriDeps(), params);
+  }
+
+  private handleOpSetSectionUri(
+    params: Record<string, string>,
+  ): Promise<UriResponsePayload> {
+    return handleOpSetSectionUriPure(this.uriDeps(), params);
   }
 
   private handleOpSetFlowUri(
@@ -1445,6 +1483,37 @@ export default class OpPlugin extends Plugin {
       });
       const target = res.mode === "body" ? "body" : "scope";
       return `${command}: ${res.issueId} ${target} ${res.replaced ? "replaced" : "appended"}`;
+    } catch (err: any) {
+      const msg = err?.message ?? String(err);
+      console.error("[op-obsidian]", command, err);
+      await writeUriResponse(this.app, { ok: false, command, error: msg });
+      return `${command} failed: ${msg}`;
+    }
+  }
+
+  private async handleOpSetSectionCli(params: Record<string, string>): Promise<string> {
+    const command = "op-set-section";
+    try {
+      const parsed = parseSetSectionParams(params);
+      if (!parsed.ok) return parsed.error;
+      const { id, name, content, append } = parsed.value;
+      const entry = this.resolveByIdOrThrow(id);
+      const res = await setSection(this.app, entry, name, content, { append });
+      await writeUriResponse(this.app, {
+        ok: true,
+        command,
+        issueId: res.issueId,
+        path: res.path,
+        section: res.section,
+        replaced: res.replaced,
+        appended: res.appended,
+      });
+      const verb = res.appended
+        ? "appended"
+        : res.replaced
+          ? "replaced"
+          : "created";
+      return `${command}: ${res.issueId} ${res.section} ${verb}`;
     } catch (err: any) {
       const msg = err?.message ?? String(err);
       console.error("[op-obsidian]", command, err);

--- a/plugins/op-obsidian/src/setSection.ts
+++ b/plugins/op-obsidian/src/setSection.ts
@@ -1,0 +1,63 @@
+import { App, TFile } from "obsidian";
+import type { IssueEntry } from "./types";
+import {
+  isSetSectionName,
+  normalizeSectionPayload,
+  rewriteSection,
+  SET_SECTION_NAMES,
+  type SetSectionName,
+} from "./setSectionPure";
+
+export interface SetSectionOptions {
+  append?: boolean;
+}
+
+export interface SetSectionResult {
+  issueId: string;
+  path: string;
+  section: SetSectionName;
+  content: string;
+  replaced: boolean;
+  appended: boolean;
+}
+
+// Replace (or, when append=true, extend) the issue body's `## <name>` section.
+// Restricted to the body sections without a dedicated verb today: Plan, Notes,
+// Summary. Frontmatter, the optional `# Title`, and any other H2 sections are
+// preserved. Payload must not contain an H2 — that would terminate the section.
+export async function setSection(
+  app: App,
+  entry: IssueEntry,
+  name: string,
+  content: string,
+  options: SetSectionOptions = {},
+): Promise<SetSectionResult> {
+  if (!isSetSectionName(name)) {
+    throw new Error(
+      `op-set-section: name must be one of ${SET_SECTION_NAMES.join("|")} (got ${JSON.stringify(name)})`,
+    );
+  }
+  const payload = normalizeSectionPayload(content, name);
+  const file = requireFile(app, entry.path);
+  const text = await app.vault.read(file);
+  const { next, replaced, appended } = rewriteSection(text, name, payload, {
+    append: options.append === true,
+  });
+  if (next !== text) {
+    await app.vault.modify(file, next);
+  }
+  return {
+    issueId: entry.id,
+    path: entry.path,
+    section: name,
+    content: payload,
+    replaced,
+    appended,
+  };
+}
+
+function requireFile(app: App, path: string): TFile {
+  const f = app.vault.getAbstractFileByPath(path);
+  if (!(f instanceof TFile)) throw new Error(`Issue file not found on disk: ${path}`);
+  return f;
+}

--- a/plugins/op-obsidian/src/setSectionPure.test.ts
+++ b/plugins/op-obsidian/src/setSectionPure.test.ts
@@ -1,0 +1,161 @@
+import { describe, it, expect } from "vitest";
+import {
+  isSetSectionName,
+  normalizeSectionPayload,
+  rewriteSection,
+  SET_SECTION_NAMES,
+} from "./setSectionPure";
+
+const FM = `---
+id: OP-1
+type: issue
+---
+`;
+
+describe("SET_SECTION_NAMES", () => {
+  it("includes Plan, Notes, Summary (and only those)", () => {
+    expect([...SET_SECTION_NAMES]).toEqual(["Plan", "Notes", "Summary"]);
+  });
+  it("isSetSectionName narrows correctly", () => {
+    expect(isSetSectionName("Plan")).toBe(true);
+    expect(isSetSectionName("Scope")).toBe(false);
+    expect(isSetSectionName("Initial Evaluation")).toBe(false);
+    expect(isSetSectionName("plan")).toBe(false);
+  });
+});
+
+describe("normalizeSectionPayload", () => {
+  it("rejects payload with H2 heading (mentions section name)", () => {
+    expect(() => normalizeSectionPayload("body\n## Nope\nx", "Plan")).toThrow(
+      /Plan payload must not contain H2 headings/,
+    );
+  });
+  it("rejects empty payload", () => {
+    expect(() => normalizeSectionPayload("   \n\n", "Notes")).toThrow(/Notes payload is empty/);
+  });
+  it("strips trailing whitespace", () => {
+    expect(normalizeSectionPayload("body\n\n  ", "Plan")).toBe("body");
+  });
+  it("normalizes CRLF to LF", () => {
+    expect(normalizeSectionPayload("a\r\nb", "Summary")).toBe("a\nb");
+  });
+});
+
+describe("rewriteSection (replace mode)", () => {
+  it("replaces an existing ## Plan section, preserving sections before/after", () => {
+    const text = `${FM}
+# Title
+
+## Scope
+- [ ] s1
+
+## Plan
+
+old plan body
+
+## Tasks
+- [ ] t1
+`;
+    const { next, replaced, appended } = rewriteSection(text, "Plan", "new plan body");
+    expect(replaced).toBe(true);
+    expect(appended).toBe(false);
+    expect(next).toContain("## Scope\n- [ ] s1");
+    expect(next).toContain("## Plan\n\nnew plan body\n");
+    expect(next).toContain("## Tasks\n- [ ] t1");
+    expect(next).not.toContain("old plan body");
+  });
+
+  it("appends ## Notes when missing", () => {
+    const text = `${FM}
+# Title
+
+Some body.
+`;
+    const { next, replaced, appended } = rewriteSection(text, "Notes", "first note");
+    expect(replaced).toBe(false);
+    expect(appended).toBe(false);
+    expect(next).toContain("Some body.\n\n## Notes\n\nfirst note\n");
+  });
+
+  it("preserves frontmatter exactly", () => {
+    const text = `${FM}
+# T
+
+## Summary
+old
+`;
+    const { next } = rewriteSection(text, "Summary", "new");
+    expect(next.startsWith(FM)).toBe(true);
+  });
+
+  it("handles section at end-of-file (no trailing section)", () => {
+    const text = `${FM}
+# T
+
+## Summary
+old
+`;
+    const { next, replaced } = rewriteSection(text, "Summary", "shipped");
+    expect(replaced).toBe(true);
+    expect(next).toMatch(/## Summary\n\nshipped\n$/);
+  });
+});
+
+describe("rewriteSection (append mode)", () => {
+  it("appends payload to existing section body with blank-line separator", () => {
+    const text = `${FM}
+# T
+
+## Notes
+
+prior block.
+
+## Summary
+done
+`;
+    const { next, replaced, appended } = rewriteSection(
+      text,
+      "Notes",
+      "### OP-1.2 — second\n\nmore detail",
+      { append: true },
+    );
+    expect(replaced).toBe(true);
+    expect(appended).toBe(true);
+    expect(next).toContain(
+      "## Notes\n\nprior block.\n\n### OP-1.2 — second\n\nmore detail\n",
+    );
+    expect(next).toContain("## Summary\ndone");
+  });
+
+  it("treats placeholder-only section as empty (no double blank)", () => {
+    const text = `${FM}
+# T
+
+## Notes
+
+
+## Summary
+done
+`;
+    const { next, replaced, appended } = rewriteSection(text, "Notes", "first", {
+      append: true,
+    });
+    expect(replaced).toBe(true);
+    expect(appended).toBe(false);
+    expect(next).toContain("## Notes\n\nfirst\n");
+  });
+
+  it("creates the section when missing (append acts as replace fallback)", () => {
+    const text = `${FM}
+# T
+
+Some body.
+`;
+    const { next, replaced, appended } = rewriteSection(text, "Notes", "first", {
+      append: true,
+    });
+    expect(replaced).toBe(false);
+    expect(appended).toBe(false);
+    expect(next).toContain("Some body.\n\n## Notes\n\nfirst\n");
+  });
+});

--- a/plugins/op-obsidian/src/setSectionPure.ts
+++ b/plugins/op-obsidian/src/setSectionPure.ts
@@ -1,0 +1,120 @@
+// Generic per-section body rewriter for issue notes. Powers the op-set-section
+// verb, which targets ## Plan / ## Notes / ## Summary — the body sections that
+// have no dedicated verb today (## Scope and ## Initial Evaluation keep their
+// specialised verbs because they carry mode=body / bullet-handling concerns).
+//
+// Two modes:
+//   - replace (default): swap the section's body for the payload, append the
+//     section at end-of-body if missing.
+//   - append: glue the payload onto the existing section body with a blank-line
+//     separator. Missing section → falls back to create-with-payload.
+
+export const SET_SECTION_NAMES = ["Plan", "Notes", "Summary"] as const;
+export type SetSectionName = (typeof SET_SECTION_NAMES)[number];
+
+export function isSetSectionName(name: string): name is SetSectionName {
+  return (SET_SECTION_NAMES as readonly string[]).includes(name);
+}
+
+export function normalizeSectionPayload(raw: string, sectionName: SetSectionName): string {
+  if (typeof raw !== "string") throw new Error(`${sectionName} payload must be a string`);
+  const trimmed = raw.replace(/\r\n/g, "\n").replace(/\s+$/g, "");
+  if (!trimmed) throw new Error(`${sectionName} payload is empty`);
+  if (/^##\s+/m.test(trimmed)) {
+    throw new Error(
+      `${sectionName} payload must not contain H2 headings (\`## ...\`) — they would terminate the ${sectionName} section`,
+    );
+  }
+  return trimmed;
+}
+
+export interface RewriteSectionOptions {
+  // When true, append the payload to the existing section body with a
+  // blank-line separator instead of replacing it. Missing section behaves the
+  // same as replace (creates the section with the payload).
+  append?: boolean;
+}
+
+export interface RewriteSectionResult {
+  next: string;
+  // Whether the section already existed before this call. False when the
+  // section was appended at end-of-body.
+  replaced: boolean;
+  // True when append=true and we appended onto existing content; false when we
+  // either replaced (append=false) or created the section fresh.
+  appended: boolean;
+}
+
+export function rewriteSection(
+  text: string,
+  sectionName: SetSectionName,
+  payload: string,
+  options: RewriteSectionOptions = {},
+): RewriteSectionResult {
+  const { frontmatter, body } = splitFrontmatter(text);
+  const heading = `## ${sectionName}`;
+  const headingRe = new RegExp(`^##\\s+${escapeRegExp(sectionName)}\\s*$`);
+
+  const lines = body.split("\n");
+  let startIdx = -1;
+  for (let i = 0; i < lines.length; i++) {
+    if (headingRe.test(lines[i])) {
+      startIdx = i;
+      break;
+    }
+  }
+
+  if (startIdx === -1) {
+    const section = `${heading}\n\n${payload}\n`;
+    const trimmedBody = body.replace(/\s+$/g, "");
+    const newBody = trimmedBody.length > 0 ? `${trimmedBody}\n\n${section}` : section;
+    return { next: frontmatter + newBody, replaced: false, appended: false };
+  }
+
+  let endIdx = lines.length;
+  for (let i = startIdx + 1; i < lines.length; i++) {
+    if (/^##\s+/.test(lines[i])) {
+      endIdx = i;
+      break;
+    }
+  }
+
+  const append = options.append === true;
+  let newSectionBody: string;
+  let appended = false;
+  if (append) {
+    const existingLines = lines.slice(startIdx + 1, endIdx);
+    const existingBody = existingLines.join("\n").replace(/^\s+|\s+$/g, "");
+    if (existingBody.length > 0) {
+      newSectionBody = `${existingBody}\n\n${payload}`;
+      appended = true;
+    } else {
+      newSectionBody = payload;
+    }
+  } else {
+    newSectionBody = payload;
+  }
+
+  const section = `${heading}\n\n${newSectionBody}\n`;
+  const before = lines.slice(0, startIdx).join("\n").replace(/\s+$/g, "");
+  const after = lines.slice(endIdx).join("\n").replace(/^\s+/g, "");
+  const parts: string[] = [];
+  if (before.length > 0) parts.push(before, "");
+  parts.push(section.replace(/\n$/, ""));
+  if (after.length > 0) parts.push("", after);
+  let newBody = parts.join("\n");
+  if (!newBody.endsWith("\n")) newBody += "\n";
+  return { next: frontmatter + newBody, replaced: true, appended };
+}
+
+function splitFrontmatter(text: string): { frontmatter: string; body: string } {
+  if (!text.startsWith("---\n")) return { frontmatter: "", body: text };
+  const end = text.indexOf("\n---\n", 4);
+  if (end === -1) return { frontmatter: "", body: text };
+  const cutoff = end + "\n---\n".length;
+  return { frontmatter: text.slice(0, cutoff), body: text.slice(cutoff) };
+}
+
+function escapeRegExp(s: string): string {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}

--- a/plugins/op-obsidian/src/uriHandlers.test.ts
+++ b/plugins/op-obsidian/src/uriHandlers.test.ts
@@ -6,6 +6,7 @@ import {
   handleOpAppendCommitUri,
   handleOpSetPrUri,
   handleOpSetScopeUri,
+  handleOpSetSectionUri,
   handleOpSetEvaluationUri,
   handleOpSetFlowUri,
   type UriHandlerDeps,
@@ -55,6 +56,14 @@ function makeDeps(overrides: Partial<UriHandlerDeps> = {}): UriHandlerDeps {
       path: e.path,
       evaluation,
       replaced: true,
+    }),
+    setSection: async (e, name, content, options) => ({
+      issueId: e.id,
+      path: e.path,
+      section: name as "Plan" | "Notes" | "Summary",
+      content,
+      replaced: true,
+      appended: options?.append === true,
     }),
     setFlow: async (e, input) => ({
       issueId: e.id,
@@ -205,6 +214,46 @@ describe("handleOpSetFlowUri", () => {
   it("passes 'null' through as null to clear", async () => {
     const r = await handleOpSetFlowUri(makeDeps(), { id: "OP-1", flow: "null" });
     expect(r.flow).toBeUndefined();
+  });
+});
+
+describe("handleOpSetSectionUri", () => {
+  it("requires id, name, content", async () => {
+    await expect(handleOpSetSectionUri(makeDeps(), {})).rejects.toThrow(
+      "op-set-section URI requires id, name, content",
+    );
+    await expect(
+      handleOpSetSectionUri(makeDeps(), { id: "OP-1", name: "Plan" }),
+    ).rejects.toThrow();
+  });
+  it("rejects name outside Plan|Notes|Summary", async () => {
+    await expect(
+      handleOpSetSectionUri(makeDeps(), { id: "OP-1", name: "Scope", content: "x" }),
+    ).rejects.toThrow(/Plan\|Notes\|Summary/);
+  });
+  it("happy path payload shape", async () => {
+    const r = await handleOpSetSectionUri(makeDeps(), {
+      id: "OP-1",
+      name: "Plan",
+      content: "approach",
+    });
+    expect(r).toMatchObject({
+      ok: true,
+      command: "op-set-section",
+      issueId: "OP-1",
+      section: "Plan",
+      replaced: true,
+      appended: false,
+    });
+  });
+  it("forwards append=true", async () => {
+    const r = await handleOpSetSectionUri(makeDeps(), {
+      id: "OP-1",
+      name: "Notes",
+      content: "### OP-1.1 — done",
+      append: "true",
+    });
+    expect(r).toMatchObject({ section: "Notes", appended: true });
   });
 });
 

--- a/plugins/op-obsidian/src/uriHandlers.ts
+++ b/plugins/op-obsidian/src/uriHandlers.ts
@@ -11,6 +11,7 @@ import type { AppendCommitResult } from "./commits";
 import type { SetPrResult } from "./commits";
 import type { SetScopeResult } from "./setScope";
 import type { SetEvaluationResult } from "./setEvaluation";
+import type { SetSectionResult } from "./setSection";
 import type { SetFlowResult, Flow, Complexity } from "./setFlow";
 import type { ResolveArgs, ResolveStatus } from "./resolve";
 import type { ApplyLinkResult, LinkCheckResult, MigrateLinksResult } from "./links";
@@ -26,6 +27,12 @@ export interface UriHandlerDeps {
     options?: { mode?: "scope" | "body" },
   ) => Promise<SetScopeResult>;
   setEvaluation: (entry: IssueEntry, evaluation: string) => Promise<SetEvaluationResult>;
+  setSection: (
+    entry: IssueEntry,
+    name: string,
+    content: string,
+    options?: { append?: boolean },
+  ) => Promise<SetSectionResult>;
   setFlow: (
     entry: IssueEntry,
     input: { flow?: Flow | null; complexity?: Complexity | null },
@@ -242,6 +249,33 @@ export async function handleOpMigrateLinksUri(
   if (!deps.migrateLinks) throw new Error("op-migrate-links not wired");
   const res = await deps.migrateLinks();
   return { ...res };
+}
+
+export async function handleOpSetSectionUri(
+  deps: UriHandlerDeps,
+  params: Record<string, string>,
+): Promise<UriResponsePayload> {
+  const id = params.id ?? params.issue;
+  const name = params.name;
+  const content = params.content;
+  if (!id || typeof name !== "string" || typeof content !== "string") {
+    throw new Error("op-set-section URI requires id, name, content");
+  }
+  if (name !== "Plan" && name !== "Notes" && name !== "Summary") {
+    throw new Error("op-set-section URI name must be one of Plan|Notes|Summary");
+  }
+  const append = params.append === "1" || params.append === "true";
+  const entry = findIssueById(deps.store, id);
+  const res = await deps.setSection(entry, name, content, { append });
+  return {
+    ok: true,
+    command: "op-set-section",
+    issueId: res.issueId,
+    path: res.path,
+    section: res.section,
+    replaced: res.replaced,
+    appended: res.appended,
+  };
 }
 
 export async function handleOpSetScopeUri(

--- a/plugins/op/.claude-plugin/plugin.json
+++ b/plugins/op/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "op",
   "description": "Obsidian Projects workflow — schema, slash commands, and agent skill for running a Jira-lite issue tracker inside an Obsidian vault.",
-  "version": "0.39.0",
+  "version": "0.40.0",
   "author": {
     "name": "Eugene Archibald"
   },


### PR DESCRIPTION
## Summary

- Adds `op-set-section name=Plan|Notes|Summary content=... [append=true]` verb backed by a generic `rewriteSection(text, name, payload, {append})` pure helper. Restricted to the body sections that have no dedicated verb today; `op-set-scope` and `op-set-evaluation` keep their specialised verbs (mode=body / bullet-handling concerns the generic verb doesn't carry).
- Replace mode mirrors the existing `rewriteScopeSection` / `rewriteEvaluationSection` shape: replace the section if present, append it at end-of-body if missing. Same H2-rejection rule (H2 in payload would terminate the section).
- `append=true` reconciles rather than replaces — payload is glued onto the existing section body with a blank-line separator. Missing section falls back to create-with-payload. Primary motivation is the per-task `### <ID>.<N>` block append pattern under `## Notes`, which agents currently do via direct Edit (racy against open editors).
- Bumps op-obsidian 0.39.1 → 0.40.0 (additive verb).

Closes #109.

## Test plan

- [x] Unit: `setSectionPure.test.ts` (13 cases) — replace + append + missing-section + frontmatter-preserved + sections-before/after-preserved + placeholder-only-section + name-allowlist + payload validation.
- [x] Unit: `cliHandlers.test.ts` — `parseSetSectionParams` (id/name/content required, name allowlist, append flag, empty-content tolerated).
- [x] Unit: `uriHandlers.test.ts` — `handleOpSetSectionUri` (required params, allowlist, response shape, append flag forwarded).
- [x] Build: `node scripts/bump-version.mjs minor` — manifest/package/plugin.json moved 0.39.1 → 0.40.0; `main.js` rebuilt.
- [x] Smoke: synced to vault, reloaded, exercised failure paths (`Issue not found`, name-outside-allowlist, missing content) and happy path (two `append=true` calls onto OP-125's `## Notes` produced "Notes appended" + the file ended up with the placeholder + two appended blocks separated by blank lines, then a replace-mode call swapped them for the real notes content).

🤖 Generated with [Claude Code](https://claude.com/claude-code)