### PR TITLE
OP-141: collapse rewriteScopeSection/rewriteEvaluationSection into rewriteSection delegates

### DIFF
--- a/plugins/op-obsidian/manifest.json
+++ b/plugins/op-obsidian/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "op-obsidian",
   "name": "Obsidian Projects (op)",
-  "version": "0.51.0",
+  "version": "0.51.1",
   "minAppVersion": "1.5.0",
   "description": "Jira-lite issue tracker for Obsidian vaults — deterministic commands backing the op workflow.",
   "author": "Eugene Archibald",

--- a/plugins/op-obsidian/package.json
+++ b/plugins/op-obsidian/package.json
@@ -1,6 +1,6 @@
 {
   "name": "op-obsidian",
-  "version": "0.51.0",
+  "version": "0.51.1",
   "description": "Obsidian plugin that owns the deterministic half of the op workflow.",
   "main": "main.js",
   "scripts": {

--- a/plugins/op-obsidian/src/setEvaluation.test.ts
+++ b/plugins/op-obsidian/src/setEvaluation.test.ts
@@ -85,11 +85,44 @@ the plan
     expect(next).toContain("## Plan\n\nthe plan");
     expect(next).not.toContain("old eval");
   });
+
+  it("does not match ## Initial   Evaluation (multiple spaces between words)", () => {
+    // escapeRegExp passes spaces through unchanged; `## Initial   Evaluation`
+    // differs from the literal `Initial Evaluation` in the regex and must not
+    // be treated as the target section.
+    const text = `${FM}
+# T
+
+## Initial   Evaluation
+old
+`;
+    const { replaced } = rewriteEvaluationSection(text, "new");
+    expect(replaced).toBe(false);
+  });
+
+  it("does not match ## Initial Evaluations (extra chars before end-of-line)", () => {
+    // The `\\s*$` anchor in the heading regex prevents over-matching a heading
+    // that has a suffix like `s`.
+    const text = `${FM}
+# T
+
+## Initial Evaluations
+old
+`;
+    const { replaced } = rewriteEvaluationSection(text, "new");
+    expect(replaced).toBe(false);
+  });
 });
 
 describe("normalizeEvaluationPayload", () => {
   it("rejects payload with H2 heading", () => {
     expect(() => normalizeEvaluationPayload("intro\n## Nope\nbody")).toThrow(/H2 headings/);
+  });
+
+  it("error mentions 'Initial Evaluation' section name (capitalised)", () => {
+    expect(() => normalizeEvaluationPayload("intro\n## Nope\nbody")).toThrow(
+      /Initial Evaluation payload must not contain H2 headings/,
+    );
   });
 
   it("rejects empty payload", () => {

--- a/plugins/op-obsidian/src/setEvaluationPure.ts
+++ b/plugins/op-obsidian/src/setEvaluationPure.ts
@@ -1,63 +1,18 @@
+import { normalizeSectionPayload, rewriteSection } from "./setSectionPure";
+
+// Thin wrappers around the generic section helpers. OP-141 folded the bespoke
+// implementations into `setSectionPure` after `rewriteSection`'s parameter type
+// was widened from the SetSectionName allowlist to `string`. Exports stay so
+// setEvaluation.ts and the existing test suite keep working.
+
 export function normalizeEvaluationPayload(raw: string): string {
-  if (typeof raw !== "string") throw new Error("evaluation payload must be a string");
-  const trimmed = raw.replace(/\r\n/g, "\n").replace(/\s+$/g, "");
-  if (!trimmed) throw new Error("evaluation payload is empty");
-  if (/^##\s+/m.test(trimmed)) {
-    throw new Error(
-      "evaluation payload must not contain H2 headings (`## ...`) — they would terminate the Initial Evaluation section",
-    );
-  }
-  return trimmed;
+  return normalizeSectionPayload(raw, "Initial Evaluation");
 }
 
 export function rewriteEvaluationSection(
   text: string,
   payload: string,
 ): { next: string; replaced: boolean } {
-  const { frontmatter, body } = splitFrontmatter(text);
-  const section = `## Initial Evaluation\n\n${payload}\n`;
-
-  const lines = body.split("\n");
-  let startIdx = -1;
-  for (let i = 0; i < lines.length; i++) {
-    if (/^##\s+Initial Evaluation\s*$/.test(lines[i])) {
-      startIdx = i;
-      break;
-    }
-  }
-
-  let newBody: string;
-  let replaced: boolean;
-  if (startIdx === -1) {
-    const trimmedBody = body.replace(/\s+$/g, "");
-    newBody = trimmedBody.length > 0 ? `${trimmedBody}\n\n${section}` : `${section}`;
-    replaced = false;
-  } else {
-    let endIdx = lines.length;
-    for (let i = startIdx + 1; i < lines.length; i++) {
-      if (/^##\s+/.test(lines[i])) {
-        endIdx = i;
-        break;
-      }
-    }
-    const before = lines.slice(0, startIdx).join("\n").replace(/\s+$/g, "");
-    const after = lines.slice(endIdx).join("\n").replace(/^\s+/g, "");
-    const parts: string[] = [];
-    if (before.length > 0) parts.push(before, "");
-    parts.push(section.replace(/\n$/, ""));
-    if (after.length > 0) parts.push("", after);
-    newBody = parts.join("\n");
-    if (!newBody.endsWith("\n")) newBody += "\n";
-    replaced = true;
-  }
-
-  return { next: frontmatter + newBody, replaced };
-}
-
-function splitFrontmatter(text: string): { frontmatter: string; body: string } {
-  if (!text.startsWith("---\n")) return { frontmatter: "", body: text };
-  const end = text.indexOf("\n---\n", 4);
-  if (end === -1) return { frontmatter: "", body: text };
-  const cutoff = end + "\n---\n".length;
-  return { frontmatter: text.slice(0, cutoff), body: text.slice(cutoff) };
+  const { next, replaced } = rewriteSection(text, "Initial Evaluation", payload);
+  return { next, replaced };
 }

--- a/plugins/op-obsidian/src/setScope.test.ts
+++ b/plugins/op-obsidian/src/setScope.test.ts
@@ -58,6 +58,12 @@ old
     expect(() => normalizeScopePayload("intro\n## Nope\nbody")).toThrow(/H2 headings/);
   });
 
+  it("error mentions 'Scope' section name (capitalised)", () => {
+    expect(() => normalizeScopePayload("intro\n## Nope\nbody")).toThrow(
+      /Scope payload must not contain H2 headings/,
+    );
+  });
+
   it("rejects empty payload", () => {
     expect(() => normalizeScopePayload("   \n\n")).toThrow(/empty/);
   });

--- a/plugins/op-obsidian/src/setScopePure.ts
+++ b/plugins/op-obsidian/src/setScopePure.ts
@@ -1,3 +1,5 @@
+import { normalizeSectionPayload, rewriteSection } from "./setSectionPure";
+
 export type NewScopeMode = "bullets" | "body";
 
 export type ParsedNewScope =
@@ -40,16 +42,11 @@ export function parseNewScopePayload(raw: string, mode: NewScopeMode): ParsedNew
   return { kind: "bullets", bullets };
 }
 
+// Thin wrapper around `normalizeSectionPayload` for the legacy scope verb.
+// OP-141 folded the bespoke implementation into the generic helper; the export
+// stays for setScope.ts and the existing test suite.
 export function normalizeScopePayload(raw: string): string {
-  if (typeof raw !== "string") throw new Error("scope payload must be a string");
-  const trimmed = raw.replace(/\r\n/g, "\n").replace(/\s+$/g, "");
-  if (!trimmed) throw new Error("scope payload is empty");
-  if (/^##\s+/m.test(trimmed)) {
-    throw new Error(
-      "scope payload must not contain H2 headings (`## ...`) — they would terminate the Scope section",
-    );
-  }
-  return trimmed;
+  return normalizeSectionPayload(raw, "Scope");
 }
 
 export function normalizeBodyPayload(raw: string): string {
@@ -78,48 +75,16 @@ export function rewriteFullBody(
   return { next: frontmatter + newBody, replaced };
 }
 
+// Thin wrapper around the generic `rewriteSection`. OP-141 folded the bespoke
+// implementation into the shared helper; the export stays for setScope.ts and
+// the existing test suite. The legacy `{ next, replaced }` return shape is
+// preserved — callers don't depend on the new `appended` field.
 export function rewriteScopeSection(
   text: string,
   payload: string,
 ): { next: string; replaced: boolean } {
-  const { frontmatter, body } = splitFrontmatter(text);
-  const section = `## Scope\n\n${payload}\n`;
-
-  const lines = body.split("\n");
-  let startIdx = -1;
-  for (let i = 0; i < lines.length; i++) {
-    if (/^##\s+Scope\s*$/.test(lines[i])) {
-      startIdx = i;
-      break;
-    }
-  }
-
-  let newBody: string;
-  let replaced: boolean;
-  if (startIdx === -1) {
-    const trimmedBody = body.replace(/\s+$/g, "");
-    newBody = trimmedBody.length > 0 ? `${trimmedBody}\n\n${section}` : `${section}`;
-    replaced = false;
-  } else {
-    let endIdx = lines.length;
-    for (let i = startIdx + 1; i < lines.length; i++) {
-      if (/^##\s+/.test(lines[i])) {
-        endIdx = i;
-        break;
-      }
-    }
-    const before = lines.slice(0, startIdx).join("\n").replace(/\s+$/g, "");
-    const after = lines.slice(endIdx).join("\n").replace(/^\s+/g, "");
-    const parts: string[] = [];
-    if (before.length > 0) parts.push(before, "");
-    parts.push(section.replace(/\n$/, ""));
-    if (after.length > 0) parts.push("", after);
-    newBody = parts.join("\n");
-    if (!newBody.endsWith("\n")) newBody += "\n";
-    replaced = true;
-  }
-
-  return { next: frontmatter + newBody, replaced };
+  const { next, replaced } = rewriteSection(text, "Scope", payload);
+  return { next, replaced };
 }
 
 function splitFrontmatter(text: string): { frontmatter: string; body: string } {

--- a/plugins/op-obsidian/src/setSectionPure.ts
+++ b/plugins/op-obsidian/src/setSectionPure.ts
@@ -16,7 +16,11 @@ export function isSetSectionName(name: string): name is SetSectionName {
   return (SET_SECTION_NAMES as readonly string[]).includes(name);
 }
 
-export function normalizeSectionPayload(raw: string, sectionName: SetSectionName): string {
+// `sectionName` is typed as `string` (not the `SetSectionName` allowlist) so the
+// legacy Scope and Initial Evaluation wrappers can delegate here. The public
+// op-set-section verb keeps its Plan|Notes|Summary restriction at the
+// setSection.ts boundary via `isSetSectionName`.
+export function normalizeSectionPayload(raw: string, sectionName: string): string {
   if (typeof raw !== "string") throw new Error(`${sectionName} payload must be a string`);
   const trimmed = raw.replace(/\r\n/g, "\n").replace(/\s+$/g, "");
   if (!trimmed) throw new Error(`${sectionName} payload is empty`);
@@ -47,7 +51,7 @@ export interface RewriteSectionResult {
 
 export function rewriteSection(
   text: string,
-  sectionName: SetSectionName,
+  sectionName: string,
   payload: string,
   options: RewriteSectionOptions = {},
 ): RewriteSectionResult {

--- a/plugins/op/.claude-plugin/plugin.json
+++ b/plugins/op/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "op",
   "description": "Obsidian Projects workflow — schema, slash commands, and agent skill for running a Jira-lite issue tracker inside an Obsidian vault.",
-  "version": "0.51.0",
+  "version": "0.51.1",
   "author": {
     "name": "Eugene Archibald"
   },


### PR DESCRIPTION
## Summary

- Widens `rewriteSection` and `normalizeSectionPayload` parameter type from `SetSectionName` → `string` so the legacy Scope and Initial Evaluation wrappers can delegate to the generic helpers. The public `op-set-section` verb keeps its Plan|Notes|Summary restriction at the `setSection.ts` boundary via `isSetSectionName`.
- `rewriteScopeSection` / `normalizeScopePayload` and `rewriteEvaluationSection` / `normalizeEvaluationPayload` are now thin one-line delegates; wrapper return shape `{ next, replaced }` preserved.
- setEvaluationPure.ts: 64 → 18 lines. setScopePure.ts: -37 lines of duplicated section-rewrite logic.
- Patch bump to 0.51.1 (internal refactor, no behavior or public-API change).

OP-125 added the generic `rewriteSection` and deliberately deferred this de-dup — this PR closes that follow-up.

Closes #135

## Test plan

- [x] `npx vitest run` — all 527 tests pass.
- [x] `npx tsc --noEmit` — clean.
- [x] Vault smoke: `op-set-scope issue=OP-141 mode=scope scope=...` and `op-set-section issue=OP-141 name=Notes content=...` against the live 0.51.1 build, no console errors.
- [ ] Adversarial review by @copilot — pressure-test for: (a) error wording change ("scope payload..." → "Scope payload..."); (b) the `appended` field dropped from the legacy wrapper return shape (verify no caller in the codebase reads it); (c) typo-in-section-name no longer caught by TS at the `rewriteSection` call site (mitigation: only three call sites, each a string literal).

🤖 Generated with [Claude Code](https://claude.com/claude-code)