### PR TITLE
OP-119: sidebar filter text entry with fuzzy matching

### DIFF
--- a/plugins/op-obsidian/manifest.json
+++ b/plugins/op-obsidian/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "op-obsidian",
   "name": "Obsidian Projects (op)",
-  "version": "0.40.1",
+  "version": "0.41.0",
   "minAppVersion": "1.5.0",
   "description": "Jira-lite issue tracker for Obsidian vaults — deterministic commands backing the op workflow.",
   "author": "Eugene Archibald",

--- a/plugins/op-obsidian/manifest.json
+++ b/plugins/op-obsidian/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "op-obsidian",
   "name": "Obsidian Projects (op)",
-  "version": "0.43.0",
+  "version": "0.44.0",
   "minAppVersion": "1.5.0",
   "description": "Jira-lite issue tracker for Obsidian vaults — deterministic commands backing the op workflow.",
   "author": "Eugene Archibald",

--- a/plugins/op-obsidian/package.json
+++ b/plugins/op-obsidian/package.json
@@ -1,6 +1,6 @@
 {
   "name": "op-obsidian",
-  "version": "0.40.1",
+  "version": "0.41.0",
   "description": "Obsidian plugin that owns the deterministic half of the op workflow.",
   "main": "main.js",
   "scripts": {

--- a/plugins/op-obsidian/package.json
+++ b/plugins/op-obsidian/package.json
@@ -1,6 +1,6 @@
 {
   "name": "op-obsidian",
-  "version": "0.43.0",
+  "version": "0.44.0",
   "description": "Obsidian plugin that owns the deterministic half of the op workflow.",
   "main": "main.js",
   "scripts": {

--- a/plugins/op-obsidian/src/sidebarView.test.ts
+++ b/plugins/op-obsidian/src/sidebarView.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect, vi } from "vitest";
+import type { IssueEntry } from "./types";
+
+vi.mock("obsidian", () => ({
+  ItemView: class {},
+  TFile: class {},
+  WorkspaceLeaf: class {},
+  setIcon: () => {},
+  setTooltip: () => {},
+  prepareFuzzySearch: () => () => null,
+}));
+
+import { filterEntries } from "./sidebarView";
+
+function entry(over: Partial<IssueEntry>): IssueEntry {
+  return {
+    path: "x.md",
+    type: "issue",
+    id: "OP-1",
+    project: "obsidian-projects",
+    status: "open",
+    title: "OP-1 placeholder",
+    resolvedFolder: false,
+    ...over,
+  };
+}
+
+const subseqMatcher = (q: string) => (text: string) => {
+  const lq = q.toLowerCase();
+  const lt = text.toLowerCase();
+  let i = 0;
+  for (const ch of lt) {
+    if (ch === lq[i]) i++;
+    if (i === lq.length) return { score: -1, matches: [] };
+  }
+  return null;
+};
+
+describe("filterEntries", () => {
+  const items = [
+    entry({ id: "OP-1", title: "OP-1 sidebar fuzzy filter" }),
+    entry({ id: "OP-2", title: "OP-2 settings tab cleanup" }),
+    entry({ id: "JB-9", title: "JB-9 link escaping", project: "jira-bases" }),
+  ];
+
+  it("returns all entries when query is empty", () => {
+    expect(filterEntries(items, "", subseqMatcher)).toHaveLength(3);
+    expect(filterEntries(items, "   ", subseqMatcher)).toHaveLength(3);
+  });
+
+  it("filters to fuzzy-matching entries by title", () => {
+    const out = filterEntries(items, "filter", subseqMatcher);
+    expect(out.map((e) => e.id)).toEqual(["OP-1"]);
+  });
+
+  it("matches against id", () => {
+    const out = filterEntries(items, "jb9", subseqMatcher);
+    expect(out.map((e) => e.id)).toEqual(["JB-9"]);
+  });
+
+  it("matches against project slug", () => {
+    const out = filterEntries(items, "jira", subseqMatcher);
+    expect(out.map((e) => e.id)).toEqual(["JB-9"]);
+  });
+
+  it("returns empty when nothing matches", () => {
+    expect(filterEntries(items, "zzznotpresent", subseqMatcher)).toEqual([]);
+  });
+
+  it("preserves input order", () => {
+    const out = filterEntries(items, "op", subseqMatcher);
+    expect(out.map((e) => e.id)).toEqual(["OP-1", "OP-2"]);
+  });
+});

--- a/plugins/op-obsidian/src/sidebarView.ts
+++ b/plugins/op-obsidian/src/sidebarView.ts
@@ -1,4 +1,4 @@
-import { ItemView, TFile, WorkspaceLeaf, setIcon, setTooltip } from "obsidian";
+import { ItemView, TFile, WorkspaceLeaf, prepareFuzzySearch, setIcon, setTooltip } from "obsidian";
 import type { IssueStore } from "./issueStore";
 import type { EventBus } from "./eventBus";
 import type { IssueEntry, LifecycleEvent } from "./types";
@@ -26,6 +26,8 @@ export class OpSidebarView extends ItemView {
   private active: TabId = "issues";
   private unsubscribe?: () => void;
   private bodyEl!: HTMLElement;
+  private filterInput!: HTMLInputElement;
+  private filterQuery = "";
   private tabButtons = new Map<TabId, HTMLElement>();
   private rafPending = false;
 
@@ -71,6 +73,20 @@ export class OpSidebarView extends ItemView {
       this.tabButtons.set(t.id, btn);
     }
 
+    this.filterInput = root.createEl("input", {
+      cls: "op-sidebar__filter",
+      attr: {
+        type: "search",
+        placeholder: "Filter issues…",
+        "aria-label": "Filter issues",
+        spellcheck: "false",
+      },
+    });
+    this.filterInput.addEventListener("input", () => {
+      this.filterQuery = this.filterInput.value;
+      this.scheduleRender();
+    });
+
     this.bodyEl = root.createDiv({ cls: "op-sidebar__body" });
 
     this.unsubscribe = this.bus.on("*", (ev) => {
@@ -99,10 +115,11 @@ export class OpSidebarView extends ItemView {
     for (const [id, btn] of this.tabButtons) {
       btn.toggleClass("is-active", id === this.active);
     }
-    const issues = this.pickFor(this.active);
+    const issues = filterEntries(this.pickFor(this.active), this.filterQuery);
     this.bodyEl.empty();
     if (issues.length === 0) {
-      this.bodyEl.createDiv({ cls: "op-sidebar__empty", text: "(none)" });
+      const emptyText = this.filterQuery.trim() ? "(no matches)" : "(none)";
+      this.bodyEl.createDiv({ cls: "op-sidebar__empty", text: emptyText });
       return;
     }
     const ul = this.bodyEl.createEl("ul", { cls: "op-sidebar__list" });
@@ -231,6 +248,22 @@ function byResolvedDesc(a: IssueEntry, b: IssueEntry): number {
 
 function stripIdPrefix(title: string, id: string): string {
   return title.startsWith(`${id} `) ? title.slice(id.length + 1) : title;
+}
+
+type MatcherFactory = (query: string) => (text: string) => unknown;
+
+export function filterEntries(
+  entries: IssueEntry[],
+  query: string,
+  makeMatcher: MatcherFactory = prepareFuzzySearch,
+): IssueEntry[] {
+  const q = query.trim();
+  if (!q) return entries;
+  const match = makeMatcher(q);
+  return entries.filter((e) => {
+    const target = `${e.id} ${stripIdPrefix(e.title, e.id)} ${e.project}`;
+    return match(target) !== null;
+  });
 }
 
 function ghIssueNumber(url: string): number | undefined {

--- a/plugins/op-obsidian/styles.css
+++ b/plugins/op-obsidian/styles.css
@@ -30,6 +30,23 @@
   border-bottom-color: var(--text-accent);
 }
 
+.op-sidebar__filter {
+  width: 100%;
+  margin-bottom: 0.4rem;
+  padding: 0.3rem 0.5rem;
+  font-size: var(--font-ui-small);
+  color: var(--text-normal);
+  background: var(--background-secondary);
+  border: 1px solid var(--background-modifier-border);
+  border-radius: 4px;
+  box-shadow: none;
+}
+
+.op-sidebar__filter:focus {
+  outline: none;
+  border-color: var(--interactive-accent);
+}
+
 .op-sidebar__body {
   margin-top: 0.25rem;
 }

--- a/plugins/op/.claude-plugin/plugin.json
+++ b/plugins/op/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "op",
   "description": "Obsidian Projects workflow — schema, slash commands, and agent skill for running a Jira-lite issue tracker inside an Obsidian vault.",
-  "version": "0.43.0",
+  "version": "0.44.0",
   "author": {
     "name": "Eugene Archibald"
   },

--- a/plugins/op/.claude-plugin/plugin.json
+++ b/plugins/op/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "op",
   "description": "Obsidian Projects workflow — schema, slash commands, and agent skill for running a Jira-lite issue tracker inside an Obsidian vault.",
-  "version": "0.40.1",
+  "version": "0.41.0",
   "author": {
     "name": "Eugene Archibald"
   },


### PR DESCRIPTION
## Summary

- Adds a search input directly below the sidebar tabs that fuzzy-filters the visible issue list against the user's query.
- Matching applied to `<id> <title> <project>` via Obsidian's `prepareFuzzySearch`. Empty query bypasses filtering.
- Filter state is view-scoped: persists across tab switches and event-bus rerenders. Empty-result state shows `(no matches)` when a query is active.

## Test plan

- [x] Unit tests for `filterEntries` (6 cases: empty query, title match, id match, project match, no match, order preservation) — `npm test` 417/417 pass.
- [x] DOM smoke test via `obsidian-cli` against the rebuilt + reloaded plugin in the active vault: 23 items → 13 ("sidebar") → 1 ("OP-119") → 0 ("zzznotpresent" → `(no matches)`) → 23 (cleared).
- [x] Filter persists across tab switch (Issues → In flight) with filtered count 4.
- [x] `obsidian dev:console` clean — no errors.

Closes OP-119.

🤖 Generated with [Claude Code](https://claude.com/claude-code)