### PR TITLE
OP-150: op:resume-last + Last-touched sidebar chip + visibility-gated tmux liveness probe

### DIFF
--- a/plugins/op-obsidian/manifest.json
+++ b/plugins/op-obsidian/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "op-obsidian",
   "name": "Obsidian Projects (op)",
-  "version": "0.50.1",
+  "version": "0.51.0",
   "minAppVersion": "1.5.0",
   "description": "Jira-lite issue tracker for Obsidian vaults — deterministic commands backing the op workflow.",
   "author": "Eugene Archibald",

--- a/plugins/op-obsidian/package.json
+++ b/plugins/op-obsidian/package.json
@@ -1,6 +1,6 @@
 {
   "name": "op-obsidian",
-  "version": "0.50.1",
+  "version": "0.51.0",
   "description": "Obsidian plugin that owns the deterministic half of the op workflow.",
   "main": "main.js",
   "scripts": {

--- a/plugins/op-obsidian/src/main.ts
+++ b/plugins/op-obsidian/src/main.ts
@@ -1091,21 +1091,45 @@ export default class OpPlugin extends Plugin {
    * entry from the recency log, opens its issue note, and (on darwin only)
    * re-attaches to the agent's tmux window if it's still alive.
    *
+   * Stale entries (issue files deleted from the vault) are pruned eagerly in a
+   * single pass so that one invocation always lands on the first surviving entry
+   * rather than requiring repeated invocations to clear tombstones one at a time.
+   *
    * On non-macOS platforms, falls through to "open the note" — the recency
    * log still works as a navigation aid even when terminal launch isn't
    * supported.
    */
   private async runResumeLastCommand(): Promise<void> {
-    const head = mostRecent(this.settings.recent);
+    // Prune all leading tombstones in one O(n) pass so a single invocation
+    // always reaches the first surviving entry (§8 adversarial: multiple
+    // deleted heads — would otherwise require one invocation per stale entry).
+    let cursor = 0;
+    while (cursor < this.settings.recent.length) {
+      const candidate = this.settings.recent[cursor];
+      const e = this.store.byId(candidate.id);
+      if (e && e.type === "issue") break;
+      cursor++;
+    }
+    const staleCount = cursor;
+    if (staleCount > 0) {
+      const staleIds = this.settings.recent.slice(0, staleCount).map((e) => e.id);
+      this.settings.recent = this.settings.recent.slice(staleCount);
+      await this.saveSettings();
+      if (staleCount === 1) {
+        new Notice(`op: ${staleIds[0]} is no longer in the vault — cleared from recency log.`);
+      } else {
+        new Notice(`op: cleared ${staleCount} stale entries from recency log.`);
+      }
+    }
+    const head = this.settings.recent[0] as (typeof this.settings.recent)[number] | undefined;
     if (!head) {
       new Notice("op: no recent issues to resume — touch one via op:work or op:open-agent first.");
       return;
     }
     const entry = this.store.byId(head.id);
     if (!entry || entry.type !== "issue") {
-      new Notice(`op: ${head.id} is no longer in the vault — clearing from recency log.`);
-      this.settings.recent = this.settings.recent.filter((e) => e.id !== head.id);
-      await this.saveSettings();
+      // Shouldn't be reachable — the loop above would have advanced cursor past
+      // this entry — but guard defensively.
       return;
     }
     await this.openIssue(entry);

--- a/plugins/op-obsidian/src/main.ts
+++ b/plugins/op-obsidian/src/main.ts
@@ -91,13 +91,14 @@ import { AgentDetector } from "./agentDetect";
 import { AGENT_IDS, isAgentLaunchMode, type AgentId, type AgentLaunchMode } from "./agentProfiles";
 import { openAgent, clearAgentOnIssue, resolveProfile } from "./openAgent";
 import { editWorkflow } from "./editWorkflow";
-import { launchInTerminal } from "./terminalLaunch";
+import { launchInTerminal, SHARED_TMUX_SESSION, tmuxWindowName } from "./terminalLaunch";
 import { installAgentHooks, type HookInstallResult } from "./agentHooks";
 import { userError } from "./userError";
 import { cleanupAgentSessions, tmuxSessionsForCleanup } from "./agentSessionCleanup";
 import { detectTmux } from "./tmuxDetect";
 import { notify, notifyAction, registerApp, unregisterApp, openNotificationLog } from "./notificationLog";
 import { probeLiveTmuxWindows, selectStaleAgentBadges } from "./staleAgentBadges";
+import { appendRecency, mostRecent } from "./recencyLog";
 import { openErrorLog, writeErrorLog } from "./errorLog";
 import { configureClient } from "./iterm/client";
 import { closeWindow as itermCloseWindow } from "./iterm/driver";
@@ -322,8 +323,18 @@ export default class OpPlugin extends Plugin {
           this.store,
           this.bus,
           () => this.settings.view,
-          (entry) => revealAgentSession(this.settings, entry.id),
+          (entry) => {
+            void this.recordRecency(entry.id);
+            return revealAgentSession(this.settings, entry.id);
+          },
           (entry, mode, forcePick) => void this.doOpenAgent(entry, { mode, forcePick }),
+          {
+            getRecent: () => this.settings.recent,
+            tmuxBinary: () => this.settings.tmuxBinary,
+            tmuxSessions: () => tmuxSessionsForCleanup(this.settings.orchestratorState),
+            recordRecency: (id) => this.recordRecency(id),
+            executeResumeLast: () => void this.runResumeLastCommand(),
+          },
         ),
     );
 
@@ -464,20 +475,18 @@ export default class OpPlugin extends Plugin {
         if (checking) return !!path;
         if (!path) return false;
         const entry = this.store.byPath(path);
-        if (entry && entry.type === "issue") void revealAgentSession(this.settings, entry.id);
+        if (entry && entry.type === "issue") {
+          void this.recordRecency(entry.id);
+          void revealAgentSession(this.settings, entry.id);
+        }
         return true;
       },
     });
 
     this.addCommand({
       id: "op-resume-last",
-      name: "op: resume last (stub — OP-149 §1)",
-      callback: () => {
-        new Notice(
-          "op: resume-last is not yet implemented. Tracked under OP-149 §1.",
-          6000,
-        );
-      },
+      name: "op: resume last",
+      callback: () => void this.runResumeLastCommand(),
     });
 
     this.addCommand({
@@ -1052,6 +1061,64 @@ export default class OpPlugin extends Plugin {
     }
   }
 
+  /**
+   * Record `id` at the head of the recency log and persist. Idempotent on
+   * `id`: an existing entry is moved to the head with the new timestamp,
+   * never duplicated. Capped at {@link RECENCY_CAP} entries via
+   * {@link appendRecency}.
+   *
+   * Called from every dispatch point that "touches" an issue — palette
+   * `op-work`, `op-open-agent` and its variants, the URI handlers for both,
+   * the CLI handlers, and the sidebar row click. Centralizing the call is
+   * what keeps the cap-25 invariant in one place (OP-150).
+   */
+  async recordRecency(issueId: string): Promise<void> {
+    if (!issueId) return;
+    this.settings.recent = appendRecency(this.settings.recent, issueId, new Date().toISOString());
+    await this.saveSettings();
+    // Tell the sidebar to re-render its Last-touched chip without forcing a
+    // full reload. We piggy-back on the lifecycle bus rather than introducing
+    // a dedicated event — the chip cares about *anything* that flipped the
+    // recency log, and `issue:updated` is the closest existing signal.
+    const entry = this.store.byId(issueId);
+    if (entry && entry.type === "issue") {
+      this.bus.emit({ kind: "issue:updated", path: entry.path, issueId });
+    }
+  }
+
+  /**
+   * Implements the `op: resume last` palette command. Reads the most-recent
+   * entry from the recency log, opens its issue note, and (on darwin only)
+   * re-attaches to the agent's tmux window if it's still alive.
+   *
+   * On non-macOS platforms, falls through to "open the note" — the recency
+   * log still works as a navigation aid even when terminal launch isn't
+   * supported.
+   */
+  private async runResumeLastCommand(): Promise<void> {
+    const head = mostRecent(this.settings.recent);
+    if (!head) {
+      new Notice("op: no recent issues to resume — touch one via op:work or op:open-agent first.");
+      return;
+    }
+    const entry = this.store.byId(head.id);
+    if (!entry || entry.type !== "issue") {
+      new Notice(`op: ${head.id} is no longer in the vault — clearing from recency log.`);
+      this.settings.recent = this.settings.recent.filter((e) => e.id !== head.id);
+      await this.saveSettings();
+      return;
+    }
+    await this.openIssue(entry);
+    if (process.platform !== "darwin") return;
+    const probe = await probeLiveTmuxWindows(
+      this.settings.tmuxBinary,
+      tmuxSessionsForCleanup(this.settings.orchestratorState),
+    );
+    if (probe.ok && probe.live.has(tmuxWindowName(head.id))) {
+      await revealAgentSession(this.settings, head.id);
+    }
+  }
+
   private async revealSidebar(): Promise<void> {
     const existing = this.app.workspace.getLeavesOfType(OP_SIDEBAR_VIEW_TYPE);
     let leaf: WorkspaceLeaf | null = existing[0] ?? null;
@@ -1234,6 +1301,7 @@ export default class OpPlugin extends Plugin {
         const res = await workIssue(this.app, this.store, entry);
         const extra = res.createdTaskPath ? ` · created ${res.createdTaskPath.split("/").pop()}` : "";
         notify(`op-work: ${res.issueId} → in-progress${extra}`);
+        await this.recordRecency(res.issueId);
         await this.openIssue(entry);
       } catch (err: any) {
         console.error("[op-obsidian] op-work failed", err);
@@ -1500,8 +1568,16 @@ export default class OpPlugin extends Plugin {
       });
   }
 
-  private handleOpWorkUri(params: Record<string, string>): Promise<UriResponsePayload> {
-    return handleOpWorkUriPure(this.uriDeps(), params);
+  private async handleOpWorkUri(params: Record<string, string>): Promise<UriResponsePayload> {
+    const payload = await handleOpWorkUriPure(this.uriDeps(), params);
+    if (payload.ok) {
+      const id =
+        typeof (payload as { issueId?: unknown }).issueId === "string"
+          ? (payload as { issueId: string }).issueId
+          : undefined;
+      if (id) await this.recordRecency(id);
+    }
+    return payload;
   }
 
   private handleOpAppendCommitUri(
@@ -1872,6 +1948,7 @@ export default class OpPlugin extends Plugin {
         alreadyHeld: res.alreadyHeld,
         conflict: res.conflict,
       });
+      await this.recordRecency(res.issueId);
       const extra = res.createdTaskPath ? ` · created ${res.createdTaskPath.split("/").pop()}` : "";
       const regNote = formatRegistrationNote(res);
       return `${command}: ${res.issueId} → in-progress${extra}${regNote}`;
@@ -2460,6 +2537,7 @@ export default class OpPlugin extends Plugin {
         },
       );
       if (res) {
+        await this.recordRecency(res.issueId);
         const modeLabel =
           res.mode === "work" || res.mode === "implement"
             ? ""
@@ -2495,6 +2573,7 @@ export default class OpPlugin extends Plugin {
       { entry, agentOverride, forcePick, mode },
     );
     if (!res) throw new Error("op-open-agent was cancelled or no agent available");
+    await this.recordRecency(res.issueId);
     return {
       ok: true,
       command: "op-open-agent",

--- a/plugins/op-obsidian/src/recencyLog.test.ts
+++ b/plugins/op-obsidian/src/recencyLog.test.ts
@@ -1,0 +1,125 @@
+import { describe, it, expect } from "vitest";
+import {
+  RECENCY_CAP,
+  appendRecency,
+  mostRecent,
+  relativeTime,
+  sanitizeRecency,
+} from "./recencyLog";
+
+describe("sanitizeRecency", () => {
+  it("returns [] for non-array inputs", () => {
+    expect(sanitizeRecency(null)).toEqual([]);
+    expect(sanitizeRecency(undefined)).toEqual([]);
+    expect(sanitizeRecency({})).toEqual([]);
+    expect(sanitizeRecency("garbage")).toEqual([]);
+    expect(sanitizeRecency(42)).toEqual([]);
+  });
+
+  it("drops malformed entries silently", () => {
+    expect(sanitizeRecency([1, 2, 3])).toEqual([]);
+    expect(sanitizeRecency([{ id: "OP-1" }])).toEqual([]);
+    expect(sanitizeRecency([{ at: "2026-04-25T00:00:00Z" }])).toEqual([]);
+    expect(sanitizeRecency([{ id: "", at: "2026-04-25T00:00:00Z" }])).toEqual([]);
+  });
+
+  it("keeps shape-valid entries in input order", () => {
+    const log = [
+      { id: "OP-1", at: "2026-04-25T10:00:00Z" },
+      { id: "OP-2", at: "2026-04-25T09:00:00Z" },
+    ];
+    expect(sanitizeRecency(log)).toEqual(log);
+  });
+
+  it("dedupes by id, keeping the first occurrence", () => {
+    const log = [
+      { id: "OP-1", at: "2026-04-25T10:00:00Z" },
+      { id: "OP-1", at: "2026-04-25T08:00:00Z" },
+    ];
+    expect(sanitizeRecency(log)).toEqual([log[0]]);
+  });
+
+  it("caps reads to RECENCY_CAP entries", () => {
+    const log = Array.from({ length: RECENCY_CAP + 5 }, (_, i) => ({
+      id: `OP-${i}`,
+      at: "2026-04-25T00:00:00Z",
+    }));
+    expect(sanitizeRecency(log)).toHaveLength(RECENCY_CAP);
+  });
+});
+
+describe("appendRecency", () => {
+  it("prepends a fresh id", () => {
+    const log = [{ id: "OP-2", at: "old" }];
+    expect(appendRecency(log, "OP-1", "new")).toEqual([
+      { id: "OP-1", at: "new" },
+      { id: "OP-2", at: "old" },
+    ]);
+  });
+
+  it("moves an existing id to the head with the new timestamp", () => {
+    const log = [
+      { id: "OP-1", at: "old1" },
+      { id: "OP-2", at: "old2" },
+      { id: "OP-3", at: "old3" },
+    ];
+    expect(appendRecency(log, "OP-2", "new2")).toEqual([
+      { id: "OP-2", at: "new2" },
+      { id: "OP-1", at: "old1" },
+      { id: "OP-3", at: "old3" },
+    ]);
+  });
+
+  it("caps the result at RECENCY_CAP", () => {
+    const log = Array.from({ length: RECENCY_CAP }, (_, i) => ({
+      id: `OP-${i}`,
+      at: "old",
+    }));
+    const next = appendRecency(log, "OP-NEW", "new");
+    expect(next).toHaveLength(RECENCY_CAP);
+    expect(next[0]).toEqual({ id: "OP-NEW", at: "new" });
+    expect(next[next.length - 1].id).toBe(`OP-${RECENCY_CAP - 2}`);
+  });
+
+  it("respects a custom cap", () => {
+    const log = [
+      { id: "A", at: "1" },
+      { id: "B", at: "2" },
+    ];
+    expect(appendRecency(log, "C", "3", 2)).toEqual([
+      { id: "C", at: "3" },
+      { id: "A", at: "1" },
+    ]);
+  });
+
+  it("ignores empty id (defensive)", () => {
+    const log = [{ id: "OP-1", at: "x" }];
+    expect(appendRecency(log, "", "y")).toEqual(log);
+  });
+});
+
+describe("mostRecent", () => {
+  it("returns the head of a non-empty log", () => {
+    const log = [{ id: "OP-1", at: "x" }, { id: "OP-2", at: "y" }];
+    expect(mostRecent(log)).toEqual({ id: "OP-1", at: "x" });
+  });
+  it("returns undefined for an empty log", () => {
+    expect(mostRecent([])).toBeUndefined();
+  });
+});
+
+describe("relativeTime", () => {
+  const now = new Date("2026-04-25T12:00:00Z");
+  it("renders just-now / minutes / hours / days", () => {
+    expect(relativeTime("2026-04-25T11:59:30Z", now)).toBe("just now");
+    expect(relativeTime("2026-04-25T11:55:00Z", now)).toBe("5m ago");
+    expect(relativeTime("2026-04-25T09:00:00Z", now)).toBe("3h ago");
+    expect(relativeTime("2026-04-22T12:00:00Z", now)).toBe("3d ago");
+  });
+  it("falls back to a date stamp for older entries", () => {
+    expect(relativeTime("2026-01-01T00:00:00Z", now)).toBe("2026-01-01");
+  });
+  it("returns empty string for unparseable input", () => {
+    expect(relativeTime("garbage", now)).toBe("");
+  });
+});

--- a/plugins/op-obsidian/src/recencyLog.ts
+++ b/plugins/op-obsidian/src/recencyLog.ts
@@ -1,0 +1,72 @@
+export interface RecencyEntry {
+  id: string;
+  /** ISO-8601 timestamp recorded when the issue was last touched. */
+  at: string;
+}
+
+export const RECENCY_CAP = 25;
+
+/**
+ * Read an unknown `recent:` value out of settings into a usable log. Anything
+ * that isn't an array, or whose entries don't shape-match `{id, at}`, is
+ * dropped entirely — the caller falls back to `[]`. Hand-corrupting `recent`
+ * in `data.json` (typing garbage, replacing with `null`/`{}`) must leave the
+ * rest of the settings recovery path untouched.
+ */
+export function sanitizeRecency(value: unknown): RecencyEntry[] {
+  if (!Array.isArray(value)) return [];
+  const out: RecencyEntry[] = [];
+  const seen = new Set<string>();
+  for (const item of value) {
+    if (!item || typeof item !== "object") continue;
+    const id = (item as { id?: unknown }).id;
+    const at = (item as { at?: unknown }).at;
+    if (typeof id !== "string" || !id) continue;
+    if (typeof at !== "string" || !at) continue;
+    if (seen.has(id)) continue;
+    seen.add(id);
+    out.push({ id, at });
+    if (out.length >= RECENCY_CAP) break;
+  }
+  return out;
+}
+
+/**
+ * Append a fresh touch onto the recency log. Idempotent on `id`: an existing
+ * entry is moved to the head with the new timestamp rather than duplicated.
+ * Caps at {@link RECENCY_CAP} entries (oldest discarded).
+ */
+export function appendRecency(
+  log: ReadonlyArray<RecencyEntry>,
+  id: string,
+  atIso: string,
+  cap: number = RECENCY_CAP,
+): RecencyEntry[] {
+  if (!id) return [...log];
+  const head: RecencyEntry = { id, at: atIso };
+  const tail = log.filter((e) => e.id !== id);
+  const next = [head, ...tail];
+  return next.length > cap ? next.slice(0, cap) : next;
+}
+
+/** The most recently touched entry, or `undefined` for an empty log. */
+export function mostRecent(log: ReadonlyArray<RecencyEntry>): RecencyEntry | undefined {
+  return log.length > 0 ? log[0] : undefined;
+}
+
+/** Format an ISO timestamp as `5m ago` / `2h ago` / `3d ago` / `<date>`. */
+export function relativeTime(atIso: string, now: Date = new Date()): string {
+  const t = Date.parse(atIso);
+  if (!Number.isFinite(t)) return "";
+  const diffMs = now.getTime() - t;
+  if (diffMs < 0) return "just now";
+  const sec = Math.floor(diffMs / 1000);
+  if (sec < 45) return "just now";
+  const min = Math.floor(sec / 60);
+  if (min < 60) return `${min}m ago`;
+  const hr = Math.floor(min / 60);
+  if (hr < 24) return `${hr}h ago`;
+  const day = Math.floor(hr / 24);
+  if (day < 30) return `${day}d ago`;
+  return atIso.slice(0, 10);
+}

--- a/plugins/op-obsidian/src/settingsPure.ts
+++ b/plugins/op-obsidian/src/settingsPure.ts
@@ -3,6 +3,7 @@ import type { ITermPlacement } from "./terminalLaunch";
 import { LAYOUT_IDS, type LayoutId } from "./layout/layouts";
 import { type RegistryData, emptyRegistry, mergeRegistry } from "./layout/registry";
 import type { OrchestratorSettings } from "./orchestrator";
+import { type RecencyEntry, sanitizeRecency } from "./recencyLog";
 
 export const EXTRA_PREAMBLE_MAX = 4000;
 
@@ -79,6 +80,10 @@ export interface OpSettings {
   // list (e.g. newly-discovered projects) sort lexically at the tail. Empty
   // array ⇒ pure lexical sort (the historical default).
   projectOrder: string[];
+  // Recency log of issues touched via op-work / op-open-agent / sidebar row
+  // click. Most-recent first, capped at RECENCY_CAP, dedup by issue id.
+  // Drives `op: resume last` and the sidebar Last-touched chip (OP-150).
+  recent: RecencyEntry[];
 }
 
 export const DEFAULT_SETTINGS: OpSettings = {
@@ -126,6 +131,7 @@ export const DEFAULT_SETTINGS: OpSettings = {
   },
   orchestratorState: emptyRegistry(),
   projectOrder: [],
+  recent: [],
 };
 
 const SIDEBAR_TABS: ReadonlySet<SidebarTab> = new Set(["issues", "in-flight", "resolved"]);
@@ -209,6 +215,7 @@ export function mergeSettings(loaded: unknown): OpSettings {
     }
     base.projectOrder = out;
   }
+  base.recent = sanitizeRecency((l as { recent?: unknown }).recent);
   if (l.flow && typeof l.flow === "object") {
     const f = l.flow as Partial<FlowSettings>;
     if (typeof f.autoAdvance === "boolean") base.flow.autoAdvance = f.autoAdvance;

--- a/plugins/op-obsidian/src/sidebarView.test.ts
+++ b/plugins/op-obsidian/src/sidebarView.test.ts
@@ -1,5 +1,16 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, vi, beforeAll, beforeEach, afterEach } from "vitest";
 import type { IssueEntry } from "./types";
+
+// `requestAnimationFrame` is a browser/Electron global absent in Node.js / Vitest.
+// Without it, `scheduleRender()` throws inside `tickTmuxProbe`'s try block, which
+// incorrectly triggers the catch path (marking liveTmuxWindows null) and adds
+// spurious console.debug noise. Stub it globally so the success path is exercised.
+beforeAll(() => {
+  vi.stubGlobal("requestAnimationFrame", (cb: FrameRequestCallback) => {
+    setTimeout(() => cb(0), 0);
+    return 0;
+  });
+});
 
 vi.mock("obsidian", () => ({
   ItemView: class {

--- a/plugins/op-obsidian/src/sidebarView.test.ts
+++ b/plugins/op-obsidian/src/sidebarView.test.ts
@@ -1,8 +1,10 @@
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import type { IssueEntry } from "./types";
 
 vi.mock("obsidian", () => ({
-  ItemView: class {},
+  ItemView: class {
+    contentEl: any = makeFakeEl();
+  },
   TFile: class {},
   WorkspaceLeaf: class {},
   setIcon: () => {},
@@ -10,7 +12,12 @@ vi.mock("obsidian", () => ({
   prepareFuzzySearch: () => () => null,
 }));
 
-import { filterEntries } from "./sidebarView";
+vi.mock("./staleAgentBadges", () => ({
+  probeLiveTmuxWindows: vi.fn(async () => ({ live: new Set<string>(), ok: true })),
+}));
+
+import { filterEntries, OpSidebarView, TMUX_PROBE_INTERVAL_MS, type OpSidebarHooks } from "./sidebarView";
+import { probeLiveTmuxWindows } from "./staleAgentBadges";
 
 function entry(over: Partial<IssueEntry>): IssueEntry {
   return {
@@ -70,5 +77,169 @@ describe("filterEntries", () => {
   it("preserves input order", () => {
     const out = filterEntries(items, "op", subseqMatcher);
     expect(out.map((e) => e.id)).toEqual(["OP-1", "OP-2"]);
+  });
+});
+
+function makeFakeEl(): any {
+  const el: any = {
+    children: [] as any[],
+    classList: new Set<string>(),
+    addClass(c: string) {
+      this.classList.add(c);
+    },
+    toggleClass(c: string, on: boolean) {
+      if (on) this.classList.add(c);
+      else this.classList.delete(c);
+    },
+    empty() {
+      this.children.length = 0;
+    },
+    createDiv(_o: any) {
+      const child = makeFakeEl();
+      this.children.push(child);
+      return child;
+    },
+    createEl(_tag: string, _o?: any) {
+      const child = makeFakeEl();
+      this.children.push(child);
+      return child;
+    },
+    createSpan(_o: any) {
+      const child = makeFakeEl();
+      this.children.push(child);
+      return child;
+    },
+    setAttr() {},
+    addEventListener() {},
+  };
+  return el;
+}
+
+class FakeStore {
+  byId() {
+    return undefined;
+  }
+  issues() {
+    return [] as IssueEntry[];
+  }
+}
+
+class FakeBus {
+  on() {
+    return () => {};
+  }
+  emit() {}
+}
+
+function makeView(hooks?: OpSidebarHooks): any {
+  const store = new FakeStore();
+  const bus = new FakeBus();
+  const view = new OpSidebarView(
+    {} as any,
+    store as any,
+    bus as any,
+    () => ({ defaultTab: "issues", recentResolvedLimit: 20, openOnStartup: false } as any),
+    undefined,
+    undefined,
+    hooks,
+  );
+  return view;
+}
+
+function withDarwin<T>(run: () => T): T {
+  const desc = Object.getOwnPropertyDescriptor(process, "platform");
+  Object.defineProperty(process, "platform", { value: "darwin", configurable: true });
+  try {
+    return run();
+  } finally {
+    if (desc) Object.defineProperty(process, "platform", desc);
+  }
+}
+
+describe("OpSidebarView visibility-gated tmux probe", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.mocked(probeLiveTmuxWindows).mockClear();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("starts the probe on onOpen and stops it on onClose (single-cycle)", async () => {
+    await withDarwin(async () => {
+      const view = makeView({
+        getRecent: () => [],
+        tmuxBinary: () => "/opt/homebrew/bin/tmux",
+        tmuxSessions: () => ["op-agents"],
+        recordRecency: async () => {},
+        executeResumeLast: () => {},
+      });
+      await view.onOpen();
+      expect(view.isProbeRunning()).toBe(true);
+
+      // The kickoff call fires immediately + we advance once to fire one
+      // interval tick. Verifies the timer is wired.
+      await Promise.resolve();
+      await Promise.resolve();
+      expect(probeLiveTmuxWindows).toHaveBeenCalled();
+      const first = (probeLiveTmuxWindows as any).mock.calls.length;
+
+      vi.advanceTimersByTime(TMUX_PROBE_INTERVAL_MS);
+      expect((probeLiveTmuxWindows as any).mock.calls.length).toBeGreaterThan(first);
+
+      await view.onClose();
+      expect(view.isProbeRunning()).toBe(false);
+
+      const afterClose = (probeLiveTmuxWindows as any).mock.calls.length;
+      vi.advanceTimersByTime(TMUX_PROBE_INTERVAL_MS * 2);
+      expect((probeLiveTmuxWindows as any).mock.calls.length).toBe(afterClose);
+    });
+  });
+
+  it("does not double-start when onOpen runs twice", async () => {
+    await withDarwin(async () => {
+      const view = makeView({
+        getRecent: () => [],
+        tmuxBinary: () => "/opt/homebrew/bin/tmux",
+        tmuxSessions: () => ["op-agents"],
+        recordRecency: async () => {},
+        executeResumeLast: () => {},
+      });
+      await view.onOpen();
+      const firstTimer = (view as any).probeTimer;
+      await view.onOpen();
+      const secondTimer = (view as any).probeTimer;
+      expect(secondTimer).toBe(firstTimer);
+      await view.onClose();
+    });
+  });
+
+  it("does not start the probe on non-darwin", async () => {
+    const desc = Object.getOwnPropertyDescriptor(process, "platform");
+    Object.defineProperty(process, "platform", { value: "linux", configurable: true });
+    try {
+      const view = makeView({
+        getRecent: () => [],
+        tmuxBinary: () => "tmux",
+        tmuxSessions: () => ["op-agents"],
+        recordRecency: async () => {},
+        executeResumeLast: () => {},
+      });
+      await view.onOpen();
+      expect(view.isProbeRunning()).toBe(false);
+      expect(probeLiveTmuxWindows).not.toHaveBeenCalled();
+      await view.onClose();
+    } finally {
+      if (desc) Object.defineProperty(process, "platform", desc);
+    }
+  });
+
+  it("does not start the probe when no hooks are wired (legacy callers)", async () => {
+    await withDarwin(async () => {
+      const view = makeView(undefined);
+      await view.onOpen();
+      expect(view.isProbeRunning()).toBe(false);
+      await view.onClose();
+    });
   });
 });

--- a/plugins/op-obsidian/src/sidebarView.ts
+++ b/plugins/op-obsidian/src/sidebarView.ts
@@ -4,6 +4,10 @@ import type { EventBus } from "./eventBus";
 import type { IssueEntry, LifecycleEvent } from "./types";
 import type { ViewSettings } from "./settings";
 import type { AgentLaunchMode } from "./agentProfiles";
+import type { RecencyEntry } from "./recencyLog";
+import { mostRecent, relativeTime } from "./recencyLog";
+import { probeLiveTmuxWindows } from "./staleAgentBadges";
+import { tmuxWindowName } from "./terminalLaunch";
 
 export const OP_SIDEBAR_VIEW_TYPE = "op-sidebar";
 
@@ -22,14 +26,44 @@ const RELEVANT: ReadonlySet<LifecycleEvent["kind"]> = new Set([
   "issue:deleted",
 ]);
 
+/** How often the sidebar re-checks tmux for live agent windows, in ms. */
+export const TMUX_PROBE_INTERVAL_MS = 5_000;
+
+/**
+ * Adapter wired in from `main.ts` so the sidebar can read the recency log,
+ * record a fresh touch when the user clicks a row, and call `op: resume last`
+ * (the chip's click handler) without depending on the plugin class directly.
+ *
+ * Optional in the constructor so existing tests that don't exercise this
+ * surface keep working unchanged.
+ */
+export interface OpSidebarHooks {
+  getRecent: () => ReadonlyArray<RecencyEntry>;
+  tmuxBinary: () => string;
+  /** Sessions to probe — typically the shared session plus per-iTerm-window
+   * derivatives from the orchestrator registry. Mirrors what the cleanup
+   * path passes around. */
+  tmuxSessions: () => string[];
+  recordRecency: (issueId: string) => Promise<void>;
+  executeResumeLast: () => void;
+}
+
 export class OpSidebarView extends ItemView {
   private active: TabId = "issues";
   private unsubscribe?: () => void;
+  private headerEl!: HTMLElement;
   private bodyEl!: HTMLElement;
   private filterInput!: HTMLInputElement;
   private filterQuery = "";
   private tabButtons = new Map<TabId, HTMLElement>();
   private rafPending = false;
+  private probeTimer: ReturnType<typeof setInterval> | undefined;
+  /** `undefined` means "not yet probed" — render renders all badges as
+   * normal until the first tick lands. `null` means "tmux unavailable",
+   * which also keeps badges as-is (no false-positive demotion). A `Set`
+   * means we know which windows are live and any agent: that points
+   * elsewhere is rendered with the muted "stale" class. */
+  private liveTmuxWindows: Set<string> | null | undefined = undefined;
 
   constructor(
     leaf: WorkspaceLeaf,
@@ -42,6 +76,7 @@ export class OpSidebarView extends ItemView {
       mode: AgentLaunchMode,
       forcePick: boolean,
     ) => void | Promise<void>,
+    private hooks?: OpSidebarHooks,
   ) {
     super(leaf);
   }
@@ -63,6 +98,8 @@ export class OpSidebarView extends ItemView {
     const root = this.contentEl;
     root.empty();
     root.addClass("op-sidebar");
+
+    this.headerEl = root.createDiv({ cls: "op-sidebar__header" });
 
     const tabsEl = root.createDiv({ cls: "op-sidebar__tabs" });
     for (const t of TABS) {
@@ -97,13 +134,64 @@ export class OpSidebarView extends ItemView {
       if (RELEVANT.has(ev.kind)) this.scheduleRender();
     });
 
+    this.startTmuxProbe();
     this.render();
   }
 
   async onClose(): Promise<void> {
     this.unsubscribe?.();
     this.unsubscribe = undefined;
+    this.stopTmuxProbe();
     this.tabButtons.clear();
+  }
+
+  /**
+   * Public hook so tests (and future commands) can force a refresh without
+   * waiting for the 5s timer or for an event-bus message.
+   */
+  refresh(): void {
+    this.scheduleRender();
+  }
+
+  /** Visible for tests: are we currently running the periodic probe? */
+  isProbeRunning(): boolean {
+    return this.probeTimer !== undefined;
+  }
+
+  private startTmuxProbe(): void {
+    if (this.probeTimer !== undefined) return; // no double-start
+    if (!this.hooks) return; // legacy callers (tests) don't supply hooks
+    if (process.platform !== "darwin") return; // macOS-only per OP-150 spec
+    // Kick off an immediate first probe so the initial render reflects
+    // reality instead of waiting up to 5s for the first interval tick.
+    void this.tickTmuxProbe();
+    this.probeTimer = setInterval(() => void this.tickTmuxProbe(), TMUX_PROBE_INTERVAL_MS);
+  }
+
+  private stopTmuxProbe(): void {
+    if (this.probeTimer === undefined) return;
+    clearInterval(this.probeTimer);
+    this.probeTimer = undefined;
+  }
+
+  private async tickTmuxProbe(): Promise<void> {
+    if (!this.hooks) return;
+    try {
+      const probe = await probeLiveTmuxWindows(this.hooks.tmuxBinary(), this.hooks.tmuxSessions());
+      const next = probe.ok ? probe.live : null;
+      if (sameLiveSet(this.liveTmuxWindows, next)) return;
+      this.liveTmuxWindows = next;
+      this.scheduleRender();
+    } catch (err) {
+      // probeLiveTmuxWindows already swallows ENOENT/timeout; anything that
+      // bubbles here is a real bug (e.g. invalid binary path), so log and
+      // fall through to "tmux unavailable".
+      console.debug("[op-obsidian] sidebar tmux probe threw", err);
+      if (this.liveTmuxWindows !== null) {
+        this.liveTmuxWindows = null;
+        this.scheduleRender();
+      }
+    }
   }
 
   private scheduleRender(): void {
@@ -116,6 +204,7 @@ export class OpSidebarView extends ItemView {
   }
 
   private render(): void {
+    this.renderHeader();
     for (const [id, btn] of this.tabButtons) {
       btn.toggleClass("is-active", id === this.active);
     }
@@ -139,17 +228,32 @@ export class OpSidebarView extends ItemView {
       setTooltip(link, linkText, { delay: 250 });
       link.addEventListener("click", (ev) => {
         ev.preventDefault();
+        if (this.hooks) void this.hooks.recordRecency(e.id);
         void this.openEntry(e);
       });
       const actions = headerRow.createDiv({ cls: "op-sidebar__actions" });
       if (e.agent) {
+        const stale = this.isAgentBadgeStale(e);
+        const classes = [
+          "op-sidebar__agent",
+          `op-sidebar__agent--${e.agent}`,
+          stale ? "op-sidebar__agent--stale is-stale" : "",
+        ]
+          .filter(Boolean)
+          .join(" ");
         const badge = actions.createEl("a", {
           text: e.agent,
-          cls: `op-sidebar__agent op-sidebar__agent--${e.agent}`,
+          cls: classes,
         });
+        if (stale) {
+          badge.setAttr("aria-label", `Stale agent badge for ${e.id} — tmux window not found`);
+          setTooltip(badge, "Stale: no live tmux window", { delay: 250 });
+        }
         if (this.revealAgent) {
           badge.setAttr("href", "#");
-          badge.setAttr("aria-label", `Reveal ${e.agent} session for ${e.id}`);
+          if (!stale) {
+            badge.setAttr("aria-label", `Reveal ${e.agent} session for ${e.id}`);
+          }
           badge.addEventListener("click", (ev) => {
             ev.preventDefault();
             ev.stopPropagation();
@@ -212,6 +316,59 @@ export class OpSidebarView extends ItemView {
     }
   }
 
+  private renderHeader(): void {
+    if (!this.headerEl) return;
+    this.headerEl.empty();
+    const head = this.hooks ? mostRecent(this.hooks.getRecent()) : undefined;
+    if (!head) {
+      this.headerEl.toggleClass("is-empty", true);
+      return;
+    }
+    this.headerEl.toggleClass("is-empty", false);
+    const entry = this.store.byId(head.id);
+    const isIssue = entry && entry.type === "issue";
+    const agentLabel = isIssue && (entry as IssueEntry).agent
+      ? this.agentLabelForChip(entry as IssueEntry)
+      : "no agent";
+    const rel = relativeTime(head.at);
+    const text = `Last touched: ${head.id} · ${agentLabel}${rel ? ` · ${rel}` : ""}`;
+    const chip = this.headerEl.createEl("a", {
+      cls: "op-sidebar__last-touched",
+      text,
+      attr: {
+        href: "#",
+        "aria-label": `Resume ${head.id}`,
+      },
+    });
+    chip.addEventListener("click", (ev) => {
+      ev.preventDefault();
+      this.hooks?.executeResumeLast();
+    });
+  }
+
+  private agentLabelForChip(entry: IssueEntry): string {
+    const stale = this.isAgentBadgeStale(entry);
+    if (stale) return `${entry.agent} (stale)`;
+    if (this.liveTmuxWindows && this.liveTmuxWindows.has(tmuxWindowName(entry.id))) {
+      return `${entry.agent} attached`;
+    }
+    return entry.agent ?? "no agent";
+  }
+
+  /**
+   * Pure-ish: does this issue's `agent:` badge claim a live session that
+   * tmux actually doesn't have? Returns false when we have no idea
+   * (initial state, tmux unavailable, no tmux info yet) so we never
+   * surface a false-positive "stale" indicator.
+   */
+  private isAgentBadgeStale(entry: IssueEntry): boolean {
+    if (!entry.agent) return false;
+    if (entry.resolvedFolder) return false;
+    if (entry.status === "resolved" || entry.status === "wontfix") return false;
+    if (!this.liveTmuxWindows) return false; // unknown → don't demote
+    return !this.liveTmuxWindows.has(tmuxWindowName(entry.id));
+  }
+
   private pickFor(tab: TabId): IssueEntry[] {
     const all = this.store.issues();
     if (tab === "in-flight") {
@@ -237,6 +394,18 @@ export class OpSidebarView extends ItemView {
       await this.app.workspace.getLeaf(false).openFile(f);
     }
   }
+}
+
+function sameLiveSet(
+  prev: Set<string> | null | undefined,
+  next: Set<string> | null,
+): boolean {
+  if (prev === undefined) return false;
+  if (prev === null && next === null) return true;
+  if (prev === null || next === null) return false;
+  if (prev.size !== next.size) return false;
+  for (const v of prev) if (!next.has(v)) return false;
+  return true;
 }
 
 function byId(a: IssueEntry, b: IssueEntry): number {

--- a/plugins/op-obsidian/styles.css
+++ b/plugins/op-obsidian/styles.css
@@ -171,6 +171,43 @@ a.op-sidebar__agent:hover {
 .op-sidebar__agent--gemini   { background: #1e88e5; }
 .op-sidebar__agent--copilot  { background: #6f42c1; }
 
+.op-sidebar__agent--stale,
+.op-sidebar__agent.is-stale {
+  background: var(--background-modifier-border);
+  color: var(--text-muted);
+  opacity: 0.55;
+  filter: saturate(0.3);
+  text-decoration: line-through;
+}
+
+.op-sidebar__header {
+  padding: 6px 10px 4px;
+}
+
+.op-sidebar__header.is-empty {
+  display: none;
+}
+
+.op-sidebar__last-touched {
+  display: inline-block;
+  max-width: 100%;
+  padding: 3px 8px;
+  border-radius: 999px;
+  background: var(--background-modifier-hover);
+  color: var(--text-muted);
+  font-size: var(--font-ui-smaller);
+  text-decoration: none;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.op-sidebar__last-touched:hover {
+  background: var(--background-modifier-active-hover);
+  color: var(--text-normal);
+  text-decoration: none;
+}
+
 .op-sidebar__github {
   color: var(--text-muted);
   text-decoration: none;

--- a/plugins/op/.claude-plugin/plugin.json
+++ b/plugins/op/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "op",
   "description": "Obsidian Projects workflow — schema, slash commands, and agent skill for running a Jira-lite issue tracker inside an Obsidian vault.",
-  "version": "0.50.1",
+  "version": "0.51.0",
   "author": {
     "name": "Eugene Archibald"
   },


### PR DESCRIPTION
## Summary

Implements §1 of OP-149 (resumability):

- New palette command **`op: resume last`** opens the most-recently-touched issue note and, on macOS, re-attaches to its agent via the existing `revealAgentSession` path when the tmux window is still alive.
- New persistent **recency log** in `data.json` (`recent: RecencyEntry[]`, capped at 25, dedup-by-id, `Array.isArray` self-healing read). Records a touch on every dispatch point that opens or attaches an issue: palette `op-work` / `op-open-agent`-and-variants, their URI handlers, the `op-work` CLI handler, `op-attach-current`, and the sidebar row click.
- New **Last-touched sidebar chip** above the tabs (hidden when empty; click triggers `op: resume last`).
- New **visibility-gated tmux liveness probe** in the sidebar: 5 s `setInterval`, started in `onOpen`, cleared in `onClose`, gated on `process.platform === "darwin"`. Issues whose `agent:` field claims a session tmux no longer has render with `op-sidebar__agent--stale / is-stale` — kept clickable, visibly muted.

## Key design call: reuse `probeLiveTmuxWindows`, no new `tmuxLiveness.ts`

The spec sketch called for a new `tmuxLiveness.ts` module with an `execFile` wrapper, 500 ms timeout, and exact-match parse against `tmuxWindowName`. Those invariants already live in `staleAgentBadges.ts::probeLiveTmuxWindows` (used by the startup stale-badge probe) and the matching pure `selectStaleAgentBadges`. Adding a parallel module would have been a second indirection to keep in sync. Funneling the sidebar's periodic probe through the same helper preserves the spec's risk mitigation ("all probes go through one module so the timeout can't be bypassed").

The macOS gate lives at the call site (sidebar's `startTmuxProbe`), not inside `probeLiveTmuxWindows` — on Linux the probe would otherwise burn 500 ms × 12 ticks/min for nothing.

## Test plan

- [x] `npx vitest run` — full suite passes (513 tests)
- [x] `recencyLog.test.ts` — read/write/cap/idempotent-move-to-head, array-guard against `null`, `{}`, `[1,2]`
- [x] `sidebarView.test.ts` — visibility-timer lifecycle: starts on `onOpen`, stops on `onClose`, no double-start, no probe on non-darwin or without hooks
- [x] Smoke test against Agent-Vault:
  - [x] `recordRecency` dedupes and caps in live `data.json`
  - [x] `op: resume last` opens the head issue note (verified post-`await` because the eval bash returned before the `openFile` resolved)
  - [x] Sidebar chip renders `Last touched: OP-150 · claude attached · 1m ago` and re-renders after `recordRecency`
  - [x] Forcing `liveTmuxWindows = new Set(["OP-150"])` demotes the OP-123 badge to `is-stale` while leaving OP-150 fresh
  - [x] Detaching the sidebar leaf flips `isProbeRunning()` from `true` → `false` with no console errors
- [x] No `obsidian dev:console` errors after a full open → recordRecency → resume → close cycle

## Risks (delta from issue body)

- The "all probes through one module" mitigation is preserved by reusing `probeLiveTmuxWindows`. No new wrapper to keep in sync.
- The `recent:` field is sanitized through `sanitizeRecency` on every read, so hand-corrupting `data.json` (typing garbage, replacing with `null`/`{}`) leaves the rest of settings intact.
- `OpSidebarHooks` is optional in the `OpSidebarView` constructor — legacy callers (existing sidebar tests) keep working unchanged; only `main.ts` wires the full hook set.

## Pressure-test prompts for adversarial review

@copilot please pressure-test:

1. **Concurrent `op-work` calls**: if `recordRecency` is invoked twice rapidly (palette + URI for the same id), do we end up with two entries in `recent:`, or is the dedup atomic? Is there a race between two `await this.saveSettings()` calls?
2. **Cap-25 invariant** when an existing entry is moved to head: confirm the result is still ≤ 25 in `appendRecency` regardless of input length.
3. **`op-open-agent` failure path**: when `openAgent` returns `undefined` (cancelled, no agent installed), do we accidentally still record the issue? (Should not — both call sites check `res` truthiness first.)
4. **Sidebar probe on a darwin host where tmux is stopped mid-session**: does `probeLiveTmuxWindows` reliably return `{ok:false}` or do we ever throw out of the timer callback and crash the next tick? See the try/catch in `tickTmuxProbe`.
5. **Schema migration**: existing users have `data.json` without a `recent:` field. Verify `mergeSettings` produces `recent: []` (does it, given my `sanitizeRecency(undefined) === []`?).
6. **`refresh()` is `public` but not used internally** — is exposing it a footgun, or is it the right escape-hatch for tests?
7. **CSS specificity**: `op-sidebar__agent--stale` overrides `op-sidebar__agent--claude`'s background — confirm the cascade order in `styles.css` produces the muted look across all three agents (claude/gemini/copilot).
8. **`op:resume-last` when the head issue's note has been moved to `RESOLVED ISSUES/`**: my `byId` lookup hits the resolved entry; do I open it correctly, or does the resolved fork need different handling?

🤖 Generated with [Claude Code](https://claude.com/claude-code)