### PR TITLE
OP-110: close orphan iTerm window when last agent resolves; bump to 0.48.0

### DIFF
--- a/plugins/op-obsidian/manifest.json
+++ b/plugins/op-obsidian/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "op-obsidian",
   "name": "Obsidian Projects (op)",
-  "version": "0.47.0",
+  "version": "0.48.0",
   "minAppVersion": "1.5.0",
   "description": "Jira-lite issue tracker for Obsidian vaults — deterministic commands backing the op workflow.",
   "author": "Eugene Archibald",

--- a/plugins/op-obsidian/package.json
+++ b/plugins/op-obsidian/package.json
@@ -1,6 +1,6 @@
 {
   "name": "op-obsidian",
-  "version": "0.47.0",
+  "version": "0.48.0",
   "description": "Obsidian plugin that owns the deterministic half of the op workflow.",
   "main": "main.js",
   "scripts": {

--- a/plugins/op-obsidian/src/agentSessionCleanup.test.ts
+++ b/plugins/op-obsidian/src/agentSessionCleanup.test.ts
@@ -1,5 +1,6 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import {
+  cleanupAgentSessions,
   pruneRegistryForIssue,
   pruneRegistryMissingIssues,
   tmuxSessionsForCleanup,
@@ -80,6 +81,115 @@ describe("pruneRegistryMissingIssues", () => {
     expect(Object.keys(removed)).toEqual(["OP-2"]);
     expect(r.surfaces["OP-1"]).toBeDefined();
     expect(r.surfaces["OP-2"]).toBeUndefined();
+  });
+});
+
+describe("cleanupAgentSessions: empty-window closure (OP-110)", () => {
+  it("closes and removes the iTerm window when the last cell is freed", async () => {
+    const r = emptyRegistry();
+    addWindow(r, win("w1", "op-agents-1"));
+    assignSurface(r, "OP-50", {
+      sessionId: "s0",
+      windowId: "w1",
+      cellIndex: 0,
+      layoutId: "2x2",
+      tmuxWindow: "OP-50",
+    });
+
+    const close = vi.fn().mockResolvedValue(undefined);
+    const res = await cleanupAgentSessions({
+      // /bin/true exits 0 with any args; killTmuxWindow returns true and
+      // moves on. Avoids touching a real tmux server during the test.
+      tmuxBinary: "/bin/true",
+      reg: r,
+      issueIds: ["OP-50"],
+      closeITermWindow: close,
+    });
+
+    expect(close).toHaveBeenCalledTimes(1);
+    expect(close).toHaveBeenCalledWith("w1");
+    expect(res.closedWindows).toEqual(["w1"]);
+    expect(r.windows["w1"]).toBeUndefined();
+    expect(r.windowOrder).toEqual([]);
+  });
+
+  it("leaves windows with surviving cells alone", async () => {
+    const r = emptyRegistry();
+    addWindow(r, win("w1", "op-agents-1"));
+    assignSurface(r, "OP-50", {
+      sessionId: "s0",
+      windowId: "w1",
+      cellIndex: 0,
+      layoutId: "2x2",
+      tmuxWindow: "OP-50",
+    });
+    assignSurface(r, "OP-51", {
+      sessionId: "s1",
+      windowId: "w1",
+      cellIndex: 1,
+      layoutId: "2x2",
+      tmuxWindow: "OP-51",
+    });
+
+    const close = vi.fn().mockResolvedValue(undefined);
+    const res = await cleanupAgentSessions({
+      tmuxBinary: "/bin/true",
+      reg: r,
+      issueIds: ["OP-50"],
+      closeITermWindow: close,
+    });
+
+    expect(close).not.toHaveBeenCalled();
+    expect(res.closedWindows).toEqual([]);
+    expect(r.windows["w1"]).toBeDefined();
+    expect(r.windows["w1"].sessionIds[1]).toBe("s1");
+  });
+
+  it("removes the empty WindowState even when the closer is omitted", async () => {
+    const r = emptyRegistry();
+    addWindow(r, win("w1", "op-agents-1"));
+    assignSurface(r, "OP-50", {
+      sessionId: "s0",
+      windowId: "w1",
+      cellIndex: 0,
+      layoutId: "2x2",
+      tmuxWindow: "OP-50",
+    });
+
+    const res = await cleanupAgentSessions({
+      tmuxBinary: "/bin/true",
+      reg: r,
+      issueIds: ["OP-50"],
+    });
+
+    expect(res.closedWindows).toEqual([]);
+    expect(r.windows["w1"]).toBeUndefined();
+    expect(r.windowOrder).toEqual([]);
+  });
+
+  it("swallows closer errors and still drops the WindowState", async () => {
+    const r = emptyRegistry();
+    addWindow(r, win("w1", "op-agents-1"));
+    assignSurface(r, "OP-50", {
+      sessionId: "s0",
+      windowId: "w1",
+      cellIndex: 0,
+      layoutId: "2x2",
+      tmuxWindow: "OP-50",
+    });
+
+    const close = vi.fn().mockRejectedValue(new Error("iTerm not connected"));
+    const res = await cleanupAgentSessions({
+      tmuxBinary: "/bin/true",
+      reg: r,
+      issueIds: ["OP-50"],
+      closeITermWindow: close,
+    });
+
+    expect(close).toHaveBeenCalledTimes(1);
+    expect(res.closedWindows).toEqual([]);
+    expect(r.windows["w1"]).toBeUndefined();
+    expect(r.windowOrder).toEqual([]);
   });
 });
 

--- a/plugins/op-obsidian/src/agentSessionCleanup.test.ts
+++ b/plugins/op-obsidian/src/agentSessionCleanup.test.ts
@@ -167,6 +167,44 @@ describe("cleanupAgentSessions: empty-window closure (OP-110)", () => {
     expect(r.windowOrder).toEqual([]);
   });
 
+  it("closes both windows when two windows are simultaneously empty", async () => {
+    const r = emptyRegistry();
+    addWindow(r, win("w1", "op-agents-1"));
+    addWindow(r, win("w2", "op-agents-2"));
+    assignSurface(r, "OP-50", {
+      sessionId: "s0",
+      windowId: "w1",
+      cellIndex: 0,
+      layoutId: "2x2",
+      tmuxWindow: "OP-50",
+    });
+    assignSurface(r, "OP-51", {
+      sessionId: "s1",
+      windowId: "w2",
+      cellIndex: 0,
+      layoutId: "2x2",
+      tmuxWindow: "OP-51",
+    });
+
+    const close = vi.fn().mockResolvedValue(undefined);
+    const res = await cleanupAgentSessions({
+      tmuxBinary: "/bin/true",
+      reg: r,
+      issueIds: ["OP-50", "OP-51"],
+      closeITermWindow: close,
+    });
+
+    expect(close).toHaveBeenCalledTimes(2);
+    expect(close).toHaveBeenCalledWith("w1");
+    expect(close).toHaveBeenCalledWith("w2");
+    expect(res.closedWindows).toHaveLength(2);
+    expect(res.closedWindows).toContain("w1");
+    expect(res.closedWindows).toContain("w2");
+    expect(r.windows["w1"]).toBeUndefined();
+    expect(r.windows["w2"]).toBeUndefined();
+    expect(r.windowOrder).toEqual([]);
+  });
+
   it("swallows closer errors and still drops the WindowState", async () => {
     const r = emptyRegistry();
     addWindow(r, win("w1", "op-agents-1"));

--- a/plugins/op-obsidian/src/agentSessionCleanup.ts
+++ b/plugins/op-obsidian/src/agentSessionCleanup.ts
@@ -68,11 +68,18 @@ export interface CleanupArgs {
   tmuxBinary: string;
   reg: RegistryData;
   issueIds: string[];
+  // Best-effort closer for an iTerm window when its last cell is freed.
+  // Optional so unit tests and non-iTerm code paths can opt out — when
+  // omitted, empty windows are still removed from the registry but the
+  // physical iTerm window is left alone.
+  closeITermWindow?: (windowId: string) => Promise<void>;
 }
 
 export interface CleanupResult {
   killed: Array<{ issueId: string; session: string; window: string }>;
   prunedSurfaces: string[];
+  // iTerm windowIds that were emptied by this cleanup and (best-effort) closed.
+  closedWindows: string[];
 }
 
 // Kill every tmux window whose name derives from one of the given issueIds,
@@ -94,5 +101,35 @@ export async function cleanupAgentSessions(args: CleanupArgs): Promise<CleanupRe
     const { removed } = pruneRegistryForIssue(args.reg, issueId);
     prunedSurfaces.push(...Object.keys(removed));
   }
-  return { killed, prunedSurfaces };
+
+  // Any window whose last cell was just freed becomes an orphan: its tmux
+  // session died with its last window, leaving iTerm panes attached to a dead
+  // session. Close the iTerm window so the user doesn't see clutter, then
+  // drop the WindowState so the next launch isn't tempted to reuse the dead
+  // surface. OP-110.
+  const closedWindows: string[] = [];
+  const emptyWindowIds = Object.values(args.reg.windows)
+    .filter((w) => w.sessionIds.every((s) => !s))
+    .map((w) => w.windowId);
+  for (const windowId of emptyWindowIds) {
+    if (args.closeITermWindow) {
+      try {
+        await args.closeITermWindow(windowId);
+        closedWindows.push(windowId);
+      } catch (err) {
+        console.warn(
+          `[op-obsidian] closeITermWindow best-effort failed (window=${windowId}): ${
+            err instanceof Error ? err.message.split("\n")[0] : String(err)
+          }`,
+        );
+      }
+    }
+    delete args.reg.windows[windowId];
+    args.reg.windowOrder = args.reg.windowOrder.filter((id) => id !== windowId);
+    for (const [issueId, ref] of Object.entries(args.reg.surfaces)) {
+      if (ref.windowId === windowId) delete args.reg.surfaces[issueId];
+    }
+  }
+
+  return { killed, prunedSurfaces, closedWindows };
 }

--- a/plugins/op-obsidian/src/iterm/client.ts
+++ b/plugins/op-obsidian/src/iterm/client.ts
@@ -185,6 +185,11 @@ export async function selectSession(sessionId: string): Promise<void> {
 // confirmation iTerm normally shows — needed because the window's PTYs are
 // still attached to the dead view scripts. NOT_FOUND is treated as success
 // (the window is already gone, which is the intended end state).
+// USER_DECLINED should not occur with force=true, but some iTerm builds or
+// misconfigured prefs may ignore the force flag. We treat USER_DECLINED as
+// non-fatal rather than surfacing a warning on every cleanup in those
+// environments — the window stays open, the registry still drops it, and the
+// next agent launch will allocate a fresh surface.
 export async function closeWindow(windowId: string): Promise<void> {
   const reply = await call({
     closeRequest: iterm2.CloseRequest.create({
@@ -197,7 +202,8 @@ export async function closeWindow(windowId: string): Promise<void> {
   for (const status of sub.statuses ?? []) {
     if (
       status !== iterm2.CloseResponse.Status.OK &&
-      status !== iterm2.CloseResponse.Status.NOT_FOUND
+      status !== iterm2.CloseResponse.Status.NOT_FOUND &&
+      status !== iterm2.CloseResponse.Status.USER_DECLINED
     ) {
       throw new Error(`op: iTerm closeWindow(${windowId}) failed with status=${status}`);
     }

--- a/plugins/op-obsidian/src/iterm/client.ts
+++ b/plugins/op-obsidian/src/iterm/client.ts
@@ -181,6 +181,29 @@ export async function selectSession(sessionId: string): Promise<void> {
   }
 }
 
+// Close an iTerm window by id. force=true bypasses the "process still running"
+// confirmation iTerm normally shows — needed because the window's PTYs are
+// still attached to the dead view scripts. NOT_FOUND is treated as success
+// (the window is already gone, which is the intended end state).
+export async function closeWindow(windowId: string): Promise<void> {
+  const reply = await call({
+    closeRequest: iterm2.CloseRequest.create({
+      windows: iterm2.CloseRequest.CloseWindows.create({ windowIds: [windowId] }),
+      force: true,
+    }),
+  });
+  const sub = reply.closeResponse;
+  if (!sub) throw new Error("op: iTerm closeWindow: missing closeResponse");
+  for (const status of sub.statuses ?? []) {
+    if (
+      status !== iterm2.CloseResponse.Status.OK &&
+      status !== iterm2.CloseResponse.Status.NOT_FOUND
+    ) {
+      throw new Error(`op: iTerm closeWindow(${windowId}) failed with status=${status}`);
+    }
+  }
+}
+
 export async function sessionExists(sessionId: string): Promise<boolean> {
   const reply = await call({
     listSessionsRequest: iterm2.ListSessionsRequest.create({}),

--- a/plugins/op-obsidian/src/iterm/driver.ts
+++ b/plugins/op-obsidian/src/iterm/driver.ts
@@ -16,6 +16,10 @@ export async function sessionExists(sessionId: string): Promise<boolean> {
   return wsClient.sessionExists(sessionId);
 }
 
+export async function closeWindow(windowId: string): Promise<void> {
+  return wsClient.closeWindow(windowId);
+}
+
 export async function createWindow(command: string): Promise<CreateWindowResult> {
   return wsClient.createWindow(command);
 }

--- a/plugins/op-obsidian/src/main.ts
+++ b/plugins/op-obsidian/src/main.ts
@@ -92,6 +92,7 @@ import { showActionableNotice } from "./actionableNotices";
 import { probeLiveTmuxWindows, selectStaleAgentBadges } from "./staleAgentBadges";
 import { openErrorLog, writeErrorLog } from "./errorLog";
 import { configureClient } from "./iterm/client";
+import { closeWindow as itermCloseWindow } from "./iterm/driver";
 import { closeTransport } from "./iterm/connection";
 import { existsSync } from "fs";
 
@@ -894,8 +895,9 @@ export default class OpPlugin extends Plugin {
         tmuxBinary: this.settings.tmuxBinary,
         reg: this.settings.orchestratorState,
         issueIds,
+        closeITermWindow: (windowId) => itermCloseWindow(windowId),
       });
-      if (res.killed.length || res.prunedSurfaces.length) {
+      if (res.killed.length || res.prunedSurfaces.length || res.closedWindows.length) {
         console.debug("[op-obsidian] cleaned up agent state", res);
         await this.saveSettings();
       }

--- a/plugins/op/.claude-plugin/plugin.json
+++ b/plugins/op/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "op",
   "description": "Obsidian Projects workflow — schema, slash commands, and agent skill for running a Jira-lite issue tracker inside an Obsidian vault.",
-  "version": "0.47.0",
+  "version": "0.48.0",
   "author": {
     "name": "Eugene Archibald"
   },


### PR DESCRIPTION
## Summary

- When the last agent in an op-agents-N iTerm window resolves, `cleanupAgentSessions` killed the tmux window (and with it, the now-empty tmux session) but left the iTerm window alive with orphan PTYs. The next launch correctly reused the tmux session *name* but spawned a brand-new iTerm window — leaving visual clutter.
- Fix: add `closeWindow(windowId)` to the iTerm WebSocket driver and call it from cleanup when a window's last cell is freed. Best-effort (logged + swallowed); the WindowState is dropped from the registry either way.

## Test plan

- [x] `npx vitest run` — 463/463 pass (4 new tests in `agentSessionCleanup.test.ts`)
- [x] Bump to 0.48.0, build, sync to active vault, reload — `obsidian dev:console` clean
- [ ] Manual: launch two agents in op-agents-1, resolve both, launch a third — expect old iTerm window closed and a fresh one for op-agents-1

🤖 Generated with [Claude Code](https://claude.com/claude-code)