### PR TITLE
OP-139: add 2x3 layout (6 cells); new default

### DIFF
--- a/plugins/op-obsidian/README.md
+++ b/plugins/op-obsidian/README.md
@@ -102,7 +102,7 @@ Per-project repo paths (slug → absolute path). Overridden by a `repo_path:` in
 
 ### iTerm layout orchestrator
 
-Optional. When enabled, op arranges agent panes in the current iTerm window using the chosen layout (`1x1`, `2x1`, `2x2`, `3x2`, …). Overflow spills to a new iTerm window with a fresh tmux session. macOS + iTerm only.
+Optional. When enabled, op arranges agent panes in the current iTerm window using the chosen layout (`1`, `1x2`, `3`, `2x2`, `2+3`, `2x3`, `2x3+2`, `3x3`). Default is `2x3` (6 panes). Overflow spills to a new iTerm window with a fresh tmux session. macOS + iTerm only.
 
 ### Sidebar view
 

--- a/plugins/op-obsidian/manifest.json
+++ b/plugins/op-obsidian/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "op-obsidian",
   "name": "Obsidian Projects (op)",
-  "version": "0.50.1",
+  "version": "0.51.0",
   "minAppVersion": "1.5.0",
   "description": "Jira-lite issue tracker for Obsidian vaults — deterministic commands backing the op workflow.",
   "author": "Eugene Archibald",

--- a/plugins/op-obsidian/package.json
+++ b/plugins/op-obsidian/package.json
@@ -1,6 +1,6 @@
 {
   "name": "op-obsidian",
-  "version": "0.50.1",
+  "version": "0.51.0",
   "description": "Obsidian plugin that owns the deterministic half of the op workflow.",
   "main": "main.js",
   "scripts": {

--- a/plugins/op-obsidian/src/layout/engine.test.ts
+++ b/plugins/op-obsidian/src/layout/engine.test.ts
@@ -40,6 +40,7 @@ describe("pickLayout", () => {
 describe("maxLayoutForCeiling", () => {
   it("returns the largest fitting layout", () => {
     expect(maxLayoutForCeiling({ maxRows: 3, maxCols: 3 })).toBe("3x3");
+    expect(maxLayoutForCeiling({ maxRows: 2, maxCols: 3 })).toBe("2x3");
     expect(maxLayoutForCeiling({ maxRows: 2, maxCols: 2 })).toBe("2x2");
     expect(maxLayoutForCeiling({ maxRows: 1, maxCols: 2 })).toBe("1x2");
     expect(maxLayoutForCeiling({ maxRows: 1, maxCols: 1 })).toBe("1");

--- a/plugins/op-obsidian/src/layout/engine.test.ts
+++ b/plugins/op-obsidian/src/layout/engine.test.ts
@@ -8,6 +8,8 @@ describe("pickLayout", () => {
     expect(pickLayout(3, { maxRows: 3, maxCols: 3 })).toBe("3");
     expect(pickLayout(4, { maxRows: 3, maxCols: 3 })).toBe("2x2");
     expect(pickLayout(5, { maxRows: 3, maxCols: 3 })).toBe("2+3");
+    expect(pickLayout(6, { maxRows: 3, maxCols: 3 })).toBe("2x3");
+    expect(pickLayout(7, { maxRows: 3, maxCols: 3 })).toBe("2x3+2");
     expect(pickLayout(8, { maxRows: 3, maxCols: 3 })).toBe("2x3+2");
     expect(pickLayout(9, { maxRows: 3, maxCols: 3 })).toBe("3x3");
   });

--- a/plugins/op-obsidian/src/layout/layouts.test.ts
+++ b/plugins/op-obsidian/src/layout/layouts.test.ts
@@ -42,6 +42,7 @@ describe("layouts", () => {
     expect(LAYOUTS["3"].cells).toBe(3);
     expect(LAYOUTS["2x2"].cells).toBe(4);
     expect(LAYOUTS["2+3"].cells).toBe(5);
+    expect(LAYOUTS["2x3"].cells).toBe(6);
     expect(LAYOUTS["2x3+2"].cells).toBe(8);
     expect(LAYOUTS["3x3"].cells).toBe(9);
   });

--- a/plugins/op-obsidian/src/layout/layouts.ts
+++ b/plugins/op-obsidian/src/layout/layouts.ts
@@ -8,9 +8,9 @@
 // Split directions match iTerm AppleScript: "vertical" creates a pane to the
 // right of the target (a vertical divider); "horizontal" creates one below.
 
-export type LayoutId = "1" | "1x2" | "3" | "2x2" | "2+3" | "2x3+2" | "3x3";
+export type LayoutId = "1" | "1x2" | "3" | "2x2" | "2+3" | "2x3" | "2x3+2" | "3x3";
 
-export const LAYOUT_IDS: readonly LayoutId[] = ["1", "1x2", "3", "2x2", "2+3", "2x3+2", "3x3"];
+export const LAYOUT_IDS: readonly LayoutId[] = ["1", "1x2", "3", "2x2", "2+3", "2x3", "2x3+2", "3x3"];
 
 export type SplitDir = "vertical" | "horizontal";
 
@@ -81,6 +81,21 @@ export const LAYOUTS: Record<LayoutId, LayoutSpec> = {
       { from: 0, dir: "vertical" }, // cell 2 = top-right
       { from: 1, dir: "vertical" }, // cell 3 = bottom-middle
       { from: 3, dir: "vertical" }, // cell 4 = bottom-right
+    ],
+  },
+
+  // 2 rows of 3. Append order: TL, BL (full bottom row), TM, TR, BM, BR.
+  "2x3": {
+    id: "2x3",
+    cells: 6,
+    rows: 2,
+    cols: 3,
+    splits: [
+      { from: 0, dir: "horizontal" }, // cell 1 = bottom-full
+      { from: 0, dir: "vertical" }, // cell 2 = top-middle
+      { from: 2, dir: "vertical" }, // cell 3 = top-right
+      { from: 1, dir: "vertical" }, // cell 4 = bottom-middle
+      { from: 4, dir: "vertical" }, // cell 5 = bottom-right
     ],
   },
 

--- a/plugins/op-obsidian/src/settingsPure.ts
+++ b/plugins/op-obsidian/src/settingsPure.ts
@@ -122,7 +122,7 @@ export const DEFAULT_SETTINGS: OpSettings = {
     enabled: false,
     maxRows: 3,
     maxCols: 3,
-    preferred: "2x2",
+    preferred: "2x3",
   },
   orchestratorState: emptyRegistry(),
   projectOrder: [],

--- a/plugins/op/.claude-plugin/plugin.json
+++ b/plugins/op/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "op",
   "description": "Obsidian Projects workflow — schema, slash commands, and agent skill for running a Jira-lite issue tracker inside an Obsidian vault.",
-  "version": "0.50.1",
+  "version": "0.51.0",
   "author": {
     "name": "Eugene Archibald"
   },


### PR DESCRIPTION
## Summary

- Adds a new `2x3` orchestrator layout (2 rows × 3 cols = 6 cells), filling the gap between `2+3` (5) and `2x3+2` (8).
- Switches `DEFAULT_SETTINGS.orchestrator.preferred` from `2x2` (4 panes) to `2x3` (6 panes). Existing users with a saved value keep it; only fresh installs get the new default.
- `pickLayout(6)` now returns `2x3` instead of `2x3+2` (smallest fitting layout).
- README updated to list the full layout menu and call out the new default.
- Bumps lockstep to `0.51.0` (minor — additive layout + new default value is user-visible new behavior).

## Test plan

- [x] `npm test` in `plugins/op-obsidian/` — 546 passed (was 534, +12 from new assertions).
- [x] Built `main.js` synced into Agent-Vault and reloaded.
- [x] Smoke-tested Settings tab: dropdown lists `1, 1x2, 3, 2x2, 2+3, 2x3, 2x3+2, 3x3` (the new option appears between `2+3` and `2x3+2`).
- [x] No console errors after opening the Settings tab.
- [ ] Adversarial Copilot review (requested below).

🤖 Generated with [Claude Code](https://claude.com/claude-code)