### PR TITLE
OP-146: sidebar PR chip beside GH Issue chip

### DIFF
--- a/plugins/op-obsidian/manifest.json
+++ b/plugins/op-obsidian/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "op-obsidian",
   "name": "Obsidian Projects (op)",
-  "version": "0.54.0",
+  "version": "0.55.0",
   "minAppVersion": "1.5.0",
   "description": "Jira-lite issue tracker for Obsidian vaults — deterministic commands backing the op workflow.",
   "author": "Eugene Archibald",

--- a/plugins/op-obsidian/package.json
+++ b/plugins/op-obsidian/package.json
@@ -1,6 +1,6 @@
 {
   "name": "op-obsidian",
-  "version": "0.54.0",
+  "version": "0.55.0",
   "description": "Obsidian plugin that owns the deterministic half of the op workflow.",
   "main": "main.js",
   "scripts": {

--- a/plugins/op-obsidian/src/sidebarView.test.ts
+++ b/plugins/op-obsidian/src/sidebarView.test.ts
@@ -34,6 +34,7 @@ import {
   filterEntries,
   OpResolveConfirmModal,
   OpSidebarView,
+  prNumber,
   shouldShowProjectChip,
   TMUX_PROBE_INTERVAL_MS,
   type OpSidebarHooks,
@@ -98,6 +99,27 @@ describe("filterEntries", () => {
   it("preserves input order", () => {
     const out = filterEntries(items, "op", subseqMatcher);
     expect(out.map((e) => e.id)).toEqual(["OP-1", "OP-2"]);
+  });
+});
+
+describe("prNumber", () => {
+  it("parses /pull/N", () => {
+    expect(prNumber("https://github.com/owner/repo/pull/42")).toBe(42);
+  });
+  it("parses /pulls/N (gh's older form)", () => {
+    expect(prNumber("https://github.com/owner/repo/pulls/7")).toBe(7);
+  });
+  it("ignores trailing path segments", () => {
+    expect(prNumber("https://github.com/owner/repo/pull/12/files")).toBe(12);
+    expect(prNumber("https://github.com/owner/repo/pull/12#issuecomment-1")).toBe(12);
+    expect(prNumber("https://github.com/owner/repo/pull/12?diff=split")).toBe(12);
+  });
+  it("returns undefined for issue URLs", () => {
+    expect(prNumber("https://github.com/owner/repo/issues/12")).toBeUndefined();
+  });
+  it("returns undefined when no number is present", () => {
+    expect(prNumber("https://github.com/owner/repo/pull/")).toBeUndefined();
+    expect(prNumber("https://example.com")).toBeUndefined();
   });
 });
 

--- a/plugins/op-obsidian/src/sidebarView.ts
+++ b/plugins/op-obsidian/src/sidebarView.ts
@@ -388,6 +388,25 @@ export class OpSidebarView extends ItemView {
           });
         }
       }
+      if (e.pr) {
+        const n = prNumber(e.pr);
+        if (n !== undefined) {
+          const url = e.pr;
+          const pr = meta.createEl("a", {
+            cls: "op-sidebar__pr",
+            text: `PR #${n}`,
+          });
+          pr.setAttr("href", url);
+          pr.setAttr("target", "_blank");
+          pr.setAttr("rel", "noopener");
+          pr.setAttr("aria-label", `Pull request ${url}`);
+          pr.addEventListener("click", (ev) => {
+            ev.preventDefault();
+            ev.stopPropagation();
+            window.open(url, "_blank");
+          });
+        }
+      }
     }
   }
 
@@ -834,6 +853,13 @@ export function filterEntries(
 
 function ghIssueNumber(url: string): number | undefined {
   const m = url.match(/\/issues\/(\d+)(?:[/?#]|$)/);
+  if (!m) return undefined;
+  const n = Number(m[1]);
+  return Number.isFinite(n) ? n : undefined;
+}
+
+export function prNumber(url: string): number | undefined {
+  const m = url.match(/\/pulls?\/(\d+)(?:[/?#]|$)/);
   if (!m) return undefined;
   const n = Number(m[1]);
   return Number.isFinite(n) ? n : undefined;

--- a/plugins/op-obsidian/styles.css
+++ b/plugins/op-obsidian/styles.css
@@ -235,13 +235,15 @@ a.op-sidebar__agent:hover {
   text-decoration: none;
 }
 
-.op-sidebar__github {
+.op-sidebar__github,
+.op-sidebar__pr {
   color: var(--text-muted);
   text-decoration: none;
   font-variant-numeric: tabular-nums;
 }
 
-.op-sidebar__github:hover {
+.op-sidebar__github:hover,
+.op-sidebar__pr:hover {
   color: var(--text-accent);
   text-decoration: underline;
 }

--- a/plugins/op/.claude-plugin/plugin.json
+++ b/plugins/op/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "op",
   "description": "Obsidian Projects workflow — schema, slash commands, and agent skill for running a Jira-lite issue tracker inside an Obsidian vault.",
-  "version": "0.54.0",
+  "version": "0.55.0",
   "author": {
     "name": "Eugene Archibald"
   },


### PR DESCRIPTION
## Summary
- Add a `PR #N` chip to the right of the existing `GH #N` chip in the op sidebar, rendered when an issue has `pr:` set in its frontmatter.
- Click opens the PR in the browser. Same affordances as the GH chip (`target=_blank`, `rel=noopener`, `aria-label`).
- New `prNumber()` helper parses `/pull/N` and the older `/pulls/N` form, with trailing-segment / query / fragment tolerance.

The `pr:` field already exists end-to-end (`IssueEntry.pr`, `IssueStore` parses it, `op-set-pr` writes it) — this PR just surfaces it in the sidebar.

Bumped to **0.55.0** (minor: additive UI).

## Test plan
- [x] `npx vitest run` (575/575 pass)
- [x] Sync to Agent-Vault, reload, confirm sidebar `querySelectorAll(".op-sidebar__pr")` returns the new chip with the right href
- [x] Confirm no console errors after reload
- [ ] Reviewer: open the sidebar in your vault and verify the PR chip appears alongside the GH chip on any in-flight issue with a `pr:` URL