### PR TITLE
OP-152: hotkey preset + op: pick & act modal (§3 of OP-149)

### DIFF
--- a/plugins/op-obsidian/manifest.json
+++ b/plugins/op-obsidian/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "op-obsidian",
   "name": "Obsidian Projects (op)",
-  "version": "0.48.0",
+  "version": "0.49.0",
   "minAppVersion": "1.5.0",
   "description": "Jira-lite issue tracker for Obsidian vaults — deterministic commands backing the op workflow.",
   "author": "Eugene Archibald",

--- a/plugins/op-obsidian/package.json
+++ b/plugins/op-obsidian/package.json
@@ -1,6 +1,6 @@
 {
   "name": "op-obsidian",
-  "version": "0.48.0",
+  "version": "0.49.0",
   "description": "Obsidian plugin that owns the deterministic half of the op workflow.",
   "main": "main.js",
   "scripts": {

--- a/plugins/op-obsidian/src/hotkeyPreset.test.ts
+++ b/plugins/op-obsidian/src/hotkeyPreset.test.ts
@@ -1,0 +1,338 @@
+import { describe, it, expect, vi } from "vitest";
+import {
+  applyPreset,
+  canonicalKey,
+  defaultPreset,
+  revertPreset,
+  type AppLike,
+  type Hotkey,
+  type HotkeyEntry,
+} from "./hotkeyPreset";
+
+describe("defaultPreset", () => {
+  const preset = defaultPreset();
+
+  it("returns exactly 10 entries", () => {
+    expect(preset).toHaveLength(10);
+  });
+
+  it("returns the expected commands in spec-defined order", () => {
+    const ids = preset.map((e) => e.command);
+    expect(ids).toEqual([
+      "op-obsidian:op-open-sidebar",
+      "op-obsidian:op-pick-and-act",
+      "op-obsidian:op-resume-last",
+      "op-obsidian:op-attach-current",
+      "op-obsidian:op-open-agent",
+      "op-obsidian:op-resolve",
+      "op-obsidian:op-new",
+      "op-obsidian:op-append-commit",
+      "op-obsidian:op-next-issue",
+      "op-obsidian:op-previous-issue",
+    ]);
+  });
+
+  it("uses Mod+Shift or Mod+Alt only — Obsidian's least-reserved namespaces", () => {
+    for (const e of preset) {
+      const mods = new Set(e.hotkey.modifiers);
+      const isModShift = mods.size === 2 && mods.has("Mod") && mods.has("Shift");
+      const isModAlt = mods.size === 2 && mods.has("Mod") && mods.has("Alt");
+      expect(isModShift || isModAlt, `unexpected modifiers for ${e.command}: ${[...mods].join(",")}`)
+        .toBe(true);
+    }
+  });
+
+  it("has no duplicate (key, modifiers) pairs", () => {
+    const seen = new Set<string>();
+    for (const e of preset) {
+      const sig = canonicalKey(e.hotkey, /*isMacOS*/ true);
+      expect(seen.has(sig), `duplicate signature for ${e.command}: ${sig}`).toBe(false);
+      seen.add(sig);
+    }
+  });
+
+  it("avoids known Obsidian-core conflicts (lookup table snapshot)", () => {
+    // Static table of stock Obsidian 1.x bindings that the preset MUST NOT
+    // collide with. The preset spec calls these out explicitly: ⌘⇧N (new
+    // window), ⌘⇧[ / ⌘⇧] (tab nav) — the preset substitutes ⌘⌥N, ⌘⇧K, ⌘⇧J.
+    const obsidianCore: Hotkey[] = [
+      { modifiers: ["Mod"], key: "S" }, // editor:save-file
+      { modifiers: ["Mod", "Shift"], key: "N" }, // window:new-window
+      { modifiers: ["Mod", "Shift"], key: "[" }, // workspace:previous-tab
+      { modifiers: ["Mod", "Shift"], key: "]" }, // workspace:next-tab
+      { modifiers: ["Mod"], key: "P" }, // command-palette
+      { modifiers: ["Mod"], key: "O" }, // quick-switcher
+    ];
+    const presetSigs = new Set(
+      preset.map((e) => canonicalKey(e.hotkey, /*isMacOS*/ true)),
+    );
+    for (const core of obsidianCore) {
+      const sig = canonicalKey(core, true);
+      expect(presetSigs.has(sig), `preset must not collide with core binding ${JSON.stringify(core)}`)
+        .toBe(false);
+    }
+  });
+
+  it("returns a fresh deep copy on each call (mutation-safe)", () => {
+    const a = defaultPreset();
+    a[0].hotkey.modifiers.push("X");
+    const b = defaultPreset();
+    expect(b[0].hotkey.modifiers).not.toContain("X");
+  });
+});
+
+describe("canonicalKey", () => {
+  it("folds Mod onto Meta on macOS", () => {
+    expect(canonicalKey({ modifiers: ["Mod"], key: "S" }, true)).toBe(
+      canonicalKey({ modifiers: ["Meta"], key: "S" }, true),
+    );
+  });
+
+  it("folds Mod onto Ctrl on non-macOS", () => {
+    expect(canonicalKey({ modifiers: ["Mod"], key: "S" }, false)).toBe(
+      canonicalKey({ modifiers: ["Ctrl"], key: "S" }, false),
+    );
+  });
+
+  it("is order-insensitive in modifiers", () => {
+    expect(canonicalKey({ modifiers: ["Mod", "Shift"], key: "I" }, true)).toBe(
+      canonicalKey({ modifiers: ["Shift", "Mod"], key: "I" }, true),
+    );
+  });
+
+  it("is case-insensitive in key", () => {
+    expect(canonicalKey({ modifiers: ["Mod"], key: "S" }, true)).toBe(
+      canonicalKey({ modifiers: ["Mod"], key: "s" }, true),
+    );
+  });
+});
+
+/**
+ * Test helper that mirrors Obsidian's HotkeyManager closely enough for the
+ * apply/revert paths: `customKeys` exposes a *snapshot* via a getter (so direct
+ * mutation is a no-op), and writes go through `setHotkeys`/`removeHotkeys`.
+ */
+function makeApp(overrides?: {
+  customKeys?: Record<string, Hotkey[]>;
+  defaultKeys?: Record<string, Hotkey[]>;
+  commands?: Record<string, { name: string }>;
+  saveImpl?: () => void;
+  setHotkeysImpl?: (id: string, hotkeys: Hotkey[]) => void;
+}): AppLike & { __saved: () => void; __internal: Record<string, Hotkey[]> } {
+  const internal: Record<string, Hotkey[]> = overrides?.customKeys
+    ? structuredClone(overrides.customKeys)
+    : {};
+  const defaultKeys = overrides?.defaultKeys ?? {};
+  const save = overrides?.saveImpl ?? vi.fn();
+  const hm = {
+    defaultKeys,
+    save,
+    setHotkeys:
+      overrides?.setHotkeysImpl ??
+      ((id: string, hotkeys: Hotkey[]) => {
+        internal[id] = hotkeys;
+      }),
+    getHotkeys: (id: string) => internal[id],
+    removeHotkeys: (id: string) => {
+      delete internal[id];
+    },
+    bake: vi.fn(),
+  };
+  // customKeys is a getter that returns a fresh copy — matches Obsidian's
+  // implementation where `Object.assign({}, this[Hb])` is built per-read.
+  Object.defineProperty(hm, "customKeys", {
+    get: () => Object.assign({}, internal),
+    enumerable: true,
+  });
+  return {
+    hotkeyManager: hm as any,
+    commands: { commands: overrides?.commands ?? {} },
+    __saved: save as () => void,
+    __internal: internal,
+  };
+}
+
+describe("applyPreset — clean apply", () => {
+  it("applies all 10 bindings when no conflicts exist", () => {
+    const app = makeApp();
+    const result = applyPreset(app, defaultPreset(), { isMacOS: true });
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.applied).toHaveLength(10);
+    expect(result.skipped).toHaveLength(0);
+    expect(Object.keys(app.__internal)).toHaveLength(10);
+    expect(app.__saved).toHaveBeenCalled();
+  });
+
+  it("snapshots customKeys before mutation for revert", () => {
+    const app = makeApp({
+      customKeys: { "user-existing": [{ modifiers: ["Mod"], key: "U" }] },
+    });
+    const result = applyPreset(app, defaultPreset(), { isMacOS: true });
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.previousCustomKeys["user-existing"]).toEqual([
+      { modifiers: ["Mod"], key: "U" },
+    ]);
+    // Snapshot is independent of post-mutation state.
+    app.__internal["user-existing"][0].key = "X";
+    expect(result.previousCustomKeys["user-existing"][0].key).toBe("U");
+  });
+});
+
+describe("applyPreset — collision skipping", () => {
+  it("skips a binding whose key+modifiers collide with another command", () => {
+    const app = makeApp({
+      defaultKeys: {
+        "third-party:pick-and-act-imposter": [
+          { modifiers: ["Mod", "Shift"], key: "I" },
+        ],
+      },
+      commands: {
+        "third-party:pick-and-act-imposter": { name: "Imposter: pick and act" },
+      },
+    });
+    const result = applyPreset(app, defaultPreset(), { isMacOS: true });
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.applied.find((e) => e.command === "op-obsidian:op-pick-and-act")).toBeUndefined();
+    expect(result.skipped).toHaveLength(1);
+    expect(result.skipped[0].binding.command).toBe("op-obsidian:op-pick-and-act");
+    expect(result.skipped[0].conflictingCommandId).toBe(
+      "third-party:pick-and-act-imposter",
+    );
+    expect(result.skipped[0].conflictingCommandName).toBe(
+      "Imposter: pick and act",
+    );
+  });
+
+  it("treats own-prefix bindings as non-conflicts (re-apply is idempotent)", () => {
+    const preset = defaultPreset();
+    const app = makeApp();
+    // First apply
+    const first = applyPreset(app, preset, { isMacOS: true });
+    expect(first.ok && first.applied).toHaveLength(10);
+    // Re-apply — every binding still maps to its op-* command, so no conflict
+    // is reported.
+    const second = applyPreset(app, preset, { isMacOS: true });
+    expect(second.ok).toBe(true);
+    if (!second.ok) return;
+    expect(second.skipped).toHaveLength(0);
+    expect(second.applied).toHaveLength(10);
+  });
+
+  it("falls back to commandId when commands registry has no display name", () => {
+    const app = makeApp({
+      defaultKeys: {
+        "anon-command": [{ modifiers: ["Mod", "Shift"], key: "I" }],
+      },
+    });
+    const result = applyPreset(app, defaultPreset(), { isMacOS: true });
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    const skip = result.skipped.find((s) => s.binding.command === "op-obsidian:op-pick-and-act");
+    expect(skip?.conflictingCommandName).toBe("anon-command");
+  });
+
+  it("treats customKeys = [] as 'user removed default' and frees the slot", () => {
+    const app = makeApp({
+      defaultKeys: {
+        "third-party:steals-i": [{ modifiers: ["Mod", "Shift"], key: "I" }],
+      },
+      customKeys: {
+        "third-party:steals-i": [], // user removed it via Obsidian Hotkeys UI
+      },
+    });
+    const result = applyPreset(app, defaultPreset(), { isMacOS: true });
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.applied.find((e) => e.command === "op-obsidian:op-pick-and-act")).toBeDefined();
+    expect(result.skipped).toHaveLength(0);
+  });
+});
+
+describe("applyPreset — fallback path", () => {
+  it("returns a JSON snippet when setHotkeys is missing (API drift)", () => {
+    const app: AppLike = {
+      // save present but no setHotkeys — represents Obsidian renaming/removing
+      // the public API surface.
+      hotkeyManager: { save: vi.fn(), customKeys: {} },
+    };
+    const result = applyPreset(app, defaultPreset(), { isMacOS: true });
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.reason).toMatch(/unavailable|drift/i);
+    const parsed = JSON.parse(result.snippet);
+    expect(Object.keys(parsed)).toHaveLength(10);
+    expect(parsed["op-obsidian:op-pick-and-act"]).toEqual([
+      { modifiers: ["Mod", "Shift"], key: "I" },
+    ]);
+  });
+
+  it("returns a JSON snippet when save() throws", () => {
+    const save = vi.fn(() => {
+      throw new Error("write failed");
+    });
+    const app = makeApp({ saveImpl: save });
+    const result = applyPreset(app, defaultPreset(), { isMacOS: true });
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.reason).toMatch(/write failed/);
+    // Snapshot was empty before the mutation began.
+    expect(result.previousCustomKeys).toEqual({});
+    const parsed = JSON.parse(result.snippet);
+    expect(Object.keys(parsed)).toHaveLength(10);
+  });
+
+  it("returns a JSON snippet when setHotkeys() throws mid-stream", () => {
+    let calls = 0;
+    const setHotkeysImpl = vi.fn(() => {
+      calls++;
+      if (calls > 3) throw new Error("write rejected");
+    });
+    const app = makeApp({ setHotkeysImpl });
+    const result = applyPreset(app, defaultPreset(), { isMacOS: true });
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.reason).toMatch(/write rejected/);
+    expect(JSON.parse(result.snippet)["op-obsidian:op-pick-and-act"]).toBeDefined();
+  });
+
+  it("returns a JSON snippet when hotkeyManager itself is missing", () => {
+    const result = applyPreset({}, defaultPreset(), { isMacOS: true });
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.snippet.length).toBeGreaterThan(0);
+  });
+});
+
+describe("revertPreset", () => {
+  it("restores customKeys from a snapshot", () => {
+    const app = makeApp({
+      customKeys: { "user-existing": [{ modifiers: ["Mod"], key: "U" }] },
+    });
+    const result = applyPreset(app, defaultPreset(), { isMacOS: true });
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(Object.keys(app.__internal).length).toBeGreaterThan(1);
+    const revert = revertPreset(app, result.previousCustomKeys);
+    expect(revert.ok).toBe(true);
+    expect(Object.keys(app.__internal)).toEqual(["user-existing"]);
+    expect(app.__internal["user-existing"]).toEqual([
+      { modifiers: ["Mod"], key: "U" },
+    ]);
+  });
+
+  it("clears bindings that didn't exist in the snapshot", () => {
+    const app = makeApp();
+    applyPreset(app, defaultPreset(), { isMacOS: true });
+    expect(Object.keys(app.__internal).length).toBe(10);
+    revertPreset(app, {});
+    expect(app.__internal).toEqual({});
+  });
+
+  it("reports failure when hotkeyManager is unavailable", () => {
+    const result = revertPreset({}, {});
+    expect(result.ok).toBe(false);
+  });
+});

--- a/plugins/op-obsidian/src/hotkeyPreset.ts
+++ b/plugins/op-obsidian/src/hotkeyPreset.ts
@@ -1,0 +1,304 @@
+/**
+ * Default hotkey preset for the op-obsidian plugin (OP-152).
+ *
+ * Two responsibilities:
+ *  - {@link defaultPreset} — the pure list of 10 keybindings the preset binds.
+ *  - {@link applyPreset} — best-effort write into Obsidian's
+ *    `app.hotkeyManager.customKeys`, with collision-skipping and a JSON-snippet
+ *    fallback when the internal API has drifted.
+ *
+ * The user must explicitly click "Apply preset" in settings — this module is
+ * never invoked on plugin load or upgrade.
+ */
+
+export interface Hotkey {
+  modifiers: string[];
+  key: string;
+}
+
+export interface HotkeyEntry {
+  command: string;
+  hotkey: Hotkey;
+}
+
+export interface SkippedBinding {
+  binding: HotkeyEntry;
+  conflictingCommandId: string;
+  conflictingCommandName: string;
+}
+
+export interface ApplyResultSuccess {
+  ok: true;
+  applied: HotkeyEntry[];
+  skipped: SkippedBinding[];
+  previousCustomKeys: Record<string, Hotkey[]>;
+}
+
+export interface ApplyResultFallback {
+  ok: false;
+  reason: string;
+  snippet: string;
+  previousCustomKeys?: Record<string, Hotkey[]>;
+}
+
+export type ApplyResult = ApplyResultSuccess | ApplyResultFallback;
+
+export interface HotkeyManagerLike {
+  /**
+   * Read-only snapshot of user-overridden hotkeys. Obsidian implements this as
+   * a getter that returns a fresh `Object.assign({}, internal)` on each access,
+   * so mutations to the returned object are silently discarded — always read
+   * via the getter, always write via {@link setHotkeys}.
+   */
+  customKeys?: Record<string, Hotkey[]>;
+  defaultKeys?: Record<string, Hotkey[]>;
+  /** `setHotkeys(commandId, hotkeys)` — Obsidian's official write API. */
+  setHotkeys?: (commandId: string, hotkeys: Hotkey[]) => void;
+  /** `getHotkeys(commandId)` — read effective custom override (no defaults). */
+  getHotkeys?: (commandId: string) => Hotkey[] | undefined;
+  /** `removeHotkeys(commandId)` — clear override and restore defaults. */
+  removeHotkeys?: (commandId: string) => void;
+  /** Recompute `bakedHotkeys`/`bakedIds` from current customKeys. */
+  bake?: () => void;
+  save?: () => void | Promise<void>;
+}
+
+export interface CommandRegistryLike {
+  commands?: Record<string, { name?: string } | undefined>;
+}
+
+export interface AppLike {
+  hotkeyManager?: HotkeyManagerLike;
+  commands?: CommandRegistryLike;
+}
+
+export interface ApplyOptions {
+  /** Override platform detection (tests). */
+  isMacOS?: boolean;
+}
+
+const PRESET: readonly HotkeyEntry[] = [
+  { command: "op-obsidian:op-open-sidebar", hotkey: { modifiers: ["Mod", "Shift"], key: "O" } },
+  { command: "op-obsidian:op-pick-and-act", hotkey: { modifiers: ["Mod", "Shift"], key: "I" } },
+  { command: "op-obsidian:op-resume-last", hotkey: { modifiers: ["Mod", "Shift"], key: "Enter" } },
+  { command: "op-obsidian:op-attach-current", hotkey: { modifiers: ["Mod", "Shift"], key: "A" } },
+  { command: "op-obsidian:op-open-agent", hotkey: { modifiers: ["Mod", "Shift"], key: "L" } },
+  { command: "op-obsidian:op-resolve", hotkey: { modifiers: ["Mod", "Shift"], key: "R" } },
+  { command: "op-obsidian:op-new", hotkey: { modifiers: ["Mod", "Alt"], key: "N" } },
+  { command: "op-obsidian:op-append-commit", hotkey: { modifiers: ["Mod", "Shift"], key: "." } },
+  { command: "op-obsidian:op-next-issue", hotkey: { modifiers: ["Mod", "Shift"], key: "J" } },
+  { command: "op-obsidian:op-previous-issue", hotkey: { modifiers: ["Mod", "Shift"], key: "K" } },
+];
+
+export function defaultPreset(): HotkeyEntry[] {
+  return PRESET.map((e) => ({
+    command: e.command,
+    hotkey: { modifiers: [...e.hotkey.modifiers], key: e.hotkey.key },
+  }));
+}
+
+/**
+ * Canonical signature for a hotkey, used for conflict comparison. Modifiers are
+ * sorted, "Mod" is folded onto the platform's actual modifier (Meta on macOS,
+ * Ctrl elsewhere) so a binding written as `["Mod"]` and one written as
+ * `["Meta"]` (literal) compare equal on macOS.
+ */
+export function canonicalKey(h: Hotkey, isMacOS: boolean): string {
+  const platformMod = isMacOS ? "Meta" : "Ctrl";
+  const mods = h.modifiers
+    .map((m) => (m === "Mod" ? platformMod : m))
+    .map((m) => m.toLowerCase())
+    .sort();
+  return `${mods.join("+")}|${h.key.toLowerCase()}`;
+}
+
+interface ConflictMap {
+  [signature: string]: { commandId: string; commandName: string };
+}
+
+function buildConflictMap(
+  app: AppLike,
+  hm: HotkeyManagerLike,
+  isMacOS: boolean,
+  ownCommands: ReadonlySet<string>,
+): ConflictMap {
+  const out: ConflictMap = {};
+  const commandIds = new Set<string>([
+    ...Object.keys(hm.customKeys ?? {}),
+    ...Object.keys(hm.defaultKeys ?? {}),
+  ]);
+
+  for (const id of commandIds) {
+    if (ownCommands.has(id)) continue; // own bindings are not collisions — re-apply is idempotent
+    const effective = effectiveBindings(hm, id);
+    for (const hk of effective) {
+      const sig = canonicalKey(hk, isMacOS);
+      // First binding wins — Obsidian's bakedHotkeys preserves insertion order;
+      // we don't have to match it exactly, we just need *some* conflicting
+      // command id to surface to the user.
+      if (out[sig]) continue;
+      const name = app.commands?.commands?.[id]?.name ?? id;
+      out[sig] = { commandId: id, commandName: name };
+    }
+  }
+  return out;
+}
+
+function effectiveBindings(hm: HotkeyManagerLike, commandId: string): Hotkey[] {
+  // customKeys overrides defaultKeys. customKeys[id] = [] means "user removed
+  // the default" — treat as no binding. Prefer `getHotkeys` (the official API)
+  // when available; fall back to reading the customKeys snapshot.
+  const custom =
+    typeof hm.getHotkeys === "function" ? hm.getHotkeys(commandId) : hm.customKeys?.[commandId];
+  if (custom !== undefined) return custom;
+  return hm.defaultKeys?.[commandId] ?? [];
+}
+
+export function applyPreset(
+  app: AppLike,
+  preset: HotkeyEntry[],
+  opts: ApplyOptions = {},
+): ApplyResult {
+  const hm = app.hotkeyManager;
+  const isMacOS = opts.isMacOS ?? detectMacOS();
+
+  // The settings UI uses `setHotkeys` to persist changes; mutating the
+  // `customKeys` getter directly is silently discarded (it returns a fresh
+  // copy each call). Both `setHotkeys` and `save` must exist for a real apply.
+  if (
+    !hm ||
+    typeof hm.save !== "function" ||
+    typeof hm.setHotkeys !== "function" ||
+    !isPlainObject(hm.customKeys)
+  ) {
+    return {
+      ok: false,
+      reason:
+        "app.hotkeyManager.setHotkeys/save is unavailable — Obsidian's internal hotkey API has drifted.",
+      snippet: snippetFor(preset),
+    };
+  }
+
+  // Capture before mutation. customKeys is a copy on every read, so this is
+  // already a snapshot — but deep-clone the array entries so callers can't
+  // accidentally mutate them.
+  const previousCustomKeys = deepCloneCustomKeys(hm.customKeys ?? {});
+  const ownCommands = new Set(preset.map((e) => e.command));
+  const conflictMap = buildConflictMap(app, hm, isMacOS, ownCommands);
+
+  const applied: HotkeyEntry[] = [];
+  const skipped: SkippedBinding[] = [];
+
+  for (const entry of preset) {
+    const sig = canonicalKey(entry.hotkey, isMacOS);
+    const conflict = conflictMap[sig];
+    if (conflict) {
+      skipped.push({
+        binding: entry,
+        conflictingCommandId: conflict.commandId,
+        conflictingCommandName: conflict.commandName,
+      });
+      continue;
+    }
+    try {
+      hm.setHotkeys(entry.command, [
+        { modifiers: [...entry.hotkey.modifiers], key: entry.hotkey.key },
+      ]);
+    } catch (err) {
+      return {
+        ok: false,
+        reason: `hotkeyManager.setHotkeys threw on ${entry.command}: ${(err as Error)?.message ?? String(err)}`,
+        snippet: snippetFor(preset),
+        previousCustomKeys,
+      };
+    }
+    applied.push(entry);
+  }
+
+  try {
+    if (typeof hm.bake === "function") hm.bake();
+    void hm.save();
+  } catch (err) {
+    return {
+      ok: false,
+      reason: `hotkeyManager.save() threw: ${(err as Error)?.message ?? String(err)}`,
+      snippet: snippetFor(preset),
+      previousCustomKeys,
+    };
+  }
+
+  return { ok: true, applied, skipped, previousCustomKeys };
+}
+
+/**
+ * Restore `customKeys` from a snapshot captured before {@link applyPreset}.
+ * Used by the results modal's "Revert" button (session-scoped).
+ */
+export function revertPreset(
+  app: AppLike,
+  snapshot: Record<string, Hotkey[]>,
+): { ok: true } | { ok: false; reason: string } {
+  const hm = app.hotkeyManager;
+  if (
+    !hm ||
+    typeof hm.save !== "function" ||
+    typeof hm.setHotkeys !== "function" ||
+    typeof hm.removeHotkeys !== "function" ||
+    !isPlainObject(hm.customKeys)
+  ) {
+    return {
+      ok: false,
+      reason:
+        "app.hotkeyManager.setHotkeys/removeHotkeys/save is unavailable — cannot revert.",
+    };
+  }
+  try {
+    // Compute the union of currently-overridden command ids and snapshot ids,
+    // then for each: if the snapshot has it, restore; otherwise clear.
+    const current = hm.customKeys ?? {};
+    const ids = new Set([...Object.keys(current), ...Object.keys(snapshot)]);
+    for (const id of ids) {
+      if (id in snapshot) {
+        hm.setHotkeys(id, snapshot[id].map((h) => ({ modifiers: [...h.modifiers], key: h.key })));
+      } else {
+        hm.removeHotkeys(id);
+      }
+    }
+    if (typeof hm.bake === "function") hm.bake();
+    void hm.save();
+    return { ok: true };
+  } catch (err) {
+    return {
+      ok: false,
+      reason: `hotkeyManager.save() threw during revert: ${(err as Error)?.message ?? String(err)}`,
+    };
+  }
+}
+
+function snippetFor(preset: HotkeyEntry[]): string {
+  const out: Record<string, Hotkey[]> = {};
+  for (const e of preset) {
+    out[e.command] = [{ modifiers: [...e.hotkey.modifiers], key: e.hotkey.key }];
+  }
+  return JSON.stringify(out, null, 2);
+}
+
+function deepCloneCustomKeys(src: Record<string, Hotkey[]>): Record<string, Hotkey[]> {
+  const out: Record<string, Hotkey[]> = {};
+  for (const [id, arr] of Object.entries(src)) {
+    out[id] = arr.map((h) => ({ modifiers: [...h.modifiers], key: h.key }));
+  }
+  return out;
+}
+
+function isPlainObject(v: unknown): v is Record<string, unknown> {
+  return typeof v === "object" && v !== null && !Array.isArray(v);
+}
+
+function detectMacOS(): boolean {
+  if (typeof navigator !== "undefined" && typeof navigator.platform === "string") {
+    return /Mac|iPhone|iPad|iPod/i.test(navigator.platform);
+  }
+  if (typeof process !== "undefined" && process.platform === "darwin") return true;
+  return false;
+}

--- a/plugins/op-obsidian/src/main.ts
+++ b/plugins/op-obsidian/src/main.ts
@@ -95,6 +95,11 @@ import { configureClient } from "./iterm/client";
 import { closeWindow as itermCloseWindow } from "./iterm/driver";
 import { closeTransport } from "./iterm/connection";
 import { existsSync } from "fs";
+import { execFile } from "child_process";
+import { promisify } from "util";
+import { PickAndActModal } from "./pickAndActModal";
+
+const pExecFile = promisify(execFile);
 
 /**
  * How long to wait after `onLayoutReady` before probing tmux for stale agent
@@ -422,6 +427,60 @@ export default class OpPlugin extends Plugin {
       id: "op-open-agent-plan-pick",
       name: "op: open agent (plan mode, pick)",
       callback: () => this.runOpenAgentCommand(true, "plan"),
+    });
+
+    this.addCommand({
+      id: "op-pick-and-act",
+      name: "op: pick & act",
+      callback: () => this.runPickAndActCommand(),
+    });
+
+    this.addCommand({
+      id: "op-attach-current",
+      name: "op: attach to agent for current issue",
+      checkCallback: (checking) => {
+        const path = this.activeIssuePath();
+        if (checking) return !!path;
+        if (!path) return false;
+        const entry = this.store.byPath(path);
+        if (entry && entry.type === "issue") void revealAgentSession(this.settings, entry.id);
+        return true;
+      },
+    });
+
+    this.addCommand({
+      id: "op-resume-last",
+      name: "op: resume last (stub — OP-149 §1)",
+      callback: () => {
+        new Notice(
+          "op: resume-last is not yet implemented. Tracked under OP-149 §1.",
+          6000,
+        );
+      },
+    });
+
+    this.addCommand({
+      id: "op-next-issue",
+      name: "op: next issue in project",
+      checkCallback: (checking) => {
+        const path = this.activeIssuePath();
+        if (checking) return !!path;
+        if (!path) return false;
+        this.runRotateIssueCommand(path, +1);
+        return true;
+      },
+    });
+
+    this.addCommand({
+      id: "op-previous-issue",
+      name: "op: previous issue in project",
+      checkCallback: (checking) => {
+        const path = this.activeIssuePath();
+        if (checking) return !!path;
+        if (!path) return false;
+        this.runRotateIssueCommand(path, -1);
+        return true;
+      },
     });
 
     this.addCommand({
@@ -2090,6 +2149,90 @@ export default class OpPlugin extends Plugin {
     });
   }
 
+  /**
+   * Open the `op: pick & act` modal — fuzzy-pick any issue and dispatch one of
+   * five actions via modifier-enter. See {@link PickAndActModal}.
+   */
+  private runPickAndActCommand(): void {
+    new PickAndActModal(this.app, () => this.store.issues(), {
+      open: (entry) => this.openIssue(entry),
+      launch: (entry) => this.doOpenAgent(entry, {}),
+      plan: (entry) => this.doOpenAgent(entry, { mode: "plan" }),
+      resolve: (entry) => this.runResolveCommand({ path: entry.path }),
+      commit: (entry) => this.runPickAndActCommitFor(entry),
+    }).open();
+  }
+
+  /**
+   * Append the project repo's HEAD commit to the issue's `commits:` list. Used
+   * by `op: pick & act` when the user hits `⌃↵` on an issue.
+   */
+  private async runPickAndActCommitFor(entry: IssueEntry): Promise<void> {
+    try {
+      const repoPath = resolveRepoPath(this.app, this.settings, entry.project);
+      if (!repoPath) {
+        new Notice(`op: no repo_path for ${entry.project} — cannot append commit`);
+        return;
+      }
+      const { stdout: shaRaw } = await pExecFile(
+        "git",
+        ["rev-parse", "--short=7", "HEAD"],
+        { cwd: repoPath },
+      );
+      const { stdout: subjRaw } = await pExecFile(
+        "git",
+        ["log", "-1", "--pretty=%s"],
+        { cwd: repoPath },
+      );
+      const sha = shaRaw.trim();
+      const subject = subjRaw.trim();
+      if (!sha || !subject) {
+        new Notice(`op: empty git output in ${repoPath} — skipping append`);
+        return;
+      }
+      const res = await appendCommit(this.app, entry, { sha, subject });
+      new Notice(
+        res.added
+          ? `op: appended ${sha} to ${res.issueId}`
+          : `op: ${sha} already on ${res.issueId}`,
+      );
+    } catch (err: any) {
+      console.error("[op-obsidian] pick-and-act commit failed", err);
+      new Notice(`op: pick & act commit failed — ${err?.message ?? err}`);
+    }
+  }
+
+  /**
+   * Open the next/previous issue in the same project as `currentPath`, sorted
+   * numerically by ID and skipping resolved entries. Wraps around at the
+   * boundaries.
+   */
+  private runRotateIssueCommand(currentPath: string, direction: 1 | -1): void {
+    const current = this.store.byPath(currentPath);
+    if (!current || current.type !== "issue") return;
+    const peers = this.store
+      .issues()
+      .filter(
+        (e) =>
+          e.project === current.project &&
+          !e.resolvedFolder &&
+          !["resolved", "wontfix"].includes(e.status),
+      )
+      .sort((a, b) => issueIdNumericSuffix(a.id) - issueIdNumericSuffix(b.id));
+    if (peers.length === 0) {
+      new Notice(`op: no other open issues in ${current.project}`);
+      return;
+    }
+    const idx = peers.findIndex((e) => e.path === current.path);
+    if (idx === -1) {
+      // current is resolved — jump to the first/last open peer
+      void this.openIssue(direction > 0 ? peers[0] : peers[peers.length - 1]);
+      return;
+    }
+    const next = peers[(idx + direction + peers.length) % peers.length];
+    void this.openIssue(next);
+  }
+
   private runEditWorkflowCommand(): void {
     const projects = applyProjectOrder(listProjects(this.app), this.settings.projectOrder);
     if (projects.length === 0) {
@@ -2523,6 +2666,11 @@ function formatRegistrationNote(res: WorkIssueResult): string {
   if (res.alreadyHeld) return " · registration unchanged";
   if (res.registration) return ` · registered as ${res.registration.agent}`;
   return "";
+}
+
+function issueIdNumericSuffix(id: string): number {
+  const m = id.match(/-(\d+)$/);
+  return m ? parseInt(m[1], 10) : 0;
 }
 
 function defaultBinaryFor(id: AgentId): string {

--- a/plugins/op-obsidian/src/main.ts
+++ b/plugins/op-obsidian/src/main.ts
@@ -2230,6 +2230,10 @@ export default class OpPlugin extends Plugin {
       return;
     }
     const next = peers[(idx + direction + peers.length) % peers.length];
+    if (next.path === current.path) {
+      new Notice(`op: only one open issue in ${current.project}`);
+      return;
+    }
     void this.openIssue(next);
   }
 

--- a/plugins/op-obsidian/src/pickAndActDispatch.test.ts
+++ b/plugins/op-obsidian/src/pickAndActDispatch.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect } from "vitest";
+import {
+  decidePickAndActAction,
+  matchesPickAndActQuery,
+  shouldIncludeResolved,
+} from "./pickAndActDispatch";
+
+describe("decidePickAndActAction (macOS)", () => {
+  const mac = (evt: Parameters<typeof decidePickAndActAction>[0]) =>
+    decidePickAndActAction(evt, true);
+
+  it("no modifiers → open", () => {
+    expect(mac({})).toBe("open");
+  });
+
+  it("metaKey → launch", () => {
+    expect(mac({ metaKey: true })).toBe("launch");
+  });
+
+  it("altKey → plan", () => {
+    expect(mac({ altKey: true })).toBe("plan");
+  });
+
+  it("shiftKey → resolve", () => {
+    expect(mac({ shiftKey: true })).toBe("resolve");
+  });
+
+  it("ctrlKey alone → commit (raw Ctrl on macOS)", () => {
+    expect(mac({ ctrlKey: true })).toBe("commit");
+  });
+
+  it("metaKey + shiftKey → launch (Cmd wins over Shift)", () => {
+    expect(mac({ metaKey: true, shiftKey: true })).toBe("launch");
+  });
+});
+
+describe("decidePickAndActAction (non-macOS)", () => {
+  const lin = (evt: Parameters<typeof decidePickAndActAction>[0]) =>
+    decidePickAndActAction(evt, false);
+
+  it("no modifiers → open", () => {
+    expect(lin({})).toBe("open");
+  });
+
+  it("ctrlKey → launch (Ctrl plays the Cmd role)", () => {
+    expect(lin({ ctrlKey: true })).toBe("launch");
+  });
+
+  it("altKey → plan", () => {
+    expect(lin({ altKey: true })).toBe("plan");
+  });
+
+  it("shiftKey → resolve", () => {
+    expect(lin({ shiftKey: true })).toBe("resolve");
+  });
+
+  it("ctrlKey + altKey → commit (deliberate two-modifier combo)", () => {
+    expect(lin({ ctrlKey: true, altKey: true })).toBe("commit");
+  });
+});
+
+describe("matchesPickAndActQuery", () => {
+  const hay = "OP-72 fix link escaping in markdown render obsidian-projects";
+
+  it("matches an empty query", () => {
+    expect(matchesPickAndActQuery(hay, "")).toBe(true);
+    expect(matchesPickAndActQuery(hay, "   ")).toBe(true);
+  });
+
+  it("matches a single token case-insensitively", () => {
+    expect(matchesPickAndActQuery(hay, "LINK")).toBe(true);
+    expect(matchesPickAndActQuery(hay, "OP-72")).toBe(true);
+  });
+
+  it("requires every whitespace-separated token to appear", () => {
+    expect(matchesPickAndActQuery(hay, "link escaping")).toBe(true);
+    expect(matchesPickAndActQuery(hay, "link banana")).toBe(false);
+  });
+
+  it("returns false when no tokens hit", () => {
+    expect(matchesPickAndActQuery(hay, "graphql")).toBe(false);
+  });
+});
+
+describe("shouldIncludeResolved", () => {
+  it("includes when query exactly matches the issue id (case-insensitive)", () => {
+    expect(shouldIncludeResolved("OP-72", "OP-72")).toBe(true);
+    expect(shouldIncludeResolved("op-72", "OP-72")).toBe(true);
+    expect(shouldIncludeResolved("  OP-72  ", "OP-72")).toBe(true);
+  });
+
+  it("does not include on partial id matches", () => {
+    expect(shouldIncludeResolved("OP-7", "OP-72")).toBe(false);
+    expect(shouldIncludeResolved("link", "OP-72")).toBe(false);
+  });
+});

--- a/plugins/op-obsidian/src/pickAndActDispatch.test.ts
+++ b/plugins/op-obsidian/src/pickAndActDispatch.test.ts
@@ -3,6 +3,8 @@ import {
   decidePickAndActAction,
   matchesPickAndActQuery,
   shouldIncludeResolved,
+  sortPickAndActResults,
+  numericIdSuffix,
 } from "./pickAndActDispatch";
 
 describe("decidePickAndActAction (macOS)", () => {
@@ -92,5 +94,74 @@ describe("shouldIncludeResolved", () => {
   it("does not include on partial id matches", () => {
     expect(shouldIncludeResolved("OP-7", "OP-72")).toBe(false);
     expect(shouldIncludeResolved("link", "OP-72")).toBe(false);
+  });
+});
+
+describe("numericIdSuffix", () => {
+  it("extracts the trailing number from a hyphenated ID", () => {
+    expect(numericIdSuffix("OP-72")).toBe(72);
+    expect(numericIdSuffix("PROJ-1")).toBe(1);
+  });
+
+  it("returns 0 for IDs with no numeric suffix", () => {
+    expect(numericIdSuffix("NOID")).toBe(0);
+    expect(numericIdSuffix("")).toBe(0);
+  });
+});
+
+describe("sortPickAndActResults", () => {
+  type Entry = { id: string; resolvedFolder?: boolean };
+
+  const open = (id: string): Entry => ({ id, resolvedFolder: false });
+  const resolved = (id: string): Entry => ({ id, resolvedFolder: true });
+
+  it("open issues sort before resolved issues", () => {
+    const result = sortPickAndActResults([resolved("OP-1"), open("OP-2")], "");
+    expect(result.map((e) => e.id)).toEqual(["OP-2", "OP-1"]);
+  });
+
+  it("within each bucket, higher numeric ID sorts first (most recent first)", () => {
+    const result = sortPickAndActResults([open("OP-1"), open("OP-3"), open("OP-2")], "");
+    expect(result.map((e) => e.id)).toEqual(["OP-3", "OP-2", "OP-1"]);
+  });
+
+  it("exact-ID match floats to top above open partial matches", () => {
+    // OP-7 is resolved but typed exactly; OP-72 is open (partial match)
+    const result = sortPickAndActResults(
+      [open("OP-72"), resolved("OP-7")],
+      "OP-7",
+    );
+    expect(result[0].id).toBe("OP-7");
+    expect(result[1].id).toBe("OP-72");
+  });
+
+  it("exact-ID match (case-insensitive) floats to top", () => {
+    const result = sortPickAndActResults(
+      [open("OP-72"), resolved("OP-7")],
+      "op-7",
+    );
+    expect(result[0].id).toBe("OP-7");
+  });
+
+  it("open exact-ID match still sorts first over other open issues", () => {
+    const result = sortPickAndActResults(
+      [open("OP-72"), open("OP-7"), open("OP-70")],
+      "OP-7",
+    );
+    expect(result[0].id).toBe("OP-7");
+  });
+
+  it("no mutation of the input array (returns a fresh copy)", () => {
+    const input = [open("OP-2"), open("OP-1")];
+    sortPickAndActResults(input, "");
+    expect(input[0].id).toBe("OP-2"); // original order preserved
+  });
+
+  it("empty query — open before resolved, descending numeric", () => {
+    const result = sortPickAndActResults(
+      [resolved("OP-5"), open("OP-3"), open("OP-10")],
+      "",
+    );
+    expect(result.map((e) => e.id)).toEqual(["OP-10", "OP-3", "OP-5"]);
   });
 });

--- a/plugins/op-obsidian/src/pickAndActDispatch.ts
+++ b/plugins/op-obsidian/src/pickAndActDispatch.ts
@@ -97,3 +97,40 @@ export function matchesPickAndActQuery(
 export function shouldIncludeResolved(query: string, issueId: string): boolean {
   return query.trim().toLowerCase() === issueId.toLowerCase();
 }
+
+/**
+ * Extract the trailing numeric suffix from an issue ID (e.g. "OP-72" → 72).
+ * Returns 0 for IDs with no numeric suffix.
+ */
+export function numericIdSuffix(id: string): number {
+  const m = id.match(/-(\d+)$/);
+  return m ? parseInt(m[1], 10) : 0;
+}
+
+/**
+ * Sort a filtered list of issues for the pick & act modal.
+ *
+ * Ordering (most-preferred first):
+ *  1. Exact-ID match — if `query` is an exact case-insensitive match for an
+ *     issue's ID, that issue floats to the top regardless of resolved status.
+ *     This ensures that typing "OP-7" while OP-7 is resolved still surfaces it
+ *     immediately above the open OP-72 partial match.
+ *  2. Open/in-progress before resolved.
+ *  3. Within each bucket, numerically descending by issue number (most-recent
+ *     first).
+ */
+export function sortPickAndActResults(
+  entries: { id: string; resolvedFolder?: boolean }[],
+  query: string,
+): typeof entries {
+  const q = query.trim().toLowerCase();
+  return [...entries].sort((a, b) => {
+    const aExact = a.id.toLowerCase() === q ? 0 : 1;
+    const bExact = b.id.toLowerCase() === q ? 0 : 1;
+    if (aExact !== bExact) return aExact - bExact;
+    const aResolved = a.resolvedFolder ? 1 : 0;
+    const bResolved = b.resolvedFolder ? 1 : 0;
+    if (aResolved !== bResolved) return aResolved - bResolved;
+    return numericIdSuffix(b.id) - numericIdSuffix(a.id);
+  });
+}

--- a/plugins/op-obsidian/src/pickAndActDispatch.ts
+++ b/plugins/op-obsidian/src/pickAndActDispatch.ts
@@ -1,0 +1,99 @@
+/**
+ * Pure dispatch helper for the `op: pick & act` modal (OP-152).
+ *
+ * The modal extends Obsidian's `SuggestModal<IssueEntry>`; its
+ * `onChooseSuggestion(entry, evt)` callback receives a `MouseEvent` (mouse pick)
+ * or `KeyboardEvent` (keyboard pick). This module decides which action to run
+ * based on the modifier-key state, so the decision logic is testable without
+ * pulling in Obsidian or the DOM.
+ *
+ * Action map (matches the spec's footer hint):
+ *   ↵ open · ⌘↵ launch · ⌥↵ plan · ⇧↵ resolve · ⌃↵ commit
+ */
+
+export type PickAndActAction =
+  | "open"
+  | "launch"
+  | "plan"
+  | "resolve"
+  | "commit";
+
+export interface ModifierState {
+  metaKey?: boolean;
+  shiftKey?: boolean;
+  altKey?: boolean;
+  ctrlKey?: boolean;
+}
+
+/**
+ * Decide which action to run for a pick & act selection.
+ *
+ * Modifier precedence is intentional:
+ *   - Cmd/Ctrl (`metaKey` on macOS, `ctrlKey` elsewhere) → "launch"
+ *   - Alt → "plan"
+ *   - Shift → "resolve"
+ *   - Ctrl on macOS (without Cmd) → "commit"
+ *   - Anything else → "open"
+ *
+ * Two modifiers held together (e.g. Cmd+Shift) take the higher-precedence
+ * one ("launch" wins over "resolve") because the spec describes each binding
+ * as a single decisive action and gives no instruction for combinations.
+ *
+ * On macOS, `Cmd↵` arrives as `metaKey: true` and `Ctrl↵` as `ctrlKey: true`.
+ * On Linux/Windows, `Ctrl↵` arrives as `ctrlKey: true` and there is no `Cmd`,
+ * so we treat `ctrlKey` as the "launch" modifier instead of "commit". The
+ * spec's footer hint uses macOS glyphs but the binding is conceptually
+ * "platform-mod for launch, raw-ctrl for commit".
+ */
+export function decidePickAndActAction(
+  evt: ModifierState,
+  isMacOS: boolean,
+): PickAndActAction {
+  if (isMacOS) {
+    if (evt.metaKey) return "launch";
+    if (evt.altKey) return "plan";
+    if (evt.shiftKey) return "resolve";
+    if (evt.ctrlKey) return "commit";
+    return "open";
+  }
+  // Non-macOS: Ctrl plays the Cmd role. We surface "commit" only if the user
+  // explicitly held Ctrl+Alt (a deliberate two-modifier combination) — there
+  // is no separate "raw-ctrl" surface on non-Mac platforms.
+  if (evt.ctrlKey && evt.altKey) return "commit";
+  if (evt.ctrlKey) return "launch";
+  if (evt.altKey) return "plan";
+  if (evt.shiftKey) return "resolve";
+  return "open";
+}
+
+/**
+ * Fuzzy-match a query against an issue's id + title + project. Pure so it can
+ * be unit-tested independently of Obsidian's `prepareFuzzySearch`.
+ *
+ * Matching rules:
+ *  - Empty query → match (the modal shows everything).
+ *  - Query is split on whitespace; every token must appear (case-insensitive)
+ *    somewhere in `${id} ${title} ${project}`.
+ *  - We don't return a score — Obsidian's modal will sort by insertion order,
+ *    which we control via the caller's pre-sort.
+ */
+export function matchesPickAndActQuery(
+  haystack: string,
+  query: string,
+): boolean {
+  if (!query.trim()) return true;
+  const hay = haystack.toLowerCase();
+  for (const token of query.trim().split(/\s+/)) {
+    if (!hay.includes(token.toLowerCase())) return false;
+  }
+  return true;
+}
+
+/**
+ * Decide whether resolved issues should be included in pick & act results
+ * for this query. The spec's convention: resolved issues appear only when
+ * the query exactly matches an issue ID (case-insensitive).
+ */
+export function shouldIncludeResolved(query: string, issueId: string): boolean {
+  return query.trim().toLowerCase() === issueId.toLowerCase();
+}

--- a/plugins/op-obsidian/src/pickAndActModal.ts
+++ b/plugins/op-obsidian/src/pickAndActModal.ts
@@ -1,0 +1,121 @@
+import { App, Platform, SuggestModal } from "obsidian";
+import type { IssueEntry } from "./types";
+import {
+  decidePickAndActAction,
+  matchesPickAndActQuery,
+  shouldIncludeResolved,
+  type PickAndActAction,
+} from "./pickAndActDispatch";
+
+/**
+ * Handler map the modal calls when a user picks an issue + action. The plugin
+ * passes its own bound methods (open issue, launch agent, etc.) so the modal
+ * stays decoupled from the plugin internals.
+ */
+export interface PickAndActHandlers {
+  open: (entry: IssueEntry) => void | Promise<void>;
+  launch: (entry: IssueEntry) => void | Promise<void>;
+  plan: (entry: IssueEntry) => void | Promise<void>;
+  resolve: (entry: IssueEntry) => void | Promise<void>;
+  commit: (entry: IssueEntry) => void | Promise<void>;
+}
+
+/**
+ * `op: pick & act` modal — fuzzy-pick an issue and dispatch one of five
+ * actions via modifier-enter. See {@link decidePickAndActAction} for the
+ * action keymap and {@link shouldIncludeResolved} for the resolved-issue
+ * inclusion convention.
+ */
+export class PickAndActModal extends SuggestModal<IssueEntry> {
+  private currentQuery = "";
+
+  constructor(
+    app: App,
+    private getIssues: () => IssueEntry[],
+    private handlers: PickAndActHandlers,
+  ) {
+    super(app);
+    this.setPlaceholder("Pick an issue — ↵ open · ⌘↵ launch · ⌥↵ plan · ⇧↵ resolve · ⌃↵ commit");
+    this.appendFooterHint();
+  }
+
+  getSuggestions(query: string): IssueEntry[] {
+    this.currentQuery = query;
+    const issues = this.getIssues();
+    const filtered = issues.filter((entry) => {
+      if (entry.resolvedFolder && !shouldIncludeResolved(query, entry.id)) {
+        return false;
+      }
+      const haystack = `${entry.id} ${entry.title} ${entry.project}`;
+      return matchesPickAndActQuery(haystack, query);
+    });
+    // Sort: open + in-progress first, then resolved at the bottom; within each
+    // bucket, numerically descending by issue number (most recent first).
+    return filtered.sort((a, b) => {
+      const aResolved = a.resolvedFolder ? 1 : 0;
+      const bResolved = b.resolvedFolder ? 1 : 0;
+      if (aResolved !== bResolved) return aResolved - bResolved;
+      return numericIdSuffix(b.id) - numericIdSuffix(a.id);
+    });
+  }
+
+  renderSuggestion(entry: IssueEntry, el: HTMLElement): void {
+    el.addClass("op-pick-and-act__row");
+    const main = el.createSpan({ cls: "op-pick-and-act__main" });
+    main.createSpan({ cls: "op-pick-and-act__id", text: entry.id });
+    main.createSpan({ cls: "op-pick-and-act__title", text: ` ${entry.title}` });
+    const status = entry.resolvedFolder ? "resolved" : entry.status;
+    el.createSpan({
+      cls: `op-pick-and-act__status op-pick-and-act__status--${status}`,
+      text: status,
+    });
+  }
+
+  onChooseSuggestion(entry: IssueEntry, evt: MouseEvent | KeyboardEvent): void {
+    const action = decidePickAndActAction(
+      {
+        metaKey: evt.metaKey,
+        shiftKey: evt.shiftKey,
+        altKey: evt.altKey,
+        ctrlKey: evt.ctrlKey,
+      },
+      Platform.isMacOS,
+    );
+    void this.dispatch(action, entry);
+  }
+
+  private async dispatch(action: PickAndActAction, entry: IssueEntry): Promise<void> {
+    const handler = this.handlers[action];
+    await handler(entry);
+  }
+
+  /**
+   * Append a static footer hint to the modal so the action keymap is always
+   * visible. Obsidian's stock modals use `.prompt-instructions` for this; we
+   * follow the same convention so the footer inherits theme styling.
+   */
+  private appendFooterHint(): void {
+    const inst = this.modalEl.createDiv({ cls: "prompt-instructions op-pick-and-act__hint" });
+    const items: Array<[string, string]> = [
+      ["↵", "open"],
+      ["⌘↵", "launch"],
+      ["⌥↵", "plan"],
+      ["⇧↵", "resolve"],
+      ["⌃↵", "commit"],
+    ];
+    for (const [keys, label] of items) {
+      const item = inst.createDiv({ cls: "prompt-instruction" });
+      item.createSpan({ cls: "prompt-instruction-command", text: keys });
+      item.createSpan({ text: ` ${label}` });
+    }
+    inst.createDiv({
+      cls: "prompt-instruction op-pick-and-act__hint-note",
+      text: "Resolved issues appear only on exact-ID match (e.g. OP-72).",
+    });
+  }
+}
+
+function numericIdSuffix(id: string): number {
+  const m = id.match(/-(\d+)$/);
+  return m ? parseInt(m[1], 10) : 0;
+}

--- a/plugins/op-obsidian/src/pickAndActModal.ts
+++ b/plugins/op-obsidian/src/pickAndActModal.ts
@@ -4,6 +4,7 @@ import {
   decidePickAndActAction,
   matchesPickAndActQuery,
   shouldIncludeResolved,
+  sortPickAndActResults,
   type PickAndActAction,
 } from "./pickAndActDispatch";
 
@@ -49,14 +50,9 @@ export class PickAndActModal extends SuggestModal<IssueEntry> {
       const haystack = `${entry.id} ${entry.title} ${entry.project}`;
       return matchesPickAndActQuery(haystack, query);
     });
-    // Sort: open + in-progress first, then resolved at the bottom; within each
-    // bucket, numerically descending by issue number (most recent first).
-    return filtered.sort((a, b) => {
-      const aResolved = a.resolvedFolder ? 1 : 0;
-      const bResolved = b.resolvedFolder ? 1 : 0;
-      if (aResolved !== bResolved) return aResolved - bResolved;
-      return numericIdSuffix(b.id) - numericIdSuffix(a.id);
-    });
+    // Sort: exact-ID matches first, then open/in-progress before resolved;
+    // within each bucket, numerically descending by issue number (most recent first).
+    return sortPickAndActResults(filtered, query) as IssueEntry[];
   }
 
   renderSuggestion(entry: IssueEntry, el: HTMLElement): void {
@@ -115,7 +111,3 @@ export class PickAndActModal extends SuggestModal<IssueEntry> {
   }
 }
 
-function numericIdSuffix(id: string): number {
-  const m = id.match(/-(\d+)$/);
-  return m ? parseInt(m[1], 10) : 0;
-}

--- a/plugins/op-obsidian/src/settings.ts
+++ b/plugins/op-obsidian/src/settings.ts
@@ -1,4 +1,13 @@
-import { App, PluginSettingTab, Setting, Notice } from "obsidian";
+import { App, Modal, PluginSettingTab, Setting, Notice } from "obsidian";
+import {
+  applyPreset,
+  defaultPreset,
+  revertPreset,
+  type ApplyResult,
+  type Hotkey,
+  type HotkeyEntry,
+  type SkippedBinding,
+} from "./hotkeyPreset";
 import { existsSync } from "fs";
 import * as path from "path";
 import type OpPlugin from "./main";
@@ -756,6 +765,29 @@ export class OpSettingsTab extends PluginSettingTab {
         }),
       );
 
+    containerEl.createEl("h2", { text: "Hotkey preset" });
+    containerEl.createEl("p", {
+      text:
+        "One-click install of the op default keyboard shortcuts. Best-effort: any binding whose key is already taken by another command is skipped, and the results modal lists what landed and what didn't. Click Apply to mutate; nothing happens automatically.",
+      cls: "setting-item-description",
+    });
+
+    new Setting(containerEl)
+      .setName("Apply op default hotkey preset")
+      .setDesc(
+        "Binds the 10 op commands to ⌘⇧* / ⌘⌥* shortcuts. Reversible from the results modal during this session.",
+      )
+      .addButton((b) =>
+        b
+          .setButtonText("Apply preset")
+          .setCta()
+          .onClick(() => {
+            const preset = defaultPreset();
+            const result = applyPreset(this.app, preset);
+            new HotkeyPresetResultsModal(this.app, preset, result).open();
+          }),
+      );
+
     containerEl.createEl("h2", { text: "Advanced" });
 
     new Setting(containerEl)
@@ -778,6 +810,158 @@ function describeWorkingDir(p: string): string {
   if (!path.isAbsolute(p)) return `⚠ not an absolute path`;
   if (!existsSync(p)) return `⚠ path does not exist`;
   return `✓ ${p}`;
+}
+
+function formatHotkey(h: Hotkey): string {
+  const order = ["Mod", "Meta", "Ctrl", "Alt", "Shift"];
+  const mods = [...h.modifiers].sort(
+    (a, b) => order.indexOf(a) - order.indexOf(b),
+  );
+  const glyphs: Record<string, string> = {
+    Mod: "⌘",
+    Meta: "⌘",
+    Ctrl: "⌃",
+    Alt: "⌥",
+    Shift: "⇧",
+  };
+  const keyGlyph = h.key === "Enter" ? "↵" : h.key;
+  return mods.map((m) => glyphs[m] ?? m).join("") + keyGlyph;
+}
+
+/**
+ * Results modal for the "Apply op default hotkey preset" button. Lists what
+ * landed and what was skipped; offers a Revert button (session-scoped, restores
+ * the snapshot captured before the apply) and an Open Hotkeys settings shortcut
+ * so the user can manually rebind anything skipped. On the JSON-snippet
+ * fallback path, surfaces the snippet in a textarea instead.
+ */
+export class HotkeyPresetResultsModal extends Modal {
+  constructor(
+    app: App,
+    private preset: HotkeyEntry[],
+    private result: ApplyResult,
+  ) {
+    super(app);
+  }
+
+  onOpen(): void {
+    const { contentEl } = this;
+    contentEl.empty();
+
+    if (!this.result.ok) {
+      this.renderFallback(contentEl, this.result.reason, this.result.snippet);
+      return;
+    }
+
+    const { applied, skipped, previousCustomKeys } = this.result;
+
+    contentEl.createEl("h2", { text: "op hotkey preset applied" });
+    contentEl.createEl("p", {
+      text: `${applied.length} binding${applied.length === 1 ? "" : "s"} landed${
+        skipped.length ? `, ${skipped.length} skipped due to conflicts` : ""
+      }.`,
+      cls: "setting-item-description",
+    });
+
+    if (applied.length > 0) {
+      contentEl.createEl("h3", { text: "Applied" });
+      const list = contentEl.createDiv({ cls: "op-hotkey-preset__results" });
+      for (const e of applied) {
+        const row = list.createDiv({ cls: "op-hotkey-preset__row" });
+        row.createSpan({ cls: "op-hotkey-preset__keys", text: formatHotkey(e.hotkey) });
+        row.createSpan({ cls: "op-hotkey-preset__cmd", text: e.command });
+      }
+    }
+
+    if (skipped.length > 0) {
+      contentEl.createEl("h3", { text: "Skipped (key already bound)" });
+      const list = contentEl.createDiv({ cls: "op-hotkey-preset__results" });
+      for (const s of skipped) {
+        const row = list.createDiv({ cls: "op-hotkey-preset__row" });
+        row.createSpan({
+          cls: "op-hotkey-preset__keys",
+          text: formatHotkey(s.binding.hotkey),
+        });
+        row.createSpan({ cls: "op-hotkey-preset__cmd", text: s.binding.command });
+        row.createSpan({
+          cls: "op-hotkey-preset__skip-reason",
+          text: `→ taken by ${s.conflictingCommandName}`,
+        });
+      }
+    }
+
+    new Setting(contentEl)
+      .addButton((b) =>
+        b
+          .setButtonText("Open Hotkeys settings")
+          .onClick(() => {
+            this.close();
+            const setting = (this.app as any).setting;
+            setting?.open?.();
+            setting?.openTabById?.("hotkeys");
+          }),
+      )
+      .addButton((b) =>
+        b
+          .setButtonText("Revert")
+          .setWarning()
+          .onClick(() => {
+            const r = revertPreset(this.app, previousCustomKeys);
+            if (r.ok) {
+              new Notice("op: hotkey preset reverted");
+              this.close();
+            } else {
+              new Notice(`op: revert failed — ${r.reason}`);
+            }
+          }),
+      )
+      .addButton((b) => b.setButtonText("Close").setCta().onClick(() => this.close()));
+  }
+
+  private renderFallback(
+    el: HTMLElement,
+    reason: string,
+    snippet: string,
+  ): void {
+    el.createEl("h2", { text: "op hotkey preset — degraded mode" });
+    el.createEl("p", {
+      cls: "setting-item-description",
+      text:
+        `Could not write hotkeys directly: ${reason}. Paste the JSON below into your vault's .obsidian/hotkeys.json (merge with any existing entries) and reload Obsidian.`,
+    });
+    const ta = el.createEl("textarea", { cls: "op-hotkey-preset__snippet" });
+    ta.value = snippet;
+    ta.readOnly = true;
+    new Setting(el)
+      .addButton((b) =>
+        b
+          .setButtonText("Copy to clipboard")
+          .setCta()
+          .onClick(async () => {
+            try {
+              await navigator.clipboard.writeText(snippet);
+              new Notice("op: snippet copied");
+            } catch (err: any) {
+              new Notice(`op: copy failed — ${err?.message ?? err}`);
+            }
+          }),
+      )
+      .addButton((b) =>
+        b
+          .setButtonText("Open Hotkeys settings")
+          .onClick(() => {
+            this.close();
+            const setting = (this.app as any).setting;
+            setting?.open?.();
+            setting?.openTabById?.("hotkeys");
+          }),
+      )
+      .addButton((b) => b.setButtonText("Close").onClick(() => this.close()));
+  }
+
+  onClose(): void {
+    this.contentEl.empty();
+  }
 }
 
 function detectionSummary(plugin: OpPlugin): string {

--- a/plugins/op-obsidian/styles.css
+++ b/plugins/op-obsidian/styles.css
@@ -256,3 +256,86 @@ a.op-sidebar__agent:hover {
   font-style: italic;
   padding: 0.5rem;
 }
+
+.op-pick-and-act__row {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.op-pick-and-act__main {
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.op-pick-and-act__id {
+  color: var(--text-muted);
+  font-family: var(--font-monospace, monospace);
+  font-weight: 600;
+}
+
+.op-pick-and-act__status {
+  font-size: var(--font-ui-smaller, 0.72rem);
+  text-transform: lowercase;
+  padding: 0 0.35rem;
+  border-radius: 3px;
+  color: var(--text-on-accent, #fff);
+  background: var(--background-modifier-border);
+  font-weight: 600;
+}
+
+.op-pick-and-act__status--in-progress { background: var(--color-blue, #1e88e5); }
+.op-pick-and-act__status--open        { background: var(--color-green, #2e7d32); }
+.op-pick-and-act__status--blocked     { background: var(--color-red, #c62828); }
+.op-pick-and-act__status--resolved    { background: var(--background-modifier-border); color: var(--text-muted); }
+.op-pick-and-act__status--wontfix     { background: var(--background-modifier-border); color: var(--text-muted); }
+
+.op-pick-and-act__hint {
+  border-top: 1px solid var(--background-modifier-border);
+}
+
+.op-pick-and-act__hint-note {
+  color: var(--text-faint);
+  font-style: italic;
+}
+
+.op-hotkey-preset__results {
+  margin-top: 0.5rem;
+}
+
+.op-hotkey-preset__row {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.25rem 0;
+  border-bottom: 1px solid var(--background-modifier-border);
+}
+
+.op-hotkey-preset__row:last-child { border-bottom: none; }
+
+.op-hotkey-preset__keys {
+  font-family: var(--font-monospace, monospace);
+  color: var(--text-accent);
+  min-width: 6rem;
+}
+
+.op-hotkey-preset__cmd {
+  flex: 1;
+  min-width: 0;
+}
+
+.op-hotkey-preset__skip-reason {
+  color: var(--text-muted);
+  font-style: italic;
+}
+
+.op-hotkey-preset__snippet {
+  width: 100%;
+  min-height: 12rem;
+  font-family: var(--font-monospace, monospace);
+  font-size: var(--font-ui-smaller, 0.75rem);
+  margin-top: 0.5rem;
+}

--- a/plugins/op/.claude-plugin/plugin.json
+++ b/plugins/op/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "op",
   "description": "Obsidian Projects workflow — schema, slash commands, and agent skill for running a Jira-lite issue tracker inside an Obsidian vault.",
-  "version": "0.48.0",
+  "version": "0.49.0",
   "author": {
     "name": "Eugene Archibald"
   },


### PR DESCRIPTION
## Summary

- Ships **§3 of OP-149** — a one-click default hotkey preset (10 bindings on `⌘⇧*` / `⌘⌥*`) and a new `op: pick & act` modal that combines fuzzy issue-picking with modifier-enter action dispatch (open / launch / plan / resolve / commit).
- Five new palette commands wired into `main.ts`: `op-pick-and-act`, `op-attach-current`, `op-resume-last` (stub awaiting §1), `op-next-issue`, `op-previous-issue` (numerically sorted, project-scoped, wrapping).
- Apply/revert routes through `app.hotkeyManager.setHotkeys`/`removeHotkeys` — direct `customKeys` mutation is silently discarded by Obsidian's getter-based snapshot. JSON-snippet fallback covers Obsidian API drift.
- 40 new unit tests (504/504 total). End-to-end smoke-tested via `obsidian eval`: apply, revert, modal open + fuzzy filter, next/previous round-trip.
- Bumped to **0.49.0** (minor).

Closes [OP-152](Projects/obsidian-projects/ISSUES/OP-152%20Hotkey%20preset%20%2B%20op%20pick%20%26%20act%20modal%20(%C2%A73%20of%20OP-149).md). Linked GitHub issue: #154.

## Test plan

- [x] `npm run build` clean
- [x] `npx vitest run` — 504/504 pass (40 new)
- [x] Smoke-tested in Agent-Vault: Apply preset → 10 bindings landed in `bakedHotkeys`; Revert → 10 cleared; `op: pick & act` modal opens with footer hint; fuzzy filter on "OP-152" surfaces the issue; `op-next-issue` rotates OP-152 → OP-153; `op-previous-issue` returns; `op-resume-last` stub fires Notice without throwing.
- [x] Console clean post-reload
- [ ] Adversarial Copilot review (requested below — touches public surface, new modal, hotkey API integration → all review-required per WORKFLOW.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)