### PR TITLE
OP-167: persistent notification log + palette accessor

### DIFF
--- a/plugins/op-obsidian/src/editWorkflow.ts
+++ b/plugins/op-obsidian/src/editWorkflow.ts
@@ -1,4 +1,5 @@
-import { App, Notice, TFile } from "obsidian";
+import { App, TFile } from "obsidian";
+import { notify } from "./notificationLog";
 import type { OpSettings } from "./settings";
 import {
   AGENT_IDS,
@@ -37,14 +38,14 @@ export async function editWorkflow(
 ): Promise<EditWorkflowResult | undefined> {
   const trimmed = slug.trim();
   if (!trimmed) {
-    new Notice("op-edit-workflow: project slug is required");
+    notify("op-edit-workflow: project slug is required");
     return undefined;
   }
 
   const detection = detector.get() ?? (await detector.refresh());
   const installed = AGENT_IDS.filter((id) => detection?.[id]?.installed);
   if (installed.length === 0) {
-    new Notice("op: no supported agent binaries found on PATH");
+    notify("op: no supported agent binaries found on PATH");
     return undefined;
   }
 
@@ -55,7 +56,7 @@ export async function editWorkflow(
 
   const det = detection[agentId];
   if (!det.installed) {
-    new Notice(`op: ${agentId} binary not found on PATH (looking for "${profile.binary}")`);
+    notify(`op: ${agentId} binary not found on PATH (looking for "${profile.binary}")`);
     return undefined;
   }
 

--- a/plugins/op-obsidian/src/main.ts
+++ b/plugins/op-obsidian/src/main.ts
@@ -88,7 +88,7 @@ import { installAgentHooks, type HookInstallResult } from "./agentHooks";
 import { userError } from "./userError";
 import { cleanupAgentSessions, tmuxSessionsForCleanup } from "./agentSessionCleanup";
 import { detectTmux } from "./tmuxDetect";
-import { notify, notifyAction, registerApp, openNotificationLog } from "./notificationLog";
+import { notify, notifyAction, registerApp, unregisterApp, openNotificationLog } from "./notificationLog";
 import { probeLiveTmuxWindows, selectStaleAgentBadges } from "./staleAgentBadges";
 import { openErrorLog, writeErrorLog } from "./errorLog";
 import { configureClient } from "./iterm/client";
@@ -938,6 +938,9 @@ export default class OpPlugin extends Plugin {
     // OP-101: drop any open iTerm WebSocket so plugin reload doesn't leak the
     // socket. Safe no-op when the WS path was never used in this session.
     closeTransport();
+    // Clear the registered App so any notify() calls that fire after unload
+    // don't attempt vault writes against a detached plugin context.
+    unregisterApp();
   }
 
   // Resolve the absolute filesystem path used for the `safeStorage`-encrypted

--- a/plugins/op-obsidian/src/main.ts
+++ b/plugins/op-obsidian/src/main.ts
@@ -1,4 +1,4 @@
-import { Notice, Plugin, TFile, WorkspaceLeaf } from "obsidian";
+import { Plugin, TFile, WorkspaceLeaf } from "obsidian";
 import { OP_SIDEBAR_VIEW_TYPE, OpSidebarView } from "./sidebarView";
 import { revealAgentSession } from "./revealAgentSession";
 import { EventBus } from "./eventBus";
@@ -88,7 +88,7 @@ import { installAgentHooks, type HookInstallResult } from "./agentHooks";
 import { userError } from "./userError";
 import { cleanupAgentSessions, tmuxSessionsForCleanup } from "./agentSessionCleanup";
 import { detectTmux } from "./tmuxDetect";
-import { showActionableNotice } from "./actionableNotices";
+import { notify, notifyAction, registerApp, openNotificationLog } from "./notificationLog";
 import { probeLiveTmuxWindows, selectStaleAgentBadges } from "./staleAgentBadges";
 import { openErrorLog, writeErrorLog } from "./errorLog";
 import { configureClient } from "./iterm/client";
@@ -158,6 +158,11 @@ export default class OpPlugin extends Plugin {
    * command registration, reconciler after `onLayoutReady`).
    */
   async onload(): Promise<void> {
+    // Register the app for the persistent notification log before any
+    // `notify(...)` call below — early Notices (tmux auto-detect failure,
+    // detector probe, settings hydration warnings) are exactly the ones
+    // users tend to dismiss by accident, so they belong in the log too.
+    registerApp(this.app);
     this.settings = mergeSettings(await this.loadData());
     // OP-101: configure the iTerm WebSocket client with the plugin version so
     // its handshake includes a usable library-version header, and with a
@@ -178,7 +183,7 @@ export default class OpPlugin extends Plugin {
         await this.saveSettings();
         console.debug(`[op-obsidian] tmux auto-detected: ${prev} → ${found.path}`);
       } else {
-        showActionableNotice({
+        notifyAction({
           text: `op: tmux not found at ${this.settings.tmuxBinary} or common paths — agent launches will fail until you install tmux or set the path in Settings → op.`,
           actions: [
             {
@@ -243,7 +248,7 @@ export default class OpPlugin extends Plugin {
       if (!this.settings.github.closeGithubIssueOnResolve) return;
       const repoPath = resolveRepoPath(this.app, this.settings, entry.project);
       if (!repoPath) {
-        new Notice(`op: no repo_path for ${entry.project} — skipping gh issue close`);
+        notify(`op: no repo_path for ${entry.project} — skipping gh issue close`);
         return;
       }
       const reason = closeReasonForStatus(entry.status);
@@ -282,13 +287,13 @@ export default class OpPlugin extends Plugin {
         .then((result) => {
           if (!result.ok) {
             console.error("[op-obsidian] auto-resolve failed", args.path, result.error);
-            new Notice(`op: auto-resolve failed — ${result.error ?? "unknown error"}`);
+            notify(`op: auto-resolve failed — ${result.error ?? "unknown error"}`);
           }
         })
         .catch((err: any) => {
           const msg = err?.message ?? String(err);
           console.error("[op-obsidian] auto-resolve threw", args.path, msg);
-          new Notice(`op: auto-resolve threw — ${msg}`);
+          notify(`op: auto-resolve threw — ${msg}`);
         });
     });
 
@@ -318,6 +323,14 @@ export default class OpPlugin extends Plugin {
       id: "op-open-sidebar",
       name: "op: open sidebar",
       callback: () => this.revealSidebar(),
+    });
+
+    // OP-167: Notices dismiss on click; the log is how users (or a
+    // delegated agent) recover what they missed.
+    this.addCommand({
+      id: "op-open-notifications",
+      name: "op: open notifications log",
+      callback: () => void openNotificationLog(this.app),
     });
 
     this.addRibbonIcon("list-checks", "op: open sidebar", () => this.revealSidebar());
@@ -386,7 +399,7 @@ export default class OpPlugin extends Plugin {
       callback: async () => {
         const path = this.activeIssuePath();
         if (!path) {
-          new Notice("op: open an issue note first");
+          notify("op: open an issue note first");
           return;
         }
         await this.runResolveCommand({ path });
@@ -541,7 +554,7 @@ export default class OpPlugin extends Plugin {
             tasks: tasks.length,
             entries: [...issues, ...tasks],
           });
-          new Notice(`op: ${issues.length} issues, ${tasks.length} tasks (see console)`);
+          notify(`op: ${issues.length} issues, ${tasks.length} tasks (see console)`);
         },
       });
 
@@ -550,7 +563,7 @@ export default class OpPlugin extends Plugin {
         name: "op-dev: rebuild IssueStore",
         callback: () => {
           this.store.rebuild();
-          new Notice("op: store rebuilt");
+          notify("op: store rebuilt");
         },
       });
     }
@@ -562,7 +575,7 @@ export default class OpPlugin extends Plugin {
     this.registerObsidianProtocolHandler("op-new", (params) => {
       this.handleOpNewUri(normalizeUriParams(params)).catch((err) => {
         console.error("[op-obsidian] op-new URI failed", err);
-        new Notice(`op-new failed: ${err.message ?? err}`);
+        notify(`op-new failed: ${err.message ?? err}`);
       });
     });
 
@@ -1002,7 +1015,7 @@ export default class OpPlugin extends Plugin {
     }
     const stale = selectStaleAgentBadges(issues, probe.live);
     for (const entry of stale) {
-      showActionableNotice({
+      notifyAction({
         text: `op: ${entry.id} has no live agent`,
         actions: [
           {
@@ -1038,14 +1051,14 @@ export default class OpPlugin extends Plugin {
           seedPriority: input.seedPriority,
         });
         const extra = res.seed ? ` · seeded ${res.seed.id}` : "";
-        new Notice(`op-scaffold: ${res.slug} (${res.prefix})${extra}`);
+        notify(`op-scaffold: ${res.slug} (${res.prefix})${extra}`);
         const status = this.app.vault.getAbstractFileByPath(res.statusPath);
         if (status instanceof TFile) {
           await this.app.workspace.getLeaf(false).openFile(status);
         }
       } catch (err: any) {
         console.error("[op-obsidian] op-scaffold failed", err);
-        new Notice(`op-scaffold failed: ${err?.message ?? err}`);
+        notify(`op-scaffold failed: ${err?.message ?? err}`);
       }
     }).open();
   }
@@ -1053,7 +1066,7 @@ export default class OpPlugin extends Plugin {
   private runNewIssueCommand(): void {
     const projects = applyProjectOrder(listProjects(this.app), this.settings.projectOrder);
     if (projects.length === 0) {
-      new Notice("No projects found under Projects/");
+      notify("No projects found under Projects/");
       return;
     }
     new ProjectSuggestModal(this.app, projects, (project) => {
@@ -1073,7 +1086,7 @@ export default class OpPlugin extends Plugin {
       const projects = listProjects(this.app);
       const result = findIssue(this.store, { raw, projects });
       if (result.matches.length === 0) {
-        new Notice(
+        notify(
           `op: no match for ${result.interpretation}. Try an ID (e.g. OP-12) or a title fragment.`,
         );
         return;
@@ -1095,7 +1108,7 @@ export default class OpPlugin extends Plugin {
     if (file instanceof TFile) {
       await this.app.workspace.getLeaf(false).openFile(file);
     } else {
-      new Notice(`op: file not found on disk: ${entry.path}`);
+      notify(`op: file not found on disk: ${entry.path}`);
     }
   }
 
@@ -1109,7 +1122,7 @@ export default class OpPlugin extends Plugin {
       if (file instanceof TFile) {
         await this.app.workspace.getLeaf(false).openFile(file);
       }
-      showActionableNotice({
+      notifyAction({
         text: `op: created ${res.id}`,
         actions: [
           {
@@ -1129,7 +1142,7 @@ export default class OpPlugin extends Plugin {
       if (!input.githubIssue && this.settings.github.autoCreateGithubIssue) {
         await this.autoCreateGithubIssueFor(res.path, res.id, input).catch((err) => {
           console.error("[op-obsidian] auto-create github issue failed", err);
-          new Notice(`op: gh create failed — ${err?.message ?? err}`);
+          notify(`op: gh create failed — ${err?.message ?? err}`);
         });
       }
       if (opts.launchPlan) {
@@ -1140,7 +1153,7 @@ export default class OpPlugin extends Plugin {
       }
     } catch (err: any) {
       console.error("[op-obsidian] createIssue failed", err);
-      new Notice(`op: create failed — ${err?.message ?? err}`);
+      notify(`op: create failed — ${err?.message ?? err}`);
     }
   }
 
@@ -1148,7 +1161,7 @@ export default class OpPlugin extends Plugin {
     entry: IssueEntry,
     input: CreateIssueInput,
   ): Promise<void> {
-    new Notice(`op: evaluating ${entry.id} — running op-evaluate…`, 6000);
+    notify(`op: evaluating ${entry.id} — running op-evaluate…`, 6000);
     const body = (input.scope ?? []).map((s) => `- ${s}`).join("\n");
     try {
       const result = await runEvaluatorFlow(
@@ -1160,13 +1173,13 @@ export default class OpPlugin extends Plugin {
         entry,
         body,
       );
-      new Notice(
+      notify(
         `op: ${entry.id} evaluated — complexity=${result.complexity}. Advance manually via the command palette.`,
         8000,
       );
     } catch (err: any) {
       console.error("[op-obsidian] evaluator flow failed", err);
-      new Notice(
+      notify(
         `op: evaluator failed for ${entry.id} — ${err?.message ?? err}. Leaving flow unset; retry manually.`,
         10000,
       );
@@ -1180,7 +1193,7 @@ export default class OpPlugin extends Plugin {
   ): Promise<void> {
     const repoPath = resolveRepoPath(this.app, this.settings, input.slug);
     if (!repoPath) {
-      new Notice(`op: no repo_path for ${input.slug} — skipping gh create`);
+      notify(`op: no repo_path for ${input.slug} — skipping gh create`);
       return;
     }
     const body = buildGithubBody(id, input);
@@ -1188,7 +1201,7 @@ export default class OpPlugin extends Plugin {
     const entry = this.store.byPath(path);
     if (entry && entry.type === "issue") {
       await setGithubIssue(this.app, entry, url);
-      new Notice(`op: linked ${id} → ${url}`);
+      notify(`op: linked ${id} → ${url}`);
     }
   }
 
@@ -1197,11 +1210,11 @@ export default class OpPlugin extends Plugin {
       try {
         const res = await workIssue(this.app, this.store, entry);
         const extra = res.createdTaskPath ? ` · created ${res.createdTaskPath.split("/").pop()}` : "";
-        new Notice(`op-work: ${res.issueId} → in-progress${extra}`);
+        notify(`op-work: ${res.issueId} → in-progress${extra}`);
         await this.openIssue(entry);
       } catch (err: any) {
         console.error("[op-obsidian] op-work failed", err);
-        new Notice(`op-work failed: ${err?.message ?? err}`);
+        notify(`op-work failed: ${err?.message ?? err}`);
       }
     });
   }
@@ -1211,14 +1224,14 @@ export default class OpPlugin extends Plugin {
       new AppendCommitModal(this.app, entry, async (sha, subject) => {
         try {
           const res = await appendCommit(this.app, entry, { sha, subject });
-          new Notice(
+          notify(
             res.added
               ? `op: appended commit to ${res.issueId}`
               : `op: commit already present on ${res.issueId}`,
           );
         } catch (err: any) {
           console.error("[op-obsidian] op-append-commit failed", err);
-          new Notice(`op-append-commit failed: ${err?.message ?? err}`);
+          notify(`op-append-commit failed: ${err?.message ?? err}`);
         }
       }).open();
     });
@@ -1229,10 +1242,10 @@ export default class OpPlugin extends Plugin {
       new SetPrModal(this.app, entry, async (url) => {
         try {
           const res = await setPr(this.app, entry, url);
-          new Notice(`op: pr set on ${res.issueId}`);
+          notify(`op: pr set on ${res.issueId}`);
         } catch (err: any) {
           console.error("[op-obsidian] op-set-pr failed", err);
-          new Notice(`op-set-pr failed: ${err?.message ?? err}`);
+          notify(`op-set-pr failed: ${err?.message ?? err}`);
         }
       }).open();
     });
@@ -1243,10 +1256,10 @@ export default class OpPlugin extends Plugin {
       new SetGithubIssueModal(this.app, entry, async (url) => {
         try {
           const res = await setGithubIssue(this.app, entry, url);
-          new Notice(`op: github_issue set on ${res.issueId}`);
+          notify(`op: github_issue set on ${res.issueId}`);
         } catch (err: any) {
           console.error("[op-obsidian] op-set-github-issue failed", err);
-          new Notice(`op-set-github-issue failed: ${err?.message ?? err}`);
+          notify(`op-set-github-issue failed: ${err?.message ?? err}`);
         }
       }).open();
     });
@@ -1257,17 +1270,17 @@ export default class OpPlugin extends Plugin {
       try {
         const repoPath = resolveRepoPath(this.app, this.settings, entry.project);
         if (!repoPath) {
-          new Notice(`op: no repo_path for ${entry.project}`);
+          notify(`op: no repo_path for ${entry.project}`);
           return;
         }
         const title = entry.title.replace(/^[A-Z]+-\d+\s+/, "");
         const body = await this.readIssueBody(entry.path);
         const url = await createGithubIssue({ repoPath, title, body });
         await setGithubIssue(this.app, entry, url);
-        new Notice(`op: created ${url}`);
+        notify(`op: created ${url}`);
       } catch (err: any) {
         console.error("[op-obsidian] op-create-github-issue failed", err);
-        new Notice(`op-create-github-issue failed: ${err?.message ?? err}`);
+        notify(`op-create-github-issue failed: ${err?.message ?? err}`);
       }
     };
     const activePath = this.activeIssuePath();
@@ -1283,7 +1296,7 @@ export default class OpPlugin extends Plugin {
     this.pickIssueInteractive((entry) => {
       const url = entry.githubIssue;
       if (!url) {
-        new Notice(`${entry.id} has no github_issue URL`);
+        notify(`${entry.id} has no github_issue URL`);
         return;
       }
       window.open(url, "_blank");
@@ -1304,7 +1317,7 @@ export default class OpPlugin extends Plugin {
       const projects = listProjects(this.app);
       const result = findIssue(this.store, { raw, projects });
       if (result.matches.length === 0) {
-        new Notice(
+        notify(
           `op: no match for ${result.interpretation}. Try an ID (e.g. OP-12) or a title fragment.`,
         );
         return;
@@ -1350,7 +1363,7 @@ export default class OpPlugin extends Plugin {
       .catch(async (err) => {
         console.error(`[op-obsidian] ${command} URI failed`, err);
         const msg = err?.message ?? String(err);
-        new Notice(`${command} failed: ${msg}`);
+        notify(`${command} failed: ${msg}`);
         await writeUriResponse(this.app, {
           ok: false,
           command,
@@ -1419,7 +1432,7 @@ export default class OpPlugin extends Plugin {
         if (!entry.githubIssue) return;
         const repoPath = resolveRepoPath(this.app, this.settings, entry.project);
         if (!repoPath) {
-          new Notice(`op: no repo_path for ${entry.project} — skipping gh issue close`);
+          notify(`op: no repo_path for ${entry.project} — skipping gh issue close`);
           return;
         }
         await closeGithubIssue(repoPath, entry.githubIssue, closeReasonForStatus(entry.status));
@@ -1474,7 +1487,7 @@ export default class OpPlugin extends Plugin {
       const status = result.status ?? "resolved";
       const movedTo = result.movedTo;
       const tail = trashed ? ` (${trashed} task${trashed === 1 ? "" : "s"} trashed)` : "";
-      showActionableNotice({
+      notifyAction({
         text: `op: ${id} ${status}${tail}`,
         actions: movedTo
           ? [
@@ -1544,12 +1557,12 @@ export default class OpPlugin extends Plugin {
           retryFired = true;
           void closeGithubIssue(repoPath, url, reason)
             .then(() => {
-              showActionableNotice({ text: `op: gh issue closed for ${entryId}` });
+              notifyAction({ text: `op: gh issue closed for ${entryId}` });
             })
             .catch((err: any) => {
               const msg = err?.message ?? String(err);
               console.error("[op-obsidian] gh issue close retry failed", msg);
-              showActionableNotice({
+              notifyAction({
                 text: `op: gh issue close retry failed — ${msg}`,
                 actions: logPath
                   ? [{ label: "Open log", onClick: () => void openErrorLog(this.app) }]
@@ -1562,7 +1575,7 @@ export default class OpPlugin extends Plugin {
     if (logPath) {
       actions.push({ label: "Open log", onClick: () => void openErrorLog(this.app) });
     }
-    showActionableNotice({
+    notifyAction({
       text: `op: gh issue close failed for ${args.entryId}`,
       actions,
     });
@@ -1593,7 +1606,7 @@ export default class OpPlugin extends Plugin {
     } catch (err: any) {
       console.error("[op-obsidian]", command, err);
       const msg = err?.message ?? String(err);
-      new Notice(`${command} failed: ${msg}`);
+      notify(`${command} failed: ${msg}`);
       await writeUriResponse(this.app, { ok: false, command, error: msg });
     }
   }
@@ -2057,10 +2070,10 @@ export default class OpPlugin extends Plugin {
       const parts = [`drift ${res.drift.length}`];
       if (repair) parts.push(`repaired ${res.repaired.length}`);
       if (dangling > 0) parts.push(`dangling ${dangling}`);
-      new Notice(`op-link-check: scanned ${res.scanned} · ${parts.join(" · ")}`);
+      notify(`op-link-check: scanned ${res.scanned} · ${parts.join(" · ")}`);
     } catch (err: any) {
       console.error("[op-obsidian] op-link-check failed", err);
-      new Notice(`op-link-check failed: ${err?.message ?? err}`);
+      notify(`op-link-check failed: ${err?.message ?? err}`);
     }
   }
 
@@ -2068,12 +2081,12 @@ export default class OpPlugin extends Plugin {
     try {
       const res = await migrateLinks(this.app, this.store);
       await writeUriResponse(this.app, { ...res });
-      new Notice(
+      notify(
         `op-migrate-links: scanned ${res.scanned} · rewrote ${res.rewrites.length}`,
       );
     } catch (err: any) {
       console.error("[op-obsidian] op-migrate-links failed", err);
-      new Notice(`op-migrate-links failed: ${err?.message ?? err}`);
+      notify(`op-migrate-links failed: ${err?.message ?? err}`);
     }
   }
 
@@ -2240,7 +2253,7 @@ export default class OpPlugin extends Plugin {
   private runEditWorkflowCommand(): void {
     const projects = applyProjectOrder(listProjects(this.app), this.settings.projectOrder);
     if (projects.length === 0) {
-      new Notice("op: no projects found under Projects/");
+      notify("op: no projects found under Projects/");
       return;
     }
     new ProjectSuggestModal(this.app, projects, (project) => {
@@ -2258,13 +2271,13 @@ export default class OpPlugin extends Plugin {
         slug,
       );
       if (res) {
-        new Notice(
+        notify(
           `op-edit-workflow: ${res.project} → ${res.agent} in ${res.workingDir} (tmux: ${res.tmuxSession}:${res.tmuxWindow})`,
         );
       }
     } catch (err: any) {
       console.error("[op-obsidian] op-edit-workflow failed", err);
-      new Notice(`op-edit-workflow failed: ${err?.message ?? err}`);
+      notify(`op-edit-workflow failed: ${err?.message ?? err}`);
     }
   }
 
@@ -2292,12 +2305,12 @@ export default class OpPlugin extends Plugin {
         agentId,
         debug: true,
       });
-      new Notice(
+      notify(
         `op-debug-agent-launch: ${issueId} (tmux: ${res.tmuxSession}:${res.tmuxWindow})`,
       );
     } catch (err: any) {
       console.error("[op-obsidian] op-debug-agent-launch failed", err);
-      new Notice(`op-debug-agent-launch failed: ${err?.message ?? err}`);
+      notify(`op-debug-agent-launch failed: ${err?.message ?? err}`);
     }
   }
 
@@ -2324,13 +2337,13 @@ export default class OpPlugin extends Plugin {
           res.mode === "work" || res.mode === "implement"
             ? ""
             : ` [${res.mode.toUpperCase()} MODE]`;
-        new Notice(
+        notify(
           `op-open-agent: ${res.issueId} → ${res.agent}${modeLabel} in ${res.workingDir} (tmux: ${res.tmuxSession}:${res.tmuxWindow})`,
         );
       }
     } catch (err: any) {
       console.error("[op-obsidian] op-open-agent failed", err);
-      new Notice(`op-open-agent failed: ${err?.message ?? err}`);
+      notify(`op-open-agent failed: ${err?.message ?? err}`);
     }
   }
 
@@ -2417,7 +2430,7 @@ export default class OpPlugin extends Plugin {
         advanced = await this.advanceFlowAndLaunch(entry, exitStatus);
       } catch (err: any) {
         console.error("[op-obsidian] flow auto-advance failed", err);
-        new Notice(`op: flow auto-advance failed — ${err?.message ?? err}`);
+        notify(`op: flow auto-advance failed — ${err?.message ?? err}`);
       }
     }
     return {
@@ -2464,13 +2477,13 @@ export default class OpPlugin extends Plugin {
       try {
         const decision = await this.advanceFlowAndLaunch(entry, "clean");
         if (!decision) {
-          new Notice(
+          notify(
             `op: ${entry.id} has no next flow stage to launch — set complexity, or current stage is terminal`,
           );
         }
       } catch (err: any) {
         console.error("[op-obsidian] op-launch-next-stage failed", err);
-        new Notice(`op-launch-next-stage failed: ${err?.message ?? err}`);
+        notify(`op-launch-next-stage failed: ${err?.message ?? err}`);
       }
     });
   }
@@ -2479,10 +2492,10 @@ export default class OpPlugin extends Plugin {
     this.pickIssueInteractive(async (entry) => {
       try {
         await setFlow(this.app, entry, { flow: null, complexity: null });
-        new Notice(`op: ${entry.id} flow + complexity cleared`);
+        notify(`op: ${entry.id} flow + complexity cleared`);
       } catch (err: any) {
         console.error("[op-obsidian] op-reset-flow failed", err);
-        new Notice(`op-reset-flow failed: ${err?.message ?? err}`);
+        notify(`op-reset-flow failed: ${err?.message ?? err}`);
       }
     });
   }
@@ -2606,11 +2619,11 @@ export default class OpPlugin extends Plugin {
         if (res.guardInstalled.length) guardParts.push(`guard on: ${res.guardInstalled.join(", ")}`);
         if (res.guardUninstalled.length) guardParts.push(`guard off: ${res.guardUninstalled.join(", ")}`);
         const guard = guardParts.length ? ` · ${guardParts.join(" · ")}` : "";
-        new Notice(`op: agent hooks ${summary}${skipped}${guard}`);
+        notify(`op: agent hooks ${summary}${skipped}${guard}`);
       }
     } catch (err: any) {
       console.error("[op-obsidian] agent hook install failed", err);
-      if (announce) new Notice(`op: agent hook install failed — ${err?.message ?? err}`);
+      if (announce) notify(`op: agent hook install failed — ${err?.message ?? err}`);
     }
   }
 
@@ -2640,7 +2653,7 @@ export default class OpPlugin extends Plugin {
       scopeBody,
       githubIssue,
     });
-    new Notice(`Created ${res.id}`);
+    notify(`Created ${res.id}`);
     const file = this.app.vault.getAbstractFileByPath(res.path);
     if (file instanceof TFile) {
       await this.app.workspace.getLeaf(false).openFile(file);

--- a/plugins/op-obsidian/src/modals.ts
+++ b/plugins/op-obsidian/src/modals.ts
@@ -1,4 +1,5 @@
-import { App, FuzzySuggestModal, Modal, Notice, Setting } from "obsidian";
+import { App, FuzzySuggestModal, Modal, Setting } from "obsidian";
+import { notify } from "./notificationLog";
 import type { ProjectInfo } from "./projects";
 import type { Priority, CreateIssueInput } from "./createIssue";
 import type { IssueEntry } from "./types";
@@ -154,7 +155,7 @@ export class NewIssueModal extends Modal {
         priority: this.priority,
       });
       if (!result.ok) {
-        new Notice(result.error);
+        notify(result.error);
         return;
       }
       this.close();
@@ -240,7 +241,7 @@ export class AppendCommitModal extends Modal {
             const sha = validateSha(this.sha);
             const subject = validateSubject(this.subject);
             if (!sha.ok || !subject.ok) {
-              new Notice("Both SHA and subject are required");
+              notify("Both SHA and subject are required");
               return;
             }
             this.close();
@@ -286,7 +287,7 @@ export class SetPrModal extends Modal {
           .onClick(() => {
             const r = validatePrUrl(this.url);
             if (!r.ok) {
-              new Notice(r.error);
+              notify(r.error);
               return;
             }
             this.close();
@@ -336,7 +337,7 @@ export class SetGithubIssueModal extends Modal {
             const u = this.url.trim() || (this.issue.githubIssue ?? "");
             const r = validateGithubIssueUrl(u);
             if (!r.ok) {
-              new Notice(r.error);
+              notify(r.error);
               return;
             }
             this.close();
@@ -429,7 +430,7 @@ export class ScaffoldProjectModal extends Modal {
               seedPriority: this.seedPriority,
             });
             if (!r.ok) {
-              new Notice(r.error);
+              notify(r.error);
               return;
             }
             this.close();
@@ -478,7 +479,7 @@ export class FindIssueModal extends Modal {
   private submit(): void {
     const v = this.raw.trim();
     if (!v) {
-      new Notice("Enter a query");
+      notify("Enter a query");
       return;
     }
     this.close();

--- a/plugins/op-obsidian/src/notificationLog.test.ts
+++ b/plugins/op-obsidian/src/notificationLog.test.ts
@@ -1,0 +1,258 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const { FakeTFile, FakeNotice } = vi.hoisted(() => {
+  class FakeTFile {
+    path: string;
+    constructor(path: string) {
+      this.path = path;
+    }
+  }
+  const noticeCalls: Array<{ text: unknown; duration?: number }> = [];
+  class FakeNotice {
+    constructor(text: unknown, duration?: number) {
+      noticeCalls.push({ text, duration });
+    }
+    hide() {}
+  }
+  (FakeNotice as any).calls = noticeCalls;
+  return { FakeTFile, FakeNotice };
+});
+
+vi.mock("obsidian", () => ({
+  TFile: FakeTFile,
+  Notice: FakeNotice,
+  normalizePath: (p: string) => p,
+}));
+
+// `showActionableNotice` builds a DocumentFragment, which needs a DOM. The
+// log itself is what we're testing — stub the Notice path so the test only
+// exercises notification-log logic.
+vi.mock("./actionableNotices", () => ({
+  showActionableNotice: (opts: any) => new FakeNotice(opts.text),
+}));
+
+import {
+  buildLog,
+  formatLine,
+  NOTIFICATION_LOG_PATH,
+  MAX_LOG_ENTRIES,
+  appendNotification,
+  notify,
+  notifyAction,
+  registerApp,
+  openNotificationLog,
+  _resetForTests,
+} from "./notificationLog";
+
+function makeApp() {
+  const files = new Map<string, { path: string; body: string }>();
+  const folders = new Set<string>();
+  let opened: string | undefined;
+  const app = {
+    vault: {
+      adapter: {
+        exists: async (p: string) => folders.has(p),
+      },
+      createFolder: async (p: string) => {
+        folders.add(p);
+      },
+      getAbstractFileByPath: (p: string) => {
+        const f = files.get(p);
+        return f ? Object.assign(new FakeTFile(p), f) : null;
+      },
+      create: async (p: string, body: string) => {
+        files.set(p, { path: p, body });
+        return Object.assign(new FakeTFile(p), { body });
+      },
+      modify: async (file: any, body: string) => {
+        const existing = files.get(file.path);
+        if (existing) existing.body = body;
+        else files.set(file.path, { path: file.path, body });
+      },
+      read: async (file: any) => files.get(file.path)?.body ?? "",
+    },
+    workspace: {
+      getLeaf: () => ({
+        openFile: async (f: any) => {
+          opened = f.path;
+        },
+      }),
+    },
+  } as any;
+  return { app, files, folders, getOpened: () => opened };
+}
+
+beforeEach(() => {
+  _resetForTests();
+  (FakeNotice as any).calls.length = 0;
+});
+
+describe("formatLine", () => {
+  it("emits ISO timestamp + bullet", () => {
+    const line = formatLine({
+      timestamp: new Date("2026-04-25T12:30:45.000Z"),
+      text: "hello",
+    });
+    expect(line).toBe("- 2026-04-25T12:30:45.000Z · hello");
+  });
+
+  it("includes [category] when present", () => {
+    const line = formatLine({
+      timestamp: new Date("2026-04-25T00:00:00.000Z"),
+      text: "boom",
+      category: "error",
+    });
+    expect(line).toBe("- 2026-04-25T00:00:00.000Z [error] · boom");
+  });
+
+  it("collapses multi-line / extra whitespace into one bullet", () => {
+    const line = formatLine({
+      timestamp: new Date("2026-04-25T00:00:00.000Z"),
+      text: "first line\n→ hint   second\tword",
+    });
+    expect(line).toBe("- 2026-04-25T00:00:00.000Z · first line → hint second word");
+  });
+});
+
+describe("buildLog", () => {
+  it("creates log from empty body, newest first under header", () => {
+    const out = buildLog("", {
+      timestamp: new Date("2026-04-25T00:00:00.000Z"),
+      text: "first",
+    });
+    expect(out).toContain("# op notifications");
+    expect(out).toContain("- 2026-04-25T00:00:00.000Z · first");
+  });
+
+  it("prepends new entry above prior entries", () => {
+    const first = buildLog("", {
+      timestamp: new Date("2026-04-25T00:00:00.000Z"),
+      text: "older",
+    });
+    const second = buildLog(first, {
+      timestamp: new Date("2026-04-25T00:00:01.000Z"),
+      text: "newer",
+    });
+    const olderIdx = second.indexOf("· older");
+    const newerIdx = second.indexOf("· newer");
+    expect(newerIdx).toBeGreaterThan(-1);
+    expect(olderIdx).toBeGreaterThan(newerIdx);
+  });
+
+  it("caps to MAX_LOG_ENTRIES bullet lines", () => {
+    let body = "";
+    for (let i = 0; i < MAX_LOG_ENTRIES + 50; i += 1) {
+      body = buildLog(body, {
+        timestamp: new Date(2_000_000_000_000 + i),
+        text: `entry ${i}`,
+      });
+    }
+    const bullets = body.split("\n").filter((l) => l.startsWith("- "));
+    expect(bullets).toHaveLength(MAX_LOG_ENTRIES);
+    // Newest is first; oldest 50 evicted.
+    expect(bullets[0]).toContain(`entry ${MAX_LOG_ENTRIES + 49}`);
+    expect(bullets[bullets.length - 1]).toContain("entry 50");
+  });
+});
+
+describe("appendNotification", () => {
+  it("creates the log file and parent folder when missing", async () => {
+    const { app, files, folders } = makeApp();
+    await appendNotification(app, "hello", {
+      timestamp: new Date("2026-04-25T00:00:00.000Z"),
+    });
+    expect(folders.has("Projects/_scratch")).toBe(true);
+    const log = files.get(NOTIFICATION_LOG_PATH);
+    expect(log).toBeDefined();
+    expect(log!.body).toContain("- 2026-04-25T00:00:00.000Z · hello");
+  });
+
+  it("appends successive entries newest-first", async () => {
+    const { app, files } = makeApp();
+    await appendNotification(app, "one", {
+      timestamp: new Date("2026-04-25T00:00:00.000Z"),
+    });
+    await appendNotification(app, "two", {
+      timestamp: new Date("2026-04-25T00:00:01.000Z"),
+    });
+    const body = files.get(NOTIFICATION_LOG_PATH)!.body;
+    const oneIdx = body.indexOf("· one");
+    const twoIdx = body.indexOf("· two");
+    expect(twoIdx).toBeLessThan(oneIdx);
+  });
+
+  it("serializes concurrent appends without losing entries", async () => {
+    const { app, files } = makeApp();
+    const ts = new Date("2026-04-25T00:00:00.000Z");
+    await Promise.all([
+      appendNotification(app, "a", { timestamp: ts }),
+      appendNotification(app, "b", { timestamp: ts }),
+      appendNotification(app, "c", { timestamp: ts }),
+    ]);
+    const body = files.get(NOTIFICATION_LOG_PATH)!.body;
+    const bullets = body.split("\n").filter((l) => l.startsWith("- "));
+    expect(bullets).toHaveLength(3);
+  });
+});
+
+describe("notify", () => {
+  it("shows a Notice and logs to vault when app is registered", async () => {
+    const { app, files } = makeApp();
+    registerApp(app);
+    notify("op-work: OP-1 → in-progress");
+    // Notice fires synchronously; log write is async — flush.
+    await new Promise((r) => setTimeout(r, 0));
+    await new Promise((r) => setTimeout(r, 0));
+    expect((FakeNotice as any).calls).toHaveLength(1);
+    expect((FakeNotice as any).calls[0].text).toBe("op-work: OP-1 → in-progress");
+    expect(files.get(NOTIFICATION_LOG_PATH)!.body).toContain(
+      "op-work: OP-1 → in-progress",
+    );
+  });
+
+  it("shows a Notice without writing when no app is registered (test/early-load)", () => {
+    notify("standalone");
+    expect((FakeNotice as any).calls).toHaveLength(1);
+  });
+
+  it("forwards duration to Notice", () => {
+    notify("hi", 12000);
+    expect((FakeNotice as any).calls[0].duration).toBe(12000);
+  });
+});
+
+describe("notifyAction", () => {
+  it("logs text + action labels", async () => {
+    const { app, files } = makeApp();
+    registerApp(app);
+    notifyAction({
+      text: "op: error happened",
+      actions: [{ label: "Open log", onClick: () => {} }],
+    });
+    await new Promise((r) => setTimeout(r, 0));
+    await new Promise((r) => setTimeout(r, 0));
+    const body = files.get(NOTIFICATION_LOG_PATH)!.body;
+    expect(body).toContain("op: error happened · [Open log]");
+  });
+});
+
+describe("openNotificationLog", () => {
+  it("opens the existing log", async () => {
+    const { app, files, getOpened } = makeApp();
+    files.set(NOTIFICATION_LOG_PATH, {
+      path: NOTIFICATION_LOG_PATH,
+      body: "x",
+    });
+    await openNotificationLog(app);
+    expect(getOpened()).toBe(NOTIFICATION_LOG_PATH);
+  });
+
+  it("creates a placeholder when no log yet, then opens it", async () => {
+    const { app, files, getOpened } = makeApp();
+    await openNotificationLog(app);
+    expect(getOpened()).toBe(NOTIFICATION_LOG_PATH);
+    expect(files.get(NOTIFICATION_LOG_PATH)!.body).toContain(
+      "No notifications recorded yet",
+    );
+  });
+});

--- a/plugins/op-obsidian/src/notificationLog.test.ts
+++ b/plugins/op-obsidian/src/notificationLog.test.ts
@@ -40,6 +40,7 @@ import {
   notify,
   notifyAction,
   registerApp,
+  unregisterApp,
   openNotificationLog,
   _resetForTests,
 } from "./notificationLog";
@@ -111,6 +112,36 @@ describe("formatLine", () => {
       text: "first line\n→ hint   second\tword",
     });
     expect(line).toBe("- 2026-04-25T00:00:00.000Z · first line → hint second word");
+  });
+
+  it("strips null bytes", () => {
+    const line = formatLine({
+      timestamp: new Date("2026-04-25T00:00:00.000Z"),
+      text: "hello\x00world",
+    });
+    expect(line).toBe("- 2026-04-25T00:00:00.000Z · helloworld");
+  });
+
+  it("strips ANSI CSI colour sequences from agent output", () => {
+    const line = formatLine({
+      timestamp: new Date("2026-04-25T00:00:00.000Z"),
+      text: "\x1b[31mERROR\x1b[0m: build failed",
+    });
+    expect(line).toBe("- 2026-04-25T00:00:00.000Z · ERROR: build failed");
+  });
+
+  it("embedded '\\n- bullet' becomes continuation text, not a new entry", () => {
+    // After sanitisation the embedded newline collapses to a space, so the
+    // resulting text stays within one bullet line — no phantom entries.
+    const line = formatLine({
+      timestamp: new Date("2026-04-25T00:00:00.000Z"),
+      text: "op: status ok\n- not a real entry\n",
+    });
+    expect(line).toBe(
+      "- 2026-04-25T00:00:00.000Z · op: status ok - not a real entry",
+    );
+    // Crucially, splitting the line by "\n" yields exactly one element.
+    expect(line.split("\n")).toHaveLength(1);
   });
 });
 
@@ -219,6 +250,17 @@ describe("notify", () => {
     notify("hi", 12000);
     expect((FakeNotice as any).calls[0].duration).toBe(12000);
   });
+
+  it("stops writing to vault after unregisterApp (simulates onunload)", async () => {
+    const { app, files } = makeApp();
+    registerApp(app);
+    unregisterApp();
+    notify("should not be logged");
+    await new Promise((r) => setTimeout(r, 0));
+    await new Promise((r) => setTimeout(r, 0));
+    expect((FakeNotice as any).calls).toHaveLength(1); // Notice still shows
+    expect(files.get(NOTIFICATION_LOG_PATH)).toBeUndefined(); // no vault write
+  });
 });
 
 describe("notifyAction", () => {
@@ -254,5 +296,23 @@ describe("openNotificationLog", () => {
     expect(files.get(NOTIFICATION_LOG_PATH)!.body).toContain(
       "No notifications recorded yet",
     );
+  });
+
+  it("handles concurrent vault.create race — falls back to existing file", async () => {
+    // Simulate a vault that throws on create (file already exists from a
+    // concurrent writeOnce) but then returns the file via getAbstractFileByPath.
+    const { app, files, getOpened } = makeApp();
+    // Pre-populate the file to simulate the concurrent write winning.
+    files.set(NOTIFICATION_LOG_PATH, {
+      path: NOTIFICATION_LOG_PATH,
+      body: "written by concurrent writeOnce",
+    });
+    // Override create to throw as Obsidian would when the file already exists.
+    (app.vault as any).create = async () => {
+      throw new Error("File already exists");
+    };
+    // Should NOT throw, and should open the pre-existing file.
+    await expect(openNotificationLog(app)).resolves.toBeUndefined();
+    expect(getOpened()).toBe(NOTIFICATION_LOG_PATH);
   });
 });

--- a/plugins/op-obsidian/src/notificationLog.test.ts
+++ b/plugins/op-obsidian/src/notificationLog.test.ts
@@ -130,6 +130,14 @@ describe("formatLine", () => {
     expect(line).toBe("- 2026-04-25T00:00:00.000Z · ERROR: build failed");
   });
 
+  it("strips non-CSI ESC sequences (e.g. ESC M cursor-up)", () => {
+    const line = formatLine({
+      timestamp: new Date("2026-04-25T00:00:00.000Z"),
+      text: "\x1bMsome text",
+    });
+    expect(line).toBe("- 2026-04-25T00:00:00.000Z · some text");
+  });
+
   it("embedded '\\n- bullet' becomes continuation text, not a new entry", () => {
     // After sanitisation the embedded newline collapses to a space, so the
     // resulting text stays within one bullet line — no phantom entries.

--- a/plugins/op-obsidian/src/notificationLog.ts
+++ b/plugins/op-obsidian/src/notificationLog.ts
@@ -1,0 +1,129 @@
+import { App, Notice, TFile, normalizePath } from "obsidian";
+import { showActionableNotice, type ActionableNoticeOptions } from "./actionableNotices";
+
+export const NOTIFICATION_LOG_PATH = "Projects/_scratch/op-notifications.md";
+export const MAX_LOG_ENTRIES = 500;
+
+const HEADER =
+  "# op notifications\n\n" +
+  "Most recent first. Capped at the latest " +
+  MAX_LOG_ENTRIES +
+  " entries.\n";
+
+export interface NotificationEntry {
+  timestamp: Date;
+  text: string;
+  category?: string;
+}
+
+// Pure formatting — exported so tests don't need a vault.
+export function formatLine(entry: NotificationEntry): string {
+  const iso = entry.timestamp.toISOString();
+  const cat = entry.category ? ` [${entry.category}]` : "";
+  // Each entry is a single bullet line; collapse internal whitespace so
+  // multi-line Notice text doesn't fragment the log shape.
+  const safe = entry.text.replace(/\s+/g, " ").trim();
+  return `- ${iso}${cat} · ${safe}`;
+}
+
+// Pure: produce the next file body given the prior body and a new entry.
+// Newest entries first. Caps at `max` total bullet lines.
+export function buildLog(
+  existing: string,
+  entry: NotificationEntry,
+  max = MAX_LOG_ENTRIES,
+): string {
+  const newLine = formatLine(entry);
+  const priorLines = existing.split("\n").filter((l) => l.startsWith("- "));
+  const all = [newLine, ...priorLines].slice(0, max);
+  return `${HEADER}\n${all.join("\n")}\n`;
+}
+
+// Module-level app + write queue so `notify(text)` stays a one-liner at
+// call sites. The app is registered once in main.ts onload; callers in
+// non-Obsidian contexts (or before onload) get a no-op log write.
+let registeredApp: App | undefined;
+let writeQueue: Promise<void> = Promise.resolve();
+
+export function registerApp(app: App): void {
+  registeredApp = app;
+}
+
+// Test helper — mirrors `errorLog.ts`'s implicit "single source of truth"
+// shape. Resets module state between tests.
+export function _resetForTests(): void {
+  registeredApp = undefined;
+  writeQueue = Promise.resolve();
+}
+
+export function appendNotification(
+  app: App,
+  text: string,
+  opts?: { category?: string; timestamp?: Date },
+): Promise<void> {
+  const entry: NotificationEntry = {
+    timestamp: opts?.timestamp ?? new Date(),
+    text,
+    category: opts?.category,
+  };
+  // Serialize writes — Notices fire close together at session start
+  // (settings load, vault scan); concurrent read-modify-write would race.
+  writeQueue = writeQueue.catch(() => {}).then(() => writeOnce(app, entry));
+  return writeQueue;
+}
+
+async function writeOnce(app: App, entry: NotificationEntry): Promise<void> {
+  const path = normalizePath(NOTIFICATION_LOG_PATH);
+  const folder = path.split("/").slice(0, -1).join("/");
+  if (folder && !(await app.vault.adapter.exists(folder))) {
+    await app.vault.createFolder(folder).catch(() => {});
+  }
+  const existing = app.vault.getAbstractFileByPath(path);
+  let body = "";
+  if (existing instanceof TFile) {
+    body = await app.vault.read(existing);
+  }
+  const next = buildLog(body, entry);
+  if (existing instanceof TFile) {
+    await app.vault.modify(existing, next);
+  } else {
+    await app.vault.create(path, next);
+  }
+}
+
+// Show a Notice and persist it to the log. Drop-in replacement for
+// `new Notice(text, durationMs)`.
+export function notify(text: string, durationMs?: number): Notice {
+  const n = new Notice(text, durationMs);
+  if (registeredApp) void appendNotification(registeredApp, text);
+  return n;
+}
+
+// Show an actionable Notice and persist text + action labels.
+export function notifyAction(opts: ActionableNoticeOptions): Notice {
+  const n = showActionableNotice(opts);
+  if (registeredApp) {
+    const labels = (opts.actions ?? []).map((a) => `[${a.label}]`).join(" ");
+    const logged = labels ? `${opts.text} · ${labels}` : opts.text;
+    void appendNotification(registeredApp, logged);
+  }
+  return n;
+}
+
+export async function openNotificationLog(app: App): Promise<void> {
+  const path = normalizePath(NOTIFICATION_LOG_PATH);
+  const existing = app.vault.getAbstractFileByPath(path);
+  if (existing instanceof TFile) {
+    await app.workspace.getLeaf(false).openFile(existing);
+    return;
+  }
+  // No log yet — create an empty one so the palette command always has
+  // something to open. Beats a silent no-op when the user goes hunting.
+  const folder = path.split("/").slice(0, -1).join("/");
+  if (folder && !(await app.vault.adapter.exists(folder))) {
+    await app.vault.createFolder(folder).catch(() => {});
+  }
+  const placeholder = `${HEADER}\n_No notifications recorded yet._\n`;
+  const created = await app.vault.create(path, placeholder);
+  await app.workspace.getLeaf(false).openFile(created);
+}

--- a/plugins/op-obsidian/src/notificationLog.ts
+++ b/plugins/op-obsidian/src/notificationLog.ts
@@ -20,9 +20,17 @@ export interface NotificationEntry {
 export function formatLine(entry: NotificationEntry): string {
   const iso = entry.timestamp.toISOString();
   const cat = entry.category ? ` [${entry.category}]` : "";
-  // Each entry is a single bullet line; collapse internal whitespace so
-  // multi-line Notice text doesn't fragment the log shape.
-  const safe = entry.text.replace(/\s+/g, " ").trim();
+  // Each entry is a single bullet line.
+  // 1. Strip null bytes — they corrupt vault files.
+  // 2. Strip ANSI CSI / escape sequences — agent output can include colour codes.
+  // 3. Collapse internal whitespace so multi-line Notice text (newlines, tabs,
+  //    embedded "- bullets") doesn't fragment the log structure.
+  const safe = entry.text
+    .replace(/\0/g, "")
+    .replace(/\x1b\[[0-9;]*[A-Za-z]/g, "")
+    .replace(/\x1b./gs, "")
+    .replace(/\s+/g, " ")
+    .trim();
   return `- ${iso}${cat} · ${safe}`;
 }
 
@@ -47,6 +55,10 @@ let writeQueue: Promise<void> = Promise.resolve();
 
 export function registerApp(app: App): void {
   registeredApp = app;
+}
+
+export function unregisterApp(): void {
+  registeredApp = undefined;
 }
 
 // Test helper — mirrors `errorLog.ts`'s implicit "single source of truth"
@@ -119,11 +131,21 @@ export async function openNotificationLog(app: App): Promise<void> {
   }
   // No log yet — create an empty one so the palette command always has
   // something to open. Beats a silent no-op when the user goes hunting.
+  // If a concurrent `writeOnce` wins the race and creates the file first,
+  // `vault.create` will throw; catch that and fall back to the now-existing file.
   const folder = path.split("/").slice(0, -1).join("/");
   if (folder && !(await app.vault.adapter.exists(folder))) {
     await app.vault.createFolder(folder).catch(() => {});
   }
   const placeholder = `${HEADER}\n_No notifications recorded yet._\n`;
-  const created = await app.vault.create(path, placeholder);
-  await app.workspace.getLeaf(false).openFile(created);
+  let target: TFile;
+  try {
+    target = await app.vault.create(path, placeholder);
+  } catch {
+    // Concurrent write already created the file.
+    const raced = app.vault.getAbstractFileByPath(path);
+    if (!(raced instanceof TFile)) return; // nothing to open
+    target = raced;
+  }
+  await app.workspace.getLeaf(false).openFile(target);
 }

--- a/plugins/op-obsidian/src/notificationLog.ts
+++ b/plugins/op-obsidian/src/notificationLog.ts
@@ -22,13 +22,14 @@ export function formatLine(entry: NotificationEntry): string {
   const cat = entry.category ? ` [${entry.category}]` : "";
   // Each entry is a single bullet line.
   // 1. Strip null bytes — they corrupt vault files.
-  // 2. Strip ANSI CSI / escape sequences — agent output can include colour codes.
-  // 3. Collapse internal whitespace so multi-line Notice text (newlines, tabs,
+  // 2. Strip ANSI CSI sequences (e.g. colour codes: ESC [ … m).
+  // 3. Strip other single-char ESC sequences (e.g. ESC M, ESC =).
+  // 4. Collapse internal whitespace so multi-line Notice text (newlines, tabs,
   //    embedded "- bullets") doesn't fragment the log structure.
   const safe = entry.text
     .replace(/\0/g, "")
     .replace(/\x1b\[[0-9;]*[A-Za-z]/g, "")
-    .replace(/\x1b./gs, "")
+    .replace(/\x1b[^[]/g, "")
     .replace(/\s+/g, " ")
     .trim();
   return `- ${iso}${cat} · ${safe}`;

--- a/plugins/op-obsidian/src/openAgent.ts
+++ b/plugins/op-obsidian/src/openAgent.ts
@@ -1,4 +1,5 @@
-import { App, Notice, TFile } from "obsidian";
+import { App, TFile } from "obsidian";
+import { notify } from "./notificationLog";
 import type { IssueStore } from "./issueStore";
 import type { IssueEntry } from "./types";
 import type { OpSettings } from "./settings";
@@ -83,7 +84,7 @@ export async function openAgent(
 
   const det = detection[agentId];
   if (!det.installed) {
-    new Notice(`op: ${agentId} binary not found on PATH (looking for "${profile.binary}")`);
+    notify(`op: ${agentId} binary not found on PATH (looking for "${profile.binary}")`);
     return undefined;
   }
 
@@ -114,7 +115,7 @@ export async function openAgent(
       args.entry.status = "in-progress";
     } catch (err) {
       console.error("[op-obsidian] op-open-agent: pre-launch op-work failed", err);
-      new Notice(`op: failed to mark ${args.entry.id} in-progress before launch — agent should run op-work itself`);
+      notify(`op: failed to mark ${args.entry.id} in-progress before launch — agent should run op-work itself`);
     }
   }
 
@@ -171,7 +172,7 @@ async function pickAgent(
 
   const installed = AGENT_IDS.filter((id) => detection?.[id]?.installed);
   if (installed.length === 0) {
-    new Notice("op: no supported agent binaries found on PATH");
+    notify("op: no supported agent binaries found on PATH");
     return undefined;
   }
 

--- a/plugins/op-obsidian/src/revealAgentSession.ts
+++ b/plugins/op-obsidian/src/revealAgentSession.ts
@@ -1,6 +1,6 @@
 import { execFile } from "child_process";
 import { promisify } from "util";
-import { Notice } from "obsidian";
+import { notify } from "./notificationLog";
 
 import type { OpSettings } from "./settings";
 import { SHARED_TMUX_SESSION, tmuxWindowName } from "./terminalLaunch";
@@ -34,7 +34,7 @@ export async function revealAgentSession(
     }
   }
 
-  new Notice(`op: no live session found for ${issueId}`);
+  notify(`op: no live session found for ${issueId}`);
 }
 
 function uniqueSessions(settings: OpSettings, extra?: string): string[] {

--- a/plugins/op-obsidian/src/settings.ts
+++ b/plugins/op-obsidian/src/settings.ts
@@ -1,4 +1,5 @@
-import { App, Modal, PluginSettingTab, Setting, Notice } from "obsidian";
+import { App, Modal, PluginSettingTab, Setting } from "obsidian";
+import { notify } from "./notificationLog";
 import {
   applyPreset,
   defaultPreset,
@@ -228,7 +229,7 @@ export class OpSettingsTab extends PluginSettingTab {
         b.setButtonText("Re-probe").onClick(async () => {
           this.plugin.detector.invalidate();
           await this.plugin.detector.refresh();
-          new Notice("op: agent detection refreshed");
+          notify("op: agent detection refreshed");
           this.display();
         }),
       );
@@ -424,15 +425,15 @@ export class OpSettingsTab extends PluginSettingTab {
           const slug = newSlug.trim();
           const p = newPath.trim();
           if (!slug || !p) {
-            new Notice("Both slug and path are required");
+            notify("Both slug and path are required");
             return;
           }
           if (!path.isAbsolute(p)) {
-            new Notice(`Path must be absolute: ${p}`);
+            notify(`Path must be absolute: ${p}`);
             return;
           }
           if (!existsSync(p)) {
-            new Notice(`Path does not exist (saved anyway): ${p}`);
+            notify(`Path does not exist (saved anyway): ${p}`);
           }
           s.workingDirs[slug] = p;
           await this.plugin.saveSettings();
@@ -454,23 +455,23 @@ export class OpSettingsTab extends PluginSettingTab {
           try {
             parsed = JSON.parse(raw);
           } catch (err: any) {
-            new Notice(`workingDirs: invalid JSON — ${err?.message ?? err}`);
+            notify(`workingDirs: invalid JSON — ${err?.message ?? err}`);
             return;
           }
           if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
-            new Notice(`workingDirs: must be a JSON object of slug → absolute path`);
+            notify(`workingDirs: must be a JSON object of slug → absolute path`);
             return;
           }
           const next: Record<string, string> = {};
           const warnings: string[] = [];
           for (const [slug, v] of Object.entries(parsed as Record<string, unknown>)) {
             if (typeof v !== "string" || !v.trim()) {
-              new Notice(`workingDirs[${slug}]: value must be a non-empty string`);
+              notify(`workingDirs[${slug}]: value must be a non-empty string`);
               return;
             }
             const p = v.trim();
             if (!path.isAbsolute(p)) {
-              new Notice(`workingDirs[${slug}]: path must be absolute — ${p}`);
+              notify(`workingDirs[${slug}]: path must be absolute — ${p}`);
               return;
             }
             if (!existsSync(p)) warnings.push(`${slug}: missing ${p}`);
@@ -478,7 +479,7 @@ export class OpSettingsTab extends PluginSettingTab {
           }
           s.workingDirs = next;
           await this.plugin.saveSettings();
-          if (warnings.length) new Notice(`workingDirs saved. Warnings: ${warnings.join("; ")}`);
+          if (warnings.length) notify(`workingDirs saved. Warnings: ${warnings.join("; ")}`);
           this.display();
         });
       });
@@ -542,7 +543,7 @@ export class OpSettingsTab extends PluginSettingTab {
         }
         try {
           const out = execFileSync(p, ["-V"], { encoding: "utf8", timeout: 3000 }).trim();
-          new Notice(`op: tmux OK — ${out}`, 6000);
+          notify(`op: tmux OK — ${out}`, 6000);
         } catch (err: any) {
           userError(
             `op: tmux at ${p} failed to run — ${err?.message ?? err}`,
@@ -557,10 +558,10 @@ export class OpSettingsTab extends PluginSettingTab {
         if (found.path) {
           s.tmuxBinary = found.path;
           await this.plugin.saveSettings();
-          new Notice(`op: tmux found at ${found.path}`);
+          notify(`op: tmux found at ${found.path}`);
           this.display();
         } else {
-          new Notice(`op: tmux not found in any of: ${found.tried.join(", ")}`);
+          notify(`op: tmux not found in any of: ${found.tried.join(", ")}`);
         }
       }),
     );
@@ -639,7 +640,7 @@ export class OpSettingsTab extends PluginSettingTab {
         b.setButtonText("Reset").onClick(async () => {
           s.orchestratorState = emptyRegistry();
           await this.plugin.saveSettings();
-          new Notice("op: orchestrator state cleared");
+          notify("op: orchestrator state cleared");
         }),
       );
 
@@ -799,7 +800,7 @@ export class OpSettingsTab extends PluginSettingTab {
         t.setValue(s.developer.showDevCommands).onChange(async (v) => {
           s.developer.showDevCommands = v;
           await this.plugin.saveSettings();
-          new Notice("Reload the plugin to apply — Settings → Community plugins → op-obsidian → toggle off then on.", 8000);
+          notify("Reload the plugin to apply — Settings → Community plugins → op-obsidian → toggle off then on.", 8000);
         }),
       );
   }
@@ -908,10 +909,10 @@ export class HotkeyPresetResultsModal extends Modal {
           .onClick(() => {
             const r = revertPreset(this.app, previousCustomKeys);
             if (r.ok) {
-              new Notice("op: hotkey preset reverted");
+              notify("op: hotkey preset reverted");
               this.close();
             } else {
-              new Notice(`op: revert failed — ${r.reason}`);
+              notify(`op: revert failed — ${r.reason}`);
             }
           }),
       )
@@ -940,9 +941,9 @@ export class HotkeyPresetResultsModal extends Modal {
           .onClick(async () => {
             try {
               await navigator.clipboard.writeText(snippet);
-              new Notice("op: snippet copied");
+              notify("op: snippet copied");
             } catch (err: any) {
-              new Notice(`op: copy failed — ${err?.message ?? err}`);
+              notify(`op: copy failed — ${err?.message ?? err}`);
             }
           }),
       )

--- a/plugins/op-obsidian/src/userError.ts
+++ b/plugins/op-obsidian/src/userError.ts
@@ -1,4 +1,4 @@
-import { Notice } from "obsidian";
+import { notify } from "./notificationLog";
 
 // Pair every user-visible failure with a one-line "what to do next" hint.
 // The composed text is what the Notice shows AND what we return, so tests can
@@ -14,7 +14,7 @@ export function formatUserError(message: string, hint?: string): string {
 export function userError(message: string, hint?: string): string {
   const text = formatUserError(message, hint);
   const timeoutMs = hint ? 12000 : 8000;
-  new Notice(text, timeoutMs);
+  notify(text, timeoutMs);
   console.warn("[op-obsidian]", text);
   return text;
 }


### PR DESCRIPTION
## Summary

- Notices dismiss on click, leaving no after-the-fact way to recover the text. This adds a vault-side persistent log at `Projects/_scratch/op-notifications.md` that captures every Notice the plugin shows.
- New palette command **`op: open notifications log`** opens the log in one click. The log is capped at 500 entries (newest-first) so it can't grow unbounded.
- `notify()` / `notifyAction()` wrappers replace `new Notice(...)` / `showActionableNotice(...)` across ~83 call sites. The `App` reference is registered once in `onload` so call-site signatures stay one-arg.
- Bump 0.48.0 → 0.49.0 (additive feature, no breakage).

Closes OP-167.

## Test plan

- [x] `npx vitest run` — 460 passing (15 new in `notificationLog.test.ts`).
- [x] `npx tsc --noEmit` — clean.
- [x] Smoke test in Agent-Vault: triggered failing `op-set-pr` and `op-append-commit` URIs; both Notices landed in the log newest-first; palette command opens the log; no console errors.
- [x] Verified concurrent appends serialize (race test in `notificationLog.test.ts`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)