### PR TITLE
OP-123: op-set-link / op-remove-link palette commands

### DIFF
--- a/plugins/op-obsidian/manifest.json
+++ b/plugins/op-obsidian/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "op-obsidian",
   "name": "Obsidian Projects (op)",
-  "version": "0.49.0",
+  "version": "0.50.0",
   "minAppVersion": "1.5.0",
   "description": "Jira-lite issue tracker for Obsidian vaults — deterministic commands backing the op workflow.",
   "author": "Eugene Archibald",

--- a/plugins/op-obsidian/manifest.json
+++ b/plugins/op-obsidian/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "op-obsidian",
   "name": "Obsidian Projects (op)",
-  "version": "0.50.0",
+  "version": "0.50.1",
   "minAppVersion": "1.5.0",
   "description": "Jira-lite issue tracker for Obsidian vaults — deterministic commands backing the op workflow.",
   "author": "Eugene Archibald",

--- a/plugins/op-obsidian/package.json
+++ b/plugins/op-obsidian/package.json
@@ -1,6 +1,6 @@
 {
   "name": "op-obsidian",
-  "version": "0.50.0",
+  "version": "0.50.1",
   "description": "Obsidian plugin that owns the deterministic half of the op workflow.",
   "main": "main.js",
   "scripts": {

--- a/plugins/op-obsidian/package.json
+++ b/plugins/op-obsidian/package.json
@@ -1,6 +1,6 @@
 {
   "name": "op-obsidian",
-  "version": "0.49.0",
+  "version": "0.50.0",
   "description": "Obsidian plugin that owns the deterministic half of the op workflow.",
   "main": "main.js",
   "scripts": {

--- a/plugins/op-obsidian/src/links.test.ts
+++ b/plugins/op-obsidian/src/links.test.ts
@@ -10,7 +10,7 @@ vi.mock("obsidian", () => {
 });
 
 import { TFile } from "obsidian";
-import { listLinkedTargets } from "./links";
+import { listLinkedTargets, listDanglingLinkedIds } from "./links";
 import type { IssueEntry } from "./types";
 import type { IssueStore } from "./issueStore";
 
@@ -116,6 +116,61 @@ describe("listLinkedTargets", () => {
     const src = entry("OP-1");
     const { app, store } = makeEnv({ src, fm: {}, others: [] });
     expect(() => listLinkedTargets(app, store, "OP-1", "not_a_relation")).toThrow(
+      /Unknown relation/,
+    );
+  });
+});
+
+describe("listDanglingLinkedIds", () => {
+  it("returns ids that no longer resolve when all links are dangling", () => {
+    const src = entry("OP-1");
+    const { app, store } = makeEnv({
+      src,
+      fm: { parent: "OP-404" },
+      others: [],
+    });
+    expect(listDanglingLinkedIds(app, store, "OP-1", "parent")).toEqual(["OP-404"]);
+  });
+
+  it("returns only the dangling ids in a mixed list (some live, some dangling)", () => {
+    const src = entry("OP-1");
+    const live = entry("OP-2");
+    const { app, store } = makeEnv({
+      src,
+      fm: { children: ["OP-2", "OP-404", "OP-405"] },
+      others: [live],
+    });
+    expect(listDanglingLinkedIds(app, store, "OP-1", "children")).toEqual(["OP-404", "OP-405"]);
+  });
+
+  it("returns [] when all linked ids resolve (no drift)", () => {
+    const src = entry("OP-1");
+    const c1 = entry("OP-2");
+    const c2 = entry("OP-3");
+    const { app, store } = makeEnv({
+      src,
+      fm: { children: ["OP-2", "OP-3"] },
+      others: [c1, c2],
+    });
+    expect(listDanglingLinkedIds(app, store, "OP-1", "children")).toEqual([]);
+  });
+
+  it("returns [] when the source has no entry under that relation", () => {
+    const src = entry("OP-1");
+    const { app, store } = makeEnv({ src, fm: {}, others: [] });
+    expect(listDanglingLinkedIds(app, store, "OP-1", "parent")).toEqual([]);
+  });
+
+  it("returns [] when the source id is unknown", () => {
+    const src = entry("OP-1");
+    const { app, store } = makeEnv({ src, fm: { children: ["OP-2"] }, others: [] });
+    expect(listDanglingLinkedIds(app, store, "OP-999", "children")).toEqual([]);
+  });
+
+  it("throws on an unknown relation name", () => {
+    const src = entry("OP-1");
+    const { app, store } = makeEnv({ src, fm: {}, others: [] });
+    expect(() => listDanglingLinkedIds(app, store, "OP-1", "not_a_relation")).toThrow(
       /Unknown relation/,
     );
   });

--- a/plugins/op-obsidian/src/links.test.ts
+++ b/plugins/op-obsidian/src/links.test.ts
@@ -1,0 +1,122 @@
+import { describe, it, expect, vi } from "vitest";
+
+vi.mock("obsidian", () => {
+  class TFile {
+    path = "";
+    basename = "";
+    name = "";
+  }
+  return { TFile };
+});
+
+import { TFile } from "obsidian";
+import { listLinkedTargets } from "./links";
+import type { IssueEntry } from "./types";
+import type { IssueStore } from "./issueStore";
+
+function entry(id: string): IssueEntry {
+  return {
+    path: `Projects/demo/ISSUES/${id} t.md`,
+    type: "issue",
+    id,
+    project: "demo",
+    status: "open",
+    title: `${id} t`,
+    resolvedFolder: false,
+  };
+}
+
+function makeEnv(opts: {
+  src: IssueEntry;
+  fm: Record<string, unknown>;
+  others: IssueEntry[];
+}) {
+  const byPath = new Map<string, IssueEntry>();
+  const byIdMap = new Map<string, IssueEntry>();
+  for (const e of [opts.src, ...opts.others]) {
+    byPath.set(e.path, e);
+    byIdMap.set(e.id, e);
+  }
+  const fileFor = (e: IssueEntry) =>
+    Object.assign(new TFile(), { path: e.path, basename: e.id, name: `${e.id}.md` });
+  const app = {
+    vault: {
+      getAbstractFileByPath: (p: string) => {
+        const e = byPath.get(p);
+        return e ? fileFor(e) : null;
+      },
+    },
+    metadataCache: {
+      getFileCache: (f: TFile) => {
+        if (f.path === opts.src.path) return { frontmatter: opts.fm };
+        return { frontmatter: {} };
+      },
+    },
+  };
+  const store = {
+    byId: (id: string) => byIdMap.get(id),
+    issues: () => [opts.src, ...opts.others],
+    tasks: () => [],
+  } as unknown as IssueStore;
+  return { app: app as any, store };
+}
+
+describe("listLinkedTargets", () => {
+  it("reads a list relation (children) and resolves to IssueEntry rows", () => {
+    const src = entry("OP-1");
+    const c1 = entry("OP-2");
+    const c2 = entry("OP-3");
+    const { app, store } = makeEnv({
+      src,
+      fm: { children: ["OP-2", "OP-3"] },
+      others: [c1, c2],
+    });
+    const out = listLinkedTargets(app, store, "OP-1", "children");
+    expect(out.map((e) => e.id)).toEqual(["OP-2", "OP-3"]);
+  });
+
+  it("reads a scalar relation (parent) and returns a single-element list", () => {
+    const src = entry("OP-1");
+    const p = entry("OP-9");
+    const { app, store } = makeEnv({
+      src,
+      fm: { parent: "OP-9" },
+      others: [p],
+    });
+    const out = listLinkedTargets(app, store, "OP-1", "parent");
+    expect(out.map((e) => e.id)).toEqual(["OP-9"]);
+  });
+
+  it("returns [] when the source has no entry under that relation", () => {
+    const src = entry("OP-1");
+    const { app, store } = makeEnv({ src, fm: {}, others: [] });
+    expect(listLinkedTargets(app, store, "OP-1", "children")).toEqual([]);
+    expect(listLinkedTargets(app, store, "OP-1", "parent")).toEqual([]);
+  });
+
+  it("drops link entries whose target id no longer resolves", () => {
+    const src = entry("OP-1");
+    const live = entry("OP-2");
+    const { app, store } = makeEnv({
+      src,
+      fm: { children: ["OP-2", "OP-404"] },
+      others: [live],
+    });
+    const out = listLinkedTargets(app, store, "OP-1", "children");
+    expect(out.map((e) => e.id)).toEqual(["OP-2"]);
+  });
+
+  it("returns [] when the source id itself is unknown", () => {
+    const src = entry("OP-1");
+    const { app, store } = makeEnv({ src, fm: { children: ["OP-2"] }, others: [] });
+    expect(listLinkedTargets(app, store, "OP-999", "children")).toEqual([]);
+  });
+
+  it("throws on an unknown relation name (consistent with validateLinkArgs)", () => {
+    const src = entry("OP-1");
+    const { app, store } = makeEnv({ src, fm: {}, others: [] });
+    expect(() => listLinkedTargets(app, store, "OP-1", "not_a_relation")).toThrow(
+      /Unknown relation/,
+    );
+  });
+});

--- a/plugins/op-obsidian/src/links.ts
+++ b/plugins/op-obsidian/src/links.ts
@@ -5,6 +5,7 @@ import {
   computeApply,
   computeMigrate,
   computeRemove,
+  getRelation,
   scanDrift,
   validateLinkArgs,
   type Cleanup,
@@ -129,6 +130,45 @@ export async function removeLink(
     changed: planned.changed,
     cleaned: [],
   };
+}
+
+/**
+ * Enumerate the issues currently linked from `srcId` under `relation`. Returns
+ * resolved IssueEntry rows so callers can present them in a picker; ids that
+ * point at a missing/unresolved file are dropped silently (link drift is the
+ * `op-link-check` command's job, not this picker's). Used by the `op-remove-link`
+ * palette flow to constrain the target picker.
+ */
+export function listLinkedTargets(
+  app: App,
+  store: IssueStore,
+  srcId: string,
+  relation: string,
+): IssueEntry[] {
+  const def = getRelation(relation);
+  const srcEntry = store.byId(srcId);
+  if (!srcEntry || srcEntry.type !== "issue") return [];
+  const file = app.vault.getAbstractFileByPath(srcEntry.path);
+  if (!(file instanceof TFile)) return [];
+  const fm = readFm(app, file);
+  const ids: string[] = [];
+  if (def.isList) {
+    const v = fm[def.name];
+    if (Array.isArray(v)) {
+      for (const x of v) {
+        if (typeof x === "string" && x.length > 0) ids.push(x);
+      }
+    }
+  } else {
+    const v = fm[def.name];
+    if (typeof v === "string" && v.length > 0) ids.push(v);
+  }
+  const out: IssueEntry[] = [];
+  for (const id of ids) {
+    const entry = store.byId(id);
+    if (entry && entry.type === "issue") out.push(entry);
+  }
+  return out;
 }
 
 export interface LinkCheckResult {

--- a/plugins/op-obsidian/src/links.ts
+++ b/plugins/op-obsidian/src/links.ts
@@ -133,19 +133,20 @@ export async function removeLink(
 }
 
 /**
- * Enumerate the issues currently linked from `srcId` under `relation`. Returns
- * resolved IssueEntry rows so callers can present them in a picker; ids that
- * point at a missing/unresolved file are dropped silently (link drift is the
- * `op-link-check` command's job, not this picker's). Used by the `op-remove-link`
- * palette flow to constrain the target picker.
+ * Read the raw ids stored in `srcId`'s `relation` field from frontmatter,
+ * regardless of whether each id resolves to a known issue. Shared by
+ * `listLinkedTargets` and `listDanglingLinkedIds`.
+ *
+ * Throws if `relation` is not a known relation name (consistent with
+ * `validateLinkArgs`).
  */
-export function listLinkedTargets(
+function readLinkedIds(
   app: App,
   store: IssueStore,
   srcId: string,
   relation: string,
-): IssueEntry[] {
-  const def = getRelation(relation);
+): string[] {
+  const def = getRelation(relation); // throws on unknown relation
   const srcEntry = store.byId(srcId);
   if (!srcEntry || srcEntry.type !== "issue") return [];
   const file = app.vault.getAbstractFileByPath(srcEntry.path);
@@ -163,12 +164,51 @@ export function listLinkedTargets(
     const v = fm[def.name];
     if (typeof v === "string" && v.length > 0) ids.push(v);
   }
+  return ids;
+}
+
+/**
+ * Enumerate the issues currently linked from `srcId` under `relation`. Returns
+ * resolved IssueEntry rows so callers can present them in a picker; ids that
+ * point at a missing/unresolved issue are dropped silently (link drift is the
+ * `op-link-check` command's job, not this picker's). Used by the `op-remove-link`
+ * palette flow to constrain the target picker.
+ *
+ * See also `listDanglingLinkedIds` to detect dropped drift entries.
+ */
+export function listLinkedTargets(
+  app: App,
+  store: IssueStore,
+  srcId: string,
+  relation: string,
+): IssueEntry[] {
+  const ids = readLinkedIds(app, store, srcId, relation);
   const out: IssueEntry[] = [];
   for (const id of ids) {
     const entry = store.byId(id);
     if (entry && entry.type === "issue") out.push(entry);
   }
   return out;
+}
+
+/**
+ * Return the ids stored in `srcId`'s `relation` field that no longer resolve
+ * to a known issue (link drift). These are the entries silently dropped by
+ * `listLinkedTargets`. Surfaced here so callers can inform the user to run
+ * `op-link-check` rather than showing a misleading "no links to remove" notice
+ * when the frontmatter still contains stale ids.
+ */
+export function listDanglingLinkedIds(
+  app: App,
+  store: IssueStore,
+  srcId: string,
+  relation: string,
+): string[] {
+  const ids = readLinkedIds(app, store, srcId, relation);
+  return ids.filter((id) => {
+    const e = store.byId(id);
+    return !e || e.type !== "issue";
+  });
 }
 
 export interface LinkCheckResult {

--- a/plugins/op-obsidian/src/main.ts
+++ b/plugins/op-obsidian/src/main.ts
@@ -26,7 +26,14 @@ import { parseNewScopePayload, type NewScopeMode } from "./setScopePure";
 import { setEvaluation } from "./setEvaluation";
 import { setSection } from "./setSection";
 import { setFlow, type Complexity, type Flow } from "./setFlow";
-import { applyLink, listLinkedTargets, removeLink, linkCheck, migrateLinks } from "./links";
+import {
+  applyLink,
+  listDanglingLinkedIds,
+  listLinkedTargets,
+  removeLink,
+  linkCheck,
+  migrateLinks,
+} from "./links";
 import { RELATION_NAMES, type RelationName } from "./relations";
 import { runEvaluatorFlow } from "./evaluator";
 import { launchHeadless } from "./launchHeadless";
@@ -1316,7 +1323,15 @@ export default class OpPlugin extends Plugin {
   private pickRemoveLinkTarget(srcEntry: IssueEntry, relation: RelationName): void {
     const linked = listLinkedTargets(this.app, this.store, srcEntry.id, relation);
     if (linked.length === 0) {
-      new Notice(`op: ${srcEntry.id} has no ${relation} links to remove`);
+      const dangling = listDanglingLinkedIds(this.app, this.store, srcEntry.id, relation);
+      if (dangling.length > 0) {
+        new Notice(
+          `op: ${srcEntry.id} has no resolvable ${relation} links` +
+            ` (${dangling.length} dangling — run 'op: check issue link drift' to repair)`,
+        );
+      } else {
+        new Notice(`op: ${srcEntry.id} has no ${relation} links to remove`);
+      }
       return;
     }
     if (linked.length === 1) {

--- a/plugins/op-obsidian/src/main.ts
+++ b/plugins/op-obsidian/src/main.ts
@@ -12,6 +12,7 @@ import {
   IssuePickerModal,
   NewIssueModal,
   ProjectSuggestModal,
+  RelationPickerModal,
   ScaffoldProjectModal,
   SetGithubIssueModal,
   SetPrModal,
@@ -25,8 +26,8 @@ import { parseNewScopePayload, type NewScopeMode } from "./setScopePure";
 import { setEvaluation } from "./setEvaluation";
 import { setSection } from "./setSection";
 import { setFlow, type Complexity, type Flow } from "./setFlow";
-import { applyLink, removeLink, linkCheck, migrateLinks } from "./links";
-import { RELATION_NAMES } from "./relations";
+import { applyLink, listLinkedTargets, removeLink, linkCheck, migrateLinks } from "./links";
+import { RELATION_NAMES, type RelationName } from "./relations";
 import { runEvaluatorFlow } from "./evaluator";
 import { launchHeadless } from "./launchHeadless";
 import {
@@ -499,6 +500,18 @@ export default class OpPlugin extends Plugin {
       id: "op-reset-flow",
       name: "op: reset flow / complexity",
       callback: () => this.runResetFlowCommand(),
+    });
+
+    this.addCommand({
+      id: "op-set-link",
+      name: "op: set issue link",
+      callback: () => this.runSetLinkCommand(),
+    });
+
+    this.addCommand({
+      id: "op-remove-link",
+      name: "op: remove issue link",
+      callback: () => this.runRemoveLinkCommand(),
     });
 
     this.addCommand({
@@ -1236,6 +1249,102 @@ export default class OpPlugin extends Plugin {
         }
       }).open();
     });
+  }
+
+  private runSetLinkCommand(): void {
+    this.pickIssueInteractive((srcEntry) => {
+      new RelationPickerModal(
+        this.app,
+        RELATION_NAMES,
+        (relation) => this.pickSetLinkTarget(srcEntry, relation),
+        `Pick relation for ${srcEntry.id}`,
+      ).open();
+    });
+  }
+
+  private pickSetLinkTarget(srcEntry: IssueEntry, relation: RelationName): void {
+    new FindIssueModal(this.app, (raw) => {
+      const projects = listProjects(this.app);
+      const result = findIssue(this.store, { raw, projects });
+      if (result.matches.length === 0) {
+        new Notice(
+          `op: no match for ${result.interpretation}. Try an ID (e.g. OP-12) or a title fragment.`,
+        );
+        return;
+      }
+      if (result.matches.length === 1) {
+        void this.doApplyLink(srcEntry, relation, result.matches[0]);
+        return;
+      }
+      new IssuePickerModal(this.app, result.matches, (dst) =>
+        void this.doApplyLink(srcEntry, relation, dst),
+      ).open();
+    }).open();
+  }
+
+  private async doApplyLink(
+    src: IssueEntry,
+    relation: RelationName,
+    dst: IssueEntry,
+  ): Promise<void> {
+    try {
+      const res = await applyLink(this.app, this.store, {
+        srcId: src.id,
+        dstId: dst.id,
+        relation,
+      });
+      const cleanedNote = res.cleaned.length ? ` · cleaned ${res.cleaned.join(", ")}` : "";
+      const changeNote = res.changed ? "linked" : "already linked";
+      new Notice(`op: ${src.id} ${relation} → ${dst.id} (${changeNote})${cleanedNote}`);
+    } catch (err: any) {
+      console.error("[op-obsidian] op-set-link failed", err);
+      new Notice(`op-set-link failed: ${err?.message ?? err}`);
+    }
+  }
+
+  private runRemoveLinkCommand(): void {
+    this.pickIssueInteractive((srcEntry) => {
+      new RelationPickerModal(
+        this.app,
+        RELATION_NAMES,
+        (relation) => this.pickRemoveLinkTarget(srcEntry, relation),
+        `Pick relation to remove from ${srcEntry.id}`,
+      ).open();
+    });
+  }
+
+  private pickRemoveLinkTarget(srcEntry: IssueEntry, relation: RelationName): void {
+    const linked = listLinkedTargets(this.app, this.store, srcEntry.id, relation);
+    if (linked.length === 0) {
+      new Notice(`op: ${srcEntry.id} has no ${relation} links to remove`);
+      return;
+    }
+    if (linked.length === 1) {
+      void this.doRemoveLink(srcEntry, relation, linked[0]);
+      return;
+    }
+    new IssuePickerModal(this.app, linked, (dst) =>
+      void this.doRemoveLink(srcEntry, relation, dst),
+    ).open();
+  }
+
+  private async doRemoveLink(
+    src: IssueEntry,
+    relation: RelationName,
+    dst: IssueEntry,
+  ): Promise<void> {
+    try {
+      const res = await removeLink(this.app, this.store, {
+        srcId: src.id,
+        dstId: dst.id,
+        relation,
+      });
+      const changeNote = res.changed ? "removed" : "already absent";
+      new Notice(`op: ${src.id} ${relation} ✗ ${dst.id} (${changeNote})`);
+    } catch (err: any) {
+      console.error("[op-obsidian] op-remove-link failed", err);
+      new Notice(`op-remove-link failed: ${err?.message ?? err}`);
+    }
   }
 
   private runSetGithubIssueCommand(): void {

--- a/plugins/op-obsidian/src/modals.ts
+++ b/plugins/op-obsidian/src/modals.ts
@@ -3,6 +3,7 @@ import type { ProjectInfo } from "./projects";
 import type { Priority, CreateIssueInput } from "./createIssue";
 import type { IssueEntry } from "./types";
 import type { AgentId } from "./agentProfiles";
+import type { RelationName } from "./relations";
 import {
   validateNewIssueInput,
   validateScaffoldInput,
@@ -30,6 +31,27 @@ export class AgentPickerModal extends FuzzySuggestModal<AgentId> {
   }
   onChooseItem(a: AgentId): void {
     this.onChoose(a);
+  }
+}
+
+export class RelationPickerModal extends FuzzySuggestModal<RelationName> {
+  constructor(
+    app: App,
+    private relations: RelationName[],
+    private onChoose: (relation: RelationName) => void,
+    private placeholder = "Pick relation",
+  ) {
+    super(app);
+    this.setPlaceholder(this.placeholder);
+  }
+  getItems(): RelationName[] {
+    return this.relations;
+  }
+  getItemText(r: RelationName): string {
+    return r;
+  }
+  onChooseItem(r: RelationName): void {
+    this.onChoose(r);
   }
 }
 

--- a/plugins/op/.claude-plugin/plugin.json
+++ b/plugins/op/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "op",
   "description": "Obsidian Projects workflow — schema, slash commands, and agent skill for running a Jira-lite issue tracker inside an Obsidian vault.",
-  "version": "0.49.0",
+  "version": "0.50.0",
   "author": {
     "name": "Eugene Archibald"
   },

--- a/plugins/op/.claude-plugin/plugin.json
+++ b/plugins/op/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "op",
   "description": "Obsidian Projects workflow — schema, slash commands, and agent skill for running a Jira-lite issue tracker inside an Obsidian vault.",
-  "version": "0.50.0",
+  "version": "0.50.1",
   "author": {
     "name": "Eugene Archibald"
   },


### PR DESCRIPTION
## Summary
- Add `op: set issue link` and `op: remove issue link` to the command palette — three-step modal flow (source → relation → target) wired to the existing `applyLink` / `removeLink` handlers.
- New `RelationPickerModal` (FuzzySuggestModal over `RELATION_NAMES`); new `listLinkedTargets` helper enumerates currently-linked issues so `op-remove-link`'s target picker is constrained to actual links.
- Bumps op-obsidian to **0.50.0** (minor — additive feature, no schema or surface removals).

## Implementation notes
- No new URI handler; CLI/URI surface for `op-set-link` / `op-remove-link` was already shipped in OP-113.
- Empty-relation edge case for `op-remove-link`: show a Notice and stop, no fall-through to a free-text picker.
- Many-to-one re-parent cleanup is inherited from `applyLink` unchanged.
- Tests: 6 new vitest cases for `listLinkedTargets` covering list/scalar/empty/dangling-target/unknown-source/unknown-relation. Full suite passes (519 tests).

## Test plan
- [x] `npx vitest run` — all 519 tests pass.
- [x] `obsidian plugin:reload id=op-obsidian` — both new commands appear in `app.commands.commands` (`op-obsidian:op-set-link`, `op-obsidian:op-remove-link`).
- [x] Console clean after running each command (no errors).
- [x] Both commands open the FindIssueModal as their first step.
- [ ] Manual: pick source → relation → target, confirm Notice and verify two-sided frontmatter write.
- [ ] Manual: `op-remove-link` against an issue with no `parent` — confirm "no parent links to remove" Notice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)