### PR TITLE
OP-143: sidebar hover preview shows last N lines of agent's tmux pane

### DIFF
--- a/plugins/op-obsidian/manifest.json
+++ b/plugins/op-obsidian/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "op-obsidian",
   "name": "Obsidian Projects (op)",
-  "version": "0.53.0",
+  "version": "0.54.0",
   "minAppVersion": "1.5.0",
   "description": "Jira-lite issue tracker for Obsidian vaults — deterministic commands backing the op workflow.",
   "author": "Eugene Archibald",

--- a/plugins/op-obsidian/package.json
+++ b/plugins/op-obsidian/package.json
@@ -1,6 +1,6 @@
 {
   "name": "op-obsidian",
-  "version": "0.53.0",
+  "version": "0.54.0",
   "description": "Obsidian plugin that owns the deterministic half of the op workflow.",
   "main": "main.js",
   "scripts": {

--- a/plugins/op-obsidian/src/agentTmuxLocation.ts
+++ b/plugins/op-obsidian/src/agentTmuxLocation.ts
@@ -1,0 +1,63 @@
+import { execFile } from "child_process";
+import { promisify } from "util";
+
+import type { OpSettings } from "./settings";
+import { SHARED_TMUX_SESSION, tmuxWindowName } from "./terminalLaunch";
+
+const pExecFile = promisify(execFile);
+
+export interface AgentTmuxLocation {
+  session: string;
+  window: string;
+}
+
+/**
+ * Resolve an issue id to the (session, window) pair of its live tmux pane,
+ * or null if no candidate session contains the expected window. Iterates
+ * the shared session plus every per-iTerm-window orchestrator session,
+ * returning the first match.
+ *
+ * Pure read — never mutates tmux state. Suitable for hover-preview captures
+ * as well as `revealAgentSession`'s select-window flow.
+ */
+export async function findAgentTmuxLocation(
+  settings: OpSettings,
+  issueId: string,
+): Promise<AgentTmuxLocation | null> {
+  const surface = settings.orchestratorState?.surfaces?.[issueId];
+  const windowName = tmuxWindowName(issueId);
+  for (const session of uniqueSessions(settings, surface?.sessionId)) {
+    if (await tmuxWindowExists(settings.tmuxBinary, session, windowName)) {
+      return { session, window: windowName };
+    }
+  }
+  return null;
+}
+
+export function uniqueSessions(settings: OpSettings, extra?: string): string[] {
+  const out = new Set<string>([SHARED_TMUX_SESSION]);
+  for (const w of Object.values(settings.orchestratorState?.windows ?? {})) {
+    if (w?.tmuxSession) out.add(w.tmuxSession);
+  }
+  if (extra) out.add(extra);
+  return [...out];
+}
+
+async function tmuxWindowExists(
+  tmuxBinary: string,
+  session: string,
+  windowName: string,
+): Promise<boolean> {
+  try {
+    const { stdout } = await pExecFile(tmuxBinary, [
+      "list-windows",
+      "-t",
+      session,
+      "-F",
+      "#W",
+    ]);
+    return stdout.split("\n").map((l) => l.trim()).includes(windowName);
+  } catch {
+    return false;
+  }
+}

--- a/plugins/op-obsidian/src/main.ts
+++ b/plugins/op-obsidian/src/main.ts
@@ -1,6 +1,8 @@
 import { Plugin, TFile, WorkspaceLeaf } from "obsidian";
 import { OP_SIDEBAR_VIEW_TYPE, OpSidebarView } from "./sidebarView";
 import { revealAgentSession } from "./revealAgentSession";
+import { findAgentTmuxLocation } from "./agentTmuxLocation";
+import { captureTmuxPane } from "./tmuxCapture";
 import { EventBus } from "./eventBus";
 import { IssueStore } from "./issueStore";
 import { createIssue, type CreateIssueInput, type Priority } from "./createIssue";
@@ -335,6 +337,16 @@ export default class OpPlugin extends Plugin {
             recordRecency: (id) => this.recordRecency(id),
             executeResumeLast: () => void this.runResumeLastCommand(),
             resolveIssue: (entry) => this.runResolveCommand({ path: entry.path }),
+          },
+          async (entry) => {
+            const loc = await findAgentTmuxLocation(this.settings, entry.id);
+            if (!loc) return null;
+            return captureTmuxPane(
+              this.settings.tmuxBinary,
+              loc.session,
+              loc.window,
+              this.settings.view.agentHoverLines,
+            );
           },
         ),
     );

--- a/plugins/op-obsidian/src/revealAgentSession.ts
+++ b/plugins/op-obsidian/src/revealAgentSession.ts
@@ -3,7 +3,7 @@ import { promisify } from "util";
 import { notify } from "./notificationLog";
 
 import type { OpSettings } from "./settings";
-import { SHARED_TMUX_SESSION, tmuxWindowName } from "./terminalLaunch";
+import { findAgentTmuxLocation } from "./agentTmuxLocation";
 import { selectSession, sessionExists } from "./iterm/driver";
 
 const pExecFile = promisify(execFile);
@@ -24,52 +24,22 @@ export async function revealAgentSession(
 
   // Tmux path: every launch lives in a window inside SHARED_TMUX_SESSION
   // (or a per-iTerm-window derivative). Select it and raise the terminal.
-  const windowName = tmuxWindowName(issueId);
-  const sessionCandidates = uniqueSessions(settings, surface?.sessionId);
-
-  for (const session of sessionCandidates) {
-    if (await tmuxSelectWindow(settings.tmuxBinary, session, windowName)) {
+  const loc = await findAgentTmuxLocation(settings, issueId);
+  if (loc) {
+    try {
+      await pExecFile(settings.tmuxBinary, [
+        "select-window",
+        "-t",
+        `${loc.session}:${loc.window}`,
+      ]);
       await activateTerminalApp(settings.terminal);
       return;
+    } catch {
+      // fall through to the not-found path
     }
   }
 
   notify(`op: no live session found for ${issueId}`);
-}
-
-function uniqueSessions(settings: OpSettings, extra?: string): string[] {
-  const out = new Set<string>([SHARED_TMUX_SESSION]);
-  for (const w of Object.values(settings.orchestratorState?.windows ?? {})) {
-    if (w?.tmuxSession) out.add(w.tmuxSession);
-  }
-  if (extra) out.add(extra);
-  return [...out];
-}
-
-async function tmuxSelectWindow(
-  tmuxBinary: string,
-  session: string,
-  windowName: string,
-): Promise<boolean> {
-  try {
-    const { stdout } = await pExecFile(tmuxBinary, [
-      "list-windows",
-      "-t",
-      session,
-      "-F",
-      "#W",
-    ]);
-    const windows = stdout.split("\n").map((l) => l.trim());
-    if (!windows.includes(windowName)) return false;
-    await pExecFile(tmuxBinary, [
-      "select-window",
-      "-t",
-      `${session}:${windowName}`,
-    ]);
-    return true;
-  } catch {
-    return false;
-  }
 }
 
 async function activateTerminalApp(app: "Terminal" | "iTerm"): Promise<void> {

--- a/plugins/op-obsidian/src/settings.test.ts
+++ b/plugins/op-obsidian/src/settings.test.ts
@@ -113,6 +113,46 @@ describe("mergeSettings", () => {
     ).toBe(DEFAULT_SETTINGS.view.openOnStartup);
   });
 
+  it("agent hover defaults: preview on, 30 lines, 400ms delay", () => {
+    const v = mergeSettings({}).view;
+    expect(v.agentHoverPreview).toBe(true);
+    expect(v.agentHoverLines).toBe(30);
+    expect(v.agentHoverDelayMs).toBe(400);
+  });
+
+  it("agent hover: accepts valid overrides; round-trips through mergeSettings", () => {
+    const out = mergeSettings({
+      view: { agentHoverPreview: false, agentHoverLines: 100, agentHoverDelayMs: 1500 },
+    });
+    expect(out.view.agentHoverPreview).toBe(false);
+    expect(out.view.agentHoverLines).toBe(100);
+    expect(out.view.agentHoverDelayMs).toBe(1500);
+  });
+
+  it("agent hover: clamps and floors out-of-range numbers (falls back to default)", () => {
+    // out of range → keep default
+    expect(mergeSettings({ view: { agentHoverLines: 0 } }).view.agentHoverLines).toBe(30);
+    expect(mergeSettings({ view: { agentHoverLines: 501 } }).view.agentHoverLines).toBe(30);
+    expect(mergeSettings({ view: { agentHoverLines: -3 } }).view.agentHoverLines).toBe(30);
+    expect(mergeSettings({ view: { agentHoverDelayMs: -1 } }).view.agentHoverDelayMs).toBe(400);
+    expect(mergeSettings({ view: { agentHoverDelayMs: 2001 } }).view.agentHoverDelayMs).toBe(400);
+    // floors fractional in-range values
+    expect(mergeSettings({ view: { agentHoverLines: 42.9 } }).view.agentHoverLines).toBe(42);
+    expect(mergeSettings({ view: { agentHoverDelayMs: 99.7 } }).view.agentHoverDelayMs).toBe(99);
+  });
+
+  it("agent hover: rejects non-boolean / non-numeric input", () => {
+    expect(
+      mergeSettings({ view: { agentHoverPreview: "yes" as unknown as boolean } }).view.agentHoverPreview,
+    ).toBe(true);
+    expect(
+      mergeSettings({ view: { agentHoverLines: "100" as unknown as number } }).view.agentHoverLines,
+    ).toBe(30);
+    expect(
+      mergeSettings({ view: { agentHoverDelayMs: NaN } }).view.agentHoverDelayMs,
+    ).toBe(400);
+  });
+
   it("rejects unknown view.defaultTab", () => {
     expect(mergeSettings({ view: { defaultTab: "resolved" } }).view.defaultTab).toBe("resolved");
     expect(

--- a/plugins/op-obsidian/src/settings.ts
+++ b/plugins/op-obsidian/src/settings.ts
@@ -702,6 +702,44 @@ export class OpSettingsTab extends PluginSettingTab {
           }),
       );
 
+    new Setting(containerEl)
+      .setName("Agent hover preview")
+      .setDesc(
+        "When hovering an agent badge in the sidebar, show the last N lines of the agent's tmux pane in a small popover.",
+      )
+      .addToggle((t) =>
+        t.setValue(s.view.agentHoverPreview).onChange(async (v) => {
+          s.view.agentHoverPreview = v;
+          await this.plugin.saveSettings();
+        }),
+      );
+
+    new Setting(containerEl)
+      .setName("Agent hover preview lines")
+      .setDesc("How many lines of the tmux pane to capture for the hover preview (1–500).")
+      .addText((t) =>
+        t.setValue(String(s.view.agentHoverLines)).onChange(async (v) => {
+          const n = parseInt(v, 10);
+          if (Number.isFinite(n) && n >= 1 && n <= 500) {
+            s.view.agentHoverLines = n;
+            await this.plugin.saveSettings();
+          }
+        }),
+      );
+
+    new Setting(containerEl)
+      .setName("Agent hover preview delay (ms)")
+      .setDesc("Delay before the popover opens on hover (0–2000 ms).")
+      .addText((t) =>
+        t.setValue(String(s.view.agentHoverDelayMs)).onChange(async (v) => {
+          const n = parseInt(v, 10);
+          if (Number.isFinite(n) && n >= 0 && n <= 2000) {
+            s.view.agentHoverDelayMs = n;
+            await this.plugin.saveSettings();
+          }
+        }),
+      );
+
     containerEl.createEl("h2", { text: "GitHub integration" });
     containerEl.createEl("p", {
       text: "Requires the `gh` CLI installed and authenticated. `gh` is run in the project's repo (repo_path in STATUS.md or the working-dir setting above).",

--- a/plugins/op-obsidian/src/settingsPure.ts
+++ b/plugins/op-obsidian/src/settingsPure.ts
@@ -31,7 +31,21 @@ export interface ViewSettings {
    * by 4px and hides the project chip when the rendered list spans only one
    * project. */
   density: SidebarDensity;
+  /** When true, hovering an agent badge in the sidebar shows a tmux pane
+   * preview after `agentHoverDelayMs`. Default true. */
+  agentHoverPreview: boolean;
+  /** Lines captured from the agent's tmux pane for the hover preview.
+   * Clamped to [1, 500]. Default 30. */
+  agentHoverLines: number;
+  /** Delay (ms) between mouseenter and the tmux capture call. Clamped to
+   * [0, 2000]. Default 400. */
+  agentHoverDelayMs: number;
 }
+
+export const AGENT_HOVER_LINES_MIN = 1;
+export const AGENT_HOVER_LINES_MAX = 500;
+export const AGENT_HOVER_DELAY_MIN = 0;
+export const AGENT_HOVER_DELAY_MAX = 2000;
 
 export interface GithubSettings {
   autoCreateGithubIssue: boolean;
@@ -113,6 +127,9 @@ export const DEFAULT_SETTINGS: OpSettings = {
     recentResolvedLimit: 20,
     openOnStartup: false,
     density: "comfortable",
+    agentHoverPreview: true,
+    agentHoverLines: 30,
+    agentHoverDelayMs: 400,
   },
   github: {
     autoCreateGithubIssue: false,
@@ -175,6 +192,21 @@ export function mergeSettings(loaded: unknown): OpSettings {
     }
     if (typeof v.openOnStartup === "boolean") base.view.openOnStartup = v.openOnStartup;
     if (v.density && SIDEBAR_DENSITIES.has(v.density)) base.view.density = v.density;
+    if (typeof v.agentHoverPreview === "boolean") {
+      base.view.agentHoverPreview = v.agentHoverPreview;
+    }
+    if (typeof v.agentHoverLines === "number" && Number.isFinite(v.agentHoverLines)) {
+      const n = Math.floor(v.agentHoverLines);
+      if (n >= AGENT_HOVER_LINES_MIN && n <= AGENT_HOVER_LINES_MAX) {
+        base.view.agentHoverLines = n;
+      }
+    }
+    if (typeof v.agentHoverDelayMs === "number" && Number.isFinite(v.agentHoverDelayMs)) {
+      const n = Math.floor(v.agentHoverDelayMs);
+      if (n >= AGENT_HOVER_DELAY_MIN && n <= AGENT_HOVER_DELAY_MAX) {
+        base.view.agentHoverDelayMs = n;
+      }
+    }
   }
   if (l.orchestrator && typeof l.orchestrator === "object") {
     const o = l.orchestrator as Partial<OrchestratorSettings>;

--- a/plugins/op-obsidian/src/sidebarView.ts
+++ b/plugins/op-obsidian/src/sidebarView.ts
@@ -81,6 +81,14 @@ export class OpSidebarView extends ItemView {
    * elsewhere is rendered with the muted "stale" class. */
   private liveTmuxWindows: Set<string> | null | undefined = undefined;
 
+  /** Single popover element owned by the view; rebuilt per hover. */
+  private hoverEl?: HTMLElement;
+  private hoverTimer: ReturnType<typeof setTimeout> | undefined;
+  /** Monotonic counter so a stale in-flight capture is ignored after the
+   * pointer has moved on. Bumped on every hover-start and hover-end. */
+  private hoverSeq = 0;
+  private hoverDocClickHandler: ((ev: MouseEvent) => void) | undefined;
+
   constructor(
     leaf: WorkspaceLeaf,
     private store: IssueStore,
@@ -93,6 +101,7 @@ export class OpSidebarView extends ItemView {
       forcePick: boolean,
     ) => void | Promise<void>,
     private hooks?: OpSidebarHooks,
+    private capturePreview?: (entry: IssueEntry) => Promise<string | null>,
   ) {
     super(leaf);
   }
@@ -169,6 +178,7 @@ export class OpSidebarView extends ItemView {
     this.unsubscribe?.();
     this.unsubscribe = undefined;
     this.stopTmuxProbe();
+    this.teardownHoverPreview();
     this.tabButtons.clear();
     if (this.keydownHandler) {
       this.contentEl.removeEventListener("keydown", this.keydownHandler);
@@ -238,6 +248,10 @@ export class OpSidebarView extends ItemView {
   }
 
   private render(): void {
+    // The list is about to be rebuilt; any popover anchored to the previous
+    // DOM is now dangling. Tear it down before re-rendering so we don't
+    // orphan a `position: fixed` element on top of the new list.
+    this.teardownHoverPreview();
     this.renderHeader();
     for (const [id, btn] of this.tabButtons) {
       btn.toggleClass("is-active", id === this.active);
@@ -318,6 +332,7 @@ export class OpSidebarView extends ItemView {
             void this.revealAgent?.(e);
           });
         }
+        this.attachHoverPreview(badge, e);
       } else if (this.launchAgent) {
         const launchBtn = actions.createEl("button", {
           cls: "op-sidebar__action op-sidebar__action--launch",
@@ -561,6 +576,90 @@ export class OpSidebarView extends ItemView {
     );
     modal.open();
   }
+
+  /**
+   * Attach mouseenter/mouseleave handlers to an agent badge so that
+   * hovering it shows a tmux pane preview popover after the configured
+   * delay. Skips wiring entirely when the feature is disabled or no
+   * capture callback is supplied (legacy callers / tests).
+   */
+  private attachHoverPreview(badge: HTMLElement, entry: IssueEntry): void {
+    const settings = this.getSettings();
+    if (!settings.agentHoverPreview) return;
+    if (!this.capturePreview) return;
+    const capture = this.capturePreview;
+
+    badge.addEventListener("mouseenter", () => {
+      const seq = ++this.hoverSeq;
+      const delay = clampHoverDelay(settings.agentHoverDelayMs);
+      this.clearHoverTimer();
+      this.hoverTimer = setTimeout(() => {
+        this.hoverTimer = undefined;
+        if (seq !== this.hoverSeq) return;
+        void capture(entry).then((text) => {
+          // Stale request? Pointer has already moved on or another hover
+          // started — drop this result rather than racing to render it.
+          if (seq !== this.hoverSeq) return;
+          if (text === null || text === undefined) return;
+          this.showHoverPreview(badge, text);
+        });
+      }, delay);
+    });
+
+    badge.addEventListener("mouseleave", () => {
+      this.hoverSeq++;
+      this.teardownHoverPreview();
+    });
+  }
+
+  private showHoverPreview(anchor: HTMLElement, text: string): void {
+    // Replace any existing popover so we never stack two.
+    this.teardownHoverPreview(/* keepSeq */ true);
+
+    const el = document.createElement("div");
+    el.addClass("op-sidebar__hover-preview");
+    const pre = document.createElement("pre");
+    pre.textContent = text;
+    el.appendChild(pre);
+    document.body.appendChild(el);
+
+    const rect = anchor.getBoundingClientRect();
+    el.style.position = "fixed";
+    el.style.left = `${Math.round(rect.left)}px`;
+    el.style.top = `${Math.round(rect.bottom + 4)}px`;
+
+    this.hoverEl = el;
+
+    // Click-outside dismissal: any document click closes the popover. We
+    // attach to `document` (not the leaf) so a click in another pane also
+    // dismisses it. Use capture phase to beat downstream stopPropagation.
+    const handler = (ev: MouseEvent) => {
+      if (ev.target instanceof Node && el.contains(ev.target)) return;
+      this.hoverSeq++;
+      this.teardownHoverPreview();
+    };
+    this.hoverDocClickHandler = handler;
+    document.addEventListener("click", handler, true);
+  }
+
+  private teardownHoverPreview(keepSeq = false): void {
+    if (!keepSeq) this.clearHoverTimer();
+    if (this.hoverEl) {
+      this.hoverEl.remove();
+      this.hoverEl = undefined;
+    }
+    if (this.hoverDocClickHandler) {
+      document.removeEventListener("click", this.hoverDocClickHandler, true);
+      this.hoverDocClickHandler = undefined;
+    }
+  }
+
+  private clearHoverTimer(): void {
+    if (this.hoverTimer !== undefined) {
+      clearTimeout(this.hoverTimer);
+      this.hoverTimer = undefined;
+    }
+  }
 }
 
 /**
@@ -671,6 +770,13 @@ export function shouldShowProjectChip(
     if (entries[i].project !== first) return true;
   }
   return false;
+}
+
+function clampHoverDelay(ms: number): number {
+  if (!Number.isFinite(ms)) return 400;
+  if (ms <= 0) return 0;
+  if (ms >= 2000) return 2000;
+  return Math.floor(ms);
 }
 
 function sameLiveSet(

--- a/plugins/op-obsidian/src/sidebarView.ts
+++ b/plugins/op-obsidian/src/sidebarView.ts
@@ -607,13 +607,13 @@ export class OpSidebarView extends ItemView {
     });
 
     badge.addEventListener("mouseleave", () => {
-      this.hoverSeq++;
       this.teardownHoverPreview();
     });
   }
 
   private showHoverPreview(anchor: HTMLElement, text: string): void {
-    // Replace any existing popover so we never stack two.
+    // Replace any existing popover so we never stack two. keepSeq=true so the
+    // seq counter is NOT bumped — the current capture is still live.
     this.teardownHoverPreview(/* keepSeq */ true);
 
     const el = document.createElement("div");
@@ -635,15 +635,25 @@ export class OpSidebarView extends ItemView {
     // dismisses it. Use capture phase to beat downstream stopPropagation.
     const handler = (ev: MouseEvent) => {
       if (ev.target instanceof Node && el.contains(ev.target)) return;
-      this.hoverSeq++;
       this.teardownHoverPreview();
     };
     this.hoverDocClickHandler = handler;
     document.addEventListener("click", handler, true);
   }
 
+  /**
+   * Cancel any pending hover timer, invalidate any in-flight capture (by
+   * bumping `hoverSeq`), and remove the popover + document click listener.
+   *
+   * Pass `keepSeq = true` only when replacing one popover with another within
+   * the same hover sequence (i.e. called from `showHoverPreview` itself) —
+   * this skips the seq bump so the current capture is not cancelled.
+   */
   private teardownHoverPreview(keepSeq = false): void {
-    if (!keepSeq) this.clearHoverTimer();
+    if (!keepSeq) {
+      this.hoverSeq++; // invalidate any in-flight tmux capture
+      this.clearHoverTimer();
+    }
     if (this.hoverEl) {
       this.hoverEl.remove();
       this.hoverEl = undefined;

--- a/plugins/op-obsidian/src/tmuxCapture.test.ts
+++ b/plugins/op-obsidian/src/tmuxCapture.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect, vi } from "vitest";
+import { captureTmuxPane, clampHoverLines, type ExecShim } from "./tmuxCapture";
+
+describe("clampHoverLines", () => {
+  it("clamps below 1 to 1", () => {
+    expect(clampHoverLines(0)).toBe(1);
+    expect(clampHoverLines(-50)).toBe(1);
+  });
+
+  it("clamps above 500 to 500", () => {
+    expect(clampHoverLines(501)).toBe(500);
+    expect(clampHoverLines(10_000)).toBe(500);
+  });
+
+  it("floors fractional values", () => {
+    expect(clampHoverLines(30.7)).toBe(30);
+  });
+
+  it("falls back to 1 for non-finite input", () => {
+    expect(clampHoverLines(NaN)).toBe(1);
+    expect(clampHoverLines(Infinity)).toBe(500);
+  });
+});
+
+describe("captureTmuxPane", () => {
+  it("invokes execFile with the documented argv", async () => {
+    const exec = vi.fn<ExecShim>(async () => ({ stdout: "hello\n", stderr: "" }));
+    await captureTmuxPane("/opt/homebrew/bin/tmux", "op-agents", "OP-1", 30, exec);
+    expect(exec).toHaveBeenCalledTimes(1);
+    expect(exec.mock.calls[0]![0]).toBe("/opt/homebrew/bin/tmux");
+    expect(exec.mock.calls[0]![1]).toEqual([
+      "capture-pane",
+      "-p",
+      "-J",
+      "-t",
+      "op-agents:OP-1",
+      "-S",
+      "-30",
+    ]);
+  });
+
+  it("returns null on rejection (window gone, tmux missing, timeout)", async () => {
+    const exec: ExecShim = async () => {
+      throw Object.assign(new Error("no server running"), { code: 1 });
+    };
+    expect(await captureTmuxPane("tmux", "op-agents", "OP-99", 30, exec)).toBeNull();
+  });
+
+  it("trims trailing whitespace from stdout", async () => {
+    const exec: ExecShim = async () => ({ stdout: "line1\nline2\n   \n\n", stderr: "" });
+    const out = await captureTmuxPane("tmux", "op-agents", "OP-1", 30, exec);
+    expect(out).toBe("line1\nline2");
+  });
+
+  it("returns null when stdout is blank", async () => {
+    const exec: ExecShim = async () => ({ stdout: "   \n\n", stderr: "" });
+    expect(await captureTmuxPane("tmux", "op-agents", "OP-1", 30, exec)).toBeNull();
+  });
+
+  it("clamps lines into [1, 500] before passing to argv", async () => {
+    const calls: Array<readonly string[]> = [];
+    const exec: ExecShim = async (_f, args) => {
+      calls.push(args);
+      return { stdout: "ok", stderr: "" };
+    };
+    await captureTmuxPane("tmux", "s", "w", 0, exec);
+    await captureTmuxPane("tmux", "s", "w", 9999, exec);
+    expect(calls[0]).toContain("-1");
+    expect(calls[1]).toContain("-500");
+  });
+});

--- a/plugins/op-obsidian/src/tmuxCapture.test.ts
+++ b/plugins/op-obsidian/src/tmuxCapture.test.ts
@@ -16,7 +16,7 @@ describe("clampHoverLines", () => {
     expect(clampHoverLines(30.7)).toBe(30);
   });
 
-  it("falls back to 1 for non-finite input", () => {
+  it("NaN falls back to MIN (1); Infinity clamps to MAX (500)", () => {
     expect(clampHoverLines(NaN)).toBe(1);
     expect(clampHoverLines(Infinity)).toBe(500);
   });

--- a/plugins/op-obsidian/src/tmuxCapture.ts
+++ b/plugins/op-obsidian/src/tmuxCapture.ts
@@ -1,0 +1,56 @@
+import { execFile } from "child_process";
+import { promisify } from "util";
+
+const pExecFile = promisify(execFile);
+
+/** Minimal shim so tests can inject a fake `execFile` without spawning real
+ * processes. Matches the shape of `promisify(execFile)`'s call signature. */
+export type ExecShim = (
+  file: string,
+  args: readonly string[],
+) => Promise<{ stdout: string; stderr: string }>;
+
+const HOVER_LINES_MIN = 1;
+const HOVER_LINES_MAX = 500;
+
+export function clampHoverLines(lines: number): number {
+  if (Number.isNaN(lines)) return HOVER_LINES_MIN;
+  if (lines >= HOVER_LINES_MAX) return HOVER_LINES_MAX;
+  if (lines <= HOVER_LINES_MIN) return HOVER_LINES_MIN;
+  return Math.floor(lines);
+}
+
+/**
+ * Capture the last `lines` rows of a tmux pane and return them as plain text.
+ * Returns null on any failure (window gone, tmux missing, timeout) so callers
+ * can silently suppress the popover instead of surfacing a tmux error.
+ *
+ * - `-p` prints to stdout instead of buffering to a paste buffer.
+ * - `-J` joins wrapped lines (more readable in a narrow popover).
+ * - `-S -<N>` starts the capture N lines back from the visible region.
+ * - We do NOT pass `-e`, so ANSI escape codes are stripped by tmux.
+ */
+export async function captureTmuxPane(
+  tmuxBinary: string,
+  session: string,
+  window: string,
+  lines: number,
+  exec: ExecShim = pExecFile,
+): Promise<string | null> {
+  const n = clampHoverLines(lines);
+  try {
+    const { stdout } = await exec(tmuxBinary, [
+      "capture-pane",
+      "-p",
+      "-J",
+      "-t",
+      `${session}:${window}`,
+      "-S",
+      `-${n}`,
+    ]);
+    const trimmed = stdout.replace(/\s+$/, "");
+    return trimmed.length === 0 ? null : trimmed;
+  } catch {
+    return null;
+  }
+}

--- a/plugins/op-obsidian/styles.css
+++ b/plugins/op-obsidian/styles.css
@@ -410,3 +410,27 @@ a.op-sidebar__agent:hover {
   font-size: var(--font-ui-smaller, 0.75rem);
   margin-top: 0.5rem;
 }
+
+.op-sidebar__hover-preview {
+  position: fixed;
+  z-index: var(--layer-popover, 30);
+  max-width: 60ch;
+  max-height: 40vh;
+  overflow: auto;
+  background: var(--background-secondary);
+  color: var(--text-normal);
+  border: 1px solid var(--background-modifier-border);
+  border-radius: var(--radius-s, 4px);
+  box-shadow: var(--shadow-s, 0 4px 12px rgba(0, 0, 0, 0.25));
+  padding: 0.5rem 0.75rem;
+  pointer-events: auto;
+}
+
+.op-sidebar__hover-preview pre {
+  margin: 0;
+  font-family: var(--font-monospace, monospace);
+  font-size: var(--font-ui-smaller, 0.75rem);
+  line-height: 1.35;
+  white-space: pre-wrap;
+  word-break: break-word;
+}

--- a/plugins/op/.claude-plugin/plugin.json
+++ b/plugins/op/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "op",
   "description": "Obsidian Projects workflow — schema, slash commands, and agent skill for running a Jira-lite issue tracker inside an Obsidian vault.",
-  "version": "0.53.0",
+  "version": "0.54.0",
   "author": {
     "name": "Eugene Archibald"
   },


### PR DESCRIPTION
## Summary

- New sidebar interaction: hovering an agent badge (e.g. `claude`) shows a small popover with the last N lines of that agent's tmux pane after a configurable delay. Suppressed silently when no live tmux window exists.
- Three new `view.*` settings (`agentHoverPreview` toggle, `agentHoverLines` / `agentHoverDelayMs` numbers) under "Sidebar view" — defaults: on, 30 lines, 400 ms.
- Pure refactor inside: `findAgentTmuxLocation` extracted from `revealAgentSession.ts` into `agentTmuxLocation.ts` so reveal-on-click and the hover preview share the shared-session + per-iTerm-window orchestrator session lookup.

Implements OP-143. Bumps op-obsidian to **0.53.0** (additive user-facing behavior).

## Test plan

- [x] `npx vitest run` — 559 / 559 pass (new `tmuxCapture.test.ts` + 4 new cases in `settings.test.ts`).
- [x] `npx tsc --noEmit` clean.
- [x] Bump+build via `scripts/bump-version.mjs` (lockstep across `manifest.json`, `package.json`, `plugin.json`); main.js fresher than manifest.
- [x] Synced into Agent-Vault; `obsidian plugin:reload id=op-obsidian` clean.
- [x] DOM-asserted the three new settings rows via `app.setting.openTabById("op-obsidian")`.
- [x] Hover smoke: live-tmux badge → popover renders the last 30 lines after the delay; mouseleave tears it down; rapid hover+leave cancels the pending capture; disabling `agentHoverPreview` suppresses it entirely.
- [x] `obsidian dev:console` — no errors after exercising the flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)