### PR TITLE
OP-160: actionable Notices — inline action links on high-value Notices

### DIFF
--- a/plugins/op-obsidian/manifest.json
+++ b/plugins/op-obsidian/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "op-obsidian",
   "name": "Obsidian Projects (op)",
-  "version": "0.46.0",
+  "version": "0.47.0",
   "minAppVersion": "1.5.0",
   "description": "Jira-lite issue tracker for Obsidian vaults — deterministic commands backing the op workflow.",
   "author": "Eugene Archibald",

--- a/plugins/op-obsidian/package.json
+++ b/plugins/op-obsidian/package.json
@@ -1,6 +1,6 @@
 {
   "name": "op-obsidian",
-  "version": "0.46.0",
+  "version": "0.47.0",
   "description": "Obsidian plugin that owns the deterministic half of the op workflow.",
   "main": "main.js",
   "scripts": {

--- a/plugins/op-obsidian/src/actionableNotices.test.ts
+++ b/plugins/op-obsidian/src/actionableNotices.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect, vi } from "vitest";
+
+vi.mock("obsidian", () => ({
+  Notice: class {
+    constructor(_msg: unknown, _duration?: number) {}
+    hide(): void {}
+  },
+}));
+
+import { durationForActions, type NoticeAction } from "./actionableNotices";
+
+const a: NoticeAction = { label: "Open", onClick: () => {} };
+
+describe("durationForActions", () => {
+  it("returns 0 (sticky) when actions are present", () => {
+    expect(durationForActions([a])).toBe(0);
+    expect(durationForActions([a, a])).toBe(0);
+  });
+
+  it("returns 5000 when no actions are present", () => {
+    expect(durationForActions([])).toBe(5000);
+  });
+
+  it("honours an explicit duration override", () => {
+    expect(durationForActions([], 1234)).toBe(1234);
+    expect(durationForActions([a], 7777)).toBe(7777);
+    expect(durationForActions([a], 0)).toBe(0);
+  });
+});

--- a/plugins/op-obsidian/src/actionableNotices.ts
+++ b/plugins/op-obsidian/src/actionableNotices.ts
@@ -1,0 +1,58 @@
+import { Notice } from "obsidian";
+
+/**
+ * One inline action link rendered after the Notice text. Clicking dismisses
+ * the Notice and runs `onClick`.
+ */
+export interface NoticeAction {
+  label: string;
+  onClick: () => void;
+}
+
+export interface ActionableNoticeOptions {
+  /** Leading prose. Plain text only. */
+  text: string;
+  /** Inline action links rendered after the text, joined by " · ". */
+  actions?: NoticeAction[];
+  /**
+   * Override duration (ms). Default: `0` (sticky) when `actions` is non-empty,
+   * else `5000` so non-actionable Notices keep current short-toast behavior.
+   */
+  duration?: number;
+}
+
+export function durationForActions(actions: NoticeAction[], override?: number): number {
+  if (typeof override === "number") return override;
+  return actions.length > 0 ? 0 : 5000;
+}
+
+/**
+ * Show an actionable Notice — `text · [action1] · [action2] · …`.
+ * Each action link is a real `<a class="op-notice-action">`; clicking it
+ * runs `onClick` then dismisses the Notice.
+ */
+export function showActionableNotice(opts: ActionableNoticeOptions): Notice {
+  const actions = opts.actions ?? [];
+  const frag = document.createDocumentFragment();
+  frag.appendChild(document.createTextNode(opts.text));
+
+  let notice: Notice | undefined;
+  for (const action of actions) {
+    frag.appendChild(document.createTextNode(" · "));
+    const link = document.createElement("a");
+    link.textContent = `[${action.label}]`;
+    link.classList.add("op-notice-action");
+    link.addEventListener("click", (ev) => {
+      ev.preventDefault();
+      try {
+        action.onClick();
+      } finally {
+        notice?.hide();
+      }
+    });
+    frag.appendChild(link);
+  }
+
+  notice = new Notice(frag, durationForActions(actions, opts.duration));
+  return notice;
+}

--- a/plugins/op-obsidian/src/errorLog.ts
+++ b/plugins/op-obsidian/src/errorLog.ts
@@ -1,0 +1,39 @@
+import { App, TFile, normalizePath } from "obsidian";
+
+export const ERROR_LOG_PATH = "Projects/_scratch/op-last-error.md";
+
+/**
+ * Persist a single op error to a vault-side scratch note so the user (or a
+ * delegated agent) can inspect it later without needing the dev console.
+ *
+ * Overwrites the previous content — same shape as `op-last-response.md`.
+ * Returns the normalized path that the caller can hand to `[Open log]`.
+ */
+export async function writeErrorLog(
+  app: App,
+  category: string,
+  details: string,
+): Promise<string> {
+  const path = normalizePath(ERROR_LOG_PATH);
+  const folder = path.split("/").slice(0, -1).join("/");
+  if (folder && !(await app.vault.adapter.exists(folder))) {
+    await app.vault.createFolder(folder).catch(() => {});
+  }
+  const stamp = new Date().toISOString();
+  const body = `# op error log\n\n- **when**: ${stamp}\n- **category**: ${category}\n\n\`\`\`\n${details}\n\`\`\`\n`;
+  const existing = app.vault.getAbstractFileByPath(path);
+  if (existing instanceof TFile) {
+    await app.vault.modify(existing, body);
+  } else {
+    await app.vault.create(path, body);
+  }
+  return path;
+}
+
+export async function openErrorLog(app: App): Promise<void> {
+  const path = normalizePath(ERROR_LOG_PATH);
+  const f = app.vault.getAbstractFileByPath(path);
+  if (f instanceof TFile) {
+    await app.workspace.getLeaf(false).openFile(f);
+  }
+}

--- a/plugins/op-obsidian/src/main.ts
+++ b/plugins/op-obsidian/src/main.ts
@@ -88,6 +88,9 @@ import { installAgentHooks, type HookInstallResult } from "./agentHooks";
 import { userError } from "./userError";
 import { cleanupAgentSessions } from "./agentSessionCleanup";
 import { detectTmux } from "./tmuxDetect";
+import { showActionableNotice } from "./actionableNotices";
+import { probeLiveTmuxWindows, selectStaleAgentBadges } from "./staleAgentBadges";
+import { openErrorLog, writeErrorLog } from "./errorLog";
 import { configureClient } from "./iterm/client";
 import { closeTransport } from "./iterm/connection";
 import { existsSync } from "fs";
@@ -162,9 +165,18 @@ export default class OpPlugin extends Plugin {
         await this.saveSettings();
         console.debug(`[op-obsidian] tmux auto-detected: ${prev} → ${found.path}`);
       } else {
-        new Notice(
-          `op: tmux not found at ${this.settings.tmuxBinary} or common paths — agent launches will fail until you install tmux or set the path in Settings → op.`,
-        );
+        showActionableNotice({
+          text: `op: tmux not found at ${this.settings.tmuxBinary} or common paths — agent launches will fail until you install tmux or set the path in Settings → op.`,
+          actions: [
+            {
+              label: "Open settings",
+              onClick: () => {
+                (this.app as any).setting?.open?.();
+                (this.app as any).setting?.openTabById?.("op-obsidian");
+              },
+            },
+          ],
+        });
       }
     }
     this.detector = new AgentDetector((id) => {
@@ -221,14 +233,12 @@ export default class OpPlugin extends Plugin {
         new Notice(`op: no repo_path for ${entry.project} — skipping gh issue close`);
         return;
       }
-      return closeGithubIssue(
-        repoPath,
-        entry.githubIssue,
-        closeReasonForStatus(entry.status),
-      ).catch((err: any) => {
+      const reason = closeReasonForStatus(entry.status);
+      const url = entry.githubIssue;
+      return closeGithubIssue(repoPath, url, reason).catch((err: any) => {
         const msg = err?.message ?? String(err);
         console.error("[op-obsidian] gh issue close failed", msg);
-        new Notice(`op: gh issue close failed — ${msg}`);
+        void this.surfaceGhCloseError({ entryId: entry.id, repoPath, url, reason, msg });
       });
     });
 
@@ -275,6 +285,7 @@ export default class OpPlugin extends Plugin {
     // whose issue no longer exists in the vault.
     this.app.workspace.onLayoutReady(() => {
       void this.reconcileAgentStateOnStartup();
+      void this.surfaceStaleAgentBadgesOnStartup();
     });
 
     this.registerView(
@@ -897,6 +908,40 @@ export default class OpPlugin extends Plugin {
     await this.cleanupAgentStateFor(stale);
   }
 
+  /**
+   * One-shot startup probe for stale `agent:` badges — issues whose
+   * frontmatter claims an attached agent but whose tmux window is gone
+   * (crash, manual `tmux kill-window`, machine reboot). Surfaces one
+   * actionable Notice per stale issue with a `[Clear badge]` action.
+   *
+   * Skipped silently when the tmux probe fails (tmux missing / timeout) —
+   * we'd rather under-warn than fire false positives during a reboot.
+   * Continuous liveness is OP-149 §1's scope; this is a per-load floor.
+   */
+  private async surfaceStaleAgentBadgesOnStartup(): Promise<void> {
+    const issues = this.store.issues().filter((e) => !!e.agent);
+    if (issues.length === 0) return;
+    const probe = await probeLiveTmuxWindows(this.settings.tmuxBinary);
+    if (!probe.ok) {
+      console.debug("[op-obsidian] stale-agent probe skipped — tmux unavailable");
+      return;
+    }
+    const stale = selectStaleAgentBadges(issues, probe.live);
+    for (const entry of stale) {
+      showActionableNotice({
+        text: `op: ${entry.id} has no live agent`,
+        actions: [
+          {
+            label: "Clear badge",
+            onClick: () => {
+              void clearAgentOnIssue(this.app, entry.path);
+            },
+          },
+        ],
+      });
+    }
+  }
+
   private async revealSidebar(): Promise<void> {
     const existing = this.app.workspace.getLeavesOfType(OP_SIDEBAR_VIEW_TYPE);
     let leaf: WorkspaceLeaf | null = existing[0] ?? null;
@@ -986,11 +1031,27 @@ export default class OpPlugin extends Plugin {
   ): Promise<void> {
     try {
       const res = await createIssue(this.app, this.store, input);
-      new Notice(`Created ${res.id}`);
       const file = this.app.vault.getAbstractFileByPath(res.path);
       if (file instanceof TFile) {
         await this.app.workspace.getLeaf(false).openFile(file);
       }
+      showActionableNotice({
+        text: `op: created ${res.id}`,
+        actions: [
+          {
+            label: "Open",
+            onClick: () => {
+              void this.openIssue(res.entry);
+            },
+          },
+          {
+            label: "Start agent",
+            onClick: () => {
+              void this.doOpenAgent(res.entry, {});
+            },
+          },
+        ],
+      });
       if (!input.githubIssue && this.settings.github.autoCreateGithubIssue) {
         await this.autoCreateGithubIssueFor(res.path, res.id, input).catch((err) => {
           console.error("[op-obsidian] auto-create github issue failed", err);
@@ -1312,10 +1373,122 @@ export default class OpPlugin extends Plugin {
     const path = this.resolveArgsToPath(args);
     if (path) this.inFlightResolvePaths.add(path);
     try {
-      return await runResolve(this.app, this.store, this.withGhCloseHook(args));
+      const result = await runResolve(this.app, this.store, this.withGhCloseHook(args));
+      this.surfaceResolveResult(result, args.issue);
+      return result;
     } finally {
       if (path) this.inFlightResolvePaths.delete(path);
     }
+  }
+
+  /**
+   * Surface a resolve result as user-facing Notices. Two paths converge here:
+   * the explicit `op-resolve` command and the `issue:status-changed`
+   * auto-resolver. Both want the same actionable output:
+   *
+   *  - on success: `op: <ID> resolved · [Open]`, where [Open] navigates to
+   *    the post-move RESOLVED ISSUES path
+   *  - on github close failure: `op: gh issue close failed · [Retry] · [Open log]`
+   */
+  private surfaceResolveResult(
+    result: Awaited<ReturnType<typeof runResolve>>,
+    rawId?: string,
+  ): void {
+    if (result.ok) {
+      const id = result.issueId ?? rawId ?? "issue";
+      const trashed = result.trashed?.length ?? 0;
+      const status = result.status ?? "resolved";
+      const movedTo = result.movedTo;
+      const tail = trashed ? ` (${trashed} task${trashed === 1 ? "" : "s"} trashed)` : "";
+      showActionableNotice({
+        text: `op: ${id} ${status}${tail}`,
+        actions: movedTo
+          ? [
+              {
+                label: "Open",
+                onClick: () => {
+                  const f = this.app.vault.getAbstractFileByPath(movedTo);
+                  if (f instanceof TFile) {
+                    void this.app.workspace.getLeaf(false).openFile(f);
+                  }
+                },
+              },
+            ]
+          : [],
+      });
+    }
+    if (result.githubCloseError && result.issueId) {
+      const entry = this.store.issues().find((e) => e.id === result.issueId);
+      const url = entry?.githubIssue;
+      const repoPath = entry
+        ? resolveRepoPath(this.app, this.settings, entry.project)
+        : undefined;
+      const reason =
+        entry && (entry.status === "resolved" || entry.status === "wontfix")
+          ? closeReasonForStatus(entry.status)
+          : closeReasonForStatus("resolved");
+      void this.surfaceGhCloseError({
+        entryId: result.issueId,
+        repoPath,
+        url,
+        reason,
+        msg: result.githubCloseError,
+      });
+    }
+  }
+
+  /**
+   * Show the actionable `gh issue close failed` Notice. `[Retry]` re-runs
+   * `closeGithubIssue` directly; `[Open log]` writes the error to a vault
+   * scratch note and opens it. When the retry context is incomplete (we
+   * couldn't resolve a repo path or URL), the retry action is dropped — the
+   * Notice still informs the user and offers `[Open log]`.
+   */
+  private async surfaceGhCloseError(args: {
+    entryId: string;
+    repoPath?: string;
+    url?: string;
+    reason: ReturnType<typeof closeReasonForStatus>;
+    msg: string;
+  }): Promise<void> {
+    const logPath = await writeErrorLog(
+      this.app,
+      `gh issue close (${args.entryId})`,
+      [`url: ${args.url ?? "<unknown>"}`, `repo: ${args.repoPath ?? "<unknown>"}`, `error: ${args.msg}`].join("\n"),
+    ).catch((err) => {
+      console.error("[op-obsidian] errorLog.write failed", err);
+      return undefined;
+    });
+    const actions: Array<{ label: string; onClick: () => void }> = [];
+    if (args.repoPath && args.url) {
+      const { repoPath, url, reason, entryId } = args;
+      actions.push({
+        label: "Retry",
+        onClick: () => {
+          void closeGithubIssue(repoPath, url, reason)
+            .then(() => {
+              showActionableNotice({ text: `op: gh issue closed for ${entryId}` });
+            })
+            .catch((err: any) => {
+              const msg = err?.message ?? String(err);
+              console.error("[op-obsidian] gh issue close retry failed", msg);
+              showActionableNotice({
+                text: `op: gh issue close retry failed — ${msg}`,
+                actions: logPath
+                  ? [{ label: "Open log", onClick: () => void openErrorLog(this.app) }]
+                  : [],
+              });
+            });
+        },
+      });
+    }
+    if (logPath) {
+      actions.push({ label: "Open log", onClick: () => void openErrorLog(this.app) });
+    }
+    showActionableNotice({
+      text: `op: gh issue close failed for ${args.entryId}`,
+      actions,
+    });
   }
 
   private resolveArgsToPath(args: ResolveArgs): string | undefined {

--- a/plugins/op-obsidian/src/main.ts
+++ b/plugins/op-obsidian/src/main.ts
@@ -86,7 +86,7 @@ import { editWorkflow } from "./editWorkflow";
 import { launchInTerminal } from "./terminalLaunch";
 import { installAgentHooks, type HookInstallResult } from "./agentHooks";
 import { userError } from "./userError";
-import { cleanupAgentSessions } from "./agentSessionCleanup";
+import { cleanupAgentSessions, tmuxSessionsForCleanup } from "./agentSessionCleanup";
 import { detectTmux } from "./tmuxDetect";
 import { showActionableNotice } from "./actionableNotices";
 import { probeLiveTmuxWindows, selectStaleAgentBadges } from "./staleAgentBadges";
@@ -921,7 +921,13 @@ export default class OpPlugin extends Plugin {
   private async surfaceStaleAgentBadgesOnStartup(): Promise<void> {
     const issues = this.store.issues().filter((e) => !!e.agent);
     if (issues.length === 0) return;
-    const probe = await probeLiveTmuxWindows(this.settings.tmuxBinary);
+    // Brief delay so `op-work` mid-flight at startup can finish creating its
+    // tmux window before we probe — reduces false-positive [Clear badge] Notices.
+    await new Promise((r) => setTimeout(r, 2000));
+    const probe = await probeLiveTmuxWindows(
+      this.settings.tmuxBinary,
+      tmuxSessionsForCleanup(this.settings.orchestratorState),
+    );
     if (!probe.ok) {
       console.debug("[op-obsidian] stale-agent probe skipped — tmux unavailable");
       return;
@@ -1462,9 +1468,12 @@ export default class OpPlugin extends Plugin {
     const actions: Array<{ label: string; onClick: () => void }> = [];
     if (args.repoPath && args.url) {
       const { repoPath, url, reason, entryId } = args;
+      let retryFired = false;
       actions.push({
         label: "Retry",
         onClick: () => {
+          if (retryFired) return;
+          retryFired = true;
           void closeGithubIssue(repoPath, url, reason)
             .then(() => {
               showActionableNotice({ text: `op: gh issue closed for ${entryId}` });

--- a/plugins/op-obsidian/src/main.ts
+++ b/plugins/op-obsidian/src/main.ts
@@ -96,6 +96,13 @@ import { closeTransport } from "./iterm/connection";
 import { existsSync } from "fs";
 
 /**
+ * How long to wait after `onLayoutReady` before probing tmux for stale agent
+ * badges. Gives `op-work` mid-flight at startup time to create its tmux window
+ * so we don't fire a false-positive [Clear badge] Notice during that window.
+ */
+const STALE_AGENT_PROBE_DELAY_MS = 2_000;
+
+/**
  * The Obsidian plugin half of the Obsidian Projects workflow.
  *
  * Responsibilities:
@@ -923,7 +930,7 @@ export default class OpPlugin extends Plugin {
     if (issues.length === 0) return;
     // Brief delay so `op-work` mid-flight at startup can finish creating its
     // tmux window before we probe — reduces false-positive [Clear badge] Notices.
-    await new Promise((r) => setTimeout(r, 2000));
+    await new Promise((r) => setTimeout(r, STALE_AGENT_PROBE_DELAY_MS));
     const probe = await probeLiveTmuxWindows(
       this.settings.tmuxBinary,
       tmuxSessionsForCleanup(this.settings.orchestratorState),

--- a/plugins/op-obsidian/src/resolve.ts
+++ b/plugins/op-obsidian/src/resolve.ts
@@ -1,4 +1,4 @@
-import { App, Modal, Notice, Setting, TFile, normalizePath } from "obsidian";
+import { App, Modal, Setting, TFile, normalizePath } from "obsidian";
 import type { IssueStore } from "./issueStore";
 import type { IssueEntry, TaskEntry } from "./types";
 import { findIssue } from "./findIssue";
@@ -91,11 +91,8 @@ export async function runResolve(
       if (entry.githubIssue) githubClosed = true;
     } catch (err: any) {
       githubCloseError = err?.message ?? String(err);
-      new Notice(`op: github close failed — ${githubCloseError}`);
     }
   }
-
-  new Notice(`op: ${entry.id} → ${targetStatus} (${trashed.length} tasks trashed)`);
 
   return {
     ok: true,

--- a/plugins/op-obsidian/src/staleAgentBadges.test.ts
+++ b/plugins/op-obsidian/src/staleAgentBadges.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect } from "vitest";
+import type { IssueEntry } from "./types";
+import { selectStaleAgentBadges } from "./staleAgentBadges";
+
+function entry(over: Partial<IssueEntry>): IssueEntry {
+  return {
+    path: "x.md",
+    type: "issue",
+    id: "OP-1",
+    project: "obsidian-projects",
+    status: "in-progress",
+    title: "OP-1 placeholder",
+    resolvedFolder: false,
+    ...over,
+  };
+}
+
+describe("selectStaleAgentBadges", () => {
+  it("returns issues with agent: set but no live window", () => {
+    const issues = [
+      entry({ id: "OP-1", agent: "claude" }),
+      entry({ id: "OP-2", agent: "gemini" }),
+    ];
+    const live = new Set(["OP-2"]);
+    expect(selectStaleAgentBadges(issues, live).map((e) => e.id)).toEqual(["OP-1"]);
+  });
+
+  it("ignores issues without agent: set", () => {
+    const issues = [entry({ id: "OP-1" })];
+    expect(selectStaleAgentBadges(issues, new Set())).toEqual([]);
+  });
+
+  it("skips resolved / wontfix issues even with agent: set", () => {
+    const issues = [
+      entry({ id: "OP-1", agent: "claude", status: "resolved" }),
+      entry({ id: "OP-2", agent: "claude", status: "wontfix" }),
+      entry({ id: "OP-3", agent: "claude", resolvedFolder: true }),
+    ];
+    expect(selectStaleAgentBadges(issues, new Set())).toEqual([]);
+  });
+
+  it("returns empty when every agent has a live window", () => {
+    const issues = [
+      entry({ id: "OP-1", agent: "claude" }),
+      entry({ id: "OP-2", agent: "gemini" }),
+    ];
+    const live = new Set(["OP-1", "OP-2"]);
+    expect(selectStaleAgentBadges(issues, live)).toEqual([]);
+  });
+
+  it("uses the tmux-window name derived from the issue id", () => {
+    // Window names sanitize non-alnum-dash-underscore — id "OP-1" maps to "OP-1"
+    // already, so a literal id match is sufficient here. Verifying with a
+    // sanitized form documents the expectation explicitly.
+    const issues = [entry({ id: "OP-1", agent: "claude" })];
+    expect(selectStaleAgentBadges(issues, new Set(["OP-1"]))).toEqual([]);
+    expect(selectStaleAgentBadges(issues, new Set(["op-1"]))).toHaveLength(1);
+  });
+});

--- a/plugins/op-obsidian/src/staleAgentBadges.ts
+++ b/plugins/op-obsidian/src/staleAgentBadges.ts
@@ -1,0 +1,60 @@
+import { execFile } from "child_process";
+import { promisify } from "util";
+import type { IssueEntry } from "./types";
+import { SHARED_TMUX_SESSION, tmuxWindowName } from "./terminalLaunch";
+
+const pExecFile = promisify(execFile);
+
+export interface TmuxProbeResult {
+  /** Set of live tmux window names (`#W`) on the shared session. */
+  live: Set<string>;
+  /** True if the probe ran successfully. False on tmux missing / timeout / error. */
+  ok: boolean;
+}
+
+/**
+ * Pure: pick the issues whose `agent:` is set but whose tmux window is not
+ * present on the shared session. Resolved/closed issues are skipped (their
+ * agent fields are cleared by the resolve flow; if one slips through, the
+ * fix is in the resolve path, not here).
+ */
+export function selectStaleAgentBadges(
+  issues: ReadonlyArray<IssueEntry>,
+  liveWindowNames: ReadonlySet<string>,
+): IssueEntry[] {
+  const stale: IssueEntry[] = [];
+  for (const e of issues) {
+    if (!e.agent) continue;
+    if (e.resolvedFolder) continue;
+    if (e.status === "resolved" || e.status === "wontfix") continue;
+    if (!liveWindowNames.has(tmuxWindowName(e.id))) stale.push(e);
+  }
+  return stale;
+}
+
+/**
+ * Probe `tmux list-windows -t op-agents -F '#W'` once. Returns the live window
+ * names plus an `ok` flag — callers must treat `ok: false` as "unknown" and
+ * skip stale-detection rather than emit false positives.
+ *
+ * Uses `execFile` (no shell) and a 500ms timeout, matching the spec's §1
+ * implementation rule.
+ */
+export async function probeLiveTmuxWindows(tmuxBinary: string): Promise<TmuxProbeResult> {
+  try {
+    const { stdout } = await pExecFile(
+      tmuxBinary,
+      ["list-windows", "-t", SHARED_TMUX_SESSION, "-F", "#W"],
+      { timeout: 500 },
+    );
+    const live = new Set(
+      stdout
+        .split("\n")
+        .map((s) => s.trim())
+        .filter(Boolean),
+    );
+    return { live, ok: true };
+  } catch {
+    return { live: new Set(), ok: false };
+  }
+}

--- a/plugins/op-obsidian/src/staleAgentBadges.ts
+++ b/plugins/op-obsidian/src/staleAgentBadges.ts
@@ -33,28 +33,42 @@ export function selectStaleAgentBadges(
 }
 
 /**
- * Probe `tmux list-windows -t op-agents -F '#W'` once. Returns the live window
- * names plus an `ok` flag — callers must treat `ok: false` as "unknown" and
- * skip stale-detection rather than emit false positives.
+ * Probe `tmux list-windows -t <session> -F '#W'` for each given session.
+ * Returns the union of live window names plus an `ok` flag — callers must
+ * treat `ok: false` as "unknown" and skip stale-detection rather than emit
+ * false positives.
  *
- * Uses `execFile` (no shell) and a 500ms timeout, matching the spec's §1
- * implementation rule.
+ * Uses `execFile` (no shell) and a 500ms timeout per session, matching the
+ * spec's §1 implementation rule.  Passing multiple sessions (shared session
+ * + per-window sessions from the orchestrator registry) mirrors what
+ * `agentSessionCleanup.ts` does when killing windows.
+ *
+ * Error semantics:
+ *   - tmux binary missing (ENOENT) or timeout → `ok: false` (abort entire probe)
+ *   - session absent (tmux exits non-zero) → treat as 0 live windows; continue
  */
-export async function probeLiveTmuxWindows(tmuxBinary: string): Promise<TmuxProbeResult> {
-  try {
-    const { stdout } = await pExecFile(
-      tmuxBinary,
-      ["list-windows", "-t", SHARED_TMUX_SESSION, "-F", "#W"],
-      { timeout: 500 },
-    );
-    const live = new Set(
-      stdout
-        .split("\n")
-        .map((s) => s.trim())
-        .filter(Boolean),
-    );
-    return { live, ok: true };
-  } catch {
-    return { live: new Set(), ok: false };
+export async function probeLiveTmuxWindows(
+  tmuxBinary: string,
+  sessions: string[] = [SHARED_TMUX_SESSION],
+): Promise<TmuxProbeResult> {
+  const live = new Set<string>();
+  for (const session of sessions) {
+    try {
+      const { stdout } = await pExecFile(
+        tmuxBinary,
+        ["list-windows", "-t", session, "-F", "#W"],
+        { timeout: 500 },
+      );
+      for (const name of stdout.split("\n").map((s) => s.trim()).filter(Boolean)) {
+        live.add(name);
+      }
+    } catch (err: any) {
+      // Binary missing or timeout → abort; we'd surface false positives otherwise.
+      if (err?.code === "ENOENT" || err?.killed) {
+        return { live: new Set(), ok: false };
+      }
+      // Session absent (tmux exits with non-zero code) — zero windows; continue.
+    }
   }
+  return { live, ok: true };
 }

--- a/plugins/op-obsidian/styles.css
+++ b/plugins/op-obsidian/styles.css
@@ -182,6 +182,17 @@ a.op-sidebar__agent:hover {
   text-decoration: underline;
 }
 
+.op-notice-action {
+  color: var(--text-accent);
+  cursor: pointer;
+  text-decoration: none;
+  font-weight: 500;
+}
+
+.op-notice-action:hover {
+  text-decoration: underline;
+}
+
 .op-project-order__list {
   list-style: none;
   margin: 0.5rem 0;

--- a/plugins/op/.claude-plugin/plugin.json
+++ b/plugins/op/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "op",
   "description": "Obsidian Projects workflow — schema, slash commands, and agent skill for running a Jira-lite issue tracker inside an Obsidian vault.",
-  "version": "0.46.0",
+  "version": "0.47.0",
   "author": {
     "name": "Eugene Archibald"
   },


### PR DESCRIPTION
## Summary

- Migrates four high-value op Notices to `DocumentFragment` form with inline `<a>` action links via a new `showActionableNotice()` helper. Sticky (`duration: 0`) when actions are present so clicks aren't lost; click dismisses.
- Adds a one-shot startup probe (`surfaceStaleAgentBadgesOnStartup`) that surfaces issues with `agent:` set but no live tmux window — currently silent — with a `[Clear badge]` action. Continuous liveness probing remains OP-149 §1's scope.
- New errors from `gh issue close` are written to a vault scratch note (`Projects/_scratch/op-last-error.md`) so `[Open log]` is vault-native rather than dev-console-only.

### Migrated call sites

| Trigger | Before | After |
|---|---|---|
| Resolve succeeded | `op: OP-72 → resolved (3 tasks trashed)` | `op: OP-72 resolved (3 tasks trashed) · [Open]` |
| `op-new` succeeded | `Created OP-149` | `op: created OP-149 · [Open] · [Start agent]` |
| `gh issue close` failed | `op: gh issue close failed — <msg>` | `op: gh issue close failed for OP-72 · [Retry] · [Open log]` |
| Stale agent badge | (silent) | `op: OP-42 has no live agent · [Clear badge]` |
| tmux missing | `op: tmux not found at …` | `op: tmux not found at … · [Open settings]` |

### Files

- NEW `plugins/op-obsidian/src/actionableNotices.{ts,test.ts}` — helper + duration-heuristic unit tests
- NEW `plugins/op-obsidian/src/staleAgentBadges.{ts,test.ts}` — pure selector + 500ms-timeout tmux probe + tests
- NEW `plugins/op-obsidian/src/errorLog.ts` — vault-scratch error log writer/opener
- EDIT `plugins/op-obsidian/src/main.ts` — migrate sites; wire startup probe; centralize resolve / gh-close surfacing in `surfaceResolveResult` / `surfaceGhCloseError`
- EDIT `plugins/op-obsidian/src/resolve.ts` — drop UI Notices; surfacing is the caller's job now
- EDIT `plugins/op-obsidian/styles.css` — `.op-notice-action`
- BUMP `0.46.0 → 0.47.0` (minor — additive helper + new startup probe)

## Test plan

- [x] `npm run test` in `plugins/op-obsidian/` — 459 tests pass (added 8 new across two suites)
- [x] `npm run build` — clean (verified main.js fresher than manifest by `bump-version.mjs`)
- [x] Plugin reloaded in Agent-Vault at 0.47.0; `obsidian dev:console` clean after probe + synthetic Notice triggers
- [x] Synthetic `surfaceGhCloseError` rendered Notice with `[Retry]` + `[Open log]`; click on `[Open log]` navigated to `Projects/_scratch/op-last-error.md` (verified via `app.workspace.getActiveFile()?.path`)
- [x] Synthetic `surfaceResolveResult` rendered `op: TEST-RES resolved (1 task trashed) · [Open]`
- [x] Stale-agent probe ran clean — both `agent:`-bearing issues had live tmux windows so no Notices fired (correct behavior; manual kill-window test would surface the Notice)

### Pressure-test prompts for review

- **Click-handler lifecycle.** The action `<a>` elements live inside a `DocumentFragment` that becomes part of the Notice DOM; we capture the `Notice` reference in a closure to call `hide()` from the click handler. Is there a leak path if the user dismisses the Notice via the built-in close `×` before any action is clicked?
- **`[Retry]` re-entrancy.** The retry path calls `closeGithubIssue` directly. If the user spam-clicks `[Retry]`, we get N parallel `gh` invocations. The Notice doesn't currently disable the link after first click — is this acceptable, or should the retry be debounced?
- **Stale-probe race vs `op-work` mid-startup.** If `op-work` is mid-flight when `onLayoutReady` fires, an issue could have `agent:` written before its tmux window appears. The probe could fire a false-positive Notice during that microscopic window. Worth noting; mitigation would be an N-second post-probe delay, but the probe is already a one-shot and `[Clear badge]` is reversible — accepting it for now.
- **`[Open log]` privacy.** The error log can include the gh URL and repo path. Persisting these to a vault scratch note is more visible than the dev console — intentional (matches the `op-last-response.md` precedent), but flag if review thinks otherwise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)