### PR TITLE
OP-159: quick-capture — op: new from selection / clipboard (§8 of OP-149)

### DIFF
--- a/plugins/op-obsidian/manifest.json
+++ b/plugins/op-obsidian/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "op-obsidian",
   "name": "Obsidian Projects (op)",
-  "version": "0.58.1",
+  "version": "0.59.0",
   "minAppVersion": "1.5.0",
   "description": "Jira-lite issue tracker for Obsidian vaults — deterministic commands backing the op workflow.",
   "author": "Eugene Archibald",

--- a/plugins/op-obsidian/manifest.json
+++ b/plugins/op-obsidian/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "op-obsidian",
   "name": "Obsidian Projects (op)",
-  "version": "0.58.2",
+  "version": "0.59.0",
   "minAppVersion": "1.5.0",
   "description": "Jira-lite issue tracker for Obsidian vaults — deterministic commands backing the op workflow.",
   "author": "Eugene Archibald",

--- a/plugins/op-obsidian/package.json
+++ b/plugins/op-obsidian/package.json
@@ -1,6 +1,6 @@
 {
   "name": "op-obsidian",
-  "version": "0.58.2",
+  "version": "0.59.0",
   "description": "Obsidian plugin that owns the deterministic half of the op workflow.",
   "main": "main.js",
   "scripts": {

--- a/plugins/op-obsidian/package.json
+++ b/plugins/op-obsidian/package.json
@@ -1,6 +1,6 @@
 {
   "name": "op-obsidian",
-  "version": "0.58.1",
+  "version": "0.59.0",
   "description": "Obsidian plugin that owns the deterministic half of the op workflow.",
   "main": "main.js",
   "scripts": {

--- a/plugins/op-obsidian/src/hotkeyPreset.test.ts
+++ b/plugins/op-obsidian/src/hotkeyPreset.test.ts
@@ -12,8 +12,8 @@ import {
 describe("defaultPreset", () => {
   const preset = defaultPreset();
 
-  it("returns exactly 10 entries", () => {
-    expect(preset).toHaveLength(10);
+  it("returns exactly 12 entries", () => {
+    expect(preset).toHaveLength(12);
   });
 
   it("returns the expected commands in spec-defined order", () => {
@@ -26,6 +26,8 @@ describe("defaultPreset", () => {
       "op-obsidian:op-open-agent",
       "op-obsidian:op-resolve",
       "op-obsidian:op-new",
+      "op-obsidian:op-new-from-selection",
+      "op-obsidian:op-new-from-clipboard",
       "op-obsidian:op-append-commit",
       "op-obsidian:op-next-issue",
       "op-obsidian:op-previous-issue",
@@ -153,14 +155,14 @@ function makeApp(overrides?: {
 }
 
 describe("applyPreset — clean apply", () => {
-  it("applies all 10 bindings when no conflicts exist", () => {
+  it("applies all 12 bindings when no conflicts exist", () => {
     const app = makeApp();
     const result = applyPreset(app, defaultPreset(), { isMacOS: true });
     expect(result.ok).toBe(true);
     if (!result.ok) return;
-    expect(result.applied).toHaveLength(10);
+    expect(result.applied).toHaveLength(12);
     expect(result.skipped).toHaveLength(0);
-    expect(Object.keys(app.__internal)).toHaveLength(10);
+    expect(Object.keys(app.__internal)).toHaveLength(12);
     expect(app.__saved).toHaveBeenCalled();
   });
 
@@ -211,14 +213,14 @@ describe("applyPreset — collision skipping", () => {
     const app = makeApp();
     // First apply
     const first = applyPreset(app, preset, { isMacOS: true });
-    expect(first.ok && first.applied).toHaveLength(10);
+    expect(first.ok && first.applied).toHaveLength(12);
     // Re-apply — every binding still maps to its op-* command, so no conflict
     // is reported.
     const second = applyPreset(app, preset, { isMacOS: true });
     expect(second.ok).toBe(true);
     if (!second.ok) return;
     expect(second.skipped).toHaveLength(0);
-    expect(second.applied).toHaveLength(10);
+    expect(second.applied).toHaveLength(12);
   });
 
   it("falls back to commandId when commands registry has no display name", () => {
@@ -263,7 +265,7 @@ describe("applyPreset — fallback path", () => {
     if (result.ok) return;
     expect(result.reason).toMatch(/unavailable|drift/i);
     const parsed = JSON.parse(result.snippet);
-    expect(Object.keys(parsed)).toHaveLength(10);
+    expect(Object.keys(parsed)).toHaveLength(12);
     expect(parsed["op-obsidian:op-pick-and-act"]).toEqual([
       { modifiers: ["Mod", "Shift"], key: "I" },
     ]);
@@ -281,7 +283,7 @@ describe("applyPreset — fallback path", () => {
     // Snapshot was empty before the mutation began.
     expect(result.previousCustomKeys).toEqual({});
     const parsed = JSON.parse(result.snippet);
-    expect(Object.keys(parsed)).toHaveLength(10);
+    expect(Object.keys(parsed)).toHaveLength(12);
   });
 
   it("returns a JSON snippet when setHotkeys() throws mid-stream", () => {
@@ -326,7 +328,7 @@ describe("revertPreset", () => {
   it("clears bindings that didn't exist in the snapshot", () => {
     const app = makeApp();
     applyPreset(app, defaultPreset(), { isMacOS: true });
-    expect(Object.keys(app.__internal).length).toBe(10);
+    expect(Object.keys(app.__internal).length).toBe(12);
     revertPreset(app, {});
     expect(app.__internal).toEqual({});
   });

--- a/plugins/op-obsidian/src/hotkeyPreset.ts
+++ b/plugins/op-obsidian/src/hotkeyPreset.ts
@@ -2,7 +2,7 @@
  * Default hotkey preset for the op-obsidian plugin (OP-152).
  *
  * Two responsibilities:
- *  - {@link defaultPreset} — the pure list of 10 keybindings the preset binds.
+ *  - {@link defaultPreset} — the pure list of 12 keybindings the preset binds.
  *  - {@link applyPreset} — best-effort write into Obsidian's
  *    `app.hotkeyManager.customKeys`, with collision-skipping and a JSON-snippet
  *    fallback when the internal API has drifted.

--- a/plugins/op-obsidian/src/hotkeyPreset.ts
+++ b/plugins/op-obsidian/src/hotkeyPreset.ts
@@ -85,6 +85,10 @@ const PRESET: readonly HotkeyEntry[] = [
   { command: "op-obsidian:op-open-agent", hotkey: { modifiers: ["Mod", "Shift"], key: "L" } },
   { command: "op-obsidian:op-resolve", hotkey: { modifiers: ["Mod", "Shift"], key: "R" } },
   { command: "op-obsidian:op-new", hotkey: { modifiers: ["Mod", "Alt"], key: "N" } },
+  // OP-159 / spec §8: quick-capture shares the `Mod+Alt+` family with op-new.
+  // S = Selection, V = clipboard (paste mnemonic).
+  { command: "op-obsidian:op-new-from-selection", hotkey: { modifiers: ["Mod", "Alt"], key: "S" } },
+  { command: "op-obsidian:op-new-from-clipboard", hotkey: { modifiers: ["Mod", "Alt"], key: "V" } },
   { command: "op-obsidian:op-append-commit", hotkey: { modifiers: ["Mod", "Shift"], key: "." } },
   { command: "op-obsidian:op-next-issue", hotkey: { modifiers: ["Mod", "Shift"], key: "J" } },
   { command: "op-obsidian:op-previous-issue", hotkey: { modifiers: ["Mod", "Shift"], key: "K" } },

--- a/plugins/op-obsidian/src/main.ts
+++ b/plugins/op-obsidian/src/main.ts
@@ -1,4 +1,4 @@
-import { Notice, Plugin, TFile, WorkspaceLeaf } from "obsidian";
+import { Notice, Plugin, TFile, WorkspaceLeaf, type Editor, type MarkdownView } from "obsidian";
 import { OP_SIDEBAR_VIEW_TYPE, OpSidebarView } from "./sidebarView";
 import { revealAgentSession } from "./revealAgentSession";
 import { findAgentTmuxLocation } from "./agentTmuxLocation";
@@ -102,6 +102,7 @@ import { detectTmux } from "./tmuxDetect";
 import { notify, notifyAction, registerApp, unregisterApp, openNotificationLog } from "./notificationLog";
 import { probeLiveTmuxWindows, selectStaleAgentBadges } from "./staleAgentBadges";
 import { appendRecency, mostRecent } from "./recencyLog";
+import { deriveTitle, packScope, resolveCaptureProject } from "./quickCapture";
 import { openErrorLog, writeErrorLog } from "./errorLog";
 import { configureClient } from "./iterm/client";
 import { closeWindow as itermCloseWindow } from "./iterm/driver";
@@ -504,6 +505,22 @@ export default class OpPlugin extends Plugin {
       id: "op-new",
       name: "op: new issue",
       callback: () => this.runNewIssueCommand(),
+    });
+
+    // Quick-capture (OP-159 / spec §8). Two thin entry-points around `op-new`
+    // that pre-fill the modal from the editor selection or system clipboard,
+    // and skip the project picker when context resolves a project.
+    this.addCommand({
+      id: "op-new-from-selection",
+      name: "op: new from selection",
+      editorCallback: (editor: Editor, view: MarkdownView) =>
+        this.runNewFromSelectionCommand(editor, view),
+    });
+
+    this.addCommand({
+      id: "op-new-from-clipboard",
+      name: "op: new from clipboard",
+      callback: () => void this.runNewFromClipboardCommand(),
     });
 
     this.addCommand({
@@ -1427,6 +1444,93 @@ export default class OpPlugin extends Plugin {
         { autoCreateGithubIssue: this.settings.github.autoCreateGithubIssue },
       ).open();
     }).open();
+  }
+
+  /**
+   * Open the New Issue modal for a quick-capture command (selection or
+   * clipboard). The capture path resolves the project per spec §8 — active
+   * note's `project:` frontmatter, then the recency log, falling through to
+   * the picker — and pre-fills the modal with the captured title + scope so
+   * the user only has to confirm. The modal still pauses for explicit
+   * confirmation per the op-skill rule.
+   */
+  private openQuickCaptureModal(args: { title: string; scopeBody: string; activeFile?: TFile | null }): void {
+    const projects = applyProjectOrder(listProjects(this.app), this.settings.projectOrder);
+    if (projects.length === 0) {
+      notify("op: no projects found under Projects/");
+      return;
+    }
+    const activeFm = args.activeFile
+      ? this.app.metadataCache.getFileCache(args.activeFile)?.frontmatter
+      : undefined;
+    const activeProjectSlug =
+      typeof activeFm?.project === "string" ? activeFm.project : undefined;
+    const resolved = resolveCaptureProject({
+      activeProjectSlug,
+      recent: this.settings.recent,
+      projects,
+    });
+    const initial = {
+      title: args.title,
+      scopeRaw: args.scopeBody,
+      scopeMode: "body" as const,
+    };
+    const open = (project: typeof projects[number]): void => {
+      new NewIssueModal(
+        this.app,
+        project,
+        (input, opts) => {
+          this.submitCreateIssue(input, opts);
+        },
+        {
+          autoCreateGithubIssue: this.settings.github.autoCreateGithubIssue,
+          initial,
+        },
+      ).open();
+    };
+    if (resolved) {
+      open(resolved);
+      return;
+    }
+    new ProjectSuggestModal(this.app, projects, open).open();
+  }
+
+  private runNewFromSelectionCommand(editor: Editor, view: MarkdownView): void {
+    const selection = editor.somethingSelected() ? editor.getSelection() : "";
+    const file = view.file ?? null;
+    let title: string;
+    let scopeBody: string;
+    if (selection.trim().length > 0) {
+      title = deriveTitle(selection);
+      scopeBody = packScope({ text: selection });
+    } else {
+      // No selection — fall back to "title = active note title", scope = backlink
+      // to that note. Spec §8: "If no selection, falls back to the current
+      // note's title + a backlink to the source note in scope."
+      const noteTitle = file?.basename ?? "";
+      title = noteTitle;
+      scopeBody = packScope({ text: "", fallbackBacklinkTo: noteTitle });
+    }
+    this.openQuickCaptureModal({ title, scopeBody, activeFile: file });
+  }
+
+  private async runNewFromClipboardCommand(): Promise<void> {
+    let text = "";
+    try {
+      // navigator.clipboard.readText() rejects when the document doesn't have
+      // focus or the user hasn't granted clipboard permission. Treat that as
+      // "fall through to a plain modal" rather than a hard failure — the user
+      // can still capture by hand.
+      text = (await navigator.clipboard.readText()) ?? "";
+    } catch (err) {
+      console.warn("[op-obsidian] clipboard read failed", err);
+      new Notice("op: clipboard unavailable — fill the form manually.");
+      text = "";
+    }
+    const file = this.app.workspace.getActiveFile();
+    const title = deriveTitle(text);
+    const scopeBody = packScope({ text });
+    this.openQuickCaptureModal({ title, scopeBody, activeFile: file ?? null });
   }
 
   private runFindIssueCommand(): void {

--- a/plugins/op-obsidian/src/main.ts
+++ b/plugins/op-obsidian/src/main.ts
@@ -1527,6 +1527,11 @@ export default class OpPlugin extends Plugin {
       new Notice("op: clipboard unavailable — fill the form manually.");
       text = "";
     }
+    // readText() resolves with "" when the clipboard is empty (no rejection).
+    // Surface a Notice so the user understands why the modal opened blank.
+    if (!text.trim()) {
+      new Notice("op: clipboard was empty — fill the form manually.");
+    }
     const file = this.app.workspace.getActiveFile();
     const title = deriveTitle(text);
     const scopeBody = packScope({ text });

--- a/plugins/op-obsidian/src/modals.ts
+++ b/plugins/op-obsidian/src/modals.ts
@@ -100,20 +100,40 @@ export interface NewIssueSubmitOptions {
   startFlow: boolean;
 }
 
+/**
+ * Optional pre-fill for the modal — used by quick-capture (OP-159) and any
+ * future caller that already knows the title/scope. `scopeMode` controls how
+ * the textarea content is submitted:
+ *   - `"bullets"` (default): textarea is split per non-empty line, each line
+ *     becomes one scope bullet. Matches the original modal behavior.
+ *   - `"body"`: textarea is submitted verbatim as `scopeBody`, preserving
+ *     paragraphs, blockquotes, blank lines. Quick-capture uses this so a
+ *     selected paragraph round-trips intact.
+ */
+export interface NewIssueInitial {
+  title?: string;
+  scopeRaw?: string;
+  scopeMode?: "bullets" | "body";
+}
+
 export class NewIssueModal extends Modal {
   private title = "";
   private priority: Priority = "med";
   private scopeRaw = "";
   private githubIssue = "";
   private evaluateComplexity = false;
+  private scopeMode: "bullets" | "body";
 
   constructor(
     app: App,
     private project: ProjectInfo,
     private onSubmit: (input: CreateIssueInput, opts: NewIssueSubmitOptions) => void,
-    private opts: { autoCreateGithubIssue?: boolean } = {},
+    private opts: { autoCreateGithubIssue?: boolean; initial?: NewIssueInitial } = {},
   ) {
     super(app);
+    this.title = opts.initial?.title ?? "";
+    this.scopeRaw = opts.initial?.scopeRaw ?? "";
+    this.scopeMode = opts.initial?.scopeMode ?? "bullets";
   }
 
   onOpen(): void {
@@ -126,7 +146,10 @@ export class NewIssueModal extends Modal {
     new Setting(contentEl)
       .setName("Title")
       .addText((t) =>
-        t.setPlaceholder("Short descriptive title").onChange((v) => (this.title = v)),
+        t
+          .setPlaceholder("Short descriptive title")
+          .setValue(this.title)
+          .onChange((v) => (this.title = v)),
       );
 
     new Setting(contentEl).setName("Priority").addDropdown((d) =>
@@ -138,11 +161,16 @@ export class NewIssueModal extends Modal {
         .onChange((v) => (this.priority = v as Priority)),
     );
 
+    const scopeDesc =
+      this.scopeMode === "body"
+        ? "Captured text — submitted verbatim under ## Scope. Edit as needed."
+        : "One bullet per line. e.g. Wire the command / Write unit tests.";
     new Setting(contentEl)
       .setName("Scope (optional)")
-      .setDesc("One bullet per line. e.g. Wire the command / Write unit tests.")
+      .setDesc(scopeDesc)
       .addTextArea((t) => {
         t.setPlaceholder("e.g.\nWire the command\nWrite unit tests");
+        t.setValue(this.scopeRaw);
         t.onChange((v) => (this.scopeRaw = v));
         t.inputEl.rows = 6;
         t.inputEl.style.width = "100%";
@@ -181,12 +209,20 @@ export class NewIssueModal extends Modal {
         return;
       }
       this.close();
+      // In "body" mode (quick-capture), submit the textarea content verbatim
+      // as `scopeBody` so paragraphs / blockquotes / blank lines round-trip
+      // intact. In "bullets" mode (default), keep the legacy bullet split.
+      const scopeBody =
+        this.scopeMode === "body" && this.scopeRaw.trim().length > 0
+          ? this.scopeRaw.replace(/\s+$/g, "")
+          : undefined;
       this.onSubmit(
         {
           slug: this.project.slug,
           title: result.value.title,
           priority: result.value.priority,
-          scope: result.value.scope,
+          scope: scopeBody === undefined ? result.value.scope : undefined,
+          scopeBody,
           githubIssue: result.value.githubIssue,
         },
         opts,

--- a/plugins/op-obsidian/src/quickCapture.test.ts
+++ b/plugins/op-obsidian/src/quickCapture.test.ts
@@ -45,6 +45,20 @@ describe("deriveTitle", () => {
       "one",
     );
   });
+
+  it("strips zero-width space / invisible chars so the title is never visually empty but non-empty", () => {
+    // U+200B is not stripped by String.prototype.trim() — without explicit
+    // handling, a line containing only a ZWS would produce a title that looks
+    // blank in the modal but passes the "title is required" validation.
+    expect(deriveTitle("\u200B")).toBe("");
+    expect(deriveTitle("\u200B\u200C\u200D\uFEFF\u00AD")).toBe("");
+    // ZWS mixed with real text is normalised out but the real text survives.
+    expect(deriveTitle("\u200Bfoo\u200B bar")).toBe("foo bar");
+  });
+
+  it("handles tab-indented list bullets", () => {
+    expect(deriveTitle("\t- foo bar")).toBe("foo bar");
+  });
 });
 
 describe("packScope", () => {
@@ -75,6 +89,18 @@ describe("packScope", () => {
 
   it("trims a whitespace-only fallback to nothing", () => {
     expect(packScope({ text: "", fallbackBacklinkTo: "   " })).toBe("");
+  });
+
+  it("sanitises wikilink-breaking chars from the fallback note title", () => {
+    // A note name containing ]] would prematurely close the [[ … ]] span and
+    // produce a split or broken wikilink in the rendered markdown.
+    expect(packScope({ text: "", fallbackBacklinkTo: "Meeting notes [2026-01]]" })).toBe(
+      "Source: [[Meeting notes 2026-01]]",
+    );
+    // Other wikilink-special chars are also stripped.
+    expect(packScope({ text: "", fallbackBacklinkTo: "Foo | bar # baz ^ qux" })).toBe(
+      "Source: [[Foo  bar  baz  qux]]",
+    );
   });
 });
 

--- a/plugins/op-obsidian/src/quickCapture.test.ts
+++ b/plugins/op-obsidian/src/quickCapture.test.ts
@@ -1,0 +1,163 @@
+import { describe, it, expect } from "vitest";
+import { deriveTitle, packScope, resolveCaptureProject } from "./quickCapture";
+import type { ProjectInfo } from "./projects";
+import type { RecencyEntry } from "./recencyLog";
+
+describe("deriveTitle", () => {
+  it("returns empty for empty / whitespace input", () => {
+    expect(deriveTitle("")).toBe("");
+    expect(deriveTitle("   \n   \n")).toBe("");
+  });
+
+  it("takes the first non-empty line", () => {
+    expect(deriveTitle("\n\nfirst real line\nsecond")).toBe("first real line");
+  });
+
+  it("strips heading markers", () => {
+    expect(deriveTitle("## A nested header")).toBe("A nested header");
+    expect(deriveTitle("# Title")).toBe("Title");
+  });
+
+  it("strips list bullets and task checkboxes", () => {
+    expect(deriveTitle("- [ ] do the thing")).toBe("do the thing");
+    expect(deriveTitle("* bullet content")).toBe("bullet content");
+    expect(deriveTitle("- [x] done already")).toBe("done already");
+  });
+
+  it("strips blockquote markers", () => {
+    expect(deriveTitle("> quoted thought")).toBe("quoted thought");
+    expect(deriveTitle("> - [ ] inside a quote")).toBe("inside a quote");
+  });
+
+  it("collapses internal whitespace", () => {
+    expect(deriveTitle("foo   bar\tbaz")).toBe("foo bar baz");
+  });
+
+  it("caps at 120 chars without ellipsis", () => {
+    const long = "a".repeat(200);
+    const out = deriveTitle(long);
+    expect(out.length).toBe(120);
+    expect(out.endsWith("…")).toBe(false);
+  });
+
+  it("never expands beyond the first line — even if first line is short", () => {
+    expect(deriveTitle("one\nand a much longer second line that would have been a better title")).toBe(
+      "one",
+    );
+  });
+});
+
+describe("packScope", () => {
+  it("returns the captured text verbatim (trailing whitespace trimmed)", () => {
+    const text = "Paragraph one.\n\nParagraph two.\n\n";
+    expect(packScope({ text })).toBe("Paragraph one.\n\nParagraph two.");
+  });
+
+  it("preserves internal markdown structure (bullets, blockquotes, blank lines)", () => {
+    const text = "- foo\n- bar\n\n> quote\n";
+    expect(packScope({ text })).toBe("- foo\n- bar\n\n> quote");
+  });
+
+  it("falls back to a backlink bullet when text is empty and a fallback is given", () => {
+    expect(packScope({ text: "", fallbackBacklinkTo: "OP-159 source note" })).toBe(
+      "Source: [[OP-159 source note]]",
+    );
+  });
+
+  it("treats whitespace-only text as empty for fallback purposes", () => {
+    expect(packScope({ text: "   \n  ", fallbackBacklinkTo: "Note" })).toBe("Source: [[Note]]");
+  });
+
+  it("returns empty string when text is empty and no fallback is given", () => {
+    expect(packScope({ text: "" })).toBe("");
+    expect(packScope({ text: "   " })).toBe("");
+  });
+
+  it("trims a whitespace-only fallback to nothing", () => {
+    expect(packScope({ text: "", fallbackBacklinkTo: "   " })).toBe("");
+  });
+});
+
+describe("resolveCaptureProject", () => {
+  const projectA: ProjectInfo = { slug: "alpha", prefix: "AL", statusPath: "Projects/alpha/STATUS.md" };
+  const projectB: ProjectInfo = { slug: "bravo", prefix: "BR", statusPath: "Projects/bravo/STATUS.md" };
+  const projects = [projectA, projectB];
+
+  function recent(...ids: string[]): RecencyEntry[] {
+    return ids.map((id, i) => ({ id, at: new Date(2026, 0, i + 1).toISOString() }));
+  }
+
+  it("(a) returns the project whose slug matches active note's frontmatter", () => {
+    const out = resolveCaptureProject({
+      activeProjectSlug: "bravo",
+      recent: recent("AL-1"),
+      projects,
+    });
+    expect(out).toBe(projectB);
+  });
+
+  it("(b) falls through to the recency log when active slug is missing", () => {
+    const out = resolveCaptureProject({
+      activeProjectSlug: undefined,
+      recent: recent("BR-3", "AL-1"),
+      projects,
+    });
+    expect(out).toBe(projectB);
+  });
+
+  it("(b) falls through to the recency log when active slug doesn't match any project", () => {
+    const out = resolveCaptureProject({
+      activeProjectSlug: "charlie-deleted",
+      recent: recent("BR-3"),
+      projects,
+    });
+    expect(out).toBe(projectB);
+  });
+
+  it("(b) advances past stale recency entries whose prefix no longer resolves", () => {
+    const out = resolveCaptureProject({
+      activeProjectSlug: undefined,
+      recent: recent("XX-9", "GONE-2", "AL-7"),
+      projects,
+    });
+    expect(out).toBe(projectA);
+  });
+
+  it("(b) skips malformed recency entries", () => {
+    const out = resolveCaptureProject({
+      activeProjectSlug: undefined,
+      recent: [
+        { id: "not-an-id", at: "2026-01-01T00:00:00Z" },
+        { id: "AL-12", at: "2026-01-02T00:00:00Z" },
+      ],
+      projects,
+    });
+    expect(out).toBe(projectA);
+  });
+
+  it("(c) returns null when both (a) and (b) fail", () => {
+    expect(
+      resolveCaptureProject({
+        activeProjectSlug: undefined,
+        recent: recent("XX-1"),
+        projects,
+      }),
+    ).toBeNull();
+  });
+
+  it("(c) returns null on empty inputs", () => {
+    expect(
+      resolveCaptureProject({ activeProjectSlug: undefined, recent: [], projects: [] }),
+    ).toBeNull();
+  });
+
+  it("ignores projects with no prefix when matching by recency", () => {
+    const noPrefix: ProjectInfo = { slug: "meta", statusPath: "Projects/meta/STATUS.md" };
+    const out = resolveCaptureProject({
+      activeProjectSlug: undefined,
+      recent: recent("AL-1"),
+      projects: [noPrefix, projectA],
+    });
+    expect(out).toBe(projectA);
+  });
+});

--- a/plugins/op-obsidian/src/quickCapture.ts
+++ b/plugins/op-obsidian/src/quickCapture.ts
@@ -37,8 +37,8 @@ export function deriveTitle(text: string): string {
     // HYPHEN, U+FEFF BOM). Without this step a line containing only a ZWS
     // would produce a title that looks blank in the modal but passes the
     // "title is required" validation, silently creating an invisible-titled
-    // issue.
-    const stripped = stripMarkdownNoise(raw).trim().replace(/[\u00AD\u200B-\u200D\uFEFF]/g, "");
+    // issue. Using explicit code points rather than a range to be precise.
+    const stripped = stripMarkdownNoise(raw).trim().replace(/[\u00AD\u200B\u200C\u200D\uFEFF]/g, "");
     if (stripped.length === 0) continue;
     const collapsed = stripped.replace(/\s+/g, " ");
     return collapsed.length > TITLE_MAX ? collapsed.slice(0, TITLE_MAX).trimEnd() : collapsed;

--- a/plugins/op-obsidian/src/quickCapture.ts
+++ b/plugins/op-obsidian/src/quickCapture.ts
@@ -31,7 +31,14 @@ export function deriveTitle(text: string): string {
   if (!text) return "";
   const lines = text.split(/\r?\n/);
   for (const raw of lines) {
-    const stripped = stripMarkdownNoise(raw).trim();
+    // Strip Markdown noise first, then ASCII whitespace, then zero-width /
+    // invisible Unicode characters that `String.prototype.trim()` does not
+    // remove (U+200B ZERO WIDTH SPACE, U+200C ZWNJ, U+200D ZWJ, U+00AD SOFT
+    // HYPHEN, U+FEFF BOM). Without this step a line containing only a ZWS
+    // would produce a title that looks blank in the modal but passes the
+    // "title is required" validation, silently creating an invisible-titled
+    // issue.
+    const stripped = stripMarkdownNoise(raw).trim().replace(/[\u00AD\u200B-\u200D\uFEFF]/g, "");
     if (stripped.length === 0) continue;
     const collapsed = stripped.replace(/\s+/g, " ");
     return collapsed.length > TITLE_MAX ? collapsed.slice(0, TITLE_MAX).trimEnd() : collapsed;
@@ -80,7 +87,11 @@ export function packScope({ text, fallbackBacklinkTo }: PackScopeOpts): string {
   const trimmed = (text ?? "").replace(/\s+$/g, "");
   if (trimmed.trim().length > 0) return trimmed;
   if (fallbackBacklinkTo && fallbackBacklinkTo.trim().length > 0) {
-    return `Source: [[${fallbackBacklinkTo.trim()}]]`;
+    // Strip characters that are syntactically meaningful inside a wikilink so
+    // a note named e.g. "Meeting [2026-01]]" does not prematurely close the
+    // `[[ … ]]` span and produce a broken or split link.
+    const safeTitle = fallbackBacklinkTo.trim().replace(/[[\]|#^]/g, "");
+    return `Source: [[${safeTitle}]]`;
   }
   return "";
 }

--- a/plugins/op-obsidian/src/quickCapture.ts
+++ b/plugins/op-obsidian/src/quickCapture.ts
@@ -1,0 +1,125 @@
+/**
+ * Pure helpers for the quick-capture commands (OP-159 / spec §8).
+ *
+ * The commands themselves (`op: new from selection` / `op: new from clipboard`)
+ * live in main.ts because they need the `App`, the editor, and the navigator
+ * clipboard. Anything that doesn't is here so it can be unit-tested without
+ * mocking the obsidian module.
+ */
+
+import type { ProjectInfo } from "./projects";
+import type { RecencyEntry } from "./recencyLog";
+
+const TITLE_MAX = 120;
+
+/**
+ * Derive an issue title from a captured text block. Pure-textual:
+ *
+ *   1. Take the first non-empty line.
+ *   2. Strip leading markdown noise: heading markers, list bullets, blockquote
+ *      `>`, and task checkboxes. So a captured `## Foo` becomes `Foo`, a
+ *      `- [ ] bar` becomes `bar`, a `> quote` becomes `quote`.
+ *   3. Collapse internal whitespace.
+ *   4. Cap at TITLE_MAX chars (no ellipsis — the user will see the prefill
+ *      and can extend if they want).
+ *
+ * Returns `""` for empty input or whitespace-only input. The caller is
+ * expected to leave the modal's title field blank in that case so the
+ * existing "title is required" validation forces the user to fill it.
+ */
+export function deriveTitle(text: string): string {
+  if (!text) return "";
+  const lines = text.split(/\r?\n/);
+  for (const raw of lines) {
+    const stripped = stripMarkdownNoise(raw).trim();
+    if (stripped.length === 0) continue;
+    const collapsed = stripped.replace(/\s+/g, " ");
+    return collapsed.length > TITLE_MAX ? collapsed.slice(0, TITLE_MAX).trimEnd() : collapsed;
+  }
+  return "";
+}
+
+function stripMarkdownNoise(line: string): string {
+  let out = line;
+  // Repeatedly peel a single layer of leading noise so `> - [ ] task` is
+  // handled. Cap the depth defensively to avoid pathological inputs looping.
+  for (let i = 0; i < 8; i++) {
+    const before = out;
+    out = out.replace(/^\s+/, "");
+    out = out.replace(/^#{1,6}\s+/, "");
+    out = out.replace(/^[-*+]\s+/, "");
+    out = out.replace(/^>\s?/, "");
+    out = out.replace(/^\[[ xX*]\]\s+/, "");
+    if (out === before) break;
+  }
+  return out;
+}
+
+export interface PackScopeOpts {
+  /** Captured text (selection or clipboard). May be empty/whitespace. */
+  text: string;
+  /**
+   * When the captured text is empty, fall back to a backlink line so the
+   * resulting issue at least points at where the user invoked from. Pass the
+   * source note's basename (no `.md`) — the wikilink resolver handles the rest.
+   */
+  fallbackBacklinkTo?: string;
+}
+
+/**
+ * Build the `scopeBody` (markdown verbatim) the modal will pre-fill into the
+ * scope textarea. Returns the empty string if there's nothing to put there
+ * (no captured text and no fallback note title).
+ *
+ * The prose is preserved as-is (including bullets/paragraphs/blockquotes) so
+ * that "I selected this paragraph" round-trips through the modal verbatim
+ * rather than being shredded into one-bullet-per-line by the bullet parser.
+ * The modal switches to `scopeBody` submission when prefill is supplied.
+ */
+export function packScope({ text, fallbackBacklinkTo }: PackScopeOpts): string {
+  const trimmed = (text ?? "").replace(/\s+$/g, "");
+  if (trimmed.trim().length > 0) return trimmed;
+  if (fallbackBacklinkTo && fallbackBacklinkTo.trim().length > 0) {
+    return `Source: [[${fallbackBacklinkTo.trim()}]]`;
+  }
+  return "";
+}
+
+export interface ResolveProjectInput {
+  /** `frontmatter.project` from the active note (or undefined). */
+  activeProjectSlug?: string;
+  recent: ReadonlyArray<RecencyEntry>;
+  projects: ReadonlyArray<ProjectInfo>;
+}
+
+/**
+ * Apply spec §8's project resolution order:
+ *   (a) active note's `project:` frontmatter slug (string-equal a known project)
+ *   (b) most-recent project from the recency log — derive slug from each
+ *       entry's id prefix, advancing past entries whose project no longer
+ *       exists (project deleted, prefix renamed)
+ *   (c) `null`, meaning the caller should fall through to the interactive
+ *       picker
+ */
+export function resolveCaptureProject(
+  input: ResolveProjectInput,
+): ProjectInfo | null {
+  const projects = input.projects;
+  const slug = input.activeProjectSlug?.trim();
+  if (slug) {
+    const match = projects.find((p) => p.slug === slug);
+    if (match) return match;
+  }
+  for (const entry of input.recent) {
+    const prefix = prefixFromId(entry.id);
+    if (!prefix) continue;
+    const match = projects.find((p) => p.prefix === prefix);
+    if (match) return match;
+  }
+  return null;
+}
+
+function prefixFromId(id: string): string | undefined {
+  const m = id.match(/^([A-Z][A-Z0-9]*)-\d+$/);
+  return m ? m[1] : undefined;
+}

--- a/plugins/op/.claude-plugin/plugin.json
+++ b/plugins/op/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "op",
   "description": "Obsidian Projects workflow — schema, slash commands, and agent skill for running a Jira-lite issue tracker inside an Obsidian vault.",
-  "version": "0.58.2",
+  "version": "0.59.0",
   "author": {
     "name": "Eugene Archibald"
   },

--- a/plugins/op/.claude-plugin/plugin.json
+++ b/plugins/op/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "op",
   "description": "Obsidian Projects workflow — schema, slash commands, and agent skill for running a Jira-lite issue tracker inside an Obsidian vault.",
-  "version": "0.58.1",
+  "version": "0.59.0",
   "author": {
     "name": "Eugene Archibald"
   },


### PR DESCRIPTION
## Summary

Implements §8 of [docs/specs/OP-149-feel-great-ux-design.md](https://github.com/earchibald/obsidian-projects/blob/main/docs/specs/OP-149-feel-great-ux-design.md) — two thin quick-capture entry points around `op-new` that pre-fill the New Issue modal and skip the project picker when context resolves a project.

- **`op: new from selection`** (`editorCallback`) — uses `editor.getSelection()` as the issue's scope body, derives the title from the first line. No selection → title = active note's basename, scope = `Source: [[<note-title>]]`.
- **`op: new from clipboard`** — reads `navigator.clipboard.readText()`. Rejection (no focus / permission denied) → empty modal + one-shot Notice.
- Project resolution: (a) active note's `project:` frontmatter, (b) most-recent project from the recency log (prefix→slug lookup, advances past stale entries), (c) `ProjectSuggestModal` as last resort.
- Pre-fill mechanism: `NewIssueModal` now accepts optional `initial: { title, scopeRaw, scopeMode }`. `scopeMode: "body"` submits the textarea verbatim as `scopeBody` so paragraphs / blockquotes / blank lines round-trip intact instead of being shredded into one-bullet-per-non-empty-line by the legacy parser.
- Hotkey preset gains `⌘⌥S` (selection) and `⌘⌥V` (clipboard) sharing the `Mod+Alt+` family with `op-new`'s `⌘⌥N`. Preset count 10 → 12, all existing collision-skip semantics unchanged.

User-facing confirmation step is preserved per the op skill's "always pause before mutating vault or repo" rule — the goal is fewer keystrokes, not silent mutation.

Spec: `docs/specs/OP-149-feel-great-ux-design.md` §8.
Issue: `Projects/obsidian-projects/ISSUES/OP-159 …`

## Test plan

- [x] 706 unit tests pass — including 22 new tests on the pure `quickCapture` helpers (title derivation across markdown-noise variants, scope-body packing with/without fallback backlink, full (a)→(b)→(c) project resolution chain incl. stale recency entries and projects without prefixes).
- [x] Smoke-tested in Agent-Vault (Obsidian 1.8.x):
  - Clipboard variant: pre-filled title `"Test capture"` (markers stripped from `## Test capture`), scope textarea verbatim with `## heading + paragraph + bullets`. Project picker skipped.
  - Selection variant via injected fake editor: same prefill behavior.
  - No-selection fallback: title = active note's basename, scope = `Source: [[<note-title>]]`.
  - Console clean across all three runs.
- [x] Built artifact (`main.js`) deployed and reloaded; both commands present in `app.commands.commands`.

## @copilot — adversarial pressure-test prompts

Please pressure-test the diff against these specific concerns:

1. **Clipboard rejection paths.** `navigator.clipboard.readText()` can reject for at least three reasons: document not focused, user denied permission, no clipboard text at all. Trace the `runNewFromClipboardCommand` rejection path — is the user always told *why* the prefill didn't happen, or do silent-failure cases exist (e.g. resolved-with-empty-string vs reject)? Should the `text = ""` resolved-empty case also surface a Notice?
2. **Project-resolution staleness window.** `resolveCaptureProject` reads `app.metadataCache.getFileCache(file)?.frontmatter?.project`. What happens if metadataCache is mid-update for the active note (frontmatter recently edited)? Does the resolution silently use the stale slug, or is there a user-visible signal that the picker would have been more correct?
3. **Recency-log prefix collisions.** Two projects sharing a prefix (legacy projects pre-`prefix:`-field, manual edits, or test fixtures) → which one does `projects.find(p => p.prefix === prefix)` return? Is the answer deterministic across reloads given `listProjects()`'s sort order?
4. **`scopeBody` vs `scope` exclusivity in createIssue.** `issueTemplate.ts` says "if both are present, `scopeBody` wins." My modal sets `scope: undefined` when `scopeBody` is set, but verify the createIssue pipeline (esp. URI / CLI dispatch) handles the both-set case correctly — paste a paragraph into a prefilled modal, then add some bullets manually; what ships?
5. **Title-derivation pathological inputs.** What does `deriveTitle` produce on: (a) a 200-char single line of all `>>>>` blockquote markers, (b) a 200-char single line where the only non-marker char is at the end, (c) text starting with `​` zero-width space, (d) tab-indented bullets `\t- foo`? Are any of these a "looks empty but isn't" footgun?
6. **Modal pre-fill XSS / injection.** The pre-filled title goes through Obsidian's `setValue` on a text input — that's safe. But does `scopeBody` ever get rendered as HTML rather than text before `createIssue` writes it to a file? Specifically: any `innerHTML` / `setText` mistake in the textarea path?
7. **Hotkey preset bypass criteria.** The preset spec at OP-149 §3 calls out three bindings deliberately *swapped* away from Obsidian core conflicts. `⌘⌥S` and `⌘⌥V` — verify against current Obsidian 1.8 default hotkeys table that these are still free; if not, propose a non-conflicting alternative.
8. **No-selection fallback note-title escaping.** `Source: [[<basename>]]` — what if the active note's basename contains `]]`, `|`, or `#`? Does the wikilink still resolve, or do we need to wrap with `<...>` per Obsidian's escape rules?

Reply with concrete findings — line-numbered if possible. If you find a real bug, push the fix as a commit on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)