### PR TITLE
OP-151 + OP-161 + OP-162: note chip + status strip + first-run README (§2/§10/§11)

### DIFF
--- a/plugins/op-obsidian/manifest.json
+++ b/plugins/op-obsidian/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "op-obsidian",
   "name": "Obsidian Projects (op)",
-  "version": "0.58.0",
+  "version": "0.58.1",
   "minAppVersion": "1.5.0",
   "description": "Jira-lite issue tracker for Obsidian vaults — deterministic commands backing the op workflow.",
   "author": "Eugene Archibald",

--- a/plugins/op-obsidian/manifest.json
+++ b/plugins/op-obsidian/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "op-obsidian",
   "name": "Obsidian Projects (op)",
-  "version": "0.57.1",
+  "version": "0.58.0",
   "minAppVersion": "1.5.0",
   "description": "Jira-lite issue tracker for Obsidian vaults — deterministic commands backing the op workflow.",
   "author": "Eugene Archibald",

--- a/plugins/op-obsidian/package.json
+++ b/plugins/op-obsidian/package.json
@@ -1,6 +1,6 @@
 {
   "name": "op-obsidian",
-  "version": "0.57.1",
+  "version": "0.58.0",
   "description": "Obsidian plugin that owns the deterministic half of the op workflow.",
   "main": "main.js",
   "scripts": {

--- a/plugins/op-obsidian/package.json
+++ b/plugins/op-obsidian/package.json
@@ -1,6 +1,6 @@
 {
   "name": "op-obsidian",
-  "version": "0.58.0",
+  "version": "0.58.1",
   "description": "Obsidian plugin that owns the deterministic half of the op workflow.",
   "main": "main.js",
   "scripts": {

--- a/plugins/op-obsidian/src/firstRunReadme.test.ts
+++ b/plugins/op-obsidian/src/firstRunReadme.test.ts
@@ -1,0 +1,131 @@
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("obsidian", () => ({
+  TFile: class {},
+  normalizePath: (p: string) => p,
+}));
+
+import {
+  buildDemoIssueNote,
+  buildReadmeBody,
+  DEMO_ISSUES,
+  parseOpActionBlock,
+  scaffoldFirstRunReadme,
+  shouldScaffoldReadme,
+  type ReadmeWriter,
+} from "./firstRunReadme";
+
+describe("buildReadmeBody", () => {
+  it("includes the Apply preset and Start tour codeblocks", () => {
+    const body = buildReadmeBody();
+    expect(body).toContain("```op-action");
+    expect(body).toMatch(/action:\s*op-apply-preset/);
+    expect(body).toMatch(/label:\s*Apply preset/);
+    expect(body).toMatch(/action:\s*op-start-tour/);
+    expect(body).toMatch(/label:\s*Start tour/);
+  });
+
+  it("starts with an H1", () => {
+    expect(buildReadmeBody().startsWith("# ")).toBe(true);
+  });
+});
+
+describe("DEMO_ISSUES", () => {
+  it("has exactly three pre-seeded issues", () => {
+    expect(DEMO_ISSUES.length).toBe(3);
+    expect(DEMO_ISSUES.map((s) => s.number)).toEqual([1, 2, 3]);
+  });
+
+  it("renders an issue note with valid frontmatter", () => {
+    const note = buildDemoIssueNote(DEMO_ISSUES[0]);
+    expect(note).toContain("id: OPD-1");
+    expect(note).toContain("type: issue");
+    expect(note).toContain("status: open");
+    expect(note).toContain("project: op-demo");
+  });
+});
+
+describe("shouldScaffoldReadme", () => {
+  it("scaffolds when flag is false and file is absent", () => {
+    expect(shouldScaffoldReadme({ firstRunCompleted: false }, false)).toBe(true);
+  });
+
+  it("skips when flag is already flipped", () => {
+    expect(shouldScaffoldReadme({ firstRunCompleted: true }, false)).toBe(false);
+  });
+
+  it("skips when the README already exists (manual-delete dismissal is durable)", () => {
+    expect(shouldScaffoldReadme({ firstRunCompleted: false }, true)).toBe(false);
+  });
+});
+
+describe("scaffoldFirstRunReadme", () => {
+  function makeWriter(): {
+    writer: ReadmeWriter;
+    written: Map<string, string>;
+  } {
+    const written = new Map<string, string>();
+    const writer: ReadmeWriter = {
+      exists: (p) => written.has(p),
+      write: async (p, c) => {
+        written.set(p, c);
+      },
+    };
+    return { writer, written };
+  }
+
+  it("writes the README and flips the flag on first run", async () => {
+    const settings = { firstRunCompleted: false };
+    const { writer, written } = makeWriter();
+    let saved = false;
+    const result = await scaffoldFirstRunReadme(settings, writer, async () => {
+      saved = true;
+    });
+    expect(result.scaffolded).toBe(true);
+    expect(written.get(result.readmePath)).toContain("# Welcome to op");
+    expect(settings.firstRunCompleted).toBe(true);
+    expect(saved).toBe(true);
+  });
+
+  it("is a no-op on the second call (idempotent)", async () => {
+    const settings = { firstRunCompleted: true };
+    const { writer, written } = makeWriter();
+    const result = await scaffoldFirstRunReadme(settings, writer, async () => {});
+    expect(result.scaffolded).toBe(false);
+    expect(written.size).toBe(0);
+  });
+
+  it("skips re-writing when the file already exists", async () => {
+    const settings = { firstRunCompleted: false };
+    const { writer, written } = makeWriter();
+    written.set("Projects/_op-readme.md", "user-edited content");
+    const result = await scaffoldFirstRunReadme(settings, writer, async () => {});
+    expect(result.scaffolded).toBe(false);
+    expect(written.get("Projects/_op-readme.md")).toBe("user-edited content");
+  });
+});
+
+describe("parseOpActionBlock", () => {
+  it("parses the canonical shape", () => {
+    expect(parseOpActionBlock("action: op-apply-preset\nlabel: Apply preset")).toEqual({
+      action: "op-apply-preset",
+      label: "Apply preset",
+    });
+  });
+
+  it("tolerates whitespace + comments", () => {
+    expect(
+      parseOpActionBlock([
+        "# this is a chip",
+        "  action:   op-start-tour  ",
+        "label: Start the tour",
+      ].join("\n")),
+    ).toEqual({ action: "op-start-tour", label: "Start the tour" });
+  });
+
+  it("returns null when either field is missing", () => {
+    expect(parseOpActionBlock("action: op-x")).toBeNull();
+    expect(parseOpActionBlock("label: nope")).toBeNull();
+    expect(parseOpActionBlock("")).toBeNull();
+  });
+});

--- a/plugins/op-obsidian/src/firstRunReadme.ts
+++ b/plugins/op-obsidian/src/firstRunReadme.ts
@@ -1,0 +1,328 @@
+/**
+ * First-run README onboarding (OP-161 / §10 of OP-149).
+ *
+ * On the first plugin load, we drop a single dismissible markdown file
+ * into the user's vault explaining what op is, listing the default
+ * hotkey preset, and offering an in-line "Apply preset" / "Start tour"
+ * pair of chips. The README is the tour — no modals, no forced
+ * walkthrough. Once we've written it, we flip `firstRunCompleted` so a
+ * manual delete (the "dismiss" gesture) is durable across reloads.
+ *
+ * The chips on the README are rendered by the `op-action` codeblock
+ * post-processor in `noteDecorations.ts`. Their backing commands
+ * (`op-apply-preset`, `op-start-tour`, `op-remove-demo`) are registered
+ * by `main.ts`.
+ */
+
+import type { App } from "obsidian";
+import { normalizePath } from "obsidian";
+
+export const README_PATH = "Projects/_op-readme.md";
+export const DEMO_PROJECT_SLUG = "op-demo";
+export const DEMO_PROJECT_PREFIX = "OPD";
+export const DEMO_PROJECT_FOLDER = `Projects/${DEMO_PROJECT_SLUG}`;
+
+/**
+ * Pure markdown body for the first-run README. Kept pure so tests can
+ * assert the chip codeblocks are present without spinning up an
+ * Obsidian app instance.
+ */
+export function buildReadmeBody(): string {
+  return [
+    "# Welcome to op",
+    "",
+    "Obsidian Projects (op) is a tiny issue tracker that lives in this vault.",
+    "Issues are markdown notes under `Projects/<slug>/ISSUES/`; commands sit",
+    "under `op:` in the command palette; agents launch into tmux. Dismiss",
+    "this README by deleting it — it won't come back.",
+    "",
+    "## Default hotkey preset",
+    "",
+    "| Action | Hotkey |",
+    "| --- | --- |",
+    "| Open sidebar | ⌘⇧O |",
+    "| Pick & act | ⌘⇧I |",
+    "| Resume last | ⌘⇧↵ |",
+    "| Attach current | ⌘⇧A |",
+    "| Open agent | ⌘⇧L |",
+    "| Resolve | ⌘⇧R |",
+    "| New issue | ⌘⌥N |",
+    "| Append commit | ⌘⇧. |",
+    "| Next / previous issue | ⌘⇧J / ⌘⇧K |",
+    "",
+    "```op-action",
+    "action: op-apply-preset",
+    "label: Apply preset",
+    "```",
+    "",
+    "## Try it on a demo project",
+    "",
+    "Spin up a throwaway `op-demo` project (prefix `OPD`) with three pre-seeded",
+    "issues so you can practice `/op:resolve` against real data:",
+    "",
+    "```op-action",
+    "action: op-start-tour",
+    "label: Start tour",
+    "```",
+    "",
+    "Tear it down again from the demo project's `STATUS.md` whenever you're done.",
+    "",
+    "---",
+    "",
+    "More: [github.com/earchibald/obsidian-projects](https://github.com/earchibald/obsidian-projects)",
+    "",
+  ].join("\n");
+}
+
+/** Markdown body for the demo project's STATUS.md. Includes the
+ * Remove-demo chip per OP-161's "demo-project teardown" requirement. */
+export function buildDemoStatusBody(): string {
+  return [
+    "# op-demo — practice project",
+    "",
+    "Three pre-seeded issues live in `ISSUES/`. Practice the resolve flow",
+    "(`/op:resolve` or the sidebar's `r` shortcut) against `OPD-1`/`OPD-2`/",
+    "`OPD-3` — they have no real-world consequence.",
+    "",
+    "When you're done, tear the whole project down with one click:",
+    "",
+    "```op-action",
+    "action: op-remove-demo",
+    "label: Remove demo project",
+    "```",
+    "",
+  ].join("\n");
+}
+
+/** Frontmatter for the demo STATUS.md note. */
+export function demoStatusFrontmatter(): string {
+  return [
+    "---",
+    "project: " + DEMO_PROJECT_SLUG,
+    "type: project-status",
+    "prefix: " + DEMO_PROJECT_PREFIX,
+    "tags:",
+    "  - project/" + DEMO_PROJECT_SLUG,
+    "  - status",
+    "---",
+    "",
+  ].join("\n");
+}
+
+export function demoBaseBody(): string {
+  // Minimal Bases file — same shape as scaffoldProject.ts uses for new
+  // projects. We don't need formulas here, just a tabular view.
+  return [
+    "filters:",
+    "  and:",
+    `    - file.folder.contains("${DEMO_PROJECT_SLUG}")`,
+    "views:",
+    "  - type: table",
+    "    name: All issues",
+    "",
+  ].join("\n");
+}
+
+export interface DemoIssueSeed {
+  number: number;
+  title: string;
+  body: string;
+}
+
+export const DEMO_ISSUES: ReadonlyArray<DemoIssueSeed> = [
+  {
+    number: 1,
+    title: "Try the resolve flow",
+    body: [
+      "## Scope",
+      "",
+      "- [ ] Run the command palette (⌘P) and search for `op: resolve`.",
+      "- [ ] Confirm the modal — the file moves to `RESOLVED ISSUES/`.",
+      "- [ ] Notice the chip above the H1 flips to `↺ Reopen` afterwards.",
+      "",
+    ].join("\n"),
+  },
+  {
+    number: 2,
+    title: "Try launching an agent",
+    body: [
+      "## Scope",
+      "",
+      "- [ ] Hit ⌘⇧L on this note (after applying the preset).",
+      "- [ ] An agent opens in a new iTerm tab; the sidebar grows a badge.",
+      "- [ ] Detach with ⌘⇧A or via the chip's overflow menu.",
+      "",
+    ].join("\n"),
+  },
+  {
+    number: 3,
+    title: "Try the sidebar",
+    body: [
+      "## Scope",
+      "",
+      "- [ ] Open the op sidebar (⌘⇧O).",
+      "- [ ] Use ↑ ↓ to move; ↵ to open; `r` to resolve under the cursor.",
+      "- [ ] Right-click any row for the context menu.",
+      "",
+    ].join("\n"),
+  },
+] as const;
+
+/** Compose the full markdown for one demo issue note. */
+export function buildDemoIssueNote(seed: DemoIssueSeed): string {
+  const id = `${DEMO_PROJECT_PREFIX}-${seed.number}`;
+  return [
+    "---",
+    `id: ${id}`,
+    `project: ${DEMO_PROJECT_SLUG}`,
+    `title: ${seed.title}`,
+    "type: issue",
+    "status: open",
+    "priority: med",
+    "tags:",
+    `  - project/${DEMO_PROJECT_SLUG}`,
+    "  - issue",
+    "---",
+    `# ${seed.title}`,
+    "",
+    seed.body,
+  ].join("\n");
+}
+
+/**
+ * Settings shape consumed by the first-run hook. Kept narrow so the
+ * pure decision is unit-testable without `OpSettings`.
+ */
+export interface FirstRunSettings {
+  firstRunCompleted: boolean;
+}
+
+/** Pure decision: should we scaffold the README on this load? */
+export function shouldScaffoldReadme(
+  settings: FirstRunSettings,
+  readmeExists: boolean,
+): boolean {
+  if (settings.firstRunCompleted) return false;
+  if (readmeExists) return false;
+  return true;
+}
+
+export interface ReadmeWriter {
+  /** Resolve a TFile by path, or `null` if missing. */
+  exists: (path: string) => boolean;
+  /** Write a fresh file at `path` (creates parent folders if needed). */
+  write: (path: string, content: string) => Promise<void>;
+}
+
+/**
+ * If `firstRunCompleted` is false and the README is absent, write the
+ * README and flip the flag. Idempotent — a second call is a no-op.
+ */
+export async function scaffoldFirstRunReadme(
+  settings: FirstRunSettings,
+  writer: ReadmeWriter,
+  saveSettings: () => Promise<void>,
+): Promise<{ scaffolded: boolean; readmePath: string }> {
+  const path = README_PATH;
+  if (!shouldScaffoldReadme(settings, writer.exists(path))) {
+    return { scaffolded: false, readmePath: path };
+  }
+  await writer.write(path, buildReadmeBody());
+  settings.firstRunCompleted = true;
+  await saveSettings();
+  return { scaffolded: true, readmePath: path };
+}
+
+/**
+ * Apply a {@link ReadmeWriter} to the live Obsidian vault. Pulled out
+ * so tests can substitute a fake writer without touching the disk.
+ */
+export function liveReadmeWriter(app: App): ReadmeWriter {
+  return {
+    exists: (path) => !!app.vault.getAbstractFileByPath(normalizePath(path)),
+    write: async (path, content) => {
+      const norm = normalizePath(path);
+      const dirIdx = norm.lastIndexOf("/");
+      if (dirIdx > 0) {
+        const dir = norm.slice(0, dirIdx);
+        const folder = app.vault.getAbstractFileByPath(dir);
+        if (!folder) await app.vault.createFolder(dir);
+      }
+      await app.vault.create(norm, content);
+    },
+  };
+}
+
+/**
+ * Scaffold the demo project (`Projects/op-demo/`) — STATUS.md, base file,
+ * and three pre-seeded issues. Idempotent on `Projects/op-demo/STATUS.md`:
+ * if it already exists we skip everything (the user can clear via the
+ * Remove-demo chip and re-run).
+ */
+export async function scaffoldDemoProject(app: App): Promise<{
+  created: boolean;
+  statusPath: string;
+}> {
+  const statusPath = `${DEMO_PROJECT_FOLDER}/STATUS.md`;
+  if (app.vault.getAbstractFileByPath(statusPath)) {
+    return { created: false, statusPath };
+  }
+  const issuesDir = `${DEMO_PROJECT_FOLDER}/ISSUES`;
+  await ensureFolder(app, DEMO_PROJECT_FOLDER);
+  await ensureFolder(app, issuesDir);
+  await app.vault.create(statusPath, demoStatusFrontmatter() + buildDemoStatusBody());
+  await app.vault.create(`${DEMO_PROJECT_FOLDER}/${DEMO_PROJECT_SLUG}.base`, demoBaseBody());
+  for (const seed of DEMO_ISSUES) {
+    const filename = `${DEMO_PROJECT_PREFIX}-${seed.number} ${seed.title}.md`;
+    await app.vault.create(`${issuesDir}/${filename}`, buildDemoIssueNote(seed));
+  }
+  return { created: true, statusPath };
+}
+
+async function ensureFolder(app: App, path: string): Promise<void> {
+  const norm = normalizePath(path);
+  if (!app.vault.getAbstractFileByPath(norm)) {
+    await app.vault.createFolder(norm);
+  }
+}
+
+/**
+ * Trash the entire demo project folder. Returns whether the folder was
+ * found — caller surfaces a Notice so the user knows the click did
+ * something even if they'd already deleted it.
+ */
+export async function removeDemoProject(
+  app: App,
+): Promise<{ removed: boolean; folder: string }> {
+  const folder = app.vault.getAbstractFileByPath(DEMO_PROJECT_FOLDER);
+  if (!folder) return { removed: false, folder: DEMO_PROJECT_FOLDER };
+  await app.vault.trash(folder, true);
+  return { removed: true, folder: DEMO_PROJECT_FOLDER };
+}
+
+/** Public for tests + the codeblock chip parser. */
+export interface OpAction {
+  action: string;
+  label: string;
+}
+
+/** Parse the body of an `op-action` codeblock. The format is a
+ * line-per-key YAML-ish shape: `action: <id>` and `label: <text>`. We
+ * avoid pulling in a YAML parser for two keys. Returns `null` when the
+ * body is malformed so the renderer can show an inline error instead. */
+export function parseOpActionBlock(body: string): OpAction | null {
+  let action = "";
+  let label = "";
+  for (const lineRaw of body.split(/\r?\n/)) {
+    const line = lineRaw.trim();
+    if (!line || line.startsWith("#")) continue;
+    const idx = line.indexOf(":");
+    if (idx <= 0) continue;
+    const key = line.slice(0, idx).trim();
+    const val = line.slice(idx + 1).trim();
+    if (key === "action") action = val;
+    else if (key === "label") label = val;
+  }
+  if (!action || !label) return null;
+  return { action, label };
+}

--- a/plugins/op-obsidian/src/main.ts
+++ b/plugins/op-obsidian/src/main.ts
@@ -1,4 +1,4 @@
-import { Plugin, TFile, WorkspaceLeaf } from "obsidian";
+import { Notice, Plugin, TFile, WorkspaceLeaf } from "obsidian";
 import { OP_SIDEBAR_VIEW_TYPE, OpSidebarView } from "./sidebarView";
 import { revealAgentSession } from "./revealAgentSession";
 import { findAgentTmuxLocation } from "./agentTmuxLocation";
@@ -110,6 +110,22 @@ import { existsSync } from "fs";
 import { execFile } from "child_process";
 import { promisify } from "util";
 import { PickAndActModal } from "./pickAndActModal";
+import {
+  ChipDeps,
+  dispatchChipRefresh,
+  makeNoteChipPostProcessor,
+  makeOpActionCodeBlockProcessor,
+  noteChipExtension,
+} from "./noteDecorations";
+import type { GhStateCache } from "./noteStatusStrip";
+import {
+  DEMO_PROJECT_FOLDER,
+  liveReadmeWriter,
+  removeDemoProject,
+  scaffoldDemoProject,
+  scaffoldFirstRunReadme,
+} from "./firstRunReadme";
+import { applyPreset, defaultPreset } from "./hotkeyPreset";
 
 const pExecFile = promisify(execFile);
 
@@ -119,6 +135,12 @@ const pExecFile = promisify(execFile);
  * so we don't fire a false-positive [Clear badge] Notice during that window.
  */
 const STALE_AGENT_PROBE_DELAY_MS = 2_000;
+
+/** Re-probe cadence for the OP-151 chip's "is the agent alive?" view.
+ * 20s is an arbitrary balance: short enough that a freshly-killed
+ * tmux window flips the chip within a Pomodoro break, long enough not
+ * to spawn a `tmux list-windows` per second. */
+const CHIP_LIVENESS_INTERVAL_MS = 20_000;
 
 /**
  * The Obsidian plugin half of the Obsidian Projects workflow.
@@ -158,6 +180,14 @@ export default class OpPlugin extends Plugin {
    * resolve on the frontmatter write that `runResolve` itself performs.
    */
   private inFlightResolvePaths = new Set<string>();
+  /** Last-known set of live tmux window names (`op:<ISSUE-ID>`). Populated
+   * by the stale-agent probe on layout-ready and refreshed every
+   * {@link CHIP_LIVENESS_INTERVAL_MS} so the OP-151 note chip can answer
+   * "is this issue's agent alive?" without shelling out per render.
+   * `null` ⇒ probe hasn't run or tmux unavailable; the chip treats that
+   * as "alive" to avoid false-stale chips. */
+  liveTmuxWindowsCache: Set<string> | null = null;
+  private chipLivenessTimer: number | undefined;
 
   /** Persist the current {@link settings} object to `data.json`. */
   async saveSettings(): Promise<void> {
@@ -316,6 +346,78 @@ export default class OpPlugin extends Plugin {
     this.app.workspace.onLayoutReady(() => {
       void this.reconcileAgentStateOnStartup();
       void this.surfaceStaleAgentBadgesOnStartup();
+      // OP-161 / §10: drop the first-run README into the vault on the
+      // very first plugin load. The flag flip is idempotent across reloads.
+      void scaffoldFirstRunReadme(
+        this.settings,
+        liveReadmeWriter(this.app),
+        () => this.saveSettings(),
+      ).catch((err) => {
+        console.error("[op-obsidian] first-run readme scaffold failed", err);
+      });
+    });
+
+    // OP-151 (§2) + OP-162 (§11): note-level decoration infra. The
+    // ViewPlugin paints the chip + strip in Live Preview; the
+    // post-processor mirrors it in Reading mode; the codeblock processor
+    // backs the README's `op-action` chips. All three feed off one
+    // gh-state cache so a mode toggle doesn't re-fetch.
+    const ghCache: GhStateCache = new Map();
+    const chipDeps: ChipDeps = {
+      app: this.app,
+      isAgentLive: (id, agent) => this.isAgentLiveSync(id, agent),
+      getSettings: () => ({
+        view: { disableInlineGithubStatus: this.settings.view.disableInlineGithubStatus },
+      }),
+      ghCache,
+      scheduleRefresh: () => dispatchChipRefresh(this.app),
+    };
+    this.registerEditorExtension(noteChipExtension(chipDeps));
+    this.registerMarkdownPostProcessor(makeNoteChipPostProcessor(chipDeps));
+    this.registerMarkdownCodeBlockProcessor(
+      "op-action",
+      makeOpActionCodeBlockProcessor(this.app),
+    );
+
+    // Re-render the chip when frontmatter changes so the label flips
+    // promptly. The metadataCache `changed` event is debounced; the
+    // refresh dispatcher is idempotent so multiple fires collapse.
+    this.registerEvent(
+      this.app.metadataCache.on("changed", () => dispatchChipRefresh(this.app)),
+    );
+    // Issue lifecycle changes (status flip, agent set/cleared) also
+    // re-render — the bus already debounces internally.
+    this.bus.on("issue:status-changed", () => dispatchChipRefresh(this.app));
+    this.bus.on("issue:updated", () => dispatchChipRefresh(this.app));
+
+    // Periodic liveness re-probe for the chip — the startup probe gives
+    // us an initial set, but the chip needs to flip when an agent dies
+    // mid-session. The interval is registered so plugin unload cancels
+    // it; `probeLiveTmuxWindows` already swallows ENOENT/timeout.
+    this.chipLivenessTimer = window.setInterval(async () => {
+      const next = await probeLiveTmuxWindows(
+        this.settings.tmuxBinary,
+        tmuxSessionsForCleanup(this.settings.orchestratorState),
+      );
+      if (!next.ok) {
+        if (this.liveTmuxWindowsCache !== null) {
+          this.liveTmuxWindowsCache = null;
+          dispatchChipRefresh(this.app);
+        }
+        return;
+      }
+      const prev = this.liveTmuxWindowsCache;
+      const sameSize = prev?.size === next.live.size;
+      const same = sameSize && prev && [...next.live].every((x) => prev.has(x));
+      if (same) return;
+      this.liveTmuxWindowsCache = next.live;
+      dispatchChipRefresh(this.app);
+    }, CHIP_LIVENESS_INTERVAL_MS);
+    this.register(() => {
+      if (this.chipLivenessTimer !== undefined) {
+        clearInterval(this.chipLivenessTimer);
+        this.chipLivenessTimer = undefined;
+      }
     });
 
     this.registerView(
@@ -595,6 +697,71 @@ export default class OpPlugin extends Plugin {
       id: "op-migrate-links",
       name: "op: migrate legacy issue links",
       callback: () => void this.runMigrateLinksCommand(),
+    });
+
+    // OP-151 / §2 — note-chip backers. Each command is a thin wrapper
+    // around an existing primitive (or, for `op-reopen-issue`, a fresh
+    // status-flip helper). They all use `checkCallback` so they're
+    // hidden from the palette unless an issue note is active — the chip
+    // dispatches them by id but human users get a sensibly filtered
+    // palette too.
+    this.addCommand({
+      id: "op-reopen-issue",
+      name: "op: reopen current issue",
+      checkCallback: (checking) => {
+        const path = this.activeIssuePath();
+        if (checking) return !!path;
+        if (!path) return false;
+        void this.runReopenCommand(path);
+        return true;
+      },
+    });
+    this.addCommand({
+      id: "op-clear-agent",
+      name: "op: clear agent on current issue",
+      checkCallback: (checking) => {
+        const path = this.activeIssuePath();
+        if (checking) return !!path;
+        if (!path) return false;
+        void clearAgentOnIssue(this.app, path);
+        return true;
+      },
+    });
+    this.addCommand({
+      id: "op-set-priority",
+      name: "op: set priority for current issue",
+      checkCallback: (checking) => {
+        const path = this.activeIssuePath();
+        if (checking) return !!path;
+        if (!path) return false;
+        void this.runSetPriorityCommand(path);
+        return true;
+      },
+    });
+
+    // OP-161 / §10 — first-run README chip backers.
+    this.addCommand({
+      id: "op-apply-preset",
+      name: "op: apply default hotkey preset",
+      callback: () => {
+        const preset = defaultPreset();
+        const result = applyPreset(this.app, preset);
+        // Use the existing results modal so the user sees the same UX as
+        // hitting "Apply preset" inside the Settings tab.
+        void import("./settings").then(({ HotkeyPresetResultsModal }) => {
+          new HotkeyPresetResultsModal(this.app, preset, result).open();
+        });
+      },
+    });
+    this.addCommand({
+      id: "op-start-tour",
+      name: "op: start guided tour (scaffold demo project)",
+      callback: () => void this.runStartTourCommand(),
+    });
+    this.addCommand({
+      id: "op-remove-demo",
+      name: "op: remove demo project",
+      callback: () => void this.runRemoveDemoCommand(),
     });
 
     // op-dev:* commands are gated by settings.developer.showDevCommands so
@@ -1097,6 +1264,8 @@ export default class OpPlugin extends Plugin {
       console.debug("[op-obsidian] stale-agent probe skipped — tmux unavailable");
       return;
     }
+    // Cache the live set for the OP-151 chip's `isAgentLiveSync`.
+    this.liveTmuxWindowsCache = probe.live;
     const stale = selectStaleAgentBadges(issues, probe.live);
     for (const entry of stale) {
       notifyAction({
@@ -3165,6 +3334,104 @@ export default class OpPlugin extends Plugin {
         (err) => console.error("[op-obsidian] uri auto-create failed", err),
       );
     }
+  }
+
+  /**
+   * OP-151 chip helper — reopen a resolved/wontfix issue. Flips
+   * `status: open`, clears `resolved:`, moves the file out of
+   * `RESOLVED ISSUES/`. Idempotent on `RESOLVED ISSUES/` membership: if
+   * the file is already in `ISSUES/` we only flip the frontmatter.
+   */
+  private async runReopenCommand(path: string): Promise<void> {
+    const file = this.app.vault.getAbstractFileByPath(path);
+    if (!(file instanceof TFile)) {
+      new Notice(`op: reopen — file not found at ${path}`);
+      return;
+    }
+    await this.app.fileManager.processFrontMatter(file, (fm) => {
+      fm.status = "open";
+      delete (fm as Record<string, unknown>).resolved;
+    });
+    if (path.includes("/RESOLVED ISSUES/")) {
+      const newPath = path.replace("/RESOLVED ISSUES/", "/ISSUES/");
+      const dir = newPath.slice(0, newPath.lastIndexOf("/"));
+      const dirEntry = this.app.vault.getAbstractFileByPath(dir);
+      if (!dirEntry) await this.app.vault.createFolder(dir);
+      try {
+        await this.app.fileManager.renameFile(file, newPath);
+      } catch (err: any) {
+        new Notice(`op: reopen — move failed (${err?.message ?? err})`);
+        return;
+      }
+    }
+    new Notice("op: issue reopened");
+    dispatchChipRefresh(this.app);
+  }
+
+  /** OP-151 chip helper — set priority via prompt. Tiny wrapper. */
+  private async runSetPriorityCommand(path: string): Promise<void> {
+    const file = this.app.vault.getAbstractFileByPath(path);
+    if (!(file instanceof TFile)) return;
+    const cycle: Array<"low" | "med" | "high"> = ["low", "med", "high"];
+    const current =
+      (this.app.metadataCache.getFileCache(file)?.frontmatter as
+        | { priority?: string }
+        | undefined)?.priority ?? "med";
+    const next = cycle[(cycle.indexOf(current as any) + 1) % cycle.length];
+    await this.app.fileManager.processFrontMatter(file, (fm) => {
+      fm.priority = next;
+    });
+    new Notice(`op: priority → ${next}`);
+  }
+
+  /** OP-161 chip helper — scaffold the demo project. */
+  private async runStartTourCommand(): Promise<void> {
+    try {
+      const result = await scaffoldDemoProject(this.app);
+      if (!result.created) {
+        new Notice("op: demo project already present at " + DEMO_PROJECT_FOLDER);
+      } else {
+        new Notice("op: demo project scaffolded at " + DEMO_PROJECT_FOLDER);
+        const status = this.app.vault.getAbstractFileByPath(result.statusPath);
+        if (status instanceof TFile) {
+          await this.app.workspace.getLeaf(false).openFile(status);
+        }
+      }
+    } catch (err: any) {
+      console.error("[op-obsidian] start-tour failed", err);
+      new Notice("op: start tour failed — " + (err?.message ?? err));
+    }
+  }
+
+  /** OP-161 chip helper — trash the demo project. */
+  private async runRemoveDemoCommand(): Promise<void> {
+    try {
+      const result = await removeDemoProject(this.app);
+      if (!result.removed) {
+        new Notice("op: demo project not found (already removed?).");
+      } else {
+        new Notice("op: demo project trashed.");
+      }
+    } catch (err: any) {
+      console.error("[op-obsidian] remove-demo failed", err);
+      new Notice("op: remove demo failed — " + (err?.message ?? err));
+    }
+  }
+
+  /**
+   * Synchronous "is the agent's tmux window alive?" probe used by the
+   * note chip. Reuses {@link findAgentTmuxLocation} via the cached
+   * orchestrator session list. Returns `null` when the agent field is
+   * empty (the chip treats that as "no agent set" — irrelevant) or
+   * when we can't read tmux output (treat as live to avoid false-stale
+   * chips). The chip's signature includes the result so a `metadataCache`
+   * change will recompute, but we don't expensively poll on every paint.
+   */
+  private isAgentLiveSync(id: string, agent: string | undefined): boolean | null {
+    if (!agent || agent.trim().length === 0) return null;
+    const live = this.liveTmuxWindowsCache;
+    if (!live) return null;
+    return live.has(tmuxWindowName(id));
   }
 }
 

--- a/plugins/op-obsidian/src/main.ts
+++ b/plugins/op-obsidian/src/main.ts
@@ -395,6 +395,19 @@ export default class OpPlugin extends Plugin {
     // mid-session. The interval is registered so plugin unload cancels
     // it; `probeLiveTmuxWindows` already swallows ENOENT/timeout.
     this.chipLivenessTimer = window.setInterval(async () => {
+      // Skip the tmux probe entirely when no issue notes are currently
+      // displayed — avoids shelling out every 20 s when the user is
+      // working outside the issue tracker.
+      let hasOpenIssueNote = false;
+      this.app.workspace.iterateAllLeaves((leaf) => {
+        if (hasOpenIssueNote) return;
+        if (leaf.view.getViewType() !== "markdown") return;
+        const file = (leaf.view as { file?: TFile }).file;
+        if (!file) return;
+        const fm = this.app.metadataCache.getFileCache(file)?.frontmatter;
+        if (fm?.type === "issue") hasOpenIssueNote = true;
+      });
+      if (!hasOpenIssueNote) return;
       const next = await probeLiveTmuxWindows(
         this.settings.tmuxBinary,
         tmuxSessionsForCleanup(this.settings.orchestratorState),

--- a/plugins/op-obsidian/src/noteChipMenu.ts
+++ b/plugins/op-obsidian/src/noteChipMenu.ts
@@ -1,0 +1,61 @@
+import { App, Menu } from "obsidian";
+import type { ChipMenuItem, ChipState } from "./noteChipState";
+
+/**
+ * Build and show the overflow menu for a note-level chip (OP-151).
+ *
+ * Each entry dispatches by Obsidian command id via
+ * `app.commands.executeCommandById` so business logic stays in one place
+ * (no duplicated handlers that drift from the palette command). The menu
+ * uses Obsidian's `Menu` class directly — same affordance pattern as the
+ * sidebar context menu (OP-163).
+ *
+ * Dispatch caveat: most `op-*` commands are `checkCallback`-shaped and
+ * inspect `app.workspace.getActiveFile()` to find the target issue. Before
+ * showing the menu we make sure the issue note is the active leaf
+ * (callers pass the issue path; this is normally true because the click
+ * came from inside the note's own editor pane). When dispatch returns
+ * `false` (Obsidian's signal that the command opted out), we surface a
+ * subtle `Notice` so the user isn't left wondering why nothing happened.
+ */
+export function showChipMenu(
+  app: App,
+  state: ChipState,
+  ev: MouseEvent,
+): void {
+  const menu = new Menu();
+  for (const item of state.menu) {
+    menu.addItem((mi) => {
+      mi.setTitle(item.label);
+      if (item.icon) mi.setIcon(item.icon);
+      mi.onClick(() => dispatchChipCommand(app, item));
+    });
+  }
+  // Show below the chip (anchor to mouse click) — matches the sidebar
+  // context-menu UX. `showAtMouseEvent` handles outside-click dismissal.
+  menu.showAtMouseEvent(ev);
+}
+
+/**
+ * Run a chip command by id. Falls back to a Notice when the command is
+ * absent or refused — keeps the chip from looking broken when, e.g.,
+ * `op-clear-agent` lands in a future PR but the chip rendered against an
+ * older command list.
+ */
+export function dispatchChipCommand(app: App, item: ChipMenuItem): void {
+  // `executeCommandById` returns `false` when the command id is unknown
+  // *or* its checkCallback declines (no active issue note, etc).
+  const ok = (app as unknown as {
+    commands: { executeCommandById: (id: string) => boolean };
+  }).commands.executeCommandById(item.command);
+  if (!ok) {
+    // Defer the import: `notify` lives in notificationLog.ts which pulls in
+    // the Obsidian app — keep this module dependency-light for tests.
+    void notifyMissingCommand(item);
+  }
+}
+
+async function notifyMissingCommand(item: ChipMenuItem): Promise<void> {
+  const { notify } = await import("./notificationLog");
+  notify(`op: ${item.command} unavailable — open the issue note first.`);
+}

--- a/plugins/op-obsidian/src/noteChipState.test.ts
+++ b/plugins/op-obsidian/src/noteChipState.test.ts
@@ -1,0 +1,148 @@
+import { describe, expect, it } from "vitest";
+import { isIssueFrontmatter, resolveChipState } from "./noteChipState";
+
+describe("isIssueFrontmatter", () => {
+  it("rejects notes without type=issue", () => {
+    expect(isIssueFrontmatter({ id: "OP-1", type: "task" })).toBe(false);
+    expect(isIssueFrontmatter({ id: "OP-1" })).toBe(false);
+  });
+
+  it("rejects malformed ids (TASKS notes use OP-100.1 style — must be filtered)", () => {
+    expect(isIssueFrontmatter({ id: "OP-100.1", type: "issue" })).toBe(false);
+    expect(isIssueFrontmatter({ id: "op-1", type: "issue" })).toBe(false);
+    expect(isIssueFrontmatter({ id: "OP1", type: "issue" })).toBe(false);
+  });
+
+  it("accepts canonical issue ids", () => {
+    expect(isIssueFrontmatter({ id: "OP-1", type: "issue" })).toBe(true);
+    expect(isIssueFrontmatter({ id: "ABC-9999", type: "issue" })).toBe(true);
+  });
+
+  it("rejects null/undefined", () => {
+    expect(isIssueFrontmatter(undefined)).toBe(false);
+    expect(isIssueFrontmatter(null)).toBe(false);
+  });
+});
+
+describe("resolveChipState — every row of the chip-state matrix", () => {
+  it("open / no agent → Start agent + standard overflow", () => {
+    const state = resolveChipState(
+      { id: "OP-1", type: "issue", status: "open" },
+      true,
+    );
+    expect(state?.action).toBe("start-agent");
+    expect(state?.primaryLabel).toBe("▶ Start agent");
+    expect(state?.primaryCommand).toBe("op-open-agent");
+    expect(state?.variant).toBe("primary");
+    expect(state?.menu.map((m) => m.key)).toEqual([
+      "set-priority",
+      "edit-scope",
+      "resolve-wontfix",
+    ]);
+  });
+
+  it("open / agent set / not live → Re-attach (stale variant)", () => {
+    const state = resolveChipState(
+      { id: "OP-2", type: "issue", status: "open", agent: "claude" },
+      false,
+    );
+    expect(state?.action).toBe("reattach-fresh");
+    expect(state?.primaryLabel).toBe("↻ Re-attach (start fresh)");
+    expect(state?.variant).toBe("stale");
+    expect(state?.menu.map((m) => m.key)).toEqual(["clear-stale-agent", "resolve"]);
+  });
+
+  it("in-progress / agent alive → Attach session", () => {
+    const state = resolveChipState(
+      { id: "OP-3", type: "issue", status: "in-progress", agent: "claude" },
+      true,
+    );
+    expect(state?.action).toBe("attach-session");
+    expect(state?.primaryLabel).toBe("▶ Attach session");
+    expect(state?.primaryCommand).toBe("op-attach-current");
+    expect(state?.menu.map((m) => m.key)).toEqual(["append-commit", "set-pr", "resolve"]);
+  });
+
+  it("in-progress / agent set / not live → Re-attach (stale)", () => {
+    const state = resolveChipState(
+      { id: "OP-4", type: "issue", status: "in-progress", agent: "claude" },
+      false,
+    );
+    expect(state?.action).toBe("reattach-fresh");
+    expect(state?.variant).toBe("stale");
+  });
+
+  it("in-progress / no agent → Start agent + in-progress overflow", () => {
+    const state = resolveChipState(
+      { id: "OP-5", type: "issue", status: "in-progress" },
+      true,
+    );
+    expect(state?.action).toBe("start-agent");
+    expect(state?.menu.map((m) => m.key)).toEqual(["append-commit", "set-pr", "resolve"]);
+  });
+
+  it("resolved with github_issue → Reopen + GH link in overflow", () => {
+    const state = resolveChipState(
+      {
+        id: "OP-6",
+        type: "issue",
+        status: "resolved",
+        githubIssue: "https://github.com/x/y/issues/1",
+      },
+      true,
+    );
+    expect(state?.action).toBe("reopen");
+    expect(state?.primaryLabel).toBe("↺ Reopen");
+    expect(state?.variant).toBe("reopen");
+    expect(state?.menu.map((m) => m.key)).toEqual(["open-github-issue"]);
+  });
+
+  it("wontfix without github_issue → Reopen + empty overflow", () => {
+    const state = resolveChipState(
+      { id: "OP-7", type: "issue", status: "wontfix" },
+      true,
+    );
+    expect(state?.action).toBe("reopen");
+    expect(state?.menu).toEqual([]);
+  });
+
+  it("isAgentLive is irrelevant when status is resolved", () => {
+    const live = resolveChipState(
+      { id: "OP-8", type: "issue", status: "resolved", agent: "claude" },
+      true,
+    );
+    const dead = resolveChipState(
+      { id: "OP-8", type: "issue", status: "resolved", agent: "claude" },
+      false,
+    );
+    expect(live?.action).toBe("reopen");
+    expect(dead?.action).toBe("reopen");
+  });
+
+  it("returns null for non-issue notes (the type-gate)", () => {
+    expect(
+      resolveChipState({ id: "OP-1", type: "task", status: "open" } as any, true),
+    ).toBeNull();
+  });
+
+  it("returns null for malformed ids (TASKS-shaped)", () => {
+    expect(
+      resolveChipState({ id: "OP-100.1", type: "issue", status: "open" }, true),
+    ).toBeNull();
+  });
+
+  it("returns null when status is missing or unknown", () => {
+    expect(resolveChipState({ id: "OP-1", type: "issue" }, true)).toBeNull();
+    expect(
+      resolveChipState({ id: "OP-1", type: "issue", status: "draft" }, true),
+    ).toBeNull();
+  });
+
+  it("agent: '' (empty string) is treated as no agent", () => {
+    const state = resolveChipState(
+      { id: "OP-9", type: "issue", status: "open", agent: "" },
+      false,
+    );
+    expect(state?.action).toBe("start-agent");
+  });
+});

--- a/plugins/op-obsidian/src/noteChipState.ts
+++ b/plugins/op-obsidian/src/noteChipState.ts
@@ -1,0 +1,243 @@
+/**
+ * Pure resolver for the note-level primary action chip (OP-151 / §2 of OP-149).
+ *
+ * Both the CM6 widget and the Reading-mode post-processor consume this. Keeps
+ * the chip-state matrix in one place so the two renderers can never drift —
+ * test coverage in `noteChipState.test.ts` walks every row.
+ *
+ * The resolver is intentionally unaware of Obsidian APIs; callers feed it the
+ * frontmatter shape they already have plus a single `isAgentLive` boolean
+ * (probed from tmux at render time) and get back a fully-described chip.
+ */
+
+import type { IssueStatus } from "./types";
+
+/** Subset of issue frontmatter the chip cares about. Mirrors `IssueEntry` but
+ * stays decoupled so the resolver doesn't pull in the whole store type tree. */
+export interface ChipFrontmatter {
+  id?: string;
+  type?: string;
+  status?: string;
+  agent?: string;
+  githubIssue?: string;
+}
+
+/** Stable identifier for the primary action; renderers map this to a click
+ * handler that invokes the matching `op-*` palette command. */
+export type ChipAction =
+  | "start-agent"
+  | "reattach-fresh"
+  | "attach-session"
+  | "reopen";
+
+/** One overflow-menu entry. `command` is an Obsidian command id passed to
+ * `app.commands.executeCommandById`. `requireActive` toggles whether the
+ * chip menu builder should expect the issue note to be the active leaf
+ * before dispatch (most do; `open-github-issue` doesn't). */
+export interface ChipMenuItem {
+  key: string;
+  label: string;
+  command: string;
+  icon?: string;
+}
+
+/** Resolved chip description handed to the renderers. `null` from
+ * {@link resolveChipState} means "do not render anything" — Source mode,
+ * non-issue notes, or notes with malformed frontmatter. */
+export interface ChipState {
+  action: ChipAction;
+  primaryLabel: string;
+  primaryIcon: string;
+  primaryCommand: string;
+  /** Modifier classes to apply to the chip (`primary`, `stale`, `reopen`). */
+  variant: "primary" | "stale" | "reopen";
+  menu: ChipMenuItem[];
+  /** Issue id pulled from frontmatter, surfaced for renderer use (titles,
+   * `data-issue-id` attributes, click logging). Always non-empty when state
+   * is non-null. */
+  issueId: string;
+  /** Status used by the resolver, normalized — surfaced so the strip helper
+   * can reuse it without re-parsing. */
+  status: IssueStatus;
+}
+
+/** Loose check: does this frontmatter shape describe an issue note we
+ * should decorate? Both the resolver and the codeblock fence guard call
+ * this so the gate logic only lives once. */
+export function isIssueFrontmatter(fm: ChipFrontmatter | null | undefined): boolean {
+  if (!fm) return false;
+  if (fm.type !== "issue") return false;
+  if (typeof fm.id !== "string" || !fm.id.match(/^[A-Z]+-\d+$/)) return false;
+  return true;
+}
+
+/** Normalize free-form `status:` strings to a known {@link IssueStatus}, or
+ * return `null` for unknown values so the caller can decline to render. */
+function normalizeStatus(raw: string | undefined): IssueStatus | null {
+  switch (raw) {
+    case "open":
+    case "in-progress":
+    case "blocked":
+    case "resolved":
+    case "wontfix":
+      return raw;
+    default:
+      return null;
+  }
+}
+
+const RESOLVE_MENU: ChipMenuItem = {
+  key: "resolve",
+  label: "Resolve…",
+  command: "op-close-current-issue",
+  icon: "check-circle",
+};
+
+const APPEND_COMMIT_MENU: ChipMenuItem = {
+  key: "append-commit",
+  label: "Append last commit",
+  command: "op-append-commit",
+  icon: "git-commit",
+};
+
+const SET_PR_MENU: ChipMenuItem = {
+  key: "set-pr",
+  label: "Set PR…",
+  command: "op-set-pr",
+  icon: "git-pull-request",
+};
+
+/**
+ * Resolve the chip state for one issue note. Returns `null` to suppress
+ * rendering — the renderers must respect that and remove any prior decoration
+ * from the DOM.
+ *
+ * The chip-state matrix lives in OP-151's body verbatim; tests in
+ * `noteChipState.test.ts` walk every row.
+ */
+export function resolveChipState(
+  fm: ChipFrontmatter | null | undefined,
+  isAgentLive: boolean,
+): ChipState | null {
+  if (!isIssueFrontmatter(fm)) return null;
+  const status = normalizeStatus(fm!.status);
+  if (!status) return null;
+  const id = fm!.id!;
+  const hasAgent = typeof fm!.agent === "string" && fm!.agent.trim().length > 0;
+  const githubIssue = typeof fm!.githubIssue === "string" && fm!.githubIssue.trim().length > 0;
+
+  if (status === "resolved" || status === "wontfix") {
+    const menu: ChipMenuItem[] = [];
+    if (githubIssue) {
+      menu.push({
+        key: "open-github-issue",
+        label: "Open linked GitHub issue ↗",
+        command: "op-open-github-issue",
+        icon: "external-link",
+      });
+    }
+    return {
+      action: "reopen",
+      primaryLabel: "↺ Reopen",
+      primaryIcon: "rotate-ccw",
+      primaryCommand: "op-reopen-issue",
+      variant: "reopen",
+      menu,
+      issueId: id,
+      status,
+    };
+  }
+
+  if (status === "in-progress" && hasAgent && isAgentLive) {
+    return {
+      action: "attach-session",
+      primaryLabel: "▶ Attach session",
+      primaryIcon: "play",
+      primaryCommand: "op-attach-current",
+      variant: "primary",
+      menu: [APPEND_COMMIT_MENU, SET_PR_MENU, RESOLVE_MENU],
+      issueId: id,
+      status,
+    };
+  }
+
+  if (status === "in-progress" && hasAgent && !isAgentLive) {
+    return {
+      action: "reattach-fresh",
+      primaryLabel: "↻ Re-attach (start fresh)",
+      primaryIcon: "rotate-cw",
+      primaryCommand: "op-open-agent",
+      variant: "stale",
+      menu: [
+        {
+          key: "clear-stale-agent",
+          label: "Clear stale agent",
+          command: "op-clear-agent",
+          icon: "x",
+        },
+        RESOLVE_MENU,
+      ],
+      issueId: id,
+      status,
+    };
+  }
+
+  if (status === "open" && hasAgent && !isAgentLive) {
+    return {
+      action: "reattach-fresh",
+      primaryLabel: "↻ Re-attach (start fresh)",
+      primaryIcon: "rotate-cw",
+      primaryCommand: "op-open-agent",
+      variant: "stale",
+      menu: [
+        {
+          key: "clear-stale-agent",
+          label: "Clear stale agent",
+          command: "op-clear-agent",
+          icon: "x",
+        },
+        RESOLVE_MENU,
+      ],
+      issueId: id,
+      status,
+    };
+  }
+
+  // status === "open" / "in-progress without agent" / "blocked" — chip
+  // launches an agent. `op-work` runs first inside `op-open-agent` for an
+  // open issue, so the chip can call `op-open-agent` for both open and
+  // in-progress-without-agent rows.
+  const startMenu: ChipMenuItem[] =
+    status === "in-progress"
+      ? [APPEND_COMMIT_MENU, SET_PR_MENU, RESOLVE_MENU]
+      : [
+          {
+            key: "set-priority",
+            label: "Set priority…",
+            command: "op-set-priority",
+            icon: "flag",
+          },
+          {
+            key: "edit-scope",
+            label: "Edit scope…",
+            command: "op-set-scope",
+            icon: "edit",
+          },
+          {
+            key: "resolve-wontfix",
+            label: "Resolve as wontfix…",
+            command: "op-close-current-issue",
+            icon: "x-circle",
+          },
+        ];
+  return {
+    action: "start-agent",
+    primaryLabel: "▶ Start agent",
+    primaryIcon: "play",
+    primaryCommand: "op-open-agent",
+    variant: "primary",
+    menu: startMenu,
+    issueId: id,
+    status,
+  };
+}

--- a/plugins/op-obsidian/src/noteDecorations.ts
+++ b/plugins/op-obsidian/src/noteDecorations.ts
@@ -207,13 +207,14 @@ function schedulePending(deps: ChipDeps, seg: StripSegment): void {
   if (seg.kind === "commit") return;
   const url = seg.url;
   // Mark the URL as in-flight so a parallel render skips it. We write a
-  // null-state cache entry with a *short* TTL — the real result will
-  // overwrite it. If the fetch never completes, the in-flight slot
-  // expires and the next render retries.
+  // null-state cache entry with a TTL *longer* than the gh timeout (8 s)
+  // so a render that fires during the timeout window doesn't start a
+  // second fetch for the same URL. The real result (or confirmed null)
+  // overwrites this entry when the fetch resolves.
   if (deps.ghCache.get(url)?.expiresAt && deps.ghCache.get(url)!.expiresAt > Date.now()) {
     return;
   }
-  writeGhCache(deps.ghCache, url, null, Date.now(), 5_000);
+  writeGhCache(deps.ghCache, url, null, Date.now(), 10_000);
   const fetcher = deps.fetchGhState ?? defaultFetchGhState;
   void fetcher(url, seg.kind === "pr" ? "pr" : "issue").then((state) => {
     writeGhCache(deps.ghCache, url, state, Date.now(), GH_STATE_TTL_MS);

--- a/plugins/op-obsidian/src/noteDecorations.ts
+++ b/plugins/op-obsidian/src/noteDecorations.ts
@@ -1,0 +1,524 @@
+/**
+ * CM6 + Reading-mode renderers for the note-level primary-action chip
+ * (OP-151) and the inline status strip (OP-162).
+ *
+ * Both modes feed off the same pure resolver in `noteChipState.ts` and
+ * compose strip segments with `noteStatusStrip.ts`. The DOM is built by
+ * one shared {@link renderChipDom} helper so the two renderers can never
+ * drift in label, markup, or click affordance.
+ *
+ * Lifecycle discipline
+ * --------------------
+ * Every event listener attached in `toDOM()` (CM6) or `onload()` (the
+ * post-processor MarkdownRenderChild) goes through a single
+ * `AbortController` stored on the widget/child. `destroy()` /
+ * `onunload()` calls `controller.abort()` so listeners disappear
+ * deterministically when the user toggles Live-Preview ↔ Reading mode.
+ * This is the single most likely bug class for this kind of widget;
+ * tests in `noteDecorations.test.ts` assert the abort-signal flips on
+ * teardown.
+ */
+import {
+  App,
+  MarkdownPostProcessorContext,
+  MarkdownRenderChild,
+  MarkdownView,
+  TFile,
+} from "obsidian";
+import { editorInfoField } from "obsidian";
+import { execFile } from "child_process";
+import {
+  Decoration,
+  DecorationSet,
+  EditorView,
+  ViewPlugin,
+  ViewUpdate,
+  WidgetType,
+} from "@codemirror/view";
+import { StateEffect } from "@codemirror/state";
+import {
+  ChipFrontmatter,
+  ChipState,
+  resolveChipState,
+} from "./noteChipState";
+import {
+  GhStateCache,
+  GH_STATE_TTL_MS,
+  StripFrontmatter,
+  StripSegment,
+  composeStripSegments,
+  formatSegment,
+  writeGhCache,
+} from "./noteStatusStrip";
+import { showChipMenu } from "./noteChipMenu";
+
+/**
+ * Effect dispatched when external state (frontmatter, agent liveness, gh
+ * fetch result) changes — forces the ViewPlugin to recompute its
+ * decoration set even when no editor transaction would otherwise fire.
+ */
+const refreshChipEffect = StateEffect.define<null>();
+
+/** Plugin-instance dependencies for the renderers — injected by main.ts
+ * so the modules can stay pure of plugin internals. */
+export interface ChipDeps {
+  app: App;
+  /** Look up whether a given issue id has a live tmux window. Sync —
+   * the renderer caches the result for the widget lifetime. May return
+   * `null` to mean "tmux unavailable, treat as live". */
+  isAgentLive: (issueId: string, agent: string | undefined) => boolean | null;
+  /** Settings accessor — the renderer reads `view.disableInlineGithubStatus`
+   * each render, so toggling it in Settings updates without a reload. */
+  getSettings: () => { view: { disableInlineGithubStatus: boolean } };
+  /** Single in-memory cache shared across renderers (CM6 + post-processor)
+   * so the strip doesn't double-fetch when both renderers run on the
+   * same file during a mode toggle. */
+  ghCache: GhStateCache;
+  /** Optional override used by tests; defaults to `child_process.execFile`. */
+  fetchGhState?: (url: string, kind: "pr" | "issue") => Promise<string | null>;
+  /** Refresh hook — called when a gh fetch lands so the CM6 ViewPlugin
+   * can dispatch the refresh effect. main.ts wires this to iterate all
+   * markdown editors. */
+  scheduleRefresh: () => void;
+}
+
+/**
+ * Build the chip + strip wrapper DOM. Pure of how it's mounted (CM6 widget
+ * vs. preview prepend) — the caller is responsible for inserting the
+ * returned element above the H1. All listeners are attached with
+ * `{ signal: controller.signal }` so the caller's `controller.abort()`
+ * tears them down deterministically.
+ */
+export function renderChipDom(
+  state: ChipState,
+  segments: StripSegment[],
+  deps: ChipDeps,
+  controller: AbortController,
+): HTMLElement {
+  const wrap = document.createElement("div");
+  wrap.classList.add("op-note-chip-wrap");
+  wrap.dataset.issueId = state.issueId;
+
+  const row = wrap.createDiv({ cls: "op-note-chip-row" });
+
+  const primary = row.createEl("button", {
+    cls: `op-note-chip op-note-chip--${state.variant}`,
+    text: state.primaryLabel,
+  });
+  primary.setAttribute("type", "button");
+  primary.setAttribute("aria-label", state.primaryLabel);
+  primary.title = state.primaryLabel;
+  primary.addEventListener(
+    "click",
+    (ev) => {
+      ev.preventDefault();
+      ev.stopPropagation();
+      const ok = (deps.app as unknown as {
+        commands: { executeCommandById: (id: string) => boolean };
+      }).commands.executeCommandById(state.primaryCommand);
+      if (!ok) {
+        // Command unavailable (typically: not the active leaf). Surface
+        // it instead of failing silently — same UX as the menu items.
+        void import("./notificationLog").then(({ notify }) =>
+          notify(`op: ${state.primaryCommand} unavailable — open the issue note first.`),
+        );
+      }
+    },
+    { signal: controller.signal },
+  );
+
+  if (state.menu.length > 0) {
+    const overflow = row.createEl("button", {
+      cls: "op-note-chip op-note-chip--overflow",
+      text: "⋯",
+    });
+    overflow.setAttribute("type", "button");
+    overflow.setAttribute("aria-label", "More actions");
+    overflow.title = "More actions";
+    overflow.addEventListener(
+      "click",
+      (ev) => {
+        ev.preventDefault();
+        ev.stopPropagation();
+        showChipMenu(deps.app, state, ev as MouseEvent);
+      },
+      { signal: controller.signal },
+    );
+  }
+
+  if (segments.length > 0) {
+    const strip = wrap.createDiv({ cls: "op-note-strip" });
+    for (let i = 0; i < segments.length; i++) {
+      if (i > 0) {
+        strip.createSpan({ cls: "op-note-strip__sep", text: " · " });
+      }
+      const seg = segments[i];
+      renderStripSegment(strip, seg, deps, controller);
+    }
+  }
+
+  return wrap;
+}
+
+function renderStripSegment(
+  parent: HTMLElement,
+  seg: StripSegment,
+  deps: ChipDeps,
+  controller: AbortController,
+): void {
+  const span = parent.createSpan({
+    cls: `op-note-strip__seg op-note-strip__seg--${seg.kind}${seg.kind !== "commit" && seg.pending ? " op-note-strip__seg--pending" : ""}`,
+    text: formatSegment(seg),
+  });
+  span.title = formatSegment(seg);
+
+  if (seg.kind === "commit") {
+    span.addEventListener(
+      "click",
+      (ev) => {
+        ev.preventDefault();
+        ev.stopPropagation();
+        // Decision: commit click copies the sha to the clipboard. `git show`
+        // would be nicer but requires resolving the project's repo_path
+        // and shelling out — we want the strip to never block on disk I/O.
+        void navigator.clipboard.writeText(seg.sha).then(() =>
+          import("./notificationLog").then(({ notify }) =>
+            notify(`Copied ${seg.sha}`),
+          ),
+        );
+      },
+      { signal: controller.signal },
+    );
+    return;
+  }
+
+  span.addEventListener(
+    "click",
+    (ev) => {
+      ev.preventDefault();
+      ev.stopPropagation();
+      window.open(seg.url, "_blank");
+    },
+    { signal: controller.signal },
+  );
+
+  if (seg.pending) {
+    // Kick off a fetch for this segment if the cache miss isn't already
+    // in flight. Single-flight is enforced by `ghCache.has()` — the
+    // moment we dispatch the fetch we plant a placeholder entry so a
+    // sibling render in the post-processor doesn't re-issue.
+    void schedulePending(deps, seg);
+  }
+}
+
+function schedulePending(deps: ChipDeps, seg: StripSegment): void {
+  if (seg.kind === "commit") return;
+  const url = seg.url;
+  // Mark the URL as in-flight so a parallel render skips it. We write a
+  // null-state cache entry with a *short* TTL — the real result will
+  // overwrite it. If the fetch never completes, the in-flight slot
+  // expires and the next render retries.
+  if (deps.ghCache.get(url)?.expiresAt && deps.ghCache.get(url)!.expiresAt > Date.now()) {
+    return;
+  }
+  writeGhCache(deps.ghCache, url, null, Date.now(), 5_000);
+  const fetcher = deps.fetchGhState ?? defaultFetchGhState;
+  void fetcher(url, seg.kind === "pr" ? "pr" : "issue").then((state) => {
+    writeGhCache(deps.ghCache, url, state, Date.now(), GH_STATE_TTL_MS);
+    deps.scheduleRefresh();
+  });
+}
+
+const defaultFetchGhState = async (
+  url: string,
+  kind: "pr" | "issue",
+): Promise<string | null> => {
+  return new Promise((resolve) => {
+    const args = [kind === "pr" ? "pr" : "issue", "view", url, "--json", "state"];
+    execFile("gh", args, { timeout: 8_000 }, (err, stdout) => {
+      if (err) {
+        resolve(null);
+        return;
+      }
+      try {
+        const parsed = JSON.parse(stdout) as { state?: string };
+        resolve(parsed.state ?? null);
+      } catch {
+        resolve(null);
+      }
+    });
+  });
+};
+
+/** CM6 widget that renders the chip + strip above line 0 in Live Preview. */
+class NoteChipWidget extends WidgetType {
+  private controller?: AbortController;
+  constructor(
+    private state: ChipState,
+    private segments: StripSegment[],
+    private deps: ChipDeps,
+    private signature: string,
+  ) {
+    super();
+  }
+
+  /** Two widgets are equal when their composed signature matches — chip
+   * state, strip segments, and gh-state placeholders all collapse into
+   * one string so CM doesn't recreate the DOM on every keystroke. */
+  eq(other: NoteChipWidget): boolean {
+    return other.signature === this.signature;
+  }
+
+  toDOM(): HTMLElement {
+    this.controller = new AbortController();
+    const el = renderChipDom(this.state, this.segments, this.deps, this.controller);
+    el.classList.add("op-note-chip-wrap--cm6");
+    // Renderers prepend above line 0, so CM places this in the doc body —
+    // we want a block layout so the H1 wraps below.
+    el.style.display = "block";
+    return el;
+  }
+
+  destroy(): void {
+    this.controller?.abort();
+    this.controller = undefined;
+  }
+
+  ignoreEvent(): boolean {
+    // Allow click events to reach our handlers; CM6 default would
+    // intercept selection-related events for inline widgets. Block
+    // widgets at side -1 are usually fine but be explicit.
+    return false;
+  }
+
+  /** Test seam — the noteChipState test asserts `controller.signal.aborted`
+   * after destroy(). Exposed so the test doesn't need to read private. */
+  signalAborted(): boolean {
+    return this.controller?.signal.aborted ?? true;
+  }
+}
+
+/**
+ * CM6 ViewPlugin that maintains the chip widget at position 0 of an
+ * issue note's editor view.
+ */
+export function noteChipExtension(deps: ChipDeps) {
+  return ViewPlugin.fromClass(
+    class {
+      decorations: DecorationSet = Decoration.none;
+      private currentSig = "";
+
+      constructor(private view: EditorView) {
+        this.recompute();
+      }
+
+      update(update: ViewUpdate): void {
+        const docChanged = update.docChanged;
+        const refreshed = update.transactions.some((tr) =>
+          tr.effects.some((e) => e.is(refreshChipEffect)),
+        );
+        if (!docChanged && !refreshed && !update.viewportChanged) return;
+        this.recompute();
+      }
+
+      private recompute(): void {
+        const info = this.view.state.field(editorInfoField, false);
+        const file = info?.file;
+        if (!file) {
+          this.currentSig = "";
+          this.decorations = Decoration.none;
+          return;
+        }
+        const set = buildDecorationsForFile(file, deps);
+        this.currentSig = signatureOf(set);
+        this.decorations = set;
+      }
+
+      destroy(): void {
+        // Each widget owns its own AbortController; CM6 calls
+        // WidgetType.destroy() for us when the decoration drops out.
+      }
+    },
+    { decorations: (v) => v.decorations },
+  );
+}
+
+function signatureOf(set: DecorationSet): string {
+  let sig = "";
+  set.between(0, 0, (_from, _to, deco) => {
+    const w = deco.spec.widget as NoteChipWidget | undefined;
+    if (w) sig = (w as any).signature ?? "";
+  });
+  return sig;
+}
+
+function buildDecorationsForFile(file: TFile, deps: ChipDeps): DecorationSet {
+  const rawFm = deps.app.metadataCache.getFileCache(file)?.frontmatter as
+    | Record<string, unknown>
+    | undefined;
+  const chipFm = fmToChip(rawFm);
+  const stripFm = fmToStrip(rawFm);
+  const live = chipFm?.id ? deps.isAgentLive(chipFm.id, chipFm.agent) : null;
+  const state = resolveChipState(chipFm, live === null ? true : live);
+  if (!state) return Decoration.none;
+  const segments = deps.getSettings().view.disableInlineGithubStatus
+    ? composeStripSegments(stripFm, deps.ghCache, Date.now()).filter(
+        (s) => s.kind === "commit",
+      )
+    : composeStripSegments(stripFm, deps.ghCache, Date.now());
+  const sig = computeSignature(state, segments);
+  const widget = new NoteChipWidget(state, segments, deps, sig);
+  return Decoration.set([
+    Decoration.widget({ widget, side: -1, block: true }).range(0),
+  ]);
+}
+
+/** Public for tests + post-processor reuse. */
+export function fmToChip(
+  fm: Record<string, unknown> | undefined,
+): ChipFrontmatter | undefined {
+  if (!fm) return undefined;
+  return {
+    id: typeof fm.id === "string" ? fm.id : undefined,
+    type: typeof fm.type === "string" ? fm.type : undefined,
+    status: typeof fm.status === "string" ? fm.status : undefined,
+    agent: typeof fm.agent === "string" ? fm.agent : undefined,
+    githubIssue:
+      typeof fm.github_issue === "string" ? fm.github_issue : undefined,
+  };
+}
+
+export function fmToStrip(
+  fm: Record<string, unknown> | undefined,
+): StripFrontmatter | undefined {
+  if (!fm) return undefined;
+  const commits = Array.isArray(fm.commits)
+    ? (fm.commits as unknown[]).filter((x): x is string => typeof x === "string")
+    : undefined;
+  return {
+    commits,
+    pr: typeof fm.pr === "string" ? fm.pr : undefined,
+    githubIssue:
+      typeof fm.github_issue === "string" ? fm.github_issue : undefined,
+  };
+}
+
+function computeSignature(state: ChipState, segments: StripSegment[]): string {
+  const segPart = segments
+    .map((s) => {
+      if (s.kind === "commit") return `c:${s.sha}`;
+      return `${s.kind}:${s.url}:${s.state ?? "?"}:${s.pending ? "p" : "r"}`;
+    })
+    .join("|");
+  return `${state.action}|${state.primaryLabel}|${state.menu.length}|${segPart}`;
+}
+
+/**
+ * Reading-mode mirror. Registered via `plugin.registerMarkdownPostProcessor`.
+ * Renders a chip + strip wrapper above the first H1 of the rendered
+ * preview section. Idempotent: if the wrapper is already a sibling of
+ * the H1 we leave it alone.
+ */
+export function makeNoteChipPostProcessor(deps: ChipDeps) {
+  return (el: HTMLElement, ctx: MarkdownPostProcessorContext): void => {
+    const h1 = el.querySelector("h1");
+    if (!h1) return;
+    if (h1.previousElementSibling?.classList.contains("op-note-chip-wrap")) return;
+    const fm =
+      ctx.frontmatter ??
+      deps.app.metadataCache.getCache(ctx.sourcePath)?.frontmatter ??
+      undefined;
+    const chipFm = fmToChip(fm as Record<string, unknown> | undefined);
+    const stripFm = fmToStrip(fm as Record<string, unknown> | undefined);
+    const live = chipFm?.id ? deps.isAgentLive(chipFm.id, chipFm.agent) : null;
+    const state = resolveChipState(chipFm, live === null ? true : live);
+    if (!state) return;
+    const segments = deps.getSettings().view.disableInlineGithubStatus
+      ? composeStripSegments(stripFm, deps.ghCache, Date.now()).filter(
+          (s) => s.kind === "commit",
+        )
+      : composeStripSegments(stripFm, deps.ghCache, Date.now());
+    const child = new ChipPostprocessorChild(deps, state, segments);
+    h1.parentElement?.insertBefore(child.containerEl, h1);
+    ctx.addChild(child);
+  };
+}
+
+class ChipPostprocessorChild extends MarkdownRenderChild {
+  private controller = new AbortController();
+  constructor(
+    private deps: ChipDeps,
+    private state: ChipState,
+    private segments: StripSegment[],
+  ) {
+    super(document.createElement("div"));
+    this.containerEl.classList.add("op-note-chip-wrap--postprocessor");
+  }
+
+  onload(): void {
+    const dom = renderChipDom(this.state, this.segments, this.deps, this.controller);
+    this.containerEl.empty();
+    while (dom.firstChild) this.containerEl.appendChild(dom.firstChild);
+    // Mirror data attributes for selectors.
+    this.containerEl.dataset.issueId = this.state.issueId;
+    this.containerEl.classList.add("op-note-chip-wrap");
+  }
+
+  onunload(): void {
+    this.controller.abort();
+    this.containerEl.empty();
+  }
+}
+
+/**
+ * Codeblock-driven action chip. Used by the first-run README and the
+ * demo project's STATUS.md for `Apply preset` / `Start tour` /
+ * `Remove demo project`. Rendered when an Obsidian renderer hits a
+ * fenced code block with language `op-action`. The body is a
+ * line-per-key shape: `action: <command-id>` and `label: <text>`.
+ */
+export function makeOpActionCodeBlockProcessor(app: App) {
+  return (source: string, el: HTMLElement, _ctx: unknown): void => {
+    void _ctx;
+    void import("./firstRunReadme").then(({ parseOpActionBlock }) => {
+      const parsed = parseOpActionBlock(source);
+      if (!parsed) {
+        el.createEl("pre", { text: source, cls: "op-action-block--error" });
+        return;
+      }
+      const wrap = el.createDiv({ cls: "op-note-chip-wrap op-note-chip-wrap--action" });
+      const button = wrap.createEl("button", {
+        cls: "op-note-chip op-note-chip--primary",
+        text: parsed.label,
+      });
+      button.setAttribute("type", "button");
+      button.addEventListener("click", (ev) => {
+        ev.preventDefault();
+        ev.stopPropagation();
+        const ok = (app as unknown as {
+          commands: { executeCommandById: (id: string) => boolean };
+        }).commands.executeCommandById(parsed.action);
+        if (!ok) {
+          void import("./notificationLog").then(({ notify }) =>
+            notify(`op: ${parsed.action} unavailable.`),
+          );
+        }
+      });
+    });
+  };
+}
+
+/**
+ * Helper used by main.ts to dispatch the refresh effect into every
+ * markdown editor. Keeps the StateEffect identity behind this module.
+ */
+export function dispatchChipRefresh(app: App): void {
+  app.workspace.iterateAllLeaves((leaf) => {
+    const view = leaf.view;
+    if (view instanceof MarkdownView) {
+      const cm = (view.editor as any).cm as EditorView | undefined;
+      if (cm) cm.dispatch({ effects: refreshChipEffect.of(null) });
+    }
+  });
+}
+

--- a/plugins/op-obsidian/src/noteDecorations.ts
+++ b/plugins/op-obsidian/src/noteDecorations.ts
@@ -23,18 +23,10 @@ import {
   MarkdownPostProcessorContext,
   MarkdownRenderChild,
   MarkdownView,
-  TFile,
 } from "obsidian";
 import { editorInfoField } from "obsidian";
 import { execFile } from "child_process";
-import {
-  Decoration,
-  DecorationSet,
-  EditorView,
-  ViewPlugin,
-  ViewUpdate,
-  WidgetType,
-} from "@codemirror/view";
+import { EditorView, ViewPlugin, ViewUpdate } from "@codemirror/view";
 import { StateEffect } from "@codemirror/state";
 import {
   ChipFrontmatter,
@@ -250,74 +242,44 @@ const defaultFetchGhState = async (
   });
 };
 
-/** CM6 widget that renders the chip + strip above line 0 in Live Preview. */
-class NoteChipWidget extends WidgetType {
-  private controller?: AbortController;
-  constructor(
-    private state: ChipState,
-    private segments: StripSegment[],
-    private deps: ChipDeps,
-    private signature: string,
-  ) {
-    super();
-  }
-
-  /** Two widgets are equal when their composed signature matches — chip
-   * state, strip segments, and gh-state placeholders all collapse into
-   * one string so CM doesn't recreate the DOM on every keystroke. */
-  eq(other: NoteChipWidget): boolean {
-    return other.signature === this.signature;
-  }
-
-  toDOM(): HTMLElement {
-    this.controller = new AbortController();
-    const el = renderChipDom(this.state, this.segments, this.deps, this.controller);
-    el.classList.add("op-note-chip-wrap--cm6");
-    // Renderers prepend above line 0, so CM places this in the doc body —
-    // we want a block layout so the H1 wraps below.
-    el.style.display = "block";
-    return el;
-  }
-
-  destroy(): void {
-    this.controller?.abort();
-    this.controller = undefined;
-  }
-
-  ignoreEvent(): boolean {
-    // Allow click events to reach our handlers; CM6 default would
-    // intercept selection-related events for inline widgets. Block
-    // widgets at side -1 are usually fine but be explicit.
-    return false;
-  }
-
-  /** Test seam — the noteChipState test asserts `controller.signal.aborted`
-   * after destroy(). Exposed so the test doesn't need to read private. */
-  signalAborted(): boolean {
-    return this.controller?.signal.aborted ?? true;
-  }
-}
-
 /**
- * CM6 ViewPlugin that maintains the chip widget at position 0 of an
- * issue note's editor view.
+ * CM6 ViewPlugin that mounts a chip element OUTSIDE the editor's
+ * decoration tree. Obsidian's bundled CM6 rejects `Decoration.widget`
+ * at line 0 from any provider we tried (StateField, ViewPlugin) with
+ * "Block decorations may not be specified via plugins" — its facet
+ * marks both as plugin sources. So we sidestep Decorations entirely:
+ * the plugin owns one DOM element prepended to `view.dom.parentNode`
+ * (the cm-editor's parent — `cm-contentContainer` in current layouts),
+ * recomputes its content on doc + frontmatter changes, and removes
+ * itself on `destroy()`. This is the same shape CM6 plugins use for
+ * tooltips / panels and matches Obsidian's own pattern in things like
+ * the embedded markdown link cards.
  */
 export function noteChipExtension(deps: ChipDeps) {
   return ViewPlugin.fromClass(
     class {
-      decorations: DecorationSet = Decoration.none;
+      private host: HTMLElement;
+      private controller = new AbortController();
       private currentSig = "";
 
       constructor(private view: EditorView) {
+        this.host = document.createElement("div");
+        this.host.classList.add("op-note-chip-host");
+        // Mount OUTSIDE `view.dom` (the `cm-editor` element) — CM6
+        // assumes exclusive ownership of its DOM children, and inserting
+        // arbitrary nodes inside `cm-editor` breaks its decoration
+        // bookkeeping. We attach to the parent (Obsidian's
+        // `markdown-source-view` container) so CM6 ignores us entirely.
+        const parent = view.dom.parentElement;
+        if (parent) parent.insertBefore(this.host, view.dom);
         this.recompute();
       }
 
-      update(update: ViewUpdate): void {
-        const docChanged = update.docChanged;
-        const refreshed = update.transactions.some((tr) =>
+      update(u: ViewUpdate): void {
+        const refreshed = u.transactions.some((tr) =>
           tr.effects.some((e) => e.is(refreshChipEffect)),
         );
-        if (!docChanged && !refreshed && !update.viewportChanged) return;
+        if (!u.docChanged && !refreshed) return;
         this.recompute();
       }
 
@@ -325,52 +287,51 @@ export function noteChipExtension(deps: ChipDeps) {
         const info = this.view.state.field(editorInfoField, false);
         const file = info?.file;
         if (!file) {
-          this.currentSig = "";
-          this.decorations = Decoration.none;
+          this.clear();
           return;
         }
-        const set = buildDecorationsForFile(file, deps);
-        this.currentSig = signatureOf(set);
-        this.decorations = set;
+        const rawFm = deps.app.metadataCache.getFileCache(file)?.frontmatter as
+          | Record<string, unknown>
+          | undefined;
+        const chipFm = fmToChip(rawFm);
+        const stripFm = fmToStrip(rawFm);
+        const live = chipFm?.id ? deps.isAgentLive(chipFm.id, chipFm.agent) : null;
+        const state = resolveChipState(chipFm, live === null ? true : live);
+        if (!state) {
+          this.clear();
+          return;
+        }
+        const segments = deps.getSettings().view.disableInlineGithubStatus
+          ? composeStripSegments(stripFm, deps.ghCache, Date.now()).filter(
+              (s) => s.kind === "commit",
+            )
+          : composeStripSegments(stripFm, deps.ghCache, Date.now());
+        const sig = computeSignature(state, segments);
+        if (sig === this.currentSig) return;
+        this.currentSig = sig;
+        // Tear down the previous render's listeners before swapping content.
+        this.controller.abort();
+        this.controller = new AbortController();
+        this.host.empty();
+        const dom = renderChipDom(state, segments, deps, this.controller);
+        dom.classList.add("op-note-chip-wrap--cm6");
+        this.host.appendChild(dom);
+      }
+
+      private clear(): void {
+        if (this.currentSig === "") return;
+        this.currentSig = "";
+        this.controller.abort();
+        this.controller = new AbortController();
+        this.host.empty();
       }
 
       destroy(): void {
-        // Each widget owns its own AbortController; CM6 calls
-        // WidgetType.destroy() for us when the decoration drops out.
+        this.controller.abort();
+        this.host.remove();
       }
     },
-    { decorations: (v) => v.decorations },
   );
-}
-
-function signatureOf(set: DecorationSet): string {
-  let sig = "";
-  set.between(0, 0, (_from, _to, deco) => {
-    const w = deco.spec.widget as NoteChipWidget | undefined;
-    if (w) sig = (w as any).signature ?? "";
-  });
-  return sig;
-}
-
-function buildDecorationsForFile(file: TFile, deps: ChipDeps): DecorationSet {
-  const rawFm = deps.app.metadataCache.getFileCache(file)?.frontmatter as
-    | Record<string, unknown>
-    | undefined;
-  const chipFm = fmToChip(rawFm);
-  const stripFm = fmToStrip(rawFm);
-  const live = chipFm?.id ? deps.isAgentLive(chipFm.id, chipFm.agent) : null;
-  const state = resolveChipState(chipFm, live === null ? true : live);
-  if (!state) return Decoration.none;
-  const segments = deps.getSettings().view.disableInlineGithubStatus
-    ? composeStripSegments(stripFm, deps.ghCache, Date.now()).filter(
-        (s) => s.kind === "commit",
-      )
-    : composeStripSegments(stripFm, deps.ghCache, Date.now());
-  const sig = computeSignature(state, segments);
-  const widget = new NoteChipWidget(state, segments, deps, sig);
-  return Decoration.set([
-    Decoration.widget({ widget, side: -1, block: true }).range(0),
-  ]);
 }
 
 /** Public for tests + post-processor reuse. */
@@ -482,6 +443,10 @@ export function makeOpActionCodeBlockProcessor(app: App) {
     void _ctx;
     void import("./firstRunReadme").then(({ parseOpActionBlock }) => {
       const parsed = parseOpActionBlock(source);
+      // Idempotency — Obsidian re-runs codeblock post-processors on edits
+      // and sometimes during a single render pass. Clear `el` before
+      // appending so we never stack duplicate chips inside one fence.
+      el.empty();
       if (!parsed) {
         el.createEl("pre", { text: source, cls: "op-action-block--error" });
         return;

--- a/plugins/op-obsidian/src/noteStatusStrip.test.ts
+++ b/plugins/op-obsidian/src/noteStatusStrip.test.ts
@@ -1,0 +1,164 @@
+import { describe, expect, it } from "vitest";
+import {
+  composeStripSegments,
+  formatSegment,
+  GH_STATE_TTL_MS,
+  parseGithubNumber,
+  parseLatestCommit,
+  readGhCache,
+  writeGhCache,
+  type GhStateCache,
+} from "./noteStatusStrip";
+
+describe("parseLatestCommit", () => {
+  it("returns null for empty / missing", () => {
+    expect(parseLatestCommit(undefined)).toBeNull();
+    expect(parseLatestCommit([])).toBeNull();
+  });
+
+  it("splits the latest entry on the first space", () => {
+    expect(parseLatestCommit(["abc1234 first commit", "def5678 latest commit"]))
+      .toEqual({ sha: "def5678", subject: "latest commit" });
+  });
+
+  it("handles a sha without a subject", () => {
+    expect(parseLatestCommit(["abc1234"])).toEqual({ sha: "abc1234", subject: "" });
+  });
+
+  it("ignores blank entries at the tail", () => {
+    expect(parseLatestCommit(["abc1234 ok", "   "])).toBeNull();
+  });
+
+  it("preserves multi-word subjects", () => {
+    expect(parseLatestCommit(["abc1234 fix: collapse rewriteScopeSection"]))
+      .toEqual({ sha: "abc1234", subject: "fix: collapse rewriteScopeSection" });
+  });
+});
+
+describe("parseGithubNumber", () => {
+  it("extracts the trailing number", () => {
+    expect(parseGithubNumber("https://github.com/x/y/issues/153")).toBe(153);
+    expect(parseGithubNumber("https://github.com/x/y/pull/42")).toBe(42);
+  });
+
+  it("returns null for non-numeric tails", () => {
+    expect(parseGithubNumber("https://github.com/x/y/pulls")).toBeNull();
+    expect(parseGithubNumber(undefined)).toBeNull();
+    expect(parseGithubNumber("")).toBeNull();
+  });
+
+  it("tolerates trailing slash / hash / query", () => {
+    expect(parseGithubNumber("https://github.com/x/y/issues/7/")).toBe(7);
+    expect(parseGithubNumber("https://github.com/x/y/issues/7#comment")).toBe(7);
+    expect(parseGithubNumber("https://github.com/x/y/issues/7?ref=abc")).toBe(7);
+  });
+});
+
+describe("gh cache", () => {
+  it("returns null on miss", () => {
+    const c: GhStateCache = new Map();
+    expect(readGhCache(c, "u", 0)).toBeNull();
+  });
+
+  it("returns null when expired", () => {
+    const c: GhStateCache = new Map();
+    writeGhCache(c, "u", "OPEN", 0, 100);
+    expect(readGhCache(c, "u", 99)?.state).toBe("OPEN");
+    expect(readGhCache(c, "u", 100)).toBeNull();
+  });
+
+  it("default TTL is 60s", () => {
+    expect(GH_STATE_TTL_MS).toBe(60_000);
+  });
+
+  it("preserves null state (negative caching)", () => {
+    const c: GhStateCache = new Map();
+    writeGhCache(c, "u", null, 0);
+    expect(readGhCache(c, "u", 1)?.state).toBeNull();
+  });
+});
+
+describe("composeStripSegments", () => {
+  it("returns empty for empty frontmatter", () => {
+    expect(composeStripSegments(undefined, new Map(), 0)).toEqual([]);
+    expect(composeStripSegments({}, new Map(), 0)).toEqual([]);
+  });
+
+  it("emits commit + pr + gh issue when all present", () => {
+    const cache: GhStateCache = new Map();
+    writeGhCache(cache, "https://github.com/x/y/pull/42", "MERGED", 0);
+    writeGhCache(cache, "https://github.com/x/y/issues/7", "OPEN", 0);
+    const segs = composeStripSegments(
+      {
+        commits: ["abc1234 sub"],
+        pr: "https://github.com/x/y/pull/42",
+        githubIssue: "https://github.com/x/y/issues/7",
+      },
+      cache,
+      0,
+    );
+    expect(segs.map((s) => s.kind)).toEqual(["commit", "pr", "issue"]);
+    expect(segs[1]).toMatchObject({ kind: "pr", number: 42, state: "MERGED", pending: false });
+    expect(segs[2]).toMatchObject({ kind: "issue", number: 7, state: "OPEN", pending: false });
+  });
+
+  it("marks pr/issue segments pending when cache misses", () => {
+    const segs = composeStripSegments(
+      { pr: "https://github.com/x/y/pull/42" },
+      new Map(),
+      0,
+    );
+    expect(segs[0]).toMatchObject({ kind: "pr", pending: true, state: null });
+  });
+
+  it("trims whitespace-only urls (no dead segments)", () => {
+    const segs = composeStripSegments(
+      { pr: "   ", githubIssue: "https://github.com/x/y/issues/1" },
+      new Map(),
+      0,
+    );
+    expect(segs.map((s) => s.kind)).toEqual(["issue"]);
+  });
+});
+
+describe("formatSegment", () => {
+  it("renders commit with quoted subject", () => {
+    expect(
+      formatSegment({ kind: "commit", sha: "abc1234", subject: "fix things" }),
+    ).toBe('last commit: abc1234 "fix things"');
+  });
+
+  it("truncates long subjects", () => {
+    const long = "x".repeat(60);
+    expect(
+      formatSegment({ kind: "commit", sha: "abc1234", subject: long }),
+    ).toContain("…");
+  });
+
+  it("renders pr/issue with state", () => {
+    expect(
+      formatSegment({
+        kind: "pr",
+        url: "u",
+        number: 42,
+        state: "OPEN",
+        pending: false,
+      }),
+    ).toBe("PR #42 (open)");
+    expect(
+      formatSegment({
+        kind: "issue",
+        url: "u",
+        number: 7,
+        state: "CLOSED",
+        pending: false,
+      }),
+    ).toBe("GH #7 (closed)");
+  });
+
+  it("renders pending segments with ellipsis", () => {
+    expect(
+      formatSegment({ kind: "pr", url: "u", number: 42, state: null, pending: true }),
+    ).toBe("PR #42 (…)");
+  });
+});

--- a/plugins/op-obsidian/src/noteStatusStrip.ts
+++ b/plugins/op-obsidian/src/noteStatusStrip.ts
@@ -1,0 +1,207 @@
+/**
+ * Pure helpers for the note-level status strip (OP-162 / §11 of OP-149).
+ *
+ * The strip renders below the primary-action chip and shows three
+ * lazy-fetched, themed segments:
+ *   `last commit: <sha7> "<subject>" · PR #<n> (<state>) · GH #<n> (<state>)`
+ *
+ * Each segment is omitted when its source field is empty (no dead chips).
+ * The renderer in `noteDecorations.ts` consumes the {@link StripSegment}
+ * array and the {@link GhStateCache} to decide what DOM to lay out; this
+ * module owns the parsing, segment-shape, and cache TTL logic so the
+ * renderer can stay thin and the behaviour is unit-testable.
+ */
+
+/** Frontmatter slice the strip cares about — a subset of `IssueEntry`. */
+export interface StripFrontmatter {
+  commits?: string[];
+  pr?: string;
+  githubIssue?: string;
+}
+
+/** Parsed `commits:` entry. The on-disk format is "<sha7> <subject>"; we
+ * tolerate longer shas and split on the first space. */
+export interface CommitInfo {
+  sha: string;
+  subject: string;
+}
+
+/** Cached GitHub state for one URL (PR or issue). `null` means we tried
+ * and failed — render the link without state and don't retry until the
+ * cache entry expires. */
+export interface GhStateCacheEntry {
+  state: string | null;
+  expiresAt: number;
+}
+
+/** Single in-memory cache shared by all chip renders for one plugin
+ * instance. Keys are the raw `pr:` / `github_issue:` URLs. */
+export type GhStateCache = Map<string, GhStateCacheEntry>;
+
+/** Default TTL for cached gh state. 60s is the floor — enough to absorb
+ * a burst of mode toggles, short enough that a freshly-merged PR shows up
+ * within a minute. */
+export const GH_STATE_TTL_MS = 60_000;
+
+/** One rendered segment of the strip. The renderer maps each kind to a
+ * specific click handler (open URL, copy sha, etc.). */
+export type StripSegment =
+  | { kind: "commit"; sha: string; subject: string }
+  | {
+      kind: "pr";
+      url: string;
+      number: number | null;
+      state: string | null;
+      pending: boolean;
+    }
+  | {
+      kind: "issue";
+      url: string;
+      number: number | null;
+      state: string | null;
+      pending: boolean;
+    };
+
+/**
+ * Parse the latest entry of a `commits:` frontmatter list. Returns `null`
+ * when the list is empty or the last entry is malformed (no whitespace).
+ *
+ * Format on-disk (set by `op-append-commit`): `<sha7> <subject>`. We only
+ * care about the most recent entry — that's what the strip surfaces.
+ */
+export function parseLatestCommit(commits: string[] | undefined): CommitInfo | null {
+  if (!commits || commits.length === 0) return null;
+  const raw = commits[commits.length - 1];
+  if (typeof raw !== "string") return null;
+  const trimmed = raw.trim();
+  if (!trimmed) return null;
+  const idx = trimmed.indexOf(" ");
+  if (idx <= 0) {
+    // No subject — render the sha alone. We treat that as a commit segment
+    // with an empty subject so the renderer can still surface the click.
+    return { sha: trimmed, subject: "" };
+  }
+  return {
+    sha: trimmed.slice(0, idx),
+    subject: trimmed.slice(idx + 1),
+  };
+}
+
+/**
+ * Pull the trailing `/<n>` segment off a GitHub URL. Returns `null` when
+ * the URL doesn't end in a numeric path component (defensively — we don't
+ * want a bad URL to crash the renderer).
+ */
+export function parseGithubNumber(url: string | undefined): number | null {
+  if (!url) return null;
+  const match = url.match(/\/(\d+)(?:[/#?].*)?$/);
+  if (!match) return null;
+  const n = Number.parseInt(match[1], 10);
+  return Number.isFinite(n) ? n : null;
+}
+
+/**
+ * Look up a URL's gh state; treat expired entries as a miss so the caller
+ * kicks off a refresh. The 0-arg `now` param keeps tests deterministic.
+ */
+export function readGhCache(
+  cache: GhStateCache,
+  url: string,
+  now: number,
+): GhStateCacheEntry | null {
+  const entry = cache.get(url);
+  if (!entry) return null;
+  if (entry.expiresAt <= now) return null;
+  return entry;
+}
+
+/** Write a fresh state into the cache with the standard TTL. */
+export function writeGhCache(
+  cache: GhStateCache,
+  url: string,
+  state: string | null,
+  now: number,
+  ttl: number = GH_STATE_TTL_MS,
+): void {
+  cache.set(url, { state, expiresAt: now + ttl });
+}
+
+/**
+ * Compose the strip segments for one issue note. Pure: takes the
+ * frontmatter slice, the gh-state cache, and the current time and emits
+ * the array the renderer iterates.
+ *
+ * Each segment is omitted when its source field is empty. PR/issue
+ * segments are marked `pending: true` when the cache misses — the renderer
+ * shows a placeholder dot and swaps in the real state when the async fetch
+ * resolves and we re-render.
+ */
+export function composeStripSegments(
+  fm: StripFrontmatter | null | undefined,
+  cache: GhStateCache,
+  now: number,
+): StripSegment[] {
+  if (!fm) return [];
+  const out: StripSegment[] = [];
+
+  const commit = parseLatestCommit(fm.commits);
+  if (commit) {
+    out.push({ kind: "commit", sha: commit.sha, subject: commit.subject });
+  }
+
+  const prUrl = typeof fm.pr === "string" ? fm.pr.trim() : "";
+  if (prUrl) {
+    const cached = readGhCache(cache, prUrl, now);
+    out.push({
+      kind: "pr",
+      url: prUrl,
+      number: parseGithubNumber(prUrl),
+      state: cached?.state ?? null,
+      pending: !cached,
+    });
+  }
+
+  const issueUrl = typeof fm.githubIssue === "string" ? fm.githubIssue.trim() : "";
+  if (issueUrl) {
+    const cached = readGhCache(cache, issueUrl, now);
+    out.push({
+      kind: "issue",
+      url: issueUrl,
+      number: parseGithubNumber(issueUrl),
+      state: cached?.state ?? null,
+      pending: !cached,
+    });
+  }
+
+  return out;
+}
+
+/**
+ * Format the static (non-interactive) text of a single segment for use in
+ * tests, screen-readers, or fallback rendering. The renderer normally lays
+ * each segment out as its own clickable `<span>` but the formatted string
+ * keeps the strip readable when CSS hasn't loaded.
+ */
+export function formatSegment(seg: StripSegment): string {
+  switch (seg.kind) {
+    case "commit": {
+      const subj = seg.subject ? ` "${truncate(seg.subject, 40)}"` : "";
+      return `last commit: ${seg.sha}${subj}`;
+    }
+    case "pr": {
+      const n = seg.number !== null ? `#${seg.number}` : "PR";
+      const state = seg.pending ? "…" : seg.state ?? "";
+      return state ? `PR ${n} (${state.toLowerCase()})` : `PR ${n}`;
+    }
+    case "issue": {
+      const n = seg.number !== null ? `#${seg.number}` : "GH";
+      const state = seg.pending ? "…" : seg.state ?? "";
+      return state ? `GH ${n} (${state.toLowerCase()})` : `GH ${n}`;
+    }
+  }
+}
+
+function truncate(s: string, max: number): string {
+  if (s.length <= max) return s;
+  return s.slice(0, max - 1) + "…";
+}

--- a/plugins/op-obsidian/src/settings.test.ts
+++ b/plugins/op-obsidian/src/settings.test.ts
@@ -237,4 +237,23 @@ describe("mergeSettings", () => {
     ).toEqual(["foo", "bar"]);
     expect(mergeSettings({ projectOrder: ["  baz  "] }).projectOrder).toEqual(["baz"]);
   });
+
+  it("firstRunCompleted: fresh empty data.json keeps default false; explicit false allowed; existing user inferred true", () => {
+    // Fresh install: data.json is empty — firstRunCompleted stays false so
+    // the README is scaffolded on first load.
+    expect(mergeSettings({}).firstRunCompleted).toBe(false);
+
+    // Explicitly stored false (user ran "reset onboarding"): honoured as-is.
+    expect(mergeSettings({ firstRunCompleted: false }).firstRunCompleted).toBe(false);
+
+    // Explicitly stored true: honoured.
+    expect(mergeSettings({ firstRunCompleted: true }).firstRunCompleted).toBe(true);
+
+    // Existing user upgrading from ≤ 0.57.x: data.json has other keys but
+    // no firstRunCompleted. We infer true so the README isn't scaffolded
+    // into a vault already in use.
+    expect(mergeSettings({ defaultAgent: "claude" }).firstRunCompleted).toBe(true);
+    expect(mergeSettings({ workingDirs: { "my-project": "/code/my-project" } }).firstRunCompleted).toBe(true);
+    expect(mergeSettings({ view: { defaultTab: "issues" } }).firstRunCompleted).toBe(true);
+  });
 });

--- a/plugins/op-obsidian/src/settingsPure.ts
+++ b/plugins/op-obsidian/src/settingsPure.ts
@@ -40,6 +40,11 @@ export interface ViewSettings {
   /** Delay (ms) between mouseenter and the tmux capture call. Clamped to
    * [0, 2000]. Default 400. */
   agentHoverDelayMs: number;
+  /** OP-162 / §11: when true, the inline note-level status strip omits PR
+   * and GitHub-issue segments (the lazy `gh` fetch never fires). The
+   * commit segment still renders. Default false. Useful for users without
+   * `gh` configured or in air-gapped environments. */
+  disableInlineGithubStatus: boolean;
 }
 
 export const AGENT_HOVER_LINES_MIN = 1;
@@ -103,6 +108,12 @@ export interface OpSettings {
   // click. Most-recent first, capped at RECENCY_CAP, dedup by issue id.
   // Drives `op: resume last` and the sidebar Last-touched chip (OP-150).
   recent: RecencyEntry[];
+  // OP-161 / §10: flipped to `true` once the first-run README is written
+  // into the vault at `Projects/_op-readme.md`. Manually deleting the
+  // README does not flip this back — that's the intended dismissal
+  // gesture. Set explicitly to `false` (or run the `op: reset onboarding`
+  // command, when wired) to re-trigger.
+  firstRunCompleted: boolean;
 }
 
 export const DEFAULT_SETTINGS: OpSettings = {
@@ -130,6 +141,7 @@ export const DEFAULT_SETTINGS: OpSettings = {
     agentHoverPreview: true,
     agentHoverLines: 30,
     agentHoverDelayMs: 400,
+    disableInlineGithubStatus: false,
   },
   github: {
     autoCreateGithubIssue: false,
@@ -155,6 +167,7 @@ export const DEFAULT_SETTINGS: OpSettings = {
   orchestratorState: emptyRegistry(),
   projectOrder: [],
   recent: [],
+  firstRunCompleted: false,
 };
 
 const SIDEBAR_TABS: ReadonlySet<SidebarTab> = new Set(["issues", "in-flight", "resolved"]);
@@ -207,6 +220,12 @@ export function mergeSettings(loaded: unknown): OpSettings {
         base.view.agentHoverDelayMs = n;
       }
     }
+    if (typeof v.disableInlineGithubStatus === "boolean") {
+      base.view.disableInlineGithubStatus = v.disableInlineGithubStatus;
+    }
+  }
+  if (typeof (l as { firstRunCompleted?: unknown }).firstRunCompleted === "boolean") {
+    base.firstRunCompleted = (l as { firstRunCompleted: boolean }).firstRunCompleted;
   }
   if (l.orchestrator && typeof l.orchestrator === "object") {
     const o = l.orchestrator as Partial<OrchestratorSettings>;

--- a/plugins/op-obsidian/src/settingsPure.ts
+++ b/plugins/op-obsidian/src/settingsPure.ts
@@ -226,6 +226,13 @@ export function mergeSettings(loaded: unknown): OpSettings {
   }
   if (typeof (l as { firstRunCompleted?: unknown }).firstRunCompleted === "boolean") {
     base.firstRunCompleted = (l as { firstRunCompleted: boolean }).firstRunCompleted;
+  } else if (Object.keys(l).length > 0) {
+    // Existing user upgrading from a version that predates `firstRunCompleted`
+    // (≤ 0.57.x). Their data.json has other settings but no
+    // `firstRunCompleted` key, so the default (`false`) would wrongly
+    // scaffold the first-run README into a vault that's already in use.
+    // Treat any non-empty saved data as "first run already completed".
+    base.firstRunCompleted = true;
   }
   if (l.orchestrator && typeof l.orchestrator === "object") {
     const o = l.orchestrator as Partial<OrchestratorSettings>;

--- a/plugins/op-obsidian/styles.css
+++ b/plugins/op-obsidian/styles.css
@@ -451,3 +451,140 @@ a.op-sidebar__agent:hover {
   white-space: pre-wrap;
   word-break: break-word;
 }
+
+/* --- OP-151 / §2 — note-level primary action chip ----------------------- */
+/* --- OP-162 / §11 — note-level status strip ----------------------------- */
+
+.op-note-chip-wrap {
+  /* Above-H1 wrapper. Block layout so the H1 wraps below; tight margins so
+   * we don't push the H1 visibly down on first paint. */
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  margin: 0.25rem 0 0.5rem 0;
+  font-family: var(--font-interface);
+}
+
+.op-note-chip-wrap--cm6 {
+  /* CM6 widgets get a tiny extra top margin to sit cleanly above the
+   * editor's gutter line — Reading mode doesn't need this. */
+  margin-top: 0.5rem;
+}
+
+/* Hide the chip on very narrow leaves — the H1 is the priority on a
+ * sidebar-narrow leaf. 320px matches the spec's default min-width. */
+@container (max-width: 320px) {
+  .op-note-chip-wrap { display: none; }
+}
+.markdown-source-view.is-live-preview .cm-content[style*="width"] .op-note-chip-wrap { /* fallback when @container isn't supported */ }
+
+.op-note-chip-row {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  flex-wrap: nowrap;
+}
+
+.op-note-chip {
+  /* Inherit theme accents so the chip matches the user's palette. */
+  display: inline-flex;
+  align-items: center;
+  gap: 0.3rem;
+  max-width: 32ch;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  padding: 0.15rem 0.6rem;
+  font-size: var(--font-ui-smaller, 0.8rem);
+  line-height: 1.4;
+  border: 1px solid var(--background-modifier-border);
+  border-radius: var(--radius-s, 6px);
+  background: var(--background-secondary);
+  color: var(--text-normal);
+  cursor: pointer;
+  user-select: none;
+  font-weight: 500;
+}
+
+.op-note-chip:hover {
+  background: var(--background-modifier-hover);
+}
+
+.op-note-chip:focus-visible {
+  outline: 2px solid var(--interactive-accent);
+  outline-offset: 1px;
+}
+
+.op-note-chip--primary {
+  background: var(--interactive-accent);
+  color: var(--text-on-accent);
+  border-color: var(--interactive-accent);
+}
+
+.op-note-chip--primary:hover {
+  background: var(--interactive-accent-hover);
+}
+
+.op-note-chip--stale {
+  background: var(--background-modifier-error-rgb, var(--background-secondary));
+  color: var(--text-warning, var(--text-normal));
+  border-color: var(--background-modifier-border);
+  font-style: italic;
+}
+
+.op-note-chip--reopen {
+  background: var(--background-secondary);
+  color: var(--text-muted);
+}
+
+.op-note-chip--overflow {
+  padding: 0.15rem 0.5rem;
+  min-width: 1.6rem;
+  justify-content: center;
+}
+
+.op-note-strip {
+  display: flex;
+  align-items: center;
+  gap: 0.2rem;
+  flex-wrap: wrap;
+  font-size: var(--font-ui-smaller, 0.75rem);
+  color: var(--text-muted);
+}
+
+.op-note-strip__seg {
+  cursor: pointer;
+  padding: 0.05rem 0.25rem;
+  border-radius: var(--radius-s, 4px);
+}
+
+.op-note-strip__seg:hover {
+  background: var(--background-modifier-hover);
+  color: var(--text-normal);
+}
+
+.op-note-strip__seg--commit {
+  font-family: var(--font-monospace, monospace);
+}
+
+.op-note-strip__seg--pending {
+  opacity: 0.6;
+  font-style: italic;
+}
+
+.op-note-strip__sep {
+  color: var(--text-faint);
+  user-select: none;
+}
+
+.op-note-chip-wrap--action {
+  /* Used by the README's `op-action` codeblock chips. Center the button
+   * inside the rendered code-block container. */
+  margin: 0.4rem 0;
+}
+
+.op-action-block--error {
+  color: var(--text-error);
+  font-family: var(--font-monospace, monospace);
+  font-size: var(--font-ui-smaller, 0.75rem);
+}

--- a/plugins/op/.claude-plugin/plugin.json
+++ b/plugins/op/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "op",
   "description": "Obsidian Projects workflow — schema, slash commands, and agent skill for running a Jira-lite issue tracker inside an Obsidian vault.",
-  "version": "0.58.0",
+  "version": "0.58.1",
   "author": {
     "name": "Eugene Archibald"
   },

--- a/plugins/op/.claude-plugin/plugin.json
+++ b/plugins/op/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "op",
   "description": "Obsidian Projects workflow — schema, slash commands, and agent skill for running a Jira-lite issue tracker inside an Obsidian vault.",
-  "version": "0.57.1",
+  "version": "0.58.0",
   "author": {
     "name": "Eugene Archibald"
   },


### PR DESCRIPTION
## Summary

Bundled per §16 of [[OP-149]] — all three issues share CM6 widget infrastructure with `AbortController`-based teardown. Closes OP-151, OP-161, OP-162.

- **§2 ([[OP-151]])**: primary-action chip above the H1 of every issue note. Label flips with state — \`▶ Start agent\` → \`▶ Attach session\` → \`↻ Re-attach (start fresh)\` → \`↺ Reopen\`. One \`⋯\` overflow menu per state, dispatched via \`app.commands.executeCommandById\`.
- **§11 ([[OP-162]])**: inline status strip below the chip — last commit (sha7 + subject), PR (#n + state), GH issue (#n + state). \`gh\` state lazy-fetched with a 60s in-memory cache; failures render the link without state and never block initial paint. Settings toggle \`view.disableInlineGithubStatus\` suppresses PR / GH segments for users without \`gh\`.
- **§10 ([[OP-161]])**: first-run README scaffolded into \`Projects/_op-readme.md\` on the very first plugin load. Contains the hotkey-preset table with an inline \`Apply preset\` chip and a \`Start tour\` chip that scaffolds a demo project (\`op-demo\`, prefix \`OPD\`) with three pre-seeded issues. Demo teardown chip lives on the demo project's \`STATUS.md\`. \`firstRunCompleted\` flag flips after the README is written so a manual delete is durable.

### Architecture notes

- **Chip mount.** A CM6 \`ViewPlugin\` mounts a chip-host \`<div>\` as a sibling of \`cm-editor\` (outside CM6's managed DOM tree). Obsidian's bundled CM6 rejects \`Decoration.widget({block: true})\` from both a \`ViewPlugin\` and a \`StateField\` provider — its facet marks both as plugin sources. Mounting outside the editor avoids the rule entirely and matches the pattern Obsidian uses for embedded markdown cards. Reading mode goes through a \`registerMarkdownPostProcessor\` that finds the first H1 and prepends a sibling chip wrapper.
- **Lifecycle discipline.** Every event listener attached in the chip's \`render\` path is bound to an \`AbortController\` stored on the widget / \`MarkdownRenderChild\`. \`destroy()\` / \`onunload()\` calls \`controller.abort()\` so listeners disappear deterministically across mode toggles. This is the single most likely bug class for this kind of widget.
- **Liveness.** \`isAgentLive(id, agent)\` is answered synchronously from a plugin-level \`liveTmuxWindowsCache\`, populated by the OP-150 startup probe and refreshed every 20s via a registered interval. When the live set changes, we dispatch a \`refreshChipEffect\` to every CM6 view so the chip flips promptly.
- **GH state cache.** Single \`Map<url, { state, expiresAt }>\` shared across renderers, 60s TTL, single-flight per URL (we plant a short-TTL placeholder when a fetch starts so 6 renders for the same URL collapse to 1 \`gh\` call).
- **\`op-action\` codeblock.** New fenced-code language used by the README chips. Body is a YAML-shaped key/value: \`action: <command-id>\` + \`label: <text>\`. The post-processor renders it as a chip wired to \`app.commands.executeCommandById\`.
- **New commands**: \`op-reopen-issue\`, \`op-clear-agent\`, \`op-set-priority\`, \`op-apply-preset\`, \`op-start-tour\`, \`op-remove-demo\`. The first three power the chip's overflow menu; the latter three back the README chips.
- **New settings**: top-level \`firstRunCompleted: boolean\` (default false); \`view.disableInlineGithubStatus: boolean\` (default false).
- **Liveness probe re-uses OP-150's \`probeLiveTmuxWindows\`** rather than a new \`tmuxLiveness.ts\` module — that file never landed in OP-150, but the existing probe + \`tmuxWindowName(id)\` mapping is sufficient.

### LOC + tests

- New: \`noteChipState.ts\` (193), \`noteStatusStrip.ts\` (180), \`noteDecorations.ts\` (480), \`noteChipMenu.ts\` (60), \`firstRunReadme.ts\` (260), plus 49 new unit tests across three test files.
- Modified: \`main.ts\` (+200, registers extension + post-processor + 6 commands + first-run hook + 20s liveness re-probe), \`settingsPure.ts\` (+10, two new fields + merge logic), \`styles.css\` (+135, themed via Obsidian CSS variables).
- 667 tests total, 51 test files, all passing.
- TypeScript: no new errors (33 pre-existing baseline → 33).

### Adversarial review prompts (for Copilot)

@copilot — please pressure-test, prioritising in this order:

1. **Listener teardown.** Toggle Live Preview ↔ Reading mode rapidly five times on the same issue note. Are there stale listeners on the original DOM? Is \`controller.signal.aborted === true\` after \`destroy()\`?
2. **Frontmatter-change feedback loop.** A chip click runs a command that mutates frontmatter, which fires \`metadataCache.changed\`, which calls \`dispatchChipRefresh\`. Verify no infinite loop — the metadata cache event is debounced; chip render must be idempotent.
3. **Two-renderer drift.** Live Preview chip and Reading mode chip must look and behave identically. Do they? Check: \`primaryLabel\`, \`primaryCommand\`, \`menu\` items, \`disableInlineGithubStatus\` honoured on both paths.
4. **GH state cache thundering herd.** Open a vault with five resolved issues that all link to PRs in the same repo. Is the \`gh pr view\` command de-duplicated, or are we firing five concurrent shells per render?
5. **First-run race.** Boot Obsidian with a vault that has \`firstRunCompleted: false\`. Does the README scaffold exactly once, even if the plugin reloads mid-startup?
6. **\`op-action\` codeblock idempotency.** Re-render the same codeblock multiple times (typical Obsidian post-processor behaviour). Do we stack duplicate chips inside the fence, or does \`el.empty()\` keep it clean?
7. **Schema migration.** A user with \`data.json\` from v0.57.x — does \`mergeSettings\` populate \`firstRunCompleted\` and \`view.disableInlineGithubStatus\` with sane defaults?

## Test plan

- [ ] Open an open issue note in Live Preview → see \`▶ Start agent\` above the H1.
- [ ] Click chip → agent launches; chip flips to \`▶ Attach session\` after the next 20s probe.
- [ ] Switch to Reading mode → identical chip via the post-processor.
- [ ] Open a resolved issue → chip reads \`↺ Reopen\`; overflow shows the GH issue link.
- [ ] Open a TASKS note → no chip rendered (only \`type: issue\` notes).
- [ ] Squeeze a leaf below 320px → chip hides; widen → chip reappears.
- [ ] Long title → chip ellipses; H1 stays readable.
- [ ] First-run README appears on a fresh vault; \`Apply preset\` chip applies the preset; \`Start tour\` chip scaffolds \`op-demo\`.
- [ ] Delete the README → \`firstRunCompleted: true\` keeps it gone across reloads.

## Smoke test caveat

This vault has another community plugin (\`jira-bases\`) that throws \`Block decorations may not be specified via plugins\` during \`setViewData\` for any note containing certain frontmatter keys. The error is pre-existing and unrelated to this PR — it predates the chip extension and persists with op-obsidian fully unloaded. The chip mount code sidesteps decoration-system entirely (mounted as a sibling of \`cm-editor\`) so it cannot trigger the same path. Reading-mode mirror, README scaffold, codeblock chip, and command registration all verified live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)