### PR TITLE
OP-145: persist full pre-sanitization issue title in frontmatter

### DIFF
--- a/plugins/op-obsidian/manifest.json
+++ b/plugins/op-obsidian/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "op-obsidian",
   "name": "Obsidian Projects (op)",
-  "version": "0.40.1",
+  "version": "0.42.0",
   "minAppVersion": "1.5.0",
   "description": "Jira-lite issue tracker for Obsidian vaults — deterministic commands backing the op workflow.",
   "author": "Eugene Archibald",

--- a/plugins/op-obsidian/package.json
+++ b/plugins/op-obsidian/package.json
@@ -1,6 +1,6 @@
 {
   "name": "op-obsidian",
-  "version": "0.40.1",
+  "version": "0.42.0",
   "description": "Obsidian plugin that owns the deterministic half of the op workflow.",
   "main": "main.js",
   "scripts": {

--- a/plugins/op-obsidian/src/createIssue.test.ts
+++ b/plugins/op-obsidian/src/createIssue.test.ts
@@ -97,6 +97,15 @@ describe("renderIssueNote", () => {
     expect(out).not.toContain("- [ ] Para one");
   });
 
+  it("emits title in frontmatter as a JSON-quoted scalar so YAML-significant chars survive", () => {
+    const out = render({ title: 'fix: handle "colons" & #hashes' });
+    expect(out).toContain(
+      `title: ${JSON.stringify('fix: handle "colons" & #hashes')}`,
+    );
+    // Body heading still uses the raw title (unquoted).
+    expect(out).toContain('# fix: handle "colons" & #hashes');
+  });
+
   it("scopeBody takes precedence over bullets when both supplied", () => {
     const out = render({
       scope: ["bullet"],
@@ -183,7 +192,7 @@ describe("createIssue", () => {
     expect(result.entry.project).toBe("demo");
     expect(result.entry.priority).toBe("high");
     expect(result.entry.assignee).toBe("alice");
-    expect(result.entry.title).toBe(result.file.basename);
+    expect(result.entry.title).toBe("smoke test");
     expect(result.entry.resolvedFolder).toBe(false);
     expect(result.entry.githubIssue).toBeUndefined();
   });
@@ -196,5 +205,26 @@ describe("createIssue", () => {
     });
     expect(result.entry.priority).toBe("med");
     expect(result.entry.assignee).toBe("earchibald");
+  });
+
+  it("preserves the full pre-sanitization title in frontmatter and on the entry", async () => {
+    const { app, store, created } = fakeApp("demo", "DM");
+    const fullTitle =
+      "fix: handle ?colons? & #hashes/path | when creating issues so the original survives";
+    const result = await createIssue(app, store, {
+      slug: "demo",
+      title: fullTitle,
+    });
+
+    // Filename remains sanitized — forbidden chars replaced with spaces.
+    const basename = result.path.split("/").pop()!;
+    expect(basename).not.toMatch(/[?#|:"<>*\\^[\]]/);
+
+    // Frontmatter keeps the raw title verbatim, JSON-quoted so YAML parses safely.
+    const file = created.find((c) => c.path === result.path)!;
+    expect(file.content).toContain(`title: ${JSON.stringify(fullTitle)}`);
+
+    // The synthesized entry uses the full title, not the truncated basename.
+    expect(result.entry.title).toBe(fullTitle);
   });
 });

--- a/plugins/op-obsidian/src/createIssue.ts
+++ b/plugins/op-obsidian/src/createIssue.ts
@@ -95,7 +95,7 @@ export async function createIssue(
     priority: input.priority ?? "med",
     assignee: input.assignee ?? "earchibald",
     githubIssue: input.githubIssue?.trim() || undefined,
-    title: file.basename,
+    title: input.title,
     resolvedFolder: false,
   };
   return { file, id, path, project, entry };

--- a/plugins/op-obsidian/src/issueStore.ts
+++ b/plugins/op-obsidian/src/issueStore.ts
@@ -174,7 +174,7 @@ export class IssueStore extends Component {
       pr: str(fm.pr),
       githubIssue: str(fm.github_issue),
       agent: str(fm.agent),
-      title: file.basename,
+      title: str(fm.title) ?? file.basename,
       resolvedFolder: inResolved,
     };
   }

--- a/plugins/op-obsidian/src/issueTemplate.ts
+++ b/plugins/op-obsidian/src/issueTemplate.ts
@@ -28,6 +28,7 @@ export function renderIssueNote(i: RenderInput): string {
     "---",
     `id: ${i.id}`,
     `project: ${i.project}`,
+    `title: ${JSON.stringify(i.title)}`,
     "type: issue",
     "status: open",
     `priority: ${i.priority}`,

--- a/plugins/op/.claude-plugin/plugin.json
+++ b/plugins/op/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "op",
   "description": "Obsidian Projects workflow — schema, slash commands, and agent skill for running a Jira-lite issue tracker inside an Obsidian vault.",
-  "version": "0.40.1",
+  "version": "0.42.0",
   "author": {
     "name": "Eugene Archibald"
   },

--- a/plugins/op/skills/op/reference/schema.md
+++ b/plugins/op/skills/op/reference/schema.md
@@ -31,6 +31,7 @@ Projects/<project-slug>/
 ---
 id: <PROJECT-N>          # e.g. JB-2  — stable, never changes
 project: <slug>          # e.g. jira-bases
+title: "<full title>"    # full pre-sanitization title; filenames are truncated and have forbidden chars stripped, this field keeps the original
 type: issue
 status: open | in-progress | blocked | resolved | wontfix
 priority: low | med | high
@@ -63,6 +64,8 @@ tags:
 Example: `JB-2 prepend id to issue filenames.md`
 
 Why: keeps the project key visible in file lists and makes wikilinks from TASKS self-documenting.
+
+**Title field.** The filename is sanitized (forbidden chars `#^[]|\/:?"<>*` replaced with spaces, capped at 80 chars at a word boundary) and may lose information. `title:` in frontmatter holds the full original title verbatim, JSON-quoted so YAML parses safely. Bases views and pickers prefer it over the file basename. Plugin-managed at `op-new` — agents shouldn't write it directly.
 
 **Body:** one-line summary checklist at minimum. Agents may expand freely.
 


### PR DESCRIPTION
## Summary

- `op-new` now writes a `title:` frontmatter field holding the raw, pre-sanitization issue title. Filenames remain sanitized (`#^[]|\/:?"<>*` → spaces, capped at 80 chars at a word boundary), but the full title now survives in queryable form.
- `IssueStore.parseIssue` prefers `fm.title` over `file.basename`, falling back to the basename for legacy issues — no migration needed.
- Schema doc updated to document the new field.
- Bumped to `0.42.0` (skipped `0.41.0` because three sibling branches — OP-119, OP-120, OP-140 — already claimed it).

## Test plan

- [x] `npx vitest run` in `plugins/op-obsidian/` — 394/394 PASS, including two new tests covering JSON-quoted frontmatter emission and round-tripping a `:#"|`-laden title through `createIssue`.
- [x] Vault smoke test on `OP-147 SMOKE probe title frontmatter OP-145.md`: filename sanitized, frontmatter `title:` parsed back identically by `app.metadataCache`. `obsidian dev:console` clean afterwards.
- [x] Legacy issues (no `title:` field) continue to render via basename fallback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)