### PR TITLE
OP-127: cmd-click sidebar launch/plan buttons to pick agent

### DIFF
--- a/plugins/op-obsidian/manifest.json
+++ b/plugins/op-obsidian/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "op-obsidian",
   "name": "Obsidian Projects (op)",
-  "version": "0.42.0",
+  "version": "0.43.0",
   "minAppVersion": "1.5.0",
   "description": "Jira-lite issue tracker for Obsidian vaults — deterministic commands backing the op workflow.",
   "author": "Eugene Archibald",

--- a/plugins/op-obsidian/package.json
+++ b/plugins/op-obsidian/package.json
@@ -1,6 +1,6 @@
 {
   "name": "op-obsidian",
-  "version": "0.42.0",
+  "version": "0.43.0",
   "description": "Obsidian plugin that owns the deterministic half of the op workflow.",
   "main": "main.js",
   "scripts": {

--- a/plugins/op-obsidian/src/main.ts
+++ b/plugins/op-obsidian/src/main.ts
@@ -286,7 +286,7 @@ export default class OpPlugin extends Plugin {
           this.bus,
           () => this.settings.view,
           (entry) => revealAgentSession(this.settings, entry.id),
-          (entry, mode) => void this.doOpenAgent(entry, { mode }),
+          (entry, mode, forcePick) => void this.doOpenAgent(entry, { mode, forcePick }),
         ),
     );
 

--- a/plugins/op-obsidian/src/sidebarView.ts
+++ b/plugins/op-obsidian/src/sidebarView.ts
@@ -35,7 +35,11 @@ export class OpSidebarView extends ItemView {
     private bus: EventBus,
     private getSettings: () => ViewSettings,
     private revealAgent?: (entry: IssueEntry) => void | Promise<void>,
-    private launchAgent?: (entry: IssueEntry, mode: AgentLaunchMode) => void | Promise<void>,
+    private launchAgent?: (
+      entry: IssueEntry,
+      mode: AgentLaunchMode,
+      forcePick: boolean,
+    ) => void | Promise<void>,
   ) {
     super(leaf);
   }
@@ -141,22 +145,22 @@ export class OpSidebarView extends ItemView {
         });
         setIcon(launchBtn, "play");
         launchBtn.setAttr("aria-label", `Launch agent for ${e.id}`);
-        launchBtn.setAttr("title", "Launch agent");
+        launchBtn.setAttr("title", "Launch agent (cmd/ctrl-click to pick agent)");
         launchBtn.addEventListener("click", (ev) => {
           ev.preventDefault();
           ev.stopPropagation();
-          void this.launchAgent?.(e, "implement");
+          void this.launchAgent?.(e, "implement", ev.metaKey || ev.ctrlKey);
         });
         const planBtn = actions.createEl("button", {
           cls: "op-sidebar__action op-sidebar__action--plan",
         });
         setIcon(planBtn, "clipboard-list");
         planBtn.setAttr("aria-label", `Launch agent in plan mode for ${e.id}`);
-        planBtn.setAttr("title", "Launch agent (plan mode)");
+        planBtn.setAttr("title", "Launch agent (plan mode) (cmd/ctrl-click to pick agent)");
         planBtn.addEventListener("click", (ev) => {
           ev.preventDefault();
           ev.stopPropagation();
-          void this.launchAgent?.(e, "plan");
+          void this.launchAgent?.(e, "plan", ev.metaKey || ev.ctrlKey);
         });
       }
       const meta = li.createDiv({ cls: "op-sidebar__meta" });

--- a/plugins/op/.claude-plugin/plugin.json
+++ b/plugins/op/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "op",
   "description": "Obsidian Projects workflow — schema, slash commands, and agent skill for running a Jira-lite issue tracker inside an Obsidian vault.",
-  "version": "0.42.0",
+  "version": "0.43.0",
   "author": {
     "name": "Eugene Archibald"
   },


### PR DESCRIPTION
## Summary
- Modifier-click (cmd on macOS, ctrl elsewhere) on the sidebar's ▶ launch and clipboard plan buttons now forces the agent picker instead of using the default agent — closes the gap between the no-modifier launch (default agent) and the `op-open-agent-pick` command (always picks).
- Plugin-internal wiring only: extends the `launchAgent` callback signature in `sidebarView.ts` with a third `forcePick: boolean`, reads `ev.metaKey || ev.ctrlKey` off the click `MouseEvent`, and forwards through `main.ts:289` into the existing `doOpenAgent({ mode, forcePick })` path. `openAgent.ts`'s `mustPick = forcePick || alwaysPick` (line 178) already does the right thing — no changes needed below the boundary.
- Tooltips updated to "Launch agent (cmd/ctrl-click to pick agent)" and "Launch agent (plan mode) (cmd/ctrl-click to pick agent)" so the gesture is discoverable.
- Bumped to 0.43.0 (minor — additive user-facing behavior, no API change).

## Test plan
- [x] Build green via `node scripts/bump-version.mjs minor`.
- [x] Sync into Agent-Vault and reload — `app.plugins.plugins["op-obsidian"].manifest.version` reports 0.43.0.
- [x] Sidebar renders 20 launch + 20 plan buttons after reload; tooltips reflect new text in the DOM.
- [x] Built `main.js` contains `metaKey`, `ctrlKey`, and the new tooltip string twice each (once per button).
- [ ] Manual: cmd-click play → AgentPickerModal appears, picked agent launches in tmux.
- [ ] Manual: plain click play → default agent launches without modal.
- [ ] Manual: cmd-click clipboard → AgentPickerModal appears, picked agent launches in plan mode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)