### PR TITLE
OP-155: background-launch + cross-app focus return + iTerm prefs Notice (§4 Steps 1, 3, 4)

### DIFF
--- a/plugins/op-obsidian/manifest.json
+++ b/plugins/op-obsidian/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "op-obsidian",
   "name": "Obsidian Projects (op)",
-  "version": "0.58.2",
+  "version": "0.59.0",
   "minAppVersion": "1.5.0",
   "description": "Jira-lite issue tracker for Obsidian vaults — deterministic commands backing the op workflow.",
   "author": "Eugene Archibald",

--- a/plugins/op-obsidian/package.json
+++ b/plugins/op-obsidian/package.json
@@ -1,6 +1,6 @@
 {
   "name": "op-obsidian",
-  "version": "0.58.2",
+  "version": "0.59.0",
   "description": "Obsidian plugin that owns the deterministic half of the op workflow.",
   "main": "main.js",
   "scripts": {

--- a/plugins/op-obsidian/src/crossAppActivate.test.ts
+++ b/plugins/op-obsidian/src/crossAppActivate.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const execFileMock = vi.fn();
+
+vi.mock("child_process", () => ({
+  execFile: (file: string, args: string[], cb: (err: Error | null) => void) => {
+    execFileMock(file, args);
+    cb(null);
+  },
+}));
+
+import { activateApp } from "./crossAppActivate";
+
+describe("activateApp", () => {
+  beforeEach(() => {
+    execFileMock.mockClear();
+  });
+
+  it("invokes /usr/bin/open -a <name>", async () => {
+    await activateApp("Obsidian");
+    expect(execFileMock).toHaveBeenCalledWith("/usr/bin/open", ["-a", "Obsidian"]);
+  });
+
+  it("works for iTerm and Terminal targets", async () => {
+    await activateApp("iTerm");
+    await activateApp("Terminal");
+    expect(execFileMock).toHaveBeenNthCalledWith(1, "/usr/bin/open", ["-a", "iTerm"]);
+    expect(execFileMock).toHaveBeenNthCalledWith(2, "/usr/bin/open", ["-a", "Terminal"]);
+  });
+
+  it("never adds new osascript callsites", async () => {
+    await activateApp("Obsidian");
+    const calls = execFileMock.mock.calls;
+    for (const [bin] of calls) {
+      expect(bin).not.toContain("osascript");
+    }
+  });
+});
+
+describe("activateApp swallows failures", () => {
+  it("does not throw when execFile errors", async () => {
+    vi.resetModules();
+    vi.doMock("child_process", () => ({
+      execFile: (
+        _file: string,
+        _args: string[],
+        cb: (err: Error | null) => void,
+      ) => {
+        cb(new Error("boom"));
+      },
+    }));
+    const { activateApp: activateAppErroring } = await import("./crossAppActivate");
+    await expect(activateAppErroring("Obsidian")).resolves.toBeUndefined();
+    vi.doUnmock("child_process");
+  });
+});

--- a/plugins/op-obsidian/src/crossAppActivate.ts
+++ b/plugins/op-obsidian/src/crossAppActivate.ts
@@ -1,0 +1,24 @@
+import { execFile } from "child_process";
+import { promisify } from "util";
+
+const pExecFile = promisify(execFile);
+
+// OP-155 §4 Step 3 — non-AppleScript cross-app activation. `open -a <name>`
+// is macOS's standard "Open With…" handler dispatch path; it activates the
+// target app the same way the dock or Spotlight would, without putting any
+// AppleScript on the wire. The OP-101 → OP-154 retirement removed every
+// scripted-activation callsite from `terminalLaunch.ts` and `client.ts`;
+// this helper is the codified replacement so future cross-app focus changes
+// don't re-introduce `osascript` callsites.
+//
+// Best-effort: if the target app isn't installed, `open` fails — swallow
+// silently because activation is cosmetic. The caller has already done its
+// work (created a tmux window, etc.); the user just won't see the focus
+// change. iTerm/Terminal/Obsidian are the three callsites today.
+export async function activateApp(name: "Obsidian" | "iTerm" | "Terminal"): Promise<void> {
+  try {
+    await pExecFile("/usr/bin/open", ["-a", name]);
+  } catch {
+    // Intentionally ignored — see comment above.
+  }
+}

--- a/plugins/op-obsidian/src/iTermPrefs.test.ts
+++ b/plugins/op-obsidian/src/iTermPrefs.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect } from "vitest";
+
+import {
+  ITERM_DEFAULTS_DOMAIN,
+  ITERM_TMUX_PREF_RECOMMENDATIONS,
+  iTermTmuxPrefsNoticeText,
+} from "./iTermPrefs";
+
+describe("ITERM_DEFAULTS_DOMAIN", () => {
+  it("is the iTerm2 bundle id", () => {
+    expect(ITERM_DEFAULTS_DOMAIN).toBe("com.googlecode.iterm2");
+  });
+});
+
+describe("ITERM_TMUX_PREF_RECOMMENDATIONS", () => {
+  it("calls out the four prefs the spec names", () => {
+    expect(ITERM_TMUX_PREF_RECOMMENDATIONS).toHaveLength(4);
+    const joined = ITERM_TMUX_PREF_RECOMMENDATIONS.join("\n");
+    expect(joined).toContain("After a session ends");
+    expect(joined).toContain("Close tmux windows after detaching");
+    expect(joined).toContain("New tmux windows not created by iTerm2");
+    expect(joined).toContain("Disable window position restoration");
+  });
+});
+
+describe("iTermTmuxPrefsNoticeText", () => {
+  it("is plain text (no newlines) so the Notice renderer doesn't choke", () => {
+    expect(iTermTmuxPrefsNoticeText()).not.toContain("\n");
+  });
+
+  it("numbers each recommendation in order", () => {
+    const t = iTermTmuxPrefsNoticeText();
+    expect(t).toMatch(/\(1\)/);
+    expect(t).toMatch(/\(2\)/);
+    expect(t).toMatch(/\(3\)/);
+    expect(t).toMatch(/\(4\)/);
+  });
+
+  it("starts with the op tip prefix", () => {
+    expect(iTermTmuxPrefsNoticeText()).toMatch(/^op: iTerm tmux integration tip/);
+  });
+});

--- a/plugins/op-obsidian/src/iTermPrefs.ts
+++ b/plugins/op-obsidian/src/iTermPrefs.ts
@@ -1,0 +1,75 @@
+import { execFile } from "child_process";
+import { promisify } from "util";
+
+import { showActionableNotice } from "./actionableNotices";
+import { activateApp } from "./crossAppActivate";
+
+const pExecFile = promisify(execFile);
+
+// OP-155 §4 Step 4 — best-effort detection that iTerm is installed (i.e. has
+// a defaults domain). The detailed advanced-pref keys (`Close tmux windows
+// after detaching?`, etc.) are not stable across iTerm builds, so the Notice
+// itself is the user-education contract; this probe just suppresses the
+// surface when iTerm isn't on the system at all.
+//
+// `defaults domains` is a single comma-space-separated string. A trailing
+// comma is normal. Match the iTerm bundle id verbatim — substring search is
+// safe because no other domain shares this prefix.
+export const ITERM_DEFAULTS_DOMAIN = "com.googlecode.iterm2";
+
+export async function iTermDefaultsDomainPresent(): Promise<boolean> {
+  try {
+    const { stdout } = await pExecFile("/usr/bin/defaults", ["domains"]);
+    return stdout.includes(ITERM_DEFAULTS_DOMAIN);
+  } catch {
+    // `defaults` is a system binary on every macOS install; if exec fails
+    // (sandbox, exotic environment) treat it as inconclusive and return
+    // false so the Notice is suppressed rather than fired blindly. The bit
+    // is left un-flipped so a subsequent launch in a friendlier environment
+    // can still surface the Notice.
+    return false;
+  }
+}
+
+// The pref names the user needs to flip. Spec §4 Step 4 calls these out
+// explicitly; we render them inline in the Notice so the user can copy
+// them straight into iTerm's settings search.
+export const ITERM_TMUX_PREF_RECOMMENDATIONS: ReadonlyArray<string> = [
+  'Settings → Profiles → Session → After a session ends → "No Action"',
+  'Settings → Advanced → Tmux Integration → "Close tmux windows after detaching?" → No',
+  'Settings → Advanced → Tmux Integration → "New tmux windows not created by iTerm2 open in current window?" → Yes',
+  'Settings → Advanced → Tmux Integration → "Disable window position restoration in tmux integration" → Yes',
+];
+
+// Single-string form rendered in the Notice text. Joined with " · " so the
+// inline links machinery doesn't choke on embedded newlines (Notice prose
+// is plain text only; we keep the enumeration compact and let the user
+// open Settings to drill down).
+export function iTermTmuxPrefsNoticeText(): string {
+  return (
+    "op: iTerm tmux integration tip — these prefs minimize tab snap-back: " +
+    ITERM_TMUX_PREF_RECOMMENDATIONS.map((s, i) => `(${i + 1}) ${s}`).join("; ")
+  );
+}
+
+// Surface the one-time Notice. The caller is responsible for the gate
+// (typically the persisted `iTermPrefsNoticeShown` bit) — this function
+// always fires when called. Returns whether the Notice was shown so the
+// caller can decide whether to flip the bit (we always recommend flipping
+// once the call has run, so the user isn't pestered on every launch).
+export function showITermTmuxPrefsNotice(): void {
+  showActionableNotice({
+    text: iTermTmuxPrefsNoticeText(),
+    actions: [
+      {
+        label: "Open iTerm settings",
+        // iTerm has no deep-link to a specific pref pane — opening the app
+        // and letting the user navigate is the best we can do. Mirrors the
+        // approach the spec recommends.
+        onClick: () => {
+          void activateApp("iTerm");
+        },
+      },
+    ],
+  });
+}

--- a/plugins/op-obsidian/src/iterm/client.test.ts
+++ b/plugins/op-obsidian/src/iterm/client.test.ts
@@ -307,3 +307,124 @@ describe("client write ops (fake transport)", () => {
     });
   });
 });
+
+// OP-155 §4 Step 1: createTab/createWindow expose an `activate` flag (default
+// true). Background-launch passes `activate: false` so iTerm doesn't come to
+// the foreground when an agent launches. Behavior is verified by counting
+// requests through a multi-message transport: the activate-then-create pair
+// becomes a single create when the flag is off.
+function multiTransport(reply: iterm2.IServerOriginatedMessage): {
+  transport: ITermTransport;
+  messages: iterm2.IClientOriginatedMessage[];
+} {
+  const messages: iterm2.IClientOriginatedMessage[] = [];
+  const transport = {
+    request: vi.fn(async (msg: iterm2.IClientOriginatedMessage) => {
+      messages.push(msg);
+      return iterm2.ServerOriginatedMessage.create(reply);
+    }),
+    connect: vi.fn(async () => undefined),
+    close: vi.fn(),
+  } as unknown as ITermTransport;
+  return { transport, messages };
+}
+
+async function withMultiTransport<T>(
+  reply: iterm2.IServerOriginatedMessage,
+  fn: (
+    messages: iterm2.IClientOriginatedMessage[],
+  ) => Promise<T>,
+): Promise<T> {
+  const { transport, messages } = multiTransport(reply);
+  const conn = await import("./connection");
+  conn.__setStateForTests({ transport, cookie: { cookie: "c", key: "k" }, socketPath: "/tmp/fake" });
+  const client = await import("./client");
+  client.configureClient({ version: "test" });
+  try {
+    return await fn(messages);
+  } finally {
+    conn.__setStateForTests(null);
+  }
+}
+
+describe("client activate flag (OP-155 Step 1)", () => {
+  it("createWindow with activate:false skips the ActivateRequest", async () => {
+    await withMultiTransport(
+      {
+        createTabResponse: {
+          status: iterm2.CreateTabResponse.Status.OK,
+          windowId: "w-1",
+          sessionId: "s-1",
+        },
+      },
+      async (messages) => {
+        const { createWindow } = await import("./client");
+        await createWindow("bash /tmp/x.sh", { activate: false });
+        const types = messages.map((m) =>
+          m.activateRequest ? "activate" : m.createTabRequest ? "createTab" : "?",
+        );
+        expect(types).toEqual(["createTab"]);
+      },
+    );
+  });
+
+  it("createWindow with activate:true (default) sends ActivateRequest first", async () => {
+    await withMultiTransport(
+      {
+        createTabResponse: {
+          status: iterm2.CreateTabResponse.Status.OK,
+          windowId: "w-1",
+          sessionId: "s-1",
+        },
+      },
+      async (messages) => {
+        const { createWindow } = await import("./client");
+        await createWindow("bash /tmp/x.sh");
+        const types = messages.map((m) =>
+          m.activateRequest ? "activate" : m.createTabRequest ? "createTab" : "?",
+        );
+        expect(types).toEqual(["activate", "createTab"]);
+      },
+    );
+  });
+
+  it("createTab with activate:false skips the ActivateRequest", async () => {
+    await withMultiTransport(
+      {
+        createTabResponse: {
+          status: iterm2.CreateTabResponse.Status.OK,
+          windowId: "w-existing",
+          sessionId: "s-new",
+        },
+      },
+      async (messages) => {
+        const { createTab } = await import("./client");
+        await createTab("bash /tmp/y.sh", "w-existing", { activate: false });
+        const types = messages.map((m) =>
+          m.activateRequest ? "activate" : m.createTabRequest ? "createTab" : "?",
+        );
+        expect(types).toEqual(["createTab"]);
+      },
+    );
+  });
+
+  it("createTab default behavior is unchanged (activates first)", async () => {
+    await withMultiTransport(
+      {
+        createTabResponse: {
+          status: iterm2.CreateTabResponse.Status.OK,
+          windowId: "w-existing",
+          sessionId: "s-new",
+        },
+      },
+      async (messages) => {
+        const { createTab } = await import("./client");
+        await createTab("bash /tmp/y.sh", "w-existing");
+        const types = messages.map((m) =>
+          m.activateRequest ? "activate" : m.createTabRequest ? "createTab" : "?",
+        );
+        expect(types).toEqual(["activate", "createTab"]);
+      },
+    );
+  });
+});

--- a/plugins/op-obsidian/src/iterm/client.ts
+++ b/plugins/op-obsidian/src/iterm/client.ts
@@ -62,10 +62,17 @@ function customCommandProperties(command: string): iterm2.ProfileProperty[] {
   ];
 }
 
-export async function createWindow(command: string): Promise<CreateWindowResult> {
-  // Raise iTerm first so the new window is visible when it appears. The
-  // legacy AppleScript did `activate` before `create window`.
-  await activateITerm();
+// `activate` (default true) controls whether iTerm is brought to the
+// foreground before the create call — mirroring the legacy AppleScript path's
+// `activate`-then-`create window` pair. Background-launch mode (OP-155 Step 1)
+// passes `activate: false` so a launch from inside Obsidian doesn't steal
+// focus; the caller is expected to have already ensured iTerm is running
+// (e.g. via `open -ga iTerm`) so the WS connection succeeds.
+export async function createWindow(
+  command: string,
+  opts: { activate?: boolean } = {},
+): Promise<CreateWindowResult> {
+  if (opts.activate !== false) await activateITerm();
 
   const reply = await call({
     createTabRequest: iterm2.CreateTabRequest.create({
@@ -76,12 +83,14 @@ export async function createWindow(command: string): Promise<CreateWindowResult>
 }
 
 // Add a tab to an existing iTerm window. Mirrors the AppleScript path's
-// `tell current window to create tab with default profile command …`. The
-// AppleScript activated iTerm before issuing the create call; we do the same
-// here so the new tab is visible. Returns `{windowId, sessionId}` of the new
-// tab — windowId echoes the hosting window in iTerm's reply.
-export async function createTab(command: string, windowId: string): Promise<CreateWindowResult> {
-  await activateITerm();
+// `tell current window to create tab with default profile command …`. See
+// `createWindow` for the `activate` flag semantics.
+export async function createTab(
+  command: string,
+  windowId: string,
+  opts: { activate?: boolean } = {},
+): Promise<CreateWindowResult> {
+  if (opts.activate !== false) await activateITerm();
 
   const reply = await call({
     createTabRequest: iterm2.CreateTabRequest.create({

--- a/plugins/op-obsidian/src/iterm/driver.test.ts
+++ b/plugins/op-obsidian/src/iterm/driver.test.ts
@@ -4,11 +4,14 @@ vi.mock("./client", () => ({
   sessionExists: vi.fn(async (_id: string) => false),
   selectSession: vi.fn(async () => undefined),
   createWindow: vi.fn(async () => ({ windowId: "ws-w", sessionId: "ws-s" })),
+  createTab: vi.fn(async () => ({ windowId: "ws-w", sessionId: "ws-s" })),
   splitSession: vi.fn(async () => "ws-split"),
   setSessionName: vi.fn(async () => undefined),
   setWindowName: vi.fn(async () => undefined),
   buildLayoutWindow: vi.fn(async () => ({ windowId: "ws-w", sessionIds: ["ws-s"] })),
   applySplit: vi.fn(async () => "ws-apply"),
+  activeWindowId: vi.fn(async () => undefined),
+  closeWindow: vi.fn(async () => undefined),
 }));
 
 import * as wsClient from "./client";
@@ -26,7 +29,22 @@ describe("iterm/driver pass-through", () => {
 
   it("forwards createWindow", async () => {
     expect(await driver.createWindow("cmd")).toEqual({ windowId: "ws-w", sessionId: "ws-s" });
-    expect(wsClient.createWindow).toHaveBeenCalledWith("cmd");
+    expect(wsClient.createWindow).toHaveBeenCalledWith("cmd", {});
+  });
+
+  it("forwards createWindow opts (e.g. activate:false for background launch)", async () => {
+    await driver.createWindow("cmd", { activate: false });
+    expect(wsClient.createWindow).toHaveBeenCalledWith("cmd", { activate: false });
+  });
+
+  it("forwards createTab", async () => {
+    await driver.createTab("cmd", "w");
+    expect(wsClient.createTab).toHaveBeenCalledWith("cmd", "w", {});
+  });
+
+  it("forwards createTab opts (activate:false for background launch)", async () => {
+    await driver.createTab("cmd", "w", { activate: false });
+    expect(wsClient.createTab).toHaveBeenCalledWith("cmd", "w", { activate: false });
   });
 
   it("forwards splitSession", async () => {

--- a/plugins/op-obsidian/src/iterm/driver.ts
+++ b/plugins/op-obsidian/src/iterm/driver.ts
@@ -20,12 +20,19 @@ export async function closeWindow(windowId: string): Promise<void> {
   return wsClient.closeWindow(windowId);
 }
 
-export async function createWindow(command: string): Promise<CreateWindowResult> {
-  return wsClient.createWindow(command);
+export async function createWindow(
+  command: string,
+  opts: { activate?: boolean } = {},
+): Promise<CreateWindowResult> {
+  return wsClient.createWindow(command, opts);
 }
 
-export async function createTab(command: string, windowId: string): Promise<CreateWindowResult> {
-  return wsClient.createTab(command, windowId);
+export async function createTab(
+  command: string,
+  windowId: string,
+  opts: { activate?: boolean } = {},
+): Promise<CreateWindowResult> {
+  return wsClient.createTab(command, windowId, opts);
 }
 
 export async function activeWindowId(): Promise<string | undefined> {

--- a/plugins/op-obsidian/src/main.ts
+++ b/plugins/op-obsidian/src/main.ts
@@ -2972,6 +2972,7 @@ export default class OpPlugin extends Plugin {
         issueId,
         agentId,
         debug: true,
+        backgroundLaunch: this.settings.backgroundLaunch,
       });
       notify(
         `op-debug-agent-launch: ${issueId} (tmux: ${res.tmuxSession}:${res.tmuxWindow})`,

--- a/plugins/op-obsidian/src/openAgent.ts
+++ b/plugins/op-obsidian/src/openAgent.ts
@@ -154,9 +154,13 @@ export async function openAgent(
   });
 
   // OP-155 §4 Step 4: first iTerm launch — surface the one-time prefs Notice
-  // and persist the bit. Fire-and-forget; failures (defaults read errors,
-  // settings-save errors) must not block the agent launch.
+  // and persist the bit. Flip the bit synchronously *before* yielding to the
+  // event loop so a second concurrent op-open-agent invocation (near-
+  // simultaneous user actions) sees the gate closed and doesn't double-fire
+  // the Notice. maybeShowITermPrefsNotice rolls it back to false if iTerm is
+  // absent (so the Notice can fire on the next launch) or if saving fails.
   if (settings.terminal === "iTerm" && !settings.iTermPrefsNoticeShown) {
+    settings.iTermPrefsNoticeShown = true; // optimistic — rolled back on failure
     void maybeShowITermPrefsNotice(settings, saveSettings);
   }
 
@@ -176,11 +180,16 @@ async function maybeShowITermPrefsNotice(
   saveSettings: () => Promise<void>,
 ): Promise<void> {
   try {
-    if (!(await iTermDefaultsDomainPresent())) return;
+    if (!(await iTermDefaultsDomainPresent())) {
+      // iTerm absent — roll back optimistic bit so the Notice can fire again
+      // when iTerm is eventually installed.
+      settings.iTermPrefsNoticeShown = false;
+      return;
+    }
     showITermTmuxPrefsNotice();
-    settings.iTermPrefsNoticeShown = true;
     await saveSettings();
   } catch (err) {
+    settings.iTermPrefsNoticeShown = false; // roll back so retry is possible
     console.warn("[op-obsidian] iTerm prefs Notice failed:", err);
   }
 }

--- a/plugins/op-obsidian/src/openAgent.ts
+++ b/plugins/op-obsidian/src/openAgent.ts
@@ -18,6 +18,7 @@ import { launchInTerminal } from "./terminalLaunch";
 import type { AgentDetector } from "./agentDetect";
 import { AgentPickerModal } from "./modals";
 import { userError } from "./userError";
+import { iTermDefaultsDomainPresent, showITermTmuxPrefsNotice } from "./iTermPrefs";
 
 /** Arguments accepted by {@link openAgent}. */
 export interface OpenAgentArgs {
@@ -139,6 +140,7 @@ export async function openAgent(
     issueId: args.entry.id,
     issueTitle: args.entry.title,
     agentId,
+    backgroundLaunch: settings.backgroundLaunch,
     orchestrator: {
       settings,
       registry: {
@@ -151,6 +153,13 @@ export async function openAgent(
     },
   });
 
+  // OP-155 §4 Step 4: first iTerm launch — surface the one-time prefs Notice
+  // and persist the bit. Fire-and-forget; failures (defaults read errors,
+  // settings-save errors) must not block the agent launch.
+  if (settings.terminal === "iTerm" && !settings.iTermPrefsNoticeShown) {
+    void maybeShowITermPrefsNotice(settings, saveSettings);
+  }
+
   return {
     issueId: args.entry.id,
     agent: agentId,
@@ -160,6 +169,20 @@ export async function openAgent(
     tmuxSession,
     tmuxWindow,
   };
+}
+
+async function maybeShowITermPrefsNotice(
+  settings: OpSettings,
+  saveSettings: () => Promise<void>,
+): Promise<void> {
+  try {
+    if (!(await iTermDefaultsDomainPresent())) return;
+    showITermTmuxPrefsNotice();
+    settings.iTermPrefsNoticeShown = true;
+    await saveSettings();
+  } catch (err) {
+    console.warn("[op-obsidian] iTerm prefs Notice failed:", err);
+  }
 }
 
 async function pickAgent(

--- a/plugins/op-obsidian/src/orchestrator.ts
+++ b/plugins/op-obsidian/src/orchestrator.ts
@@ -51,6 +51,12 @@ export interface OrchestrateArgs {
   // Session name for the "work" tmux session in use. The orchestrator also
   // derives per-window tmux sessions (e.g. op-agents-1, op-agents-2).
   baseTmuxSession: string;
+  // OP-155 §4 Step 1: when true, do not bring iTerm to the foreground.
+  // `open -ga iTerm` is run first so the WS connect succeeds, and the
+  // `createWindow` call is issued with `activate: false`. The split path
+  // (growth into an existing window) does not need additional treatment —
+  // `splitSession` does not call ActivateRequest in the first place.
+  backgroundLaunch?: boolean;
 }
 
 export interface OrchestrateResult {
@@ -197,7 +203,14 @@ export async function orchestrateLaunch(
 
   await ensureAgentWindow({ args, tmuxSession, windowName });
   const viewScript = await writeViewScript({ args, tmuxSession, tmuxWindow: windowName });
-  const { windowId, sessionId } = await createWindow(quoteForBash(viewScript));
+  // OP-155 §4 Step 1: cold-start iTerm in the background and skip the WS
+  // ActivateRequest when `backgroundLaunch` is on.
+  if (args.backgroundLaunch) {
+    await pExecFile("/usr/bin/open", ["-ga", "iTerm"]);
+  }
+  const { windowId, sessionId } = await createWindow(quoteForBash(viewScript), {
+    activate: !args.backgroundLaunch,
+  });
   await setWindowName(windowId, tmuxSession);
   await setSessionName(sessionId, sessionTitle);
 

--- a/plugins/op-obsidian/src/revealAgentSession.ts
+++ b/plugins/op-obsidian/src/revealAgentSession.ts
@@ -5,6 +5,7 @@ import { notify } from "./notificationLog";
 import type { OpSettings } from "./settings";
 import { findAgentTmuxLocation } from "./agentTmuxLocation";
 import { selectSession, sessionExists } from "./iterm/driver";
+import { activateApp } from "./crossAppActivate";
 
 const pExecFile = promisify(execFile);
 
@@ -43,12 +44,10 @@ export async function revealAgentSession(
 }
 
 async function activateTerminalApp(app: "Terminal" | "iTerm"): Promise<void> {
-  const target = app === "iTerm" ? "iTerm2" : "Terminal";
-  const script = `tell application "${target}" to activate`;
-  try {
-    await pExecFile("/usr/bin/osascript", ["-e", script]);
-  } catch {
-    // Best effort — if the terminal isn't running there's nothing to
-    // reveal anyway; the tmux window exists but is detached.
-  }
+  // OP-155 §4 Step 3: cross-app activation via `open -a` instead of
+  // `tell application "…" to activate`. `activateApp` swallows ENOENT/Etc
+  // already, so the best-effort semantics are unchanged. Note `open -a`
+  // matches the user-visible app name, not the bundle identifier — pass
+  // "iTerm" (not "iTerm2"); macOS resolves it via LaunchServices.
+  await activateApp(app);
 }

--- a/plugins/op-obsidian/src/settings.ts
+++ b/plugins/op-obsidian/src/settings.ts
@@ -582,6 +582,18 @@ export class OpSettingsTab extends PluginSettingTab {
           }),
       );
 
+    new Setting(containerEl)
+      .setName("Launch agent without stealing focus")
+      .setDesc(
+        "When on, op cold-starts iTerm via `open -ga` and creates the agent's tab via the WebSocket API without bringing iTerm to the foreground — Obsidian keeps focus. Off: iTerm comes forward as today. iTerm only; Terminal.app has no equivalent non-activating launch path. (OP-155 §4 Step 1)",
+      )
+      .addToggle((t) =>
+        t.setValue(s.backgroundLaunch).onChange(async (v) => {
+          s.backgroundLaunch = v;
+          await this.plugin.saveSettings();
+        }),
+      );
+
     containerEl.createEl("h2", { text: "iTerm layout orchestrator" });
     containerEl.createEl("p", {
       text: "When enabled, op lays out agent panes in the current iTerm window per the chosen layout. Overflow spills to a new iTerm window backed by a fresh tmux session. macOS + iTerm only.",

--- a/plugins/op-obsidian/src/settingsPure.ts
+++ b/plugins/op-obsidian/src/settingsPure.ts
@@ -92,6 +92,18 @@ export interface OpSettings {
   workingDirs: Record<string, string>;
   terminal: "Terminal" | "iTerm";
   iTermPlacement: ITermPlacement;
+  /** OP-155 §4 Step 1: when true, agent launches do not bring the terminal
+   * app to the foreground. iTerm path uses `open -ga iTerm` (cold-start
+   * without activation) and skips the WS `ActivateRequest`. Default false —
+   * matches today's behavior, which most users expect when they hit
+   * "launch agent". On for users who launch from inside a flow and want
+   * Obsidian to keep focus. */
+  backgroundLaunch: boolean;
+  /** OP-155 §4 Step 4: one-shot bit gating the iTerm-tmux-prefs Notice.
+   * Flipped to true after the Notice has been surfaced (or skipped because
+   * all prefs already match the recommended values) on the first iTerm
+   * tmux-CC launch. Persists across reloads so the Notice never repeats. */
+  iTermPrefsNoticeShown: boolean;
   tmuxBinary: string;
   view: ViewSettings;
   github: GithubSettings;
@@ -132,6 +144,8 @@ export const DEFAULT_SETTINGS: OpSettings = {
   workingDirs: {},
   terminal: "Terminal",
   iTermPlacement: "new-tab",
+  backgroundLaunch: false,
+  iTermPrefsNoticeShown: false,
   tmuxBinary: "/opt/homebrew/bin/tmux",
   view: {
     defaultTab: "issues",
@@ -193,6 +207,10 @@ export function mergeSettings(loaded: unknown): OpSettings {
   if (l.terminal === "Terminal" || l.terminal === "iTerm") base.terminal = l.terminal;
   if (l.iTermPlacement === "new-tab" || l.iTermPlacement === "new-window") {
     base.iTermPlacement = l.iTermPlacement;
+  }
+  if (typeof l.backgroundLaunch === "boolean") base.backgroundLaunch = l.backgroundLaunch;
+  if (typeof l.iTermPrefsNoticeShown === "boolean") {
+    base.iTermPrefsNoticeShown = l.iTermPrefsNoticeShown;
   }
   if (typeof l.tmuxBinary === "string" && l.tmuxBinary.trim()) {
     base.tmuxBinary = l.tmuxBinary.trim();

--- a/plugins/op-obsidian/src/terminalLaunch.backgroundLaunch.test.ts
+++ b/plugins/op-obsidian/src/terminalLaunch.backgroundLaunch.test.ts
@@ -126,4 +126,3 @@ describe("launchInTerminal backgroundLaunch wiring (OP-155 §4 Step 1)", () => {
     );
   });
 });
-

--- a/plugins/op-obsidian/src/terminalLaunch.backgroundLaunch.test.ts
+++ b/plugins/op-obsidian/src/terminalLaunch.backgroundLaunch.test.ts
@@ -1,0 +1,129 @@
+// OP-155 §4 Step 1 — integration-level tests for launchInTerminal's
+// background-launch wiring: that `backgroundLaunch:true` triggers
+// `open -ga iTerm` and passes `activate:false` through to the WS driver.
+//
+// All I/O is mocked so the tests run without tmux / iTerm / a real FS:
+// • child_process.execFile  — captures all process invocations
+// • ./iterm/driver          — stubs the WS create/tab calls
+// • fs.promises             — stubs mkdtemp + writeFile
+//
+// The function also guards `process.platform === "darwin"`; we stub that
+// for the test run so the CI Linux environment doesn't short-circuit.
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+
+// ── platform stub ──────────────────────────────────────────────────────────
+const originalPlatform = process.platform;
+beforeAll(() => {
+  Object.defineProperty(process, "platform", { value: "darwin", configurable: true });
+});
+afterAll(() => {
+  Object.defineProperty(process, "platform", { value: originalPlatform, configurable: true });
+});
+
+// ── child_process mock ─────────────────────────────────────────────────────
+// Capture (file, args) for every execFile call; always succeed with empty
+// stdout. Empty stdout from `tmux list-clients` → isSessionAttached returns
+// false → the open/createTab path runs as expected.
+const execFileMock = vi.fn();
+vi.mock("child_process", () => ({
+  execFile: (
+    file: string,
+    args: string[],
+    cb: (err: null, result: { stdout: string; stderr: string }) => void,
+  ) => {
+    execFileMock(file, args);
+    cb(null, { stdout: "", stderr: "" });
+  },
+}));
+
+// ── iterm driver mock ──────────────────────────────────────────────────────
+vi.mock("./iterm/driver", () => ({
+  activeWindowId: vi.fn(async () => "w-active"),
+  createTab: vi.fn(async () => ({ windowId: "w-active", sessionId: "s-new" })),
+  createWindow: vi.fn(async () => ({ windowId: "w-new", sessionId: "s-new" })),
+}));
+
+// ── fs mock ────────────────────────────────────────────────────────────────
+vi.mock("fs", () => ({
+  promises: {
+    mkdtemp: vi.fn(async () => "/tmp/op-agent-test"),
+    writeFile: vi.fn(async () => undefined),
+  },
+}));
+
+import * as driver from "./iterm/driver";
+import { launchInTerminal } from "./terminalLaunch";
+
+const BASE = {
+  cwd: "/tmp",
+  binary: "/usr/bin/env",
+  launchFlags: [] as string[],
+  prompt: "do stuff",
+  terminalApp: "iTerm" as const,
+  iTermPlacement: "new-tab" as const,
+  tmuxBinary: "/opt/homebrew/bin/tmux",
+  agentId: "agt-1",
+  issueId: "OP-1",
+};
+
+describe("launchInTerminal backgroundLaunch wiring (OP-155 §4 Step 1)", () => {
+  beforeEach(() => {
+    execFileMock.mockClear();
+    vi.mocked(driver.activeWindowId).mockResolvedValue("w-active");
+    vi.mocked(driver.createTab).mockResolvedValue({ windowId: "w-active", sessionId: "s-new" });
+    vi.mocked(driver.createWindow).mockResolvedValue({ windowId: "w-new", sessionId: "s-new" });
+  });
+
+  it("calls /usr/bin/open -ga iTerm when backgroundLaunch:true", async () => {
+    await launchInTerminal({ ...BASE, backgroundLaunch: true });
+    expect(execFileMock).toHaveBeenCalledWith("/usr/bin/open", ["-ga", "iTerm"]);
+  });
+
+  it("does not call open -ga when backgroundLaunch is false", async () => {
+    await launchInTerminal({ ...BASE, backgroundLaunch: false });
+    const bgCalls = execFileMock.mock.calls.filter(
+      ([f, a]: [string, string[]]) => f === "/usr/bin/open" && a.includes("-ga"),
+    );
+    expect(bgCalls).toHaveLength(0);
+  });
+
+  it("does not call open -ga when backgroundLaunch is absent (default)", async () => {
+    await launchInTerminal({ ...BASE });
+    const bgCalls = execFileMock.mock.calls.filter(
+      ([f, a]: [string, string[]]) => f === "/usr/bin/open" && a.includes("-ga"),
+    );
+    expect(bgCalls).toHaveLength(0);
+  });
+
+  it("passes activate:false to createTab (new-tab, active window) when backgroundLaunch:true", async () => {
+    vi.mocked(driver.activeWindowId).mockResolvedValue("w-active");
+    await launchInTerminal({ ...BASE, backgroundLaunch: true });
+    expect(driver.createTab).toHaveBeenCalledWith(
+      expect.any(String),
+      "w-active",
+      { activate: false },
+    );
+  });
+
+  it("passes activate:false to createWindow (new-tab, no active window) when backgroundLaunch:true", async () => {
+    vi.mocked(driver.activeWindowId).mockResolvedValue(undefined);
+    await launchInTerminal({ ...BASE, backgroundLaunch: true });
+    expect(driver.createWindow).toHaveBeenCalledWith(expect.any(String), { activate: false });
+  });
+
+  it("passes activate:false to createWindow (new-window placement) when backgroundLaunch:true", async () => {
+    await launchInTerminal({ ...BASE, iTermPlacement: "new-window", backgroundLaunch: true });
+    expect(driver.createWindow).toHaveBeenCalledWith(expect.any(String), { activate: false });
+  });
+
+  it("passes activate:true to createTab when backgroundLaunch is false (default behavior preserved)", async () => {
+    vi.mocked(driver.activeWindowId).mockResolvedValue("w-active");
+    await launchInTerminal({ ...BASE, backgroundLaunch: false });
+    expect(driver.createTab).toHaveBeenCalledWith(
+      expect.any(String),
+      "w-active",
+      { activate: true },
+    );
+  });
+});
+

--- a/plugins/op-obsidian/src/terminalLaunch.ts
+++ b/plugins/op-obsidian/src/terminalLaunch.ts
@@ -52,6 +52,12 @@ export interface LaunchArgs {
     settings: import("./settingsPure").OpSettings;
     registry: import("./orchestrator").RegistryIO;
   };
+  // OP-155 §4 Step 1: when true and `terminalApp === "iTerm"`, the launch
+  // does not bring iTerm to the foreground. iTerm is started (if needed)
+  // via `open -ga iTerm` and the WebSocket `CreateTab`/`CreateWindow` call
+  // skips the `ActivateRequest`. No effect on Terminal.app — Terminal has
+  // no equivalent non-activating launch path. Defaults to false.
+  backgroundLaunch?: boolean;
 }
 
 export interface LaunchResult {
@@ -93,6 +99,7 @@ export async function launchInTerminal(args: LaunchArgs): Promise<LaunchResult> 
         debug: args.debug,
         tmuxBinary: args.tmuxBinary,
         baseTmuxSession: SHARED_TMUX_SESSION,
+        backgroundLaunch: args.backgroundLaunch,
       },
       args.orchestrator.settings,
       args.orchestrator.registry,
@@ -117,19 +124,31 @@ export async function launchInTerminal(args: LaunchArgs): Promise<LaunchResult> 
       return { scriptPath: innerPath, tmuxSession: session, tmuxWindow: windowName };
     }
 
+    // OP-155 §4 Step 1: in background-launch mode, ensure iTerm is running
+    // without activating it (`-g` = launch in background, `-a` = by app name)
+    // before opening the WS connection. Skipping this on a cold-start would
+    // race the WS connect against macOS's app-launch slot — and even when
+    // iTerm comes up, the connect might happen before the API server is
+    // listening. `open -ga` returns synchronously once the app has been
+    // launched; the WS client then activates iTerm via Activate{App} only if
+    // we ask it to (we don't, in background mode).
+    const wsActivate = !args.backgroundLaunch;
+    if (args.backgroundLaunch) {
+      await pExecFile("/usr/bin/open", ["-ga", "iTerm"]);
+    }
     const command = buildITermAttachCommand(args.tmuxBinary, session);
     if (args.iTermPlacement === "new-tab") {
       const targetWindow = await activeWindowId();
       if (targetWindow) {
-        await createTab(command, targetWindow);
+        await createTab(command, targetWindow, { activate: wsActivate });
       } else {
         // No iTerm window is currently key (iTerm not running, all windows
         // minimized, etc.) — fall back to opening a new window. Mirrors the
         // legacy AppleScript `if (count of windows) = 0 then create window`.
-        await createWindow(command);
+        await createWindow(command, { activate: wsActivate });
       }
     } else {
-      await createWindow(command);
+      await createWindow(command, { activate: wsActivate });
     }
     return { scriptPath: innerPath, tmuxSession: session, tmuxWindow: windowName };
   }

--- a/plugins/op/.claude-plugin/plugin.json
+++ b/plugins/op/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "op",
   "description": "Obsidian Projects workflow — schema, slash commands, and agent skill for running a Jira-lite issue tracker inside an Obsidian vault.",
-  "version": "0.58.2",
+  "version": "0.59.0",
   "author": {
     "name": "Eugene Archibald"
   },


### PR DESCRIPTION
@copilot please pressure-test:
- Verify background-launch behavior really doesn't activate iTerm: trace the call graph from `backgroundLaunch=true` → `terminalLaunch.ts:launchInTerminal` → either `createTab(..., { activate: false })` or `createWindow(..., { activate: false })`. Are there *any* other code paths that could still bring iTerm forward (e.g. `setSessionName`, profile-property side-effects)?
- The orchestrator path: when growing into an existing iTerm window via `splitSession`, does the split-pane RPC have any inherent activate side-effect? My read is no — only `ActivateRequest` activates. Confirm.
- `iterm/cookie.ts` should be the *only* `osascript` call left in the bundle. Run `grep "osascript" plugins/op-obsidian/main.js` after building and confirm exactly one match. Is the cookie path reachable in this PR's flow without re-introducing scripted activation?
- The one-time Notice is gated on `iTermPrefsNoticeShown` AND `iTermDefaultsDomainPresent()`. Is there a race where `openAgent` returns before the (async) `maybeShowITermPrefsNotice` flips the bit, and a second concurrent launch double-fires the Notice? My take: not reachable because Obsidian commands are user-driven and `openAgent` itself is awaited per-invocation, but I want a second pair of eyes.
- Settings UI: I rendered the toggle inline under the existing Terminal section. Reasonable placement, or should it land closer to the orchestrator settings (since both gate iTerm focus behavior)?
- Cross-app `open -a "iTerm"` vs the legacy `iTerm2` (`tell application "iTerm2"`): I claim `open -a` matches the user-visible app name (LaunchServices), so "iTerm" is the right token. Verify against your understanding of LaunchServices resolution rules.
- Test coverage: the multi-message transport in `iterm/client.test.ts` asserts the activate→createTab pair becomes a single createTab when activate is false. Are there integration-level test gaps (e.g. terminalLaunch.ts wiring of `open -ga`) that should be unit-tested too?

## Summary
- **§4 Step 1 — Background-launch mode.** New `backgroundLaunch` setting + UI toggle. When on, `open -ga iTerm` cold-starts iTerm without activation; WS `CreateTab`/`CreateWindow` calls skip the `ActivateRequest`. Default off (current behavior).
- **§4 Step 3 — Cross-app focus return without `osascript`.** New `crossAppActivate.activateApp()` helper uses `open -a`. `revealAgentSession.ts` migrated off `osascript`; the only remaining osascript callsite in the bundle is `iterm/cookie.ts` (first-run auth, spec-sanctioned).
- **§4 Step 4 — One-time iTerm tmux-prefs Notice.** New `iTermPrefs.ts` surfaces an actionable Notice on the first iTerm launch listing the four pref recommendations from the spec, with an `[Open iTerm settings]` action button (`open -a iTerm`). Gated by persisted `iTermPrefsNoticeShown` + `iTermDefaultsDomainPresent()`.

Out of scope: §4 Step 2 (per-launch ⌥+click override) — OP-155 covers Steps 1, 3, 4 per its title.

Builds on top of OP-154 squash `6e34205` (AppleScript retirement). Net `osascript` callsite count: 1 (cookie.ts), unchanged from OP-154.

## Test plan
- [x] `npx vitest run` — 698 tests pass, including the 4 new client-activate-flag tests, 2 new driver pass-through tests, the iTermPrefs unit tests, and the crossAppActivate tests.
- [x] `npm run build` — production esbuild succeeds; bundle size 800K.
- [x] Smoke: `obsidian eval` confirms the new `backgroundLaunch` and `iTermPrefsNoticeShown` keys appear on `app.plugins.plugins["op-obsidian"].settings`, default to `false`, and round-trip through `saveSettings()`.
- [x] Smoke: Settings tab renders the new toggle (`Launch agent without stealing focus`) under the Terminal section.
- [x] Smoke: `dev:console` clean after plugin reload — no errors.
- [x] Smoke: `grep osascript plugins/op-obsidian/main.js` returns exactly 1 match (the cookie.ts site).
- [ ] Manual: flip `backgroundLaunch` on, launch a real agent, confirm Obsidian keeps focus and iTerm tab spawns in the background.
- [ ] Manual: clear `iTermPrefsNoticeShown` (`obsidian eval`), launch an iTerm agent, confirm the Notice fires with the `[Open iTerm settings]` action.

🤖 Generated with [Claude Code](https://claude.com/claude-code)