### PR TITLE
OP-157: sidebar keyboard nav + density preference (§6 of OP-149)

### DIFF
--- a/plugins/op-obsidian/manifest.json
+++ b/plugins/op-obsidian/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "op-obsidian",
   "name": "Obsidian Projects (op)",
-  "version": "0.51.1",
+  "version": "0.52.0",
   "minAppVersion": "1.5.0",
   "description": "Jira-lite issue tracker for Obsidian vaults — deterministic commands backing the op workflow.",
   "author": "Eugene Archibald",

--- a/plugins/op-obsidian/package.json
+++ b/plugins/op-obsidian/package.json
@@ -1,6 +1,6 @@
 {
   "name": "op-obsidian",
-  "version": "0.51.1",
+  "version": "0.52.0",
   "description": "Obsidian plugin that owns the deterministic half of the op workflow.",
   "main": "main.js",
   "scripts": {

--- a/plugins/op-obsidian/src/main.ts
+++ b/plugins/op-obsidian/src/main.ts
@@ -334,6 +334,7 @@ export default class OpPlugin extends Plugin {
             tmuxSessions: () => tmuxSessionsForCleanup(this.settings.orchestratorState),
             recordRecency: (id) => this.recordRecency(id),
             executeResumeLast: () => void this.runResumeLastCommand(),
+            resolveIssue: (entry) => this.runResolveCommand({ path: entry.path }),
           },
         ),
     );

--- a/plugins/op-obsidian/src/settings.test.ts
+++ b/plugins/op-obsidian/src/settings.test.ts
@@ -120,6 +120,18 @@ describe("mergeSettings", () => {
     ).toBe(DEFAULT_SETTINGS.view.defaultTab);
   });
 
+  it("view.density accepts the two literals; rejects anything else", () => {
+    expect(DEFAULT_SETTINGS.view.density).toBe("comfortable");
+    expect(mergeSettings({ view: { density: "compact" } }).view.density).toBe("compact");
+    expect(mergeSettings({ view: { density: "comfortable" } }).view.density).toBe("comfortable");
+    expect(
+      mergeSettings({ view: { density: "tight" as unknown as "compact" } }).view.density,
+    ).toBe(DEFAULT_SETTINGS.view.density);
+    expect(
+      mergeSettings({ view: { density: 1 as unknown as "compact" } }).view.density,
+    ).toBe(DEFAULT_SETTINGS.view.density);
+  });
+
   it("only accepts terminal === 'Terminal' | 'iTerm'", () => {
     expect(mergeSettings({ terminal: "iTerm" }).terminal).toBe("iTerm");
     expect(mergeSettings({ terminal: "Terminal" }).terminal).toBe("Terminal");

--- a/plugins/op-obsidian/src/settings.ts
+++ b/plugins/op-obsidian/src/settings.ts
@@ -24,6 +24,7 @@ import { execFileSync } from "child_process";
 import {
   EXTRA_PREAMBLE_MAX,
   type SidebarTab,
+  type SidebarDensity,
   type OpSettings,
   DEFAULT_SETTINGS,
   mergeSettings,
@@ -37,6 +38,7 @@ export {
 export type {
   InjectionSettings,
   SidebarTab,
+  SidebarDensity,
   ViewSettings,
   GithubSettings,
   AgentsSettings,
@@ -682,6 +684,22 @@ export class OpSettingsTab extends PluginSettingTab {
           s.view.openOnStartup = v;
           await this.plugin.saveSettings();
         }),
+      );
+
+    new Setting(containerEl)
+      .setName("Sidebar density")
+      .setDesc(
+        "Compact tightens vertical row padding by 4px and hides the project chip when only one project is rendered. Comfortable matches the historical default.",
+      )
+      .addDropdown((d) =>
+        d
+          .addOption("comfortable", "Comfortable")
+          .addOption("compact", "Compact")
+          .setValue(s.view.density)
+          .onChange(async (v) => {
+            s.view.density = v as SidebarDensity;
+            await this.plugin.saveSettings();
+          }),
       );
 
     containerEl.createEl("h2", { text: "GitHub integration" });

--- a/plugins/op-obsidian/src/settingsPure.ts
+++ b/plugins/op-obsidian/src/settingsPure.ts
@@ -21,11 +21,16 @@ export interface InjectionSettings {
 }
 
 export type SidebarTab = "issues" | "in-flight" | "resolved";
+export type SidebarDensity = "comfortable" | "compact";
 
 export interface ViewSettings {
   defaultTab: SidebarTab;
   recentResolvedLimit: number;
   openOnStartup: boolean;
+  /** Visual density of the sidebar list. `compact` tightens vertical padding
+   * by 4px and hides the project chip when the rendered list spans only one
+   * project. */
+  density: SidebarDensity;
 }
 
 export interface GithubSettings {
@@ -107,6 +112,7 @@ export const DEFAULT_SETTINGS: OpSettings = {
     defaultTab: "issues",
     recentResolvedLimit: 20,
     openOnStartup: false,
+    density: "comfortable",
   },
   github: {
     autoCreateGithubIssue: false,
@@ -135,6 +141,7 @@ export const DEFAULT_SETTINGS: OpSettings = {
 };
 
 const SIDEBAR_TABS: ReadonlySet<SidebarTab> = new Set(["issues", "in-flight", "resolved"]);
+const SIDEBAR_DENSITIES: ReadonlySet<SidebarDensity> = new Set(["comfortable", "compact"]);
 
 export function mergeSettings(loaded: unknown): OpSettings {
   const base: OpSettings = JSON.parse(JSON.stringify(DEFAULT_SETTINGS));
@@ -167,6 +174,7 @@ export function mergeSettings(loaded: unknown): OpSettings {
       base.view.recentResolvedLimit = Math.floor(v.recentResolvedLimit);
     }
     if (typeof v.openOnStartup === "boolean") base.view.openOnStartup = v.openOnStartup;
+    if (v.density && SIDEBAR_DENSITIES.has(v.density)) base.view.density = v.density;
   }
   if (l.orchestrator && typeof l.orchestrator === "object") {
     const o = l.orchestrator as Partial<OrchestratorSettings>;

--- a/plugins/op-obsidian/src/sidebarView.test.ts
+++ b/plugins/op-obsidian/src/sidebarView.test.ts
@@ -13,9 +13,11 @@ beforeAll(() => {
 });
 
 vi.mock("obsidian", () => ({
+  App: class {},
   ItemView: class {
     contentEl: any = makeFakeEl();
   },
+  Modal: class {},
   TFile: class {},
   WorkspaceLeaf: class {},
   setIcon: () => {},
@@ -27,7 +29,13 @@ vi.mock("./staleAgentBadges", () => ({
   probeLiveTmuxWindows: vi.fn(async () => ({ live: new Set<string>(), ok: true })),
 }));
 
-import { filterEntries, OpSidebarView, TMUX_PROBE_INTERVAL_MS, type OpSidebarHooks } from "./sidebarView";
+import {
+  filterEntries,
+  OpSidebarView,
+  shouldShowProjectChip,
+  TMUX_PROBE_INTERVAL_MS,
+  type OpSidebarHooks,
+} from "./sidebarView";
 import { probeLiveTmuxWindows } from "./staleAgentBadges";
 
 function entry(over: Partial<IssueEntry>): IssueEntry {
@@ -91,6 +99,33 @@ describe("filterEntries", () => {
   });
 });
 
+describe("shouldShowProjectChip", () => {
+  const op1 = entry({ id: "OP-1", project: "obsidian-projects" });
+  const op2 = entry({ id: "OP-2", project: "obsidian-projects" });
+  const jb1 = entry({ id: "JB-1", project: "jira-bases" });
+
+  it("always shows the chip in comfortable density, even single-project", () => {
+    expect(shouldShowProjectChip("comfortable", [])).toBe(true);
+    expect(shouldShowProjectChip("comfortable", [op1])).toBe(true);
+    expect(shouldShowProjectChip("comfortable", [op1, op2])).toBe(true);
+    expect(shouldShowProjectChip("comfortable", [op1, jb1])).toBe(true);
+  });
+
+  it("hides the chip in compact density when every entry shares one project", () => {
+    expect(shouldShowProjectChip("compact", [op1])).toBe(false);
+    expect(shouldShowProjectChip("compact", [op1, op2])).toBe(false);
+  });
+
+  it("keeps the chip in compact density when projects differ", () => {
+    expect(shouldShowProjectChip("compact", [op1, jb1])).toBe(true);
+    expect(shouldShowProjectChip("compact", [jb1, op1, op2])).toBe(true);
+  });
+
+  it("treats an empty list as 'show' so the empty-state placeholder isn't rare-cased", () => {
+    expect(shouldShowProjectChip("compact", [])).toBe(true);
+  });
+});
+
 function makeFakeEl(): any {
   const el: any = {
     children: [] as any[],
@@ -122,6 +157,10 @@ function makeFakeEl(): any {
     },
     setAttr() {},
     addEventListener() {},
+    removeEventListener() {},
+    removeClass() {},
+    focus() {},
+    scrollIntoView() {},
   };
   return el;
 }
@@ -149,7 +188,13 @@ function makeView(hooks?: OpSidebarHooks): any {
     {} as any,
     store as any,
     bus as any,
-    () => ({ defaultTab: "issues", recentResolvedLimit: 20, openOnStartup: false } as any),
+    () =>
+      ({
+        defaultTab: "issues",
+        recentResolvedLimit: 20,
+        openOnStartup: false,
+        density: "comfortable",
+      } as any),
     undefined,
     undefined,
     hooks,

--- a/plugins/op-obsidian/src/sidebarView.test.ts
+++ b/plugins/op-obsidian/src/sidebarView.test.ts
@@ -32,6 +32,7 @@ vi.mock("./staleAgentBadges", () => ({
 import {
   decideKeyAction,
   filterEntries,
+  OpResolveConfirmModal,
   OpSidebarView,
   shouldShowProjectChip,
   TMUX_PROBE_INTERVAL_MS,
@@ -360,5 +361,94 @@ describe("OpSidebarView visibility-gated tmux probe", () => {
       expect(view.isProbeRunning()).toBe(false);
       await view.onClose();
     });
+  });
+});
+
+// ─── OpResolveConfirmModal ────────────────────────────────────────────────────
+
+describe("OpResolveConfirmModal", () => {
+  it("calls onDismiss when closed (Cancel / Resolve / Esc all hit onClose)", () => {
+    const onConfirm = vi.fn();
+    const onDismiss = vi.fn();
+    const modal = new OpResolveConfirmModal(
+      {} as any,
+      entry({ id: "OP-42", title: "OP-42 example" }),
+      onConfirm,
+      onDismiss,
+    );
+    (modal as any).contentEl = makeFakeEl();
+    modal.onClose();
+    expect(onDismiss).toHaveBeenCalledTimes(1);
+    expect(onConfirm).not.toHaveBeenCalled();
+  });
+
+  it("does not throw when onDismiss is omitted", () => {
+    const modal = new OpResolveConfirmModal(
+      {} as any,
+      entry({ id: "OP-1", title: "OP-1 placeholder" }),
+      vi.fn(),
+    );
+    (modal as any).contentEl = makeFakeEl();
+    expect(() => modal.onClose()).not.toThrow();
+  });
+});
+
+// ─── render() selection identity preservation ────────────────────────────────
+
+describe("render() selection identity", () => {
+  function makeViewWithIssues(issues: IssueEntry[]): any {
+    const bus = new FakeBus();
+    const store = {
+      byId: () => undefined,
+      issues: () => issues,
+    };
+    return new OpSidebarView(
+      {} as any,
+      store as any,
+      bus as any,
+      () =>
+        ({
+          defaultTab: "issues",
+          recentResolvedLimit: 20,
+          openOnStartup: false,
+          density: "comfortable",
+        } as any),
+      undefined,
+      undefined,
+      undefined,
+    );
+  }
+
+  it("preserves the selected row by id when a new issue inserts before it", async () => {
+    const op100 = entry({ id: "OP-100", title: "OP-100 original" });
+    const issues: IssueEntry[] = [op100];
+    const view = makeViewWithIssues(issues);
+    await view.onOpen();
+    expect((view as any).selectedIndex).toBe(0);
+    expect((view as any).displayedIssues[0].id).toBe("OP-100");
+
+    // OP-001 sorts before OP-100 numerically — the selection must stay on OP-100.
+    issues.unshift(entry({ id: "OP-001", title: "OP-001 new" }));
+    (view as any).render();
+    expect((view as any).selectedIndex).toBe(1);
+    expect((view as any).displayedIssues[(view as any).selectedIndex].id).toBe("OP-100");
+
+    await view.onClose();
+  });
+
+  it("falls back to index 0 when the previously selected issue leaves the list", async () => {
+    const op1 = entry({ id: "OP-1" });
+    const op2 = entry({ id: "OP-2" });
+    const issues: IssueEntry[] = [op1, op2];
+    const view = makeViewWithIssues(issues);
+    await view.onOpen();
+    (view as any).selectedIndex = 1;
+
+    issues.splice(1, 1); // OP-2 leaves the rendered list
+    (view as any).render();
+    expect((view as any).selectedIndex).toBe(0);
+    expect((view as any).displayedIssues[0].id).toBe("OP-1");
+
+    await view.onClose();
   });
 });

--- a/plugins/op-obsidian/src/sidebarView.test.ts
+++ b/plugins/op-obsidian/src/sidebarView.test.ts
@@ -30,6 +30,7 @@ vi.mock("./staleAgentBadges", () => ({
 }));
 
 import {
+  decideKeyAction,
   filterEntries,
   OpSidebarView,
   shouldShowProjectChip,
@@ -123,6 +124,68 @@ describe("shouldShowProjectChip", () => {
 
   it("treats an empty list as 'show' so the empty-state placeholder isn't rare-cased", () => {
     expect(shouldShowProjectChip("compact", [])).toBe(true);
+  });
+});
+
+describe("decideKeyAction", () => {
+  const k = (
+    key: string,
+    mods: Partial<{ alt: boolean; shift: boolean; meta: boolean; ctrl: boolean }> = {},
+  ) => ({
+    key,
+    altKey: !!mods.alt,
+    shiftKey: !!mods.shift,
+    metaKey: !!mods.meta,
+    ctrlKey: !!mods.ctrl,
+  });
+
+  it("plain ArrowDown / ArrowUp / Enter map to next / prev / open in both contexts", () => {
+    for (const inFilter of [false, true]) {
+      expect(decideKeyAction(k("ArrowDown"), { inFilter })).toBe("next");
+      expect(decideKeyAction(k("ArrowUp"), { inFilter })).toBe("prev");
+      expect(decideKeyAction(k("Enter"), { inFilter })).toBe("open");
+    }
+  });
+
+  it("Cmd+Enter and Ctrl+Enter both map to launch in both contexts", () => {
+    for (const inFilter of [false, true]) {
+      expect(decideKeyAction(k("Enter", { meta: true }), { inFilter })).toBe("launch");
+      expect(decideKeyAction(k("Enter", { ctrl: true }), { inFilter })).toBe("launch");
+    }
+  });
+
+  it("plain j / k / r map to next / prev / resolve when the filter input is unfocused", () => {
+    expect(decideKeyAction(k("j"), { inFilter: false })).toBe("next");
+    expect(decideKeyAction(k("k"), { inFilter: false })).toBe("prev");
+    expect(decideKeyAction(k("r"), { inFilter: false })).toBe("resolve");
+  });
+
+  it("ignores letter shortcuts when the filter input is focused so users can type", () => {
+    expect(decideKeyAction(k("j"), { inFilter: true })).toBe("ignore");
+    expect(decideKeyAction(k("k"), { inFilter: true })).toBe("ignore");
+    expect(decideKeyAction(k("r"), { inFilter: true })).toBe("ignore");
+  });
+
+  it("ignores modifier-laden letter keys to avoid hijacking Cmd-J / Shift-K / etc.", () => {
+    expect(decideKeyAction(k("j", { meta: true }), { inFilter: false })).toBe("ignore");
+    expect(decideKeyAction(k("j", { shift: true }), { inFilter: false })).toBe("ignore");
+    expect(decideKeyAction(k("k", { ctrl: true }), { inFilter: false })).toBe("ignore");
+    expect(decideKeyAction(k("r", { alt: true }), { inFilter: false })).toBe("ignore");
+  });
+
+  it("ignores unrelated keys (letters, function keys, punctuation)", () => {
+    expect(decideKeyAction(k("a"), { inFilter: false })).toBe("ignore");
+    expect(decideKeyAction(k("Escape"), { inFilter: false })).toBe("ignore");
+    expect(decideKeyAction(k("F1"), { inFilter: false })).toBe("ignore");
+    expect(decideKeyAction(k("/"), { inFilter: false })).toBe("ignore");
+  });
+
+  it("ignores Shift+Enter and Alt+Enter (only plain or Cmd/Ctrl+Enter trigger an action)", () => {
+    expect(decideKeyAction(k("Enter", { shift: true }), { inFilter: false })).toBe("ignore");
+    expect(decideKeyAction(k("Enter", { alt: true }), { inFilter: false })).toBe("ignore");
+    expect(decideKeyAction(k("Enter", { meta: true, alt: true }), { inFilter: false })).toBe(
+      "ignore",
+    );
   });
 });
 

--- a/plugins/op-obsidian/src/sidebarView.ts
+++ b/plugins/op-obsidian/src/sidebarView.ts
@@ -62,6 +62,10 @@ export class OpSidebarView extends ItemView {
   private tabButtons = new Map<TabId, HTMLElement>();
   private rafPending = false;
   private probeTimer: ReturnType<typeof setInterval> | undefined;
+  /** Guard against `r` auto-repeat (or rapid double-tap) stacking multiple
+   * resolve modals on top of each other. Set when a modal opens, cleared via
+   * the `onDismiss` callback when it closes (Cancel OR Resolve). */
+  private resolveModalOpen = false;
   /** Last list rendered into the body — keyed by index so j/k can map cleanly
    * onto a row without re-running the filter. */
   private displayedIssues: IssueEntry[] = [];
@@ -243,10 +247,17 @@ export class OpSidebarView extends ItemView {
     this.contentEl.toggleClass("op-sidebar--density-comfortable", density !== "compact");
 
     const issues = filterEntries(this.pickFor(this.active), this.filterQuery);
+    // Preserve selection identity across re-renders by id. Without this, a new
+    // issue that sorts before the current selection (e.g. OP-001 arriving
+    // while OP-100 is highlighted at index 0) silently shifts the highlight
+    // to a different row mid-keypress. O(n) findIndex is fine — renders are
+    // RAF-debounced and project-vault issue lists are small.
+    const selectedId = this.displayedIssues[this.selectedIndex]?.id;
     this.displayedIssues = issues;
     this.rowEls = [];
-    // Clamp the selection to the new list shape. Empty list ⇒ -1 (no row).
+    const identityIdx = selectedId !== undefined ? issues.findIndex((e) => e.id === selectedId) : -1;
     if (issues.length === 0) this.selectedIndex = -1;
+    else if (identityIdx >= 0) this.selectedIndex = identityIdx;
     else if (this.selectedIndex < 0 || this.selectedIndex >= issues.length) this.selectedIndex = 0;
 
     const showProjectChip = shouldShowProjectChip(density, issues);
@@ -486,6 +497,9 @@ export class OpSidebarView extends ItemView {
     const action = decideKeyAction(ev, { inFilter: ev.target === this.filterInput });
     if (action === "ignore") return;
     ev.preventDefault();
+    // For Cmd/Ctrl+Enter we additionally stopPropagation so Obsidian's global
+    // "Open link in new pane" handler doesn't double-fire on the same chord.
+    if (action === "launch") ev.stopPropagation();
     switch (action) {
       case "next":
         this.setSelectedIndex(this.selectedIndex + 1);
@@ -525,15 +539,26 @@ export class OpSidebarView extends ItemView {
   }
 
   private async resolveSelected(): Promise<void> {
+    // Guard against `r` auto-repeat (or rapid double-tap) stacking modals.
+    // Cleared via the modal's onDismiss callback below.
+    if (this.resolveModalOpen) return;
     const entry = this.currentSelection();
     if (!entry || !this.hooks?.resolveIssue) return;
     if (entry.resolvedFolder || entry.status === "resolved" || entry.status === "wontfix") {
       return;
     }
+    this.resolveModalOpen = true;
     const hook = this.hooks.resolveIssue;
-    const modal = new OpResolveConfirmModal(this.app, entry, async () => {
-      await hook(entry);
-    });
+    const modal = new OpResolveConfirmModal(
+      this.app,
+      entry,
+      async () => {
+        await hook(entry);
+      },
+      () => {
+        this.resolveModalOpen = false;
+      },
+    );
     modal.open();
   }
 }
@@ -548,6 +573,10 @@ export class OpResolveConfirmModal extends Modal {
     app: App,
     private entry: IssueEntry,
     private onConfirm: () => void | Promise<void>,
+    /** Called when the modal closes for any reason (Cancel, Resolve, or
+     * Esc/click-outside). The sidebar uses it to clear the auto-repeat
+     * stacking guard so the next `r` keypress works normally. */
+    private onDismiss?: () => void,
   ) {
     super(app);
   }
@@ -580,6 +609,7 @@ export class OpResolveConfirmModal extends Modal {
 
   onClose(): void {
     this.contentEl.empty();
+    this.onDismiss?.();
   }
 }
 

--- a/plugins/op-obsidian/src/sidebarView.ts
+++ b/plugins/op-obsidian/src/sidebarView.ts
@@ -111,8 +111,9 @@ export class OpSidebarView extends ItemView {
     root.empty();
     root.addClass("op-sidebar");
     // Make the leaf focusable so j/k/Enter/r work without first clicking a
-    // row. Negative tabindex keeps the leaf out of the global Tab order while
-    // still allowing programmatic focus.
+    // row. tabindex=0 keeps the leaf in the natural Tab order so users can
+    // also reach it via keyboard from elsewhere in Obsidian; we additionally
+    // focus it programmatically in onOpen.
     root.setAttr("tabindex", "0");
 
     this.headerEl = root.createDiv({ cls: "op-sidebar__header" });
@@ -468,11 +469,12 @@ export class OpSidebarView extends ItemView {
   }
 
   /**
-   * Keyboard router. Three contexts in priority order:
+   * Keyboard router. Two contexts in priority order:
    *
-   *   1. Filter input focused — only navigation/open/launch keys; letters
-   *      go through to the input untouched.
-   *   2. Anything else inside the sidebar — full set including `j`/`k`/`r`.
+   *   1. Filter input focused — only navigation/open/launch keys (Arrows,
+   *      Enter, Cmd/Ctrl+Enter); letter keys (`j`/`k`/`r`) fall through
+   *      so typing a query stays unobstructed.
+   *   2. Anywhere else inside the sidebar — full set including `j`/`k`/`r`.
    *
    * Modifier rule: only the bare modifier set documented per binding triggers
    * the action. `Cmd+J` is a global Obsidian shortcut so we never claim it;
@@ -480,52 +482,26 @@ export class OpSidebarView extends ItemView {
    * after deciding to act, so unknown keys propagate normally.
    */
   private handleKeydown(ev: KeyboardEvent): void {
-    // Bail on IME composition so half-typed characters aren't intercepted.
     if (ev.isComposing) return;
-    const target = ev.target as Element | null;
-    const inFilter = target === this.filterInput;
-    const meta = ev.metaKey || ev.ctrlKey;
-    const plain = !ev.altKey && !ev.shiftKey && !ev.metaKey && !ev.ctrlKey;
-    const enterWithMeta = ev.key === "Enter" && meta && !ev.altKey && !ev.shiftKey;
-
-    if (ev.key === "ArrowDown" && plain) {
-      ev.preventDefault();
-      this.setSelectedIndex(this.selectedIndex + 1);
-      return;
-    }
-    if (ev.key === "ArrowUp" && plain) {
-      ev.preventDefault();
-      this.setSelectedIndex(this.selectedIndex - 1);
-      return;
-    }
-    if (ev.key === "Enter" && plain) {
-      ev.preventDefault();
-      void this.activateSelected();
-      return;
-    }
-    if (enterWithMeta) {
-      ev.preventDefault();
-      void this.launchSelected();
-      return;
-    }
-
-    // Letter keys: only honored when the filter input doesn't own focus, so
-    // typing a query stays unobstructed.
-    if (inFilter) return;
-    if (ev.key === "j" && plain) {
-      ev.preventDefault();
-      this.setSelectedIndex(this.selectedIndex + 1);
-      return;
-    }
-    if (ev.key === "k" && plain) {
-      ev.preventDefault();
-      this.setSelectedIndex(this.selectedIndex - 1);
-      return;
-    }
-    if (ev.key === "r" && plain) {
-      ev.preventDefault();
-      void this.resolveSelected();
-      return;
+    const action = decideKeyAction(ev, { inFilter: ev.target === this.filterInput });
+    if (action === "ignore") return;
+    ev.preventDefault();
+    switch (action) {
+      case "next":
+        this.setSelectedIndex(this.selectedIndex + 1);
+        return;
+      case "prev":
+        this.setSelectedIndex(this.selectedIndex - 1);
+        return;
+      case "open":
+        void this.activateSelected();
+        return;
+      case "launch":
+        void this.launchSelected();
+        return;
+      case "resolve":
+        void this.resolveSelected();
+        return;
     }
   }
 
@@ -605,6 +581,44 @@ export class OpResolveConfirmModal extends Modal {
   onClose(): void {
     this.contentEl.empty();
   }
+}
+
+export type SidebarKeyAction =
+  | "ignore"
+  | "next"
+  | "prev"
+  | "open"
+  | "launch"
+  | "resolve";
+
+/**
+ * Pure key-router decision. Inputs: the keyboard event and whether the filter
+ * input owns focus. Output: the action label the view should perform, or
+ * `"ignore"` to let the key propagate untouched.
+ *
+ * Lifted out of the class so the binding map is unit-testable without a DOM.
+ */
+export function decideKeyAction(
+  ev: Pick<KeyboardEvent, "key" | "altKey" | "shiftKey" | "metaKey" | "ctrlKey">,
+  opts: { inFilter: boolean },
+): SidebarKeyAction {
+  const { key, altKey, shiftKey, metaKey, ctrlKey } = ev;
+  const meta = metaKey || ctrlKey;
+  const plain = !altKey && !shiftKey && !metaKey && !ctrlKey;
+
+  if (key === "ArrowDown" && plain) return "next";
+  if (key === "ArrowUp" && plain) return "prev";
+  if (key === "Enter" && plain) return "open";
+  if (key === "Enter" && meta && !altKey && !shiftKey) return "launch";
+
+  // Letter shortcuts: skipped when the filter input owns focus so typing a
+  // query stays unobstructed.
+  if (opts.inFilter) return "ignore";
+  if (key === "j" && plain) return "next";
+  if (key === "k" && plain) return "prev";
+  if (key === "r" && plain) return "resolve";
+
+  return "ignore";
 }
 
 /**

--- a/plugins/op-obsidian/src/sidebarView.ts
+++ b/plugins/op-obsidian/src/sidebarView.ts
@@ -1,8 +1,8 @@
-import { ItemView, TFile, WorkspaceLeaf, prepareFuzzySearch, setIcon, setTooltip } from "obsidian";
+import { App, ItemView, Modal, TFile, WorkspaceLeaf, prepareFuzzySearch, setIcon, setTooltip } from "obsidian";
 import type { IssueStore } from "./issueStore";
 import type { EventBus } from "./eventBus";
 import type { IssueEntry, LifecycleEvent } from "./types";
-import type { ViewSettings } from "./settings";
+import type { SidebarDensity, ViewSettings } from "./settings";
 import type { AgentLaunchMode } from "./agentProfiles";
 import type { RecencyEntry } from "./recencyLog";
 import { mostRecent, relativeTime } from "./recencyLog";
@@ -46,6 +46,10 @@ export interface OpSidebarHooks {
   tmuxSessions: () => string[];
   recordRecency: (issueId: string) => Promise<void>;
   executeResumeLast: () => void;
+  /** Trigger the same code path as `op-resolve` (Notice + post-move chip
+   * included). Called from the `r` keyboard shortcut after the user confirms
+   * via {@link OpResolveConfirmModal}. Optional so tests can omit it. */
+  resolveIssue?: (entry: IssueEntry) => void | Promise<void>;
 }
 
 export class OpSidebarView extends ItemView {
@@ -58,6 +62,14 @@ export class OpSidebarView extends ItemView {
   private tabButtons = new Map<TabId, HTMLElement>();
   private rafPending = false;
   private probeTimer: ReturnType<typeof setInterval> | undefined;
+  /** Last list rendered into the body — keyed by index so j/k can map cleanly
+   * onto a row without re-running the filter. */
+  private displayedIssues: IssueEntry[] = [];
+  /** -1 ⇒ no row selected (empty list). Otherwise an index into
+   * {@link displayedIssues}. Clamped on every render. */
+  private selectedIndex = -1;
+  private rowEls: HTMLElement[] = [];
+  private keydownHandler?: (ev: KeyboardEvent) => void;
   /** `undefined` means "not yet probed" — render renders all badges as
    * normal until the first tick lands. `null` means "tmux unavailable",
    * which also keeps badges as-is (no false-positive demotion). A `Set`
@@ -98,6 +110,10 @@ export class OpSidebarView extends ItemView {
     const root = this.contentEl;
     root.empty();
     root.addClass("op-sidebar");
+    // Make the leaf focusable so j/k/Enter/r work without first clicking a
+    // row. Negative tabindex keeps the leaf out of the global Tab order while
+    // still allowing programmatic focus.
+    root.setAttr("tabindex", "0");
 
     this.headerEl = root.createDiv({ cls: "op-sidebar__header" });
 
@@ -134,8 +150,14 @@ export class OpSidebarView extends ItemView {
       if (RELEVANT.has(ev.kind)) this.scheduleRender();
     });
 
+    this.keydownHandler = (ev) => this.handleKeydown(ev);
+    root.addEventListener("keydown", this.keydownHandler);
+
     this.startTmuxProbe();
     this.render();
+    // Defer the focus until after Obsidian finishes its layout pass, otherwise
+    // the workspace re-grabs focus and the keydown listener never sees keys.
+    queueMicrotask(() => root.focus({ preventScroll: true }));
   }
 
   async onClose(): Promise<void> {
@@ -143,6 +165,13 @@ export class OpSidebarView extends ItemView {
     this.unsubscribe = undefined;
     this.stopTmuxProbe();
     this.tabButtons.clear();
+    if (this.keydownHandler) {
+      this.contentEl.removeEventListener("keydown", this.keydownHandler);
+      this.keydownHandler = undefined;
+    }
+    this.rowEls = [];
+    this.displayedIssues = [];
+    this.selectedIndex = -1;
   }
 
   /**
@@ -208,7 +237,19 @@ export class OpSidebarView extends ItemView {
     for (const [id, btn] of this.tabButtons) {
       btn.toggleClass("is-active", id === this.active);
     }
+    const density = this.getSettings().density;
+    this.contentEl.toggleClass("op-sidebar--density-compact", density === "compact");
+    this.contentEl.toggleClass("op-sidebar--density-comfortable", density !== "compact");
+
     const issues = filterEntries(this.pickFor(this.active), this.filterQuery);
+    this.displayedIssues = issues;
+    this.rowEls = [];
+    // Clamp the selection to the new list shape. Empty list ⇒ -1 (no row).
+    if (issues.length === 0) this.selectedIndex = -1;
+    else if (this.selectedIndex < 0 || this.selectedIndex >= issues.length) this.selectedIndex = 0;
+
+    const showProjectChip = shouldShowProjectChip(density, issues);
+
     this.bodyEl.empty();
     if (issues.length === 0) {
       const emptyText = this.filterQuery.trim() ? "(no matches)" : "(none)";
@@ -216,9 +257,12 @@ export class OpSidebarView extends ItemView {
       return;
     }
     const ul = this.bodyEl.createEl("ul", { cls: "op-sidebar__list" });
-    for (const e of issues) {
+    for (let idx = 0; idx < issues.length; idx++) {
+      const e = issues[idx];
       const li = ul.createEl("li", { cls: "op-sidebar__item" });
       const headerRow = li.createDiv({ cls: "op-sidebar__row" });
+      if (idx === this.selectedIndex) headerRow.addClass("is-selected");
+      this.rowEls.push(headerRow);
       const linkText = `${e.id} · ${stripIdPrefix(e.title, e.id)}`;
       const link = headerRow.createEl("a", {
         cls: "op-sidebar__link",
@@ -226,8 +270,10 @@ export class OpSidebarView extends ItemView {
       });
       link.setAttr("href", "#");
       setTooltip(link, linkText, { delay: 250 });
+      const itemIndex = idx;
       link.addEventListener("click", (ev) => {
         ev.preventDefault();
+        this.setSelectedIndex(itemIndex, { scroll: false });
         if (this.hooks) void this.hooks.recordRecency(e.id);
         void this.openEntry(e);
       });
@@ -285,7 +331,9 @@ export class OpSidebarView extends ItemView {
         });
       }
       const meta = li.createDiv({ cls: "op-sidebar__meta" });
-      meta.createSpan({ text: e.project, cls: "op-sidebar__project" });
+      if (showProjectChip) {
+        meta.createSpan({ text: e.project, cls: "op-sidebar__project" });
+      }
       if (e.priority) {
         meta.createSpan({ text: e.priority, cls: `op-sidebar__prio op-sidebar__prio--${e.priority}` });
       }
@@ -394,6 +442,191 @@ export class OpSidebarView extends ItemView {
       await this.app.workspace.getLeaf(false).openFile(f);
     }
   }
+
+  /**
+   * Single source of truth for selection state. Updates the rendered
+   * `.is-selected` class on the row elements without re-running render(),
+   * scrolls the new row into view (default), and clamps to the visible range.
+   */
+  private setSelectedIndex(next: number, opts: { scroll?: boolean } = {}): void {
+    const last = this.displayedIssues.length - 1;
+    if (last < 0) {
+      this.selectedIndex = -1;
+      return;
+    }
+    const clamped = Math.max(0, Math.min(last, next));
+    if (clamped === this.selectedIndex) return;
+    if (this.selectedIndex >= 0 && this.rowEls[this.selectedIndex]) {
+      this.rowEls[this.selectedIndex].removeClass("is-selected");
+    }
+    this.selectedIndex = clamped;
+    const el = this.rowEls[this.selectedIndex];
+    if (el) {
+      el.addClass("is-selected");
+      if (opts.scroll !== false) el.scrollIntoView({ block: "nearest" });
+    }
+  }
+
+  /**
+   * Keyboard router. Three contexts in priority order:
+   *
+   *   1. Filter input focused — only navigation/open/launch keys; letters
+   *      go through to the input untouched.
+   *   2. Anything else inside the sidebar — full set including `j`/`k`/`r`.
+   *
+   * Modifier rule: only the bare modifier set documented per binding triggers
+   * the action. `Cmd+J` is a global Obsidian shortcut so we never claim it;
+   * `Shift+J` falls through too. The handler uses `preventDefault()` only
+   * after deciding to act, so unknown keys propagate normally.
+   */
+  private handleKeydown(ev: KeyboardEvent): void {
+    // Bail on IME composition so half-typed characters aren't intercepted.
+    if (ev.isComposing) return;
+    const target = ev.target as Element | null;
+    const inFilter = target === this.filterInput;
+    const meta = ev.metaKey || ev.ctrlKey;
+    const plain = !ev.altKey && !ev.shiftKey && !ev.metaKey && !ev.ctrlKey;
+    const enterWithMeta = ev.key === "Enter" && meta && !ev.altKey && !ev.shiftKey;
+
+    if (ev.key === "ArrowDown" && plain) {
+      ev.preventDefault();
+      this.setSelectedIndex(this.selectedIndex + 1);
+      return;
+    }
+    if (ev.key === "ArrowUp" && plain) {
+      ev.preventDefault();
+      this.setSelectedIndex(this.selectedIndex - 1);
+      return;
+    }
+    if (ev.key === "Enter" && plain) {
+      ev.preventDefault();
+      void this.activateSelected();
+      return;
+    }
+    if (enterWithMeta) {
+      ev.preventDefault();
+      void this.launchSelected();
+      return;
+    }
+
+    // Letter keys: only honored when the filter input doesn't own focus, so
+    // typing a query stays unobstructed.
+    if (inFilter) return;
+    if (ev.key === "j" && plain) {
+      ev.preventDefault();
+      this.setSelectedIndex(this.selectedIndex + 1);
+      return;
+    }
+    if (ev.key === "k" && plain) {
+      ev.preventDefault();
+      this.setSelectedIndex(this.selectedIndex - 1);
+      return;
+    }
+    if (ev.key === "r" && plain) {
+      ev.preventDefault();
+      void this.resolveSelected();
+      return;
+    }
+  }
+
+  private currentSelection(): IssueEntry | undefined {
+    if (this.selectedIndex < 0) return undefined;
+    return this.displayedIssues[this.selectedIndex];
+  }
+
+  private async activateSelected(): Promise<void> {
+    const entry = this.currentSelection();
+    if (!entry) return;
+    if (this.hooks) await this.hooks.recordRecency(entry.id);
+    await this.openEntry(entry);
+  }
+
+  private async launchSelected(): Promise<void> {
+    const entry = this.currentSelection();
+    if (!entry || !this.launchAgent) return;
+    if (entry.agent) return; // a live agent already exists; don't double-launch
+    await this.launchAgent(entry, "implement", false);
+  }
+
+  private async resolveSelected(): Promise<void> {
+    const entry = this.currentSelection();
+    if (!entry || !this.hooks?.resolveIssue) return;
+    if (entry.resolvedFolder || entry.status === "resolved" || entry.status === "wontfix") {
+      return;
+    }
+    const hook = this.hooks.resolveIssue;
+    const modal = new OpResolveConfirmModal(this.app, entry, async () => {
+      await hook(entry);
+    });
+    modal.open();
+  }
+}
+
+/**
+ * Confirmation gate for the `r` keyboard shortcut. Tiny on purpose — the real
+ * resolve work happens in `runResolveCommand` via the wired hook. We only
+ * stand between an accidental keypress and the irreversible move-to-RESOLVED.
+ */
+export class OpResolveConfirmModal extends Modal {
+  constructor(
+    app: App,
+    private entry: IssueEntry,
+    private onConfirm: () => void | Promise<void>,
+  ) {
+    super(app);
+  }
+
+  onOpen(): void {
+    const { contentEl } = this;
+    contentEl.empty();
+    contentEl.createEl("h2", { text: `Resolve ${this.entry.id}?` });
+    const title = stripIdPrefix(this.entry.title, this.entry.id);
+    contentEl.createEl("p", {
+      text: title,
+      cls: "setting-item-description",
+    });
+    contentEl.createEl("p", {
+      text: "This moves the note to RESOLVED ISSUES/, sets status to resolved, trashes linked TASKS, and (if configured) closes the linked GitHub issue.",
+      cls: "setting-item-description",
+    });
+
+    const buttons = contentEl.createDiv({ cls: "op-resolve-confirm__buttons" });
+    const cancel = buttons.createEl("button", { text: "Cancel" });
+    cancel.addEventListener("click", () => this.close());
+    const resolve = buttons.createEl("button", { text: "Resolve", cls: "mod-cta" });
+    resolve.addEventListener("click", () => {
+      this.close();
+      void this.onConfirm();
+    });
+    // Default focus on Resolve so Enter inside the modal confirms.
+    queueMicrotask(() => resolve.focus());
+  }
+
+  onClose(): void {
+    this.contentEl.empty();
+  }
+}
+
+/**
+ * Decide whether to render the per-row project chip given the current density
+ * preference and the rendered list. Pure helper for unit tests; the sidebar
+ * caches the result per render and skips the chip when this returns false.
+ *
+ * The chip stays visible in `comfortable` regardless. In `compact`, it's only
+ * suppressed when every rendered row is from the same project — repeating it
+ * down a single-project list is the noise we're trying to remove.
+ */
+export function shouldShowProjectChip(
+  density: SidebarDensity,
+  entries: ReadonlyArray<IssueEntry>,
+): boolean {
+  if (density !== "compact") return true;
+  if (entries.length === 0) return true;
+  const first = entries[0].project;
+  for (let i = 1; i < entries.length; i++) {
+    if (entries[i].project !== first) return true;
+  }
+  return false;
 }
 
 function sameLiveSet(

--- a/plugins/op-obsidian/styles.css
+++ b/plugins/op-obsidian/styles.css
@@ -72,6 +72,24 @@
   display: flex;
   align-items: center;
   gap: 0.35rem;
+  border-radius: 3px;
+  padding: 0 0.15rem;
+  margin: 0 -0.15rem;
+}
+
+.op-sidebar__row.is-selected {
+  background: var(--background-modifier-hover);
+  box-shadow: inset 0 0 0 1px var(--interactive-accent);
+}
+
+.op-sidebar:focus,
+.op-sidebar:focus-visible {
+  outline: none;
+}
+
+.op-sidebar--density-compact .op-sidebar__item {
+  padding-top: calc(0.35rem - 2px);
+  padding-bottom: calc(0.35rem - 2px);
 }
 
 .op-sidebar__link {
@@ -228,6 +246,13 @@ a.op-sidebar__agent:hover {
 
 .op-notice-action:hover {
   text-decoration: underline;
+}
+
+.op-resolve-confirm__buttons {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.5rem;
+  margin-top: 1rem;
 }
 
 .op-project-order__list {

--- a/plugins/op-obsidian/styles.css
+++ b/plugins/op-obsidian/styles.css
@@ -82,9 +82,18 @@
   box-shadow: inset 0 0 0 1px var(--interactive-accent);
 }
 
-.op-sidebar:focus,
-.op-sidebar:focus-visible {
+/* Suppress the default ring when focus arrives via the auto-focus in
+ * onOpen — that focus is implicit and already telegraphed by the row's
+ * `.is-selected` highlight. Keep a visible ring for keyboard focus
+ * (`:focus-visible`) so Tab navigation still has an affordance. */
+.op-sidebar:focus {
   outline: none;
+}
+
+.op-sidebar:focus-visible {
+  outline: 1px solid var(--interactive-accent);
+  outline-offset: -1px;
+  border-radius: 4px;
 }
 
 .op-sidebar--density-compact .op-sidebar__item {

--- a/plugins/op/.claude-plugin/plugin.json
+++ b/plugins/op/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "op",
   "description": "Obsidian Projects workflow — schema, slash commands, and agent skill for running a Jira-lite issue tracker inside an Obsidian vault.",
-  "version": "0.51.1",
+  "version": "0.52.0",
   "author": {
     "name": "Eugene Archibald"
   },


### PR DESCRIPTION
## Summary

- New `view.density: 'comfortable' | 'compact'` setting; `compact` tightens vertical row padding by 4px and hides the project chip when every rendered row shares one project (`shouldShowProjectChip` helper, unit-tested).
- Keyboard nav inside the sidebar leaf: `j`/`k`/`ArrowDown`/`ArrowUp` cycle `.is-selected`, `Enter` opens, `Cmd/Ctrl+Enter` launches an agent, `r` opens a confirmation modal that calls a new `resolveIssue` hook (wired to `runResolveCommand`). Listener is scoped to the sidebar's `contentEl` and skips letter keys when the filter input owns focus.
- The Last-touched header chip from §6 already shipped in OP-150 (c3464a4), so no chip plumbing was needed in this PR.
- Bumped op-obsidian 0.51.0 → 0.52.0 (additive feature; two new public surfaces).

Spec: `docs/specs/OP-149-feel-great-ux-design.md` §6.

## Test plan

- [x] Unit tests added: `view.density` accept/reject in `settings.test.ts`; `shouldShowProjectChip` cases in `sidebarView.test.ts`. Full suite: 570/570 pass.
- [x] Settings UI smoke: `app.setting.openTabById("op-obsidian")` shows the new "Sidebar density" dropdown.
- [x] Live keyboard smoke in Agent-Vault: dispatched `KeyboardEvent`s for `j`, `k`, `ArrowDown`, `ArrowUp` cycle the `.is-selected` index across the rendered list (verified across 30 issues).
- [x] `r` opens the resolve confirmation modal (title `Resolve OP-NNN?`, Cancel + Resolve buttons); Cancel dismisses without mutating the vault.
- [x] Density toggle: `compact` + filter to a single project drops the project chips (21 rows, 0 chips); `comfortable` restores them; class `op-sidebar--density-compact` toggles on the sidebar root.
- [x] Build green; no console errors after a full reload.
- [ ] User verification of the keyboard ergonomics in their day-to-day flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)