### PR TITLE
OP-158: command palette — hide op-dev:*, trim names

### DIFF
--- a/plugins/op-obsidian/manifest.json
+++ b/plugins/op-obsidian/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "op-obsidian",
   "name": "Obsidian Projects (op)",
-  "version": "0.45.0",
+  "version": "0.46.0",
   "minAppVersion": "1.5.0",
   "description": "Jira-lite issue tracker for Obsidian vaults — deterministic commands backing the op workflow.",
   "author": "Eugene Archibald",

--- a/plugins/op-obsidian/package.json
+++ b/plugins/op-obsidian/package.json
@@ -1,6 +1,6 @@
 {
   "name": "op-obsidian",
-  "version": "0.45.0",
+  "version": "0.46.0",
   "description": "Obsidian plugin that owns the deterministic half of the op workflow.",
   "main": "main.js",
   "scripts": {

--- a/plugins/op-obsidian/src/main.ts
+++ b/plugins/op-obsidian/src/main.ts
@@ -605,6 +605,9 @@ export default class OpPlugin extends Plugin {
     }
 
     // Install hooks in the background so SessionEnd reports land reliably.
+    // Intentionally ungated — this is the silent background path that must
+    // always run regardless of showDevCommands. Only the *palette command*
+    // (above) is gated; removing it from the palette does not disable hooks.
     void this.runInstallAgentHooks(false);
 
     const resolveFlags = {

--- a/plugins/op-obsidian/src/main.ts
+++ b/plugins/op-obsidian/src/main.ts
@@ -389,19 +389,19 @@ export default class OpPlugin extends Plugin {
 
     this.addCommand({
       id: "op-open-agent-pick",
-      name: "op: open agent (pick at runtime)",
+      name: "op: open agent (pick)",
       callback: () => this.runOpenAgentCommand(true),
     });
 
     this.addCommand({
       id: "op-open-agent-plan",
-      name: "op: open agent for issue in PLAN MODE",
+      name: "op: open agent (plan mode)",
       callback: () => this.runOpenAgentCommand(false, "plan"),
     });
 
     this.addCommand({
       id: "op-open-agent-plan-pick",
-      name: "op: open agent in PLAN MODE (pick at runtime)",
+      name: "op: open agent (plan mode, pick)",
       callback: () => this.runOpenAgentCommand(true, "plan"),
     });
 
@@ -437,39 +437,45 @@ export default class OpPlugin extends Plugin {
 
     this.addCommand({
       id: "op-migrate-links",
-      name: "op: migrate legacy parent_issue/subissues to parent/children",
+      name: "op: migrate legacy issue links",
       callback: () => void this.runMigrateLinksCommand(),
     });
 
-    this.addCommand({
-      id: "op-debug-agent-launch",
-      name: "op-dev: open agent to debug agent launch",
-      callback: () => void this.runDebugAgentLaunch(),
-    });
+    // op-dev:* commands are gated by settings.developer.showDevCommands so
+    // end-user palettes aren't crowded with plugin-author diagnostics. The
+    // toggle takes effect on next plugin reload — Obsidian's addCommand has
+    // no removeCommand companion.
+    if (this.settings.developer.showDevCommands) {
+      this.addCommand({
+        id: "op-debug-agent-launch",
+        name: "op-dev: open agent to debug agent launch",
+        callback: () => void this.runDebugAgentLaunch(),
+      });
 
-    this.addCommand({
-      id: "op-dump-store",
-      name: "op-dev: dump IssueStore to console",
-      callback: () => {
-        const issues = this.store.issues();
-        const tasks = this.store.tasks();
-        console.log("[op-obsidian] IssueStore dump", {
-          issues: issues.length,
-          tasks: tasks.length,
-          entries: [...issues, ...tasks],
-        });
-        new Notice(`op: ${issues.length} issues, ${tasks.length} tasks (see console)`);
-      },
-    });
+      this.addCommand({
+        id: "op-dump-store",
+        name: "op-dev: dump IssueStore to console",
+        callback: () => {
+          const issues = this.store.issues();
+          const tasks = this.store.tasks();
+          console.log("[op-obsidian] IssueStore dump", {
+            issues: issues.length,
+            tasks: tasks.length,
+            entries: [...issues, ...tasks],
+          });
+          new Notice(`op: ${issues.length} issues, ${tasks.length} tasks (see console)`);
+        },
+      });
 
-    this.addCommand({
-      id: "op-rebuild-store",
-      name: "op-dev: rebuild IssueStore",
-      callback: () => {
-        this.store.rebuild();
-        new Notice("op: store rebuilt");
-      },
-    });
+      this.addCommand({
+        id: "op-rebuild-store",
+        name: "op-dev: rebuild IssueStore",
+        callback: () => {
+          this.store.rebuild();
+          new Notice("op: store rebuilt");
+        },
+      });
+    }
 
     this.registerObsidianProtocolHandler("op-scaffold", (params) => {
       this.runUri("op-scaffold", normalizeUriParams(params), (p) => this.handleOpScaffoldUri(p));
@@ -588,13 +594,15 @@ export default class OpPlugin extends Plugin {
       );
     });
 
-    this.addCommand({
-      id: "op-install-agent-hooks",
-      name: "op-dev: install SessionEnd hooks for agents",
-      callback: () => {
-        void this.runInstallAgentHooks(true);
-      },
-    });
+    if (this.settings.developer.showDevCommands) {
+      this.addCommand({
+        id: "op-install-agent-hooks",
+        name: "op-dev: install SessionEnd hooks for agents",
+        callback: () => {
+          void this.runInstallAgentHooks(true);
+        },
+      });
+    }
 
     // Install hooks in the background so SessionEnd reports land reliably.
     void this.runInstallAgentHooks(false);

--- a/plugins/op-obsidian/src/settings.test.ts
+++ b/plugins/op-obsidian/src/settings.test.ts
@@ -170,6 +170,9 @@ describe("mergeSettings", () => {
     expect(mergeSettings({ developer: "garbage" as unknown as object }).developer.showDevCommands).toBe(
       false,
     );
+    // null and array inputs fall through to default (matches agents/github pattern)
+    expect(mergeSettings({ developer: null as unknown as object }).developer.showDevCommands).toBe(false);
+    expect(mergeSettings({ developer: [] as unknown as object }).developer.showDevCommands).toBe(false);
   });
 
   it("projectOrder rejects non-array, drops non-string / blank / duplicate entries", () => {

--- a/plugins/op-obsidian/src/settings.test.ts
+++ b/plugins/op-obsidian/src/settings.test.ts
@@ -13,6 +13,7 @@ describe("mergeSettings", () => {
       expect(out.view).not.toBe(DEFAULT_SETTINGS.view);
       expect(out.github).not.toBe(DEFAULT_SETTINGS.github);
       expect(out.agents).not.toBe(DEFAULT_SETTINGS.agents);
+      expect(out.developer).not.toBe(DEFAULT_SETTINGS.developer);
       expect(out.flow).not.toBe(DEFAULT_SETTINGS.flow);
       expect(out.orchestrator).not.toBe(DEFAULT_SETTINGS.orchestrator);
       expect(out.workingDirs).not.toBe(DEFAULT_SETTINGS.workingDirs);
@@ -155,6 +156,20 @@ describe("mergeSettings", () => {
   it("projectOrder defaults to [] and accepts a sanitised string array", () => {
     expect(mergeSettings({}).projectOrder).toEqual([]);
     expect(mergeSettings({ projectOrder: ["foo", "bar"] }).projectOrder).toEqual(["foo", "bar"]);
+  });
+
+  it("developer.showDevCommands defaults to false; accepts boolean override; rejects non-boolean", () => {
+    expect(mergeSettings({}).developer.showDevCommands).toBe(false);
+    expect(mergeSettings({ developer: { showDevCommands: true } }).developer.showDevCommands).toBe(
+      true,
+    );
+    expect(
+      mergeSettings({ developer: { showDevCommands: "yes" as unknown as boolean } }).developer
+        .showDevCommands,
+    ).toBe(false);
+    expect(mergeSettings({ developer: "garbage" as unknown as object }).developer.showDevCommands).toBe(
+      false,
+    );
   });
 
   it("projectOrder rejects non-array, drops non-string / blank / duplicate entries", () => {

--- a/plugins/op-obsidian/src/settings.ts
+++ b/plugins/op-obsidian/src/settings.ts
@@ -30,6 +30,7 @@ export type {
   ViewSettings,
   GithubSettings,
   AgentsSettings,
+  DeveloperSettings,
   FlowSettings,
   OpSettings,
 } from "./settingsPure";
@@ -752,6 +753,20 @@ export class OpSettingsTab extends PluginSettingTab {
             s.flow.headlessTimeoutMs = n;
             await this.plugin.saveSettings();
           }
+        }),
+      );
+
+    containerEl.createEl("h2", { text: "Advanced" });
+
+    new Setting(containerEl)
+      .setName("Show developer commands in palette")
+      .setDesc(
+        "Show op-dev:* debugging commands (dump-store, rebuild-store, install-agent-hooks, debug agent launch) in the command palette. Reload the plugin after changing — Obsidian only registers commands at plugin load.",
+      )
+      .addToggle((t) =>
+        t.setValue(s.developer.showDevCommands).onChange(async (v) => {
+          s.developer.showDevCommands = v;
+          await this.plugin.saveSettings();
         }),
       );
   }

--- a/plugins/op-obsidian/src/settings.ts
+++ b/plugins/op-obsidian/src/settings.ts
@@ -767,6 +767,7 @@ export class OpSettingsTab extends PluginSettingTab {
         t.setValue(s.developer.showDevCommands).onChange(async (v) => {
           s.developer.showDevCommands = v;
           await this.plugin.saveSettings();
+          new Notice("Reload the plugin to apply — Settings → Community plugins → op-obsidian → toggle off then on.", 8000);
         }),
       );
   }

--- a/plugins/op-obsidian/src/settingsPure.ts
+++ b/plugins/op-obsidian/src/settingsPure.ts
@@ -36,6 +36,14 @@ export interface AgentsSettings {
   enforceWorktree: boolean;
 }
 
+export interface DeveloperSettings {
+  // When true, `op-dev:*` debugging commands appear in the command palette.
+  // Default false so end-user palettes aren't crowded with plugin-author
+  // diagnostics. Reload the plugin after toggling — Obsidian's `addCommand`
+  // is a one-shot at plugin-load and has no `removeCommand` companion.
+  showDevCommands: boolean;
+}
+
 export interface FlowSettings {
   // When true, the SessionEnd hook auto-launches the next stage per the
   // flowOrchestrator transition matrix. Default false so the v1 ship doesn't
@@ -63,6 +71,7 @@ export interface OpSettings {
   view: ViewSettings;
   github: GithubSettings;
   agents: AgentsSettings;
+  developer: DeveloperSettings;
   flow: FlowSettings;
   orchestrator: OrchestratorSettings;
   orchestratorState: RegistryData;
@@ -100,6 +109,9 @@ export const DEFAULT_SETTINGS: OpSettings = {
   },
   agents: {
     enforceWorktree: false,
+  },
+  developer: {
+    showDevCommands: false,
   },
   flow: {
     autoAdvance: false,
@@ -177,6 +189,12 @@ export function mergeSettings(loaded: unknown): OpSettings {
     const a = l.agents as Partial<AgentsSettings>;
     if (typeof a.enforceWorktree === "boolean") {
       base.agents.enforceWorktree = a.enforceWorktree;
+    }
+  }
+  if (l.developer && typeof l.developer === "object") {
+    const d = l.developer as Partial<DeveloperSettings>;
+    if (typeof d.showDevCommands === "boolean") {
+      base.developer.showDevCommands = d.showDevCommands;
     }
   }
   if (Array.isArray((l as { projectOrder?: unknown }).projectOrder)) {

--- a/plugins/op/.claude-plugin/plugin.json
+++ b/plugins/op/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "op",
   "description": "Obsidian Projects workflow — schema, slash commands, and agent skill for running a Jira-lite issue tracker inside an Obsidian vault.",
-  "version": "0.45.0",
+  "version": "0.46.0",
   "author": {
     "name": "Eugene Archibald"
   },


### PR DESCRIPTION
## Summary

§7 of OP-149 (`docs/specs/OP-149-feel-great-ux-design.md`). First PR in the spec rollout (per OP-165 §16, "Recommended order" #1).

- New default-off setting `Show developer commands in palette` (under a new **Advanced** section in the op settings tab). Gates the four `op-dev:*` registrations (`op-debug-agent-launch`, `op-dump-store`, `op-rebuild-store`, `op-install-agent-hooks`) behind a single `if (this.settings.developer.showDevCommands)`. Reload required to take effect — Obsidian's `addCommand` has no `removeCommand` companion; setting description calls this out.
- Trims four wordy command `name:` fields — IDs unchanged so any existing user hotkey bindings keep working:

  | id | before | after |
  |---|---|---|
  | `op-open-agent-pick` | op: open agent (pick at runtime) | op: open agent (pick) |
  | `op-open-agent-plan` | op: open agent for issue in PLAN MODE | op: open agent (plan mode) |
  | `op-open-agent-plan-pick` | op: open agent in PLAN MODE (pick at runtime) | op: open agent (plan mode, pick) |
  | `op-migrate-links` | op: migrate legacy parent_issue/subissues to parent/children | op: migrate legacy issue links |

  The bonus fourth trim (`op-open-agent-plan-pick`) keeps the trio of plan/pick names uniform — without it the lone unaltered name was the longest of the four.
- Defers `op: resume last` (§1) and `op: pick & act` (§3) — those commands belong to OP-150/OP-152 (later in the §16 rollout) and self-register when their plumbing lands.
- Bump `0.45.0 → 0.46.0` (minor — additive, user-facing) per WORKFLOW.md.

## Test plan

- [x] `npm test` in `plugins/op-obsidian/` — 39 files / 434 tests passing, including new `developer.showDevCommands` default + override + reject-non-boolean cases.
- [x] `node scripts/bump-version.mjs minor` — manifest, package.json, plugin.json all at `0.46.0`; `main.js` rebuilt and fresher than `manifest.json` (the OP-105 guardrail check).
- [x] Synced build to active vault and reloaded plugin.
- [x] Probed `app.commands.commands` with toggle off: 22 op-obsidian commands, no `op-dev:*` visible; the four trimmed commands have the new short names.
- [x] Probed with toggle on: 26 commands (4 dev commands appear).
- [x] Settings UI smoke-test: `app.setting.openTabById("op-obsidian")` renders the new `Advanced` H2 and the `Show developer commands in palette` toggle binds.
- [x] `obsidian dev:console` empty after both reloads.

## Adversarial review

Required (per WORKFLOW.md — touches palette + settings public surface, fails bypass criterion 4). Will request `@copilot` review with concrete pressure-test prompts after this PR opens.

🤖 Generated with [Claude Code](https://claude.com/claude-code)