### PR TITLE
OP-144: encapsulate op skill into a plugin CLI verb (op-get-skill)

### DIFF
--- a/plugins/op-obsidian/esbuild.config.mjs
+++ b/plugins/op-obsidian/esbuild.config.mjs
@@ -31,6 +31,7 @@ const context = await esbuild.context({
   outfile: "main.js",
   platform: "node",
   minify: prod,
+  loader: { ".md": "text" },
 });
 
 if (prod) {

--- a/plugins/op-obsidian/manifest.json
+++ b/plugins/op-obsidian/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "op-obsidian",
   "name": "Obsidian Projects (op)",
-  "version": "0.61.0",
+  "version": "0.61.1",
   "minAppVersion": "1.5.0",
   "description": "Jira-lite issue tracker for Obsidian vaults — deterministic commands backing the op workflow.",
   "author": "Eugene Archibald",

--- a/plugins/op-obsidian/manifest.json
+++ b/plugins/op-obsidian/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "op-obsidian",
   "name": "Obsidian Projects (op)",
-  "version": "0.60.1",
+  "version": "0.61.0",
   "minAppVersion": "1.5.0",
   "description": "Jira-lite issue tracker for Obsidian vaults — deterministic commands backing the op workflow.",
   "author": "Eugene Archibald",

--- a/plugins/op-obsidian/package.json
+++ b/plugins/op-obsidian/package.json
@@ -1,6 +1,6 @@
 {
   "name": "op-obsidian",
-  "version": "0.60.1",
+  "version": "0.61.0",
   "description": "Obsidian plugin that owns the deterministic half of the op workflow.",
   "main": "main.js",
   "scripts": {
@@ -22,6 +22,7 @@
     "builtin-modules": "^3.3.0",
     "esbuild": "^0.20.0",
     "obsidian": "latest",
+    "protobufjs-cli": "^2.0.1",
     "tslib": "^2.6.2",
     "typescript": "^5.3.0",
     "vitest": "^4.1.4"

--- a/plugins/op-obsidian/package.json
+++ b/plugins/op-obsidian/package.json
@@ -1,6 +1,6 @@
 {
   "name": "op-obsidian",
-  "version": "0.61.0",
+  "version": "0.61.1",
   "description": "Obsidian plugin that owns the deterministic half of the op workflow.",
   "main": "main.js",
   "scripts": {

--- a/plugins/op-obsidian/src/cliHandlers.test.ts
+++ b/plugins/op-obsidian/src/cliHandlers.test.ts
@@ -11,6 +11,7 @@ import {
   parseScaffoldParams,
   parseGetWorkflowParams,
   parseEditWorkflowParams,
+  parseGetSkillParams,
 } from "./cliHandlers";
 
 describe("parseWorkParams", () => {
@@ -228,5 +229,29 @@ describe("parseEditWorkflowParams", () => {
   it("project beats slug when both present", () => {
     const r = parseEditWorkflowParams({ project: "a", slug: "b" });
     expect(r.ok && r.value.project).toBe("a");
+  });
+});
+
+describe("parseGetSkillParams", () => {
+  it("always succeeds — name= is optional", () => {
+    expect(parseGetSkillParams({}).ok).toBe(true);
+    expect(parseGetSkillParams({ name: "" }).ok).toBe(true);
+    expect(parseGetSkillParams({ name: "skill" }).ok).toBe(true);
+  });
+  it("trims whitespace from name", () => {
+    const r = parseGetSkillParams({ name: "  skill  " });
+    expect(r.ok && r.value.name).toBe("skill");
+  });
+  it("returns empty string when name is absent", () => {
+    const r = parseGetSkillParams({});
+    expect(r.ok && r.value.name).toBe("");
+  });
+  it("returns empty string when name is blank (URI: ?name=%20%20)", () => {
+    const r = parseGetSkillParams({ name: "  " });
+    expect(r.ok && r.value.name).toBe("");
+  });
+  it("preserves casing for downstream case-folding in getSkill", () => {
+    const r = parseGetSkillParams({ name: "Skill" });
+    expect(r.ok && r.value.name).toBe("Skill");
   });
 });

--- a/plugins/op-obsidian/src/cliHandlers.ts
+++ b/plugins/op-obsidian/src/cliHandlers.ts
@@ -235,3 +235,10 @@ export function parseEditWorkflowParams(
   if (!project) return { ok: false, error: "op-edit-workflow failed: --project is required" };
   return { ok: true, value: { project } };
 }
+
+export function parseGetSkillParams(
+  params: Record<string, string>,
+): ParamsResult<{ name: string }> {
+  const raw = typeof params.name === "string" ? params.name.trim() : "";
+  return { ok: true, value: { name: raw } };
+}

--- a/plugins/op-obsidian/src/main.ts
+++ b/plugins/op-obsidian/src/main.ts
@@ -23,6 +23,7 @@ import { scaffoldProject, type ScaffoldProjectResult } from "./scaffoldProject";
 import { workIssue, type WorkIssueResult } from "./workIssue";
 import { appendCommit, setPr } from "./commits";
 import { getWorkflow } from "./workflow";
+import { getSkill } from "./skill";
 import { setScope } from "./setScope";
 import { parseNewScopePayload, type NewScopeMode } from "./setScopePure";
 import { setEvaluation } from "./setEvaluation";
@@ -70,6 +71,7 @@ import {
   handleOpLinkCheckUri as handleOpLinkCheckUriPure,
   handleOpMigrateLinksUri as handleOpMigrateLinksUriPure,
   handleOpGetWorkflowUri as handleOpGetWorkflowUriPure,
+  handleOpGetSkillUri as handleOpGetSkillUriPure,
   type UriHandlerDeps,
 } from "./uriHandlers";
 import {
@@ -86,6 +88,7 @@ import {
   parseLinkCheckParams,
   parseGetWorkflowParams,
   parseEditWorkflowParams,
+  parseGetSkillParams,
 } from "./cliHandlers";
 import type { IssueEntry, LifecycleEvent } from "./types";
 import { DEFAULT_SETTINGS, mergeSettings, OpSettingsTab, type OpSettings } from "./settings";
@@ -861,6 +864,12 @@ export default class OpPlugin extends Plugin {
       );
     });
 
+    this.registerObsidianProtocolHandler("op-get-skill", (params) => {
+      this.runUri("op-get-skill", normalizeUriParams(params), (p) =>
+        handleOpGetSkillUriPure(this.uriDeps(), p),
+      );
+    });
+
     this.registerObsidianProtocolHandler("op-edit-workflow", (params) => {
       this.runUri("op-edit-workflow", normalizeUriParams(params), (p) =>
         this.handleOpEditWorkflowUri(p),
@@ -1068,6 +1077,18 @@ export default class OpPlugin extends Plugin {
         project: { value: "<slug>", description: "Project slug (folder name under Projects/)" },
       },
       (params) => this.handleOpGetWorkflowCli(params),
+    );
+
+    this.registerCliHandler(
+      "op-get-skill",
+      "Return the canonical op skill body (operating manual) bundled with the plugin. Read-only.",
+      {
+        name: {
+          value: "<name>",
+          description: "Skill body to return (default: skill). Currently only \"skill\" is recognized.",
+        },
+      },
+      (params) => this.handleOpGetSkillCli(params),
     );
 
     this.registerCliHandler(
@@ -2552,6 +2573,28 @@ export default class OpPlugin extends Plugin {
       return res.exists
         ? `${command}: ${res.project} → ${res.path} (${res.size} chars)`
         : `${command}: ${res.project} → no WORKFLOW.md (would live at ${res.path})`;
+    } catch (err: any) {
+      const msg = err?.message ?? String(err);
+      console.error("[op-obsidian]", command, err);
+      await writeUriResponse(this.app, { ok: false, command, error: msg });
+      return `${command} failed: ${msg}`;
+    }
+  }
+
+  private async handleOpGetSkillCli(params: Record<string, string>): Promise<string> {
+    const command = "op-get-skill";
+    try {
+      const parsed = parseGetSkillParams(params);
+      if (!parsed.ok) return parsed.error;
+      const res = getSkill(parsed.value.name);
+      await writeUriResponse(this.app, {
+        ok: true,
+        command,
+        name: res.name,
+        content: res.content,
+        size: res.size,
+      });
+      return `${command}: ${res.name} (${res.size} chars)`;
     } catch (err: any) {
       const msg = err?.message ?? String(err);
       console.error("[op-obsidian]", command, err);

--- a/plugins/op-obsidian/src/skill.test.ts
+++ b/plugins/op-obsidian/src/skill.test.ts
@@ -23,7 +23,7 @@ describe("getSkill", () => {
   });
 
   it("rejects unknown names with a clear error", () => {
-    expect(() => getSkill("nope")).toThrow(/unknown name "nope"/);
+    expect(() => getSkill("nope")).toThrow(/^unknown name "nope" \(expected one of skill\)$/);
   });
 
   it("rejects future names that are not yet implemented", () => {

--- a/plugins/op-obsidian/src/skill.test.ts
+++ b/plugins/op-obsidian/src/skill.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vitest";
+import { SKILL_NAMES, getSkill } from "./skill";
+
+describe("getSkill", () => {
+  it("returns bundled content for the default name", () => {
+    const res = getSkill("skill");
+    expect(res.name).toBe("skill");
+    expect(res.size).toBeGreaterThan(0);
+    expect(res.size).toBe(res.content.length);
+    // Sanity-check that we got the operational manual, not some other doc:
+    expect(res.content).toMatch(/Obsidian Projects \(op\) workflow/);
+  });
+
+  it("defaults to the canonical skill when name is empty", () => {
+    expect(getSkill("").name).toBe("skill");
+    expect(getSkill("   ").name).toBe("skill");
+  });
+
+  it("rejects unknown names with a clear error", () => {
+    expect(() => getSkill("nope")).toThrow(/unknown name "nope"/);
+  });
+
+  it("only knows about names declared in SKILL_NAMES", () => {
+    expect(SKILL_NAMES).toEqual(["skill"]);
+  });
+});

--- a/plugins/op-obsidian/src/skill.test.ts
+++ b/plugins/op-obsidian/src/skill.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { SKILL_NAMES, getSkill } from "./skill";
+import { parseGetSkillParams } from "./cliHandlers";
 
 describe("getSkill", () => {
   it("returns bundled content for the default name", () => {
@@ -16,11 +17,41 @@ describe("getSkill", () => {
     expect(getSkill("   ").name).toBe("skill");
   });
 
+  it("is case-insensitive — Skill and SKILL both resolve to skill", () => {
+    expect(getSkill("Skill").name).toBe("skill");
+    expect(getSkill("SKILL").name).toBe("skill");
+  });
+
   it("rejects unknown names with a clear error", () => {
     expect(() => getSkill("nope")).toThrow(/unknown name "nope"/);
   });
 
+  it("rejects future names that are not yet implemented", () => {
+    expect(() => getSkill("cli-gotchas")).toThrow(/unknown name "cli-gotchas"/);
+  });
+
+  it("the error message lists expected names", () => {
+    let msg = "";
+    try {
+      getSkill("nope");
+    } catch (e: any) {
+      msg = e.message;
+    }
+    for (const name of SKILL_NAMES) {
+      expect(msg).toContain(name);
+    }
+  });
+
   it("only knows about names declared in SKILL_NAMES", () => {
     expect(SKILL_NAMES).toEqual(["skill"]);
+  });
+
+  it("parseGetSkillParams → getSkill round-trip handles capitalized input end-to-end", () => {
+    const parsed = parseGetSkillParams({ name: "Skill" });
+    expect(parsed.ok).toBe(true);
+    if (!parsed.ok) return;
+    const res = getSkill(parsed.value.name);
+    expect(res.name).toBe("skill");
+    expect(res.size).toBeGreaterThan(0);
   });
 });

--- a/plugins/op-obsidian/src/skill.ts
+++ b/plugins/op-obsidian/src/skill.ts
@@ -14,7 +14,7 @@ export interface GetSkillResult {
 }
 
 export function getSkill(name: string): GetSkillResult {
-  const trimmed = name.trim();
+  const trimmed = name.trim().toLowerCase();
   const target = trimmed === "" ? "skill" : trimmed;
   if (!isSkillName(target)) {
     throw new Error(

--- a/plugins/op-obsidian/src/skill.ts
+++ b/plugins/op-obsidian/src/skill.ts
@@ -18,7 +18,7 @@ export function getSkill(name: string): GetSkillResult {
   const target = trimmed === "" ? "skill" : trimmed;
   if (!isSkillName(target)) {
     throw new Error(
-      `op-get-skill: unknown name ${JSON.stringify(target)} (expected one of ${SKILL_NAMES.join("|")})`,
+      `unknown name ${JSON.stringify(target)} (expected one of ${SKILL_NAMES.join("|")})`,
     );
   }
   const content = CONTENT[target];

--- a/plugins/op-obsidian/src/skill.ts
+++ b/plugins/op-obsidian/src/skill.ts
@@ -1,0 +1,30 @@
+import manual from "./skill/manual.md";
+
+export const SKILL_NAMES = ["skill"] as const;
+export type SkillName = (typeof SKILL_NAMES)[number];
+
+const CONTENT: Record<SkillName, string> = {
+  skill: manual,
+};
+
+export interface GetSkillResult {
+  name: SkillName;
+  content: string;
+  size: number;
+}
+
+export function getSkill(name: string): GetSkillResult {
+  const trimmed = name.trim();
+  const target = trimmed === "" ? "skill" : trimmed;
+  if (!isSkillName(target)) {
+    throw new Error(
+      `op-get-skill: unknown name ${JSON.stringify(target)} (expected one of ${SKILL_NAMES.join("|")})`,
+    );
+  }
+  const content = CONTENT[target];
+  return { name: target, content, size: content.length };
+}
+
+function isSkillName(v: string): v is SkillName {
+  return (SKILL_NAMES as readonly string[]).includes(v);
+}

--- a/plugins/op-obsidian/src/skill/manual.md
+++ b/plugins/op-obsidian/src/skill/manual.md
@@ -5,7 +5,7 @@ description: Run the Obsidian Projects workflow — scaffold new projects, creat
 
 # Obsidian Projects (op) workflow
 
-You are operating on an Obsidian vault that uses the **Projects schema** — a Jira-lite issue tracker where each project is a folder under `Projects/` and each issue/task/doc is a markdown note with structured frontmatter. Schema details live in [`reference/schema.md`](reference/schema.md); read it on first use or when frontmatter shape comes up.
+You are operating on an Obsidian vault that uses the **Projects schema** — a Jira-lite issue tracker where each project is a folder under `Projects/` and each issue/task/doc is a markdown note with structured frontmatter. Schema details live in `reference/schema.md` inside the op skill folder (the path your Claude Code surfaced this body from); read it on first use or when frontmatter shape comes up.
 
 ## Scope of this skill
 
@@ -19,7 +19,7 @@ All vault mutations go through the **`op-obsidian`** plugin. Probe once per sess
 obsidian eval code='({enabled: app.plugins.enabledPlugins.has("op-obsidian"), version: app.plugins.plugins["op-obsidian"]?.manifest?.version})'
 ```
 
-If the plugin is missing or disabled, **stop and ask the user to install/enable it** rather than improvising with raw `obsidian` CLI primitives — the plugin owns filename sanitization, ID numbering, frontmatter shape, atomic move-and-trash on resolve, and the JSON response payload. For emergencies where the user can't enable it, [`reference/cli-gotchas.md`](reference/cli-gotchas.md) documents the raw-CLI fallbacks (including the read-append-rewrite recipe for appending to `commits:` without `op-append-commit`).
+If the plugin is missing or disabled, **stop and ask the user to install/enable it** rather than improvising with raw `obsidian` CLI primitives — the plugin owns filename sanitization, ID numbering, frontmatter shape, atomic move-and-trash on resolve, and the JSON response payload. For emergencies where the user can't enable it, the op skill's `reference/cli-gotchas.md` documents the raw-CLI fallbacks (including the read-append-rewrite recipe for appending to `commits:` without `op-append-commit`).
 
 **Delegating vault/CLI work.** This plugin ships an `obsidian-ops-specialist` subagent. When you're a coding agent working an issue and the next step is a raw Obsidian CLI call, a vault introspection, or a mutation the plugin owns, prefer delegating it via the Agent tool (`subagent_type: obsidian-ops-specialist`) over running the CLI yourself. The specialist knows the CLI gotchas, the op-obsidian dispatch surface, and keeps vault-side behavior consistent with this skill's lifecycle rules. You still own the skill's invariants — the specialist executes, you orchestrate.
 
@@ -155,7 +155,7 @@ obsidian op-set-pr issue=<PREFIX>-<N> url=<pr-url>
 
 **When and whether to call these is project policy** — the project's `CLAUDE.md` decides whether `commits:` is mirrored 1:1 to commits, batch-filled at resolve, or never populated at all; whether PRs are required or skipped; whether commit subjects must reference the issue id. If the project says nothing, ask the user rather than inventing a cadence.
 
-For diagnostic detail on what to do when these calls fail (git not a repo, missing id, plugin unreachable mid-session), see [`reference/cli-gotchas.md`](reference/cli-gotchas.md).
+For diagnostic detail on what to do when these calls fail (git not a repo, missing id, plugin unreachable mid-session), see the op skill's `reference/cli-gotchas.md`.
 
 ### Linking issues
 

--- a/plugins/op-obsidian/src/skill/manual.md
+++ b/plugins/op-obsidian/src/skill/manual.md
@@ -1,0 +1,229 @@
+---
+name: op
+description: Run the Obsidian Projects workflow — scaffold new projects, create/work/resolve issues, and maintain schema-conformant notes in an Obsidian vault that follows the Projects schema. Use whenever the user invokes /op:* commands or references an Obsidian project by ID prefix (e.g. JB-3, TMB-9, OP-11).
+---
+
+# Obsidian Projects (op) workflow
+
+You are operating on an Obsidian vault that uses the **Projects schema** — a Jira-lite issue tracker where each project is a folder under `Projects/` and each issue/task/doc is a markdown note with structured frontmatter. Schema details live in [`reference/schema.md`](reference/schema.md); read it on first use or when frontmatter shape comes up.
+
+## Scope of this skill
+
+This skill manages **vault state and the issue schema** only — folder layout, frontmatter shape, ID numbering, status transitions, atomic resolve, the `op-*` command surface as capabilities. **It does not define a development workflow.** Whether you work straight to main, require PRs, run a multi-stage feature → integration → dev → main pipeline, use git worktrees, bump versions on every issue, or never bump versions at all is the **project's** decision, documented in that project's own `CLAUDE.md` (or equivalent). The skill stays out of the way.
+
+The frontmatter fields `commits:`, `pr:`, `version:`, and `github_issue:` are **optional capabilities** the skill exposes for projects that want them. Whether and when to populate them is project policy. If your project's `CLAUDE.md` says nothing about commit tracking, branching, or release cadence, treat those concerns as out of scope for the skill — do what the project tells you, and if the project says nothing, ask the user rather than inventing a convention.
+
+All vault mutations go through the **`op-obsidian`** plugin. Probe once per session and cache the result:
+
+```bash
+obsidian eval code='({enabled: app.plugins.enabledPlugins.has("op-obsidian"), version: app.plugins.plugins["op-obsidian"]?.manifest?.version})'
+```
+
+If the plugin is missing or disabled, **stop and ask the user to install/enable it** rather than improvising with raw `obsidian` CLI primitives — the plugin owns filename sanitization, ID numbering, frontmatter shape, atomic move-and-trash on resolve, and the JSON response payload. For emergencies where the user can't enable it, [`reference/cli-gotchas.md`](reference/cli-gotchas.md) documents the raw-CLI fallbacks (including the read-append-rewrite recipe for appending to `commits:` without `op-append-commit`).
+
+**Delegating vault/CLI work.** This plugin ships an `obsidian-ops-specialist` subagent. When you're a coding agent working an issue and the next step is a raw Obsidian CLI call, a vault introspection, or a mutation the plugin owns, prefer delegating it via the Agent tool (`subagent_type: obsidian-ops-specialist`) over running the CLI yourself. The specialist knows the CLI gotchas, the op-obsidian dispatch surface, and keeps vault-side behavior consistent with this skill's lifecycle rules. You still own the skill's invariants — the specialist executes, you orchestrate.
+
+Run `obsidian vault` once to learn the active vault name and path; cache both.
+
+**Target the vault explicitly on every CLI call.** The `obsidian` CLI accepts a top-level `vault=<name>` argument that routes the command at that named vault regardless of which Obsidian window is currently focused — e.g. `obsidian vault=Agent-Vault eval code='app.vault.getName()'`. Use it. Without it, the CLI binds to whichever vault happens to be the active window at that moment, which is a race when more than one agent (or the user) can switch focus between calls. The form is `vault=<name>` (key=value), **not** `--vault <name>`; `obsidian help` documents it as the only top-level option. See the op skill's `reference/cli-gotchas.md` for the canonical worked example.
+
+## Link back to the issue note
+
+Whenever you surface a vault path to the user — post-action summaries, the "may I resolve?" confirmation pause, any step that mentions an issue or seed note — pair the path with a clickable `obsidian://` URI so the user can jump straight to the note without copy-pasting.
+
+- Cache the vault **name** (not just the path) from the first `obsidian vault` call — it's the first tab-separated column on the `path\t…` line (e.g. `Agent-Vault`).
+- Canonical URI: `obsidian://open?vault=<vault-name>&file=<vault-relative-path-without-.md>`.
+- Source of truth for the vault-relative path: the plugin's JSON payload at `Projects/_scratch/op-last-response.md`. Prefer it over reconstructing paths by hand.
+- Encoding: URI-encode the vault name if it contains spaces; for the file component, `encodeURIComponent` is safest but you may leave `/` unescaped for readability — Obsidian accepts either. Strip the trailing `.md`. `#` and `?` in filenames **must** be percent-encoded (`%23`, `%3F`) or the URI parses wrong.
+- Render alongside the path so terminal users still see something useful:
+
+  ```
+  path: Projects/obsidian-projects/ISSUES/OP-102 ….md
+  [Open in Obsidian](obsidian://open?vault=Agent-Vault&file=Projects%2Fobsidian-projects%2FISSUES%2FOP-102%20…)
+  ```
+
+Example: `obsidian://open?vault=Agent-Vault&file=Projects%2Fobsidian-projects%2FISSUES%2FOP-102%20Update%20agent%20guidance%20…`
+
+---
+
+## Plugin commands
+
+All `op-*` commands take `key=value` arguments (not `--flag`). Each prints a one-line summary to stdout and writes a full JSON payload to `Projects/_scratch/op-last-response.md` — read that note for structured fields (paths, trashed-task list, etc.).
+
+| Command | Required | Optional | Effect |
+| :--- | :--- | :--- | :--- |
+| `op-scaffold` | `slug`, `prefix` | `repo_path`, `title`, `priority`, `scope`, `scope_mode` | creates `Projects/<slug>/<slug>.base` + `STATUS.md`; writes `repo_path:` (absolute path only) if given; seeds `<PREFIX>-1` if `title` given. `scope_mode=bullets\|body` matches `op-new` semantics |
+| `op-new` | `project`, `title` | `priority`, `scope`, `scope_mode`, `github_issue` | creates next-N issue with sanitized filename and schema-conformant frontmatter. Default `scope_mode=bullets` splits `scope=` on newlines and wraps each line as `- [ ]`; rejects payloads containing `## ` H2s or code fences (would be flattened). Pass `scope_mode=body` to write `scope=` verbatim under `## Scope` (bullets, paragraphs, code fences allowed; H2s still rejected since they would terminate the section). When the plugin's `autoCreateGithubIssue` setting is on and no `github_issue` is passed, also runs `gh issue create` in the project's `repo_path` and writes the URL to `github_issue:` |
+| `op-work` | `issue` | `agent`, `agent_session` (alias: `session`), `force` | sets `status: in-progress`; creates the initial TASKS note. Optional params: `agent=` records the working agent id; `agent_session=` adds an opaque per-session id. If a different agent or session is already registered, returns `conflict` in the JSON payload and refuses to write (pass `force=true` to override). Force-overwriting a different agent without supplying `agent_session=` clears the stale session from the previous agent. |
+| `op-append-commit` | `issue`, `sha`, `subject` | — | idempotent append to issue's `commits:` list |
+| `op-set-pr` | `issue`, `url` | — | sets scalar `pr:` |
+| `op-get-workflow` | `project` | — | reads `Projects/<project>/WORKFLOW.md` (the project's SDLC policy, optional). Returns `{exists, path, content, size}`. Read-only. |
+| `op-edit-workflow` | `project` | — | launches an agent in tmux to interview the user and author/refine `Projects/<project>/WORKFLOW.md`. Window naming `op-workflow-<slug>` keeps it distinct from issue sessions. The session has full edit capability but is bounded to writing the workflow file (no `op-work` / `op-resolve` / version bump). |
+| `op-set-scope` | `issue`, `scope` | `mode=scope\|body` | default `mode=scope` replaces the issue body's `## Scope` section (appends it if missing); payload is markdown without H2 headings. `mode=body` replaces the entire body content after the optional `# Title` heading; payload may include H2s. Use this when you genuinely want to rewrite Scope or the whole body — not for routine Plan/Notes/Summary edits, where `op-set-section` is safer (it scopes to one section). |
+| `op-set-evaluation` | `issue`, `evaluation` | — | replace (or append if missing) the issue body's `## Initial Evaluation` section. Frontmatter, the `# Title`, and every other H2 section are preserved; payload must not contain a bare `## ` H2 (would terminate the section). Use this when an evaluate-mode agent persists its output — it's section-scoped and won't clobber `## Plan`, `## Notes`, or `## Summary`. |
+| `op-set-section` | `issue`, `name`, `content` | `append=true` | replace (or, with `append=true`, extend) the issue body's `## <name>` section. `name` must be one of `Plan`, `Notes`, `Summary`. Frontmatter, the `# Title`, and any other H2 sections are preserved; payload must not contain its own `## ` H2 (would terminate the section). Preferred path for the Plan/Notes/Summary writes the workflow does on every issue — including the racy `### <ID>.<N>` block append under `## Notes` as tasks complete. |
+| `op-set-link` | `issue`, `relation`, `target` | — | writes both sides of an inter-issue link atomically. Plugin owns the inverse — agents MUST NOT touch link frontmatter directly. Relations: `parent` / `children` (many-to-one), `depends_on` / `depended_on_by` (many-to-many), `related_to` (symmetric). |
+| `op-remove-link` | `issue`, `relation`, `target` | — | removes both sides of a link. Idempotent. |
+| `op-link-check` | — | `repair=true` | walks every issue, reports any one-sided link drift (`missing-inverse` / `dangling-target`); with `repair=true` reconciles drift by re-applying links. |
+| `op-migrate-links` | — | — | one-shot rewrite of legacy `parent_issue` / `subissues` to canonical `parent` / `children`. Idempotent. |
+| `op-resolve` (or `op-close-current-issue`) | `issue` (or `path`) | `status=wontfix` | sets `status: resolved`, writes `resolved: <today>`, moves into `RESOLVED ISSUES/`, trashes linked TASKS — atomically. When `closeGithubIssueOnResolve` is on and the issue has a `github_issue:` URL, also runs `gh issue close` on it; the JSON response reports `githubClosed` / `githubCloseError` |
+
+`scope` is a single value containing newline-separated bullets. To pass richer markdown (paragraphs, sub-bullets, code fences) for the issue's `## Scope` section, set `scope_mode=body` and the payload is written verbatim. H2 headings (`## ...`) are rejected in either mode because they would terminate the Scope section.
+
+**URI senders (`obsidian://op-new?…`):** Obsidian's protocol parser is `Record<string, string>` and last-wins, so repeated `scope=a&scope=b` keys collapse to only the last value. Pack multi-value lists into a single `scope=` param using `%0A` (newline) or `,` as the delimiter; the plugin's `collectRepeated` helper splits on either. Spaces and `+`: the parser uses `decodeURIComponent`, which leaves `+` untouched — but the plugin normalizes `+` → space at the dispatch boundary to match `URLSearchParams.toString()` semantics. To preserve a literal `+`, encode it as `%2B`.
+
+Prefix → slug is **not** a plugin command — scan `Projects/*/STATUS.md` directly and read the `prefix:` frontmatter to disambiguate. Do not use `obsidian search` for this (it misreads `prefix:` as a query operator). **Legacy fallback:** if no `STATUS.md` declares that prefix (pre-`prefix:`-field projects, or the file is missing), scan `Projects/*/ISSUES/<PREFIX>-*.md` and `Projects/*/RESOLVED ISSUES/<PREFIX>-*.md` filenames instead and infer the slug from the parent folder. If still no match, stop and ask the user for the slug, then write `prefix:` into that project's `STATUS.md` before continuing so the next lookup is deterministic.
+
+---
+
+## Verb: scaffold
+
+`/op:scaffold <slug> <PREFIX> [<title>]`
+
+1. Validate `slug` (lowercase + hyphens, `Projects/<slug>/` doesn't already exist).
+2. If the project has a code repo, ask the user for its absolute path (e.g. `/Users/you/Projects/<slug>`) and pass it as `repo_path=`. The plugin writes it to `STATUS.md` frontmatter, where `op:open-agent` reads it to set the agent's working directory and skip the working-dir modal. Must be absolute — no `~`, no vault-relative. Skip this prompt for meta-only projects with no repo.
+3. Run `obsidian op-scaffold slug=<slug> prefix=<PREFIX> [repo_path=/abs/path] [title="…"] [priority=med] [scope="bullet 1\nbullet 2"]`.
+4. Report `projectFolder`, `basePath`, `statusPath`, and `seedPath` (if any) from the JSON response — and include the `obsidian://` link for `seedPath` if it was created. Suggest `/op:new <slug>` next.
+
+---
+
+## Verb: new
+
+`/op:new <project-or-prefix> [description]`
+
+1. Resolve `project-or-prefix` to a slug (folder match, else prefix scan over STATUS.md).
+2. Gather scope by description length:
+   - **None** → ask interactively for title, priority (default `med`), optional scope bullets.
+   - **Brief** (description ≤ 140 chars, single line) → propose title, priority guess, 2–5 bullet checklist; confirm.
+   - **Detailed** (> 140 chars, or multi-line regardless of length) → propose title, priority, summary paragraph + checklist; preserve any explicit acceptance criteria verbatim; confirm.
+   - **If unsure** (borderline length, ambiguous structure) → treat as detailed and surface the ambiguity in the confirm step rather than guessing silently.
+3. **Always pause for explicit user confirmation before mutating vault or repo** — even in auto mode. Issue creation is a commitment artifact.
+4. Run `obsidian op-new project=<slug> title="<title>" priority=<low|med|high> [scope="bullet 1\nbullet 2"]`. For multi-paragraph scope or scope with code fences/sub-bullets, add `scope_mode=body` so the payload is written verbatim under `## Scope` instead of being wrapped per-line as `- [ ]`. Bullets-mode payloads must not contain `## ` H2s or code fences — the plugin rejects them rather than mangle the body.
+5. Report the new id and path, and include the `obsidian://` link for the new issue note so the user can open it in one click; suggest `/op:issue <PREFIX>-<N>`.
+
+---
+
+## Verb: work
+
+`/op:issue <project-or-prefix> [<N-or-ID>]`
+
+### Pick the issue
+
+Accepts `slug N`, `slug PREFIX-N`, `PREFIX N`, `PREFIX-N`, or just `slug`/`PREFIX` (auto-pick). Without N, prefer the lowest-numbered `in-progress`, else the lowest-numbered `open`. Multiple matches → stop and ask.
+
+### Start
+
+1. `obsidian op-work issue=<PREFIX>-<N> agent=<your-agent-id> [agent_session=<session-id>]`. The `agent` value is your runtime's identity (`claude`, `codex`, `gemini`, `copilot`, …) — pass the literal id, not the model name. The `agent_session` value should be a stable per-session identifier from your runtime; for Claude Code use `$CLAUDE_SESSION_ID` (exported in hook environments and via `--env`), and for other runtimes use whatever equivalent your harness exposes. Omit `agent_session=` if no stable id is available.
+
+   Read the JSON payload at `Projects/_scratch/op-last-response.md` after the call:
+   - `registered: true` and no `conflict` → you own the issue, proceed.
+   - `alreadyHeld: true` → idempotent re-entry, proceed.
+   - `conflict: { agent?, session? }` → another agent (or another session) is already registered. **Stop and ask the user** whether to take over — never pass `force=true` on your own. If they confirm, retry with `force=true`.
+
+   Emit a one-line ack with the issue's `obsidian://` link so the user can open the note while you write `## Plan`.
+2. **Check for a project workflow.** Read `Projects/<slug>/WORKFLOW.md` if it exists — that's the project's authoritative SDLC policy (branching, version cadence, PR rules, commit-to-issue mapping). Programmatic access: `obsidian op-get-workflow project=<slug>` returns `{exists, path, content}`. If absent, the project has no opinion — ask the user when policy ambiguity comes up; if the user wants to author one, the **`op: edit project workflow (WORKFLOW.md)`** palette command (or `obsidian op-edit-workflow project=<slug>`) launches an agent dedicated to that. (When you're launched via `op:open-agent`, the kickoff prompt already inlines the workflow text up to a configurable cap; use the CLI when you need the full file or want to verify.)
+3. If the body is empty or one line, scope is ambiguous — state your interpretation and confirm before implementing, even in auto mode.
+4. Reconcile scope vs. current repo/vault state — skip items already done; flag drift between the schema and observed reality.
+5. **Write the `## Plan` section now** (approach, key decisions, files to touch, risks) via `obsidian op-set-section issue=<PREFIX>-<N> name=Plan content="…"`. The verb scopes the rewrite to `## Plan` only — frontmatter, `## Scope`, `## Tasks`, `## Notes`, `## Summary`, and any other sections are untouched. Reconcile, don't overwrite: if the section already has user or prior-agent content, read the file first (`obsidian read`) and pass the merged Plan as `content=` rather than blowing existing prose away. Replace the italic placeholder if still present.
+6. The plugin creates the first TASKS note for you. For additional logical subtasks, create more TASKS notes (`obsidian create` is fine for these auxiliary notes — they're trashed at resolve).
+7. **Mirror every TASK note into a `## Tasks` checklist in the issue body.** After creating the TASK notes (planned upfront, or fix-up tasks discovered mid-session), append a line to the issue body's `## Tasks` section for each one:
+
+   ```markdown
+   ## Tasks
+
+   - [ ] <ISSUE-ID>.<N> — <task title>
+   ```
+
+   Reconcile rather than overwrite: if the section already exists (prior session, completed task, user-authored entry), preserve existing entries (`- [completed]` / `- [x]`) and append any new tasks not already listed. Mark entries `- [completed]` when the corresponding TASK note flips to `status: completed`. The body checklist is the durable record — TASK notes are trashed at resolve, the issue body isn't.
+
+   When a TASK note flips to `status: completed`, also **append a `### <ISSUE-ID>.<N> — <title>` block under `## Notes`** recording what was done and any deviations from the plan. Use `obsidian op-set-section issue=<ISSUE-ID> name=Notes content="### <ISSUE-ID>.<N> — <title>\n\n…" append=true` — `append=true` extends the section instead of replacing it, which is the racy read-append-rewrite path the verb was built for. Idempotent at the agent level: before appending, check the current Notes section (`obsidian read`); if a block with the same `### <ISSUE-ID>.<N>` heading already exists, call `op-set-section name=Notes content="…"` (no `append=true`) with the merged Notes content to update in place rather than duplicating.
+8. Confirm before any action affecting shared systems (push, release, deploy, external API).
+
+**Reconcile rule for legacy issues.** If the issue body is missing any of `## Plan`, `## Notes`, or `## Summary`, insert the missing sections in canonical order (`Scope → Plan → Tasks → Notes → Summary`) before writing. Never modify user-authored prose in other sections.
+
+### Tracking refs (capabilities, not policy)
+
+The plugin exposes two capabilities for recording git artifacts on an issue:
+
+```bash
+# Append a commit ref (idempotent; safe to call repeatedly)
+obsidian op-append-commit issue=<PREFIX>-<N> sha=<sha7> subject=<subject>
+
+# Set the PR URL on an issue
+obsidian op-set-pr issue=<PREFIX>-<N> url=<pr-url>
+```
+
+**When and whether to call these is project policy** — the project's `CLAUDE.md` decides whether `commits:` is mirrored 1:1 to commits, batch-filled at resolve, or never populated at all; whether PRs are required or skipped; whether commit subjects must reference the issue id. If the project says nothing, ask the user rather than inventing a cadence.
+
+For diagnostic detail on what to do when these calls fail (git not a repo, missing id, plugin unreachable mid-session), see [`reference/cli-gotchas.md`](reference/cli-gotchas.md).
+
+### Linking issues
+
+Issue-to-issue links live as plugin-managed frontmatter fields. **Never write `parent`, `children`, `depends_on`, `depended_on_by`, or `related_to` directly** — call `op-set-link` / `op-remove-link` and let the plugin maintain both sides. Direct frontmatter edits are tolerated for human convenience but `op-link-check` will flag the drift.
+
+Canonical relations and call shape:
+
+```bash
+# X is a child of umbrella Y (many-to-one)
+obsidian op-set-link issue=OP-95 relation=parent target=OP-92
+
+# Equivalent from the umbrella side (same effect — plugin writes both)
+obsidian op-set-link issue=OP-92 relation=children target=OP-95
+
+# X blocks on Y (many-to-many)
+obsidian op-set-link issue=OP-X relation=depends_on target=OP-Y
+
+# X and Y are related (symmetric)
+obsidian op-set-link issue=OP-X relation=related_to target=OP-Y
+
+# Remove a link (idempotent)
+obsidian op-remove-link issue=OP-95 relation=parent target=OP-92
+
+# Audit the entire vault for one-sided drift
+obsidian op-link-check                # report-only
+obsidian op-link-check repair=true    # reconcile drift in place
+```
+
+Resolved-folder issues are valid link targets — a parent→child link must remain valid after the child resolves and moves into `RESOLVED ISSUES/`. The plugin's resolver looks at both folders.
+
+When you discover a parent/child relationship mid-session, set the link with `op-set-link` and append a one-line note in the issue's `## Notes` block — don't paste a bare wikilink.
+
+If the issue has a `github_issue:` frontmatter field, it mirrors a GitHub issue. The URL may have been populated automatically at `op-new` time (when `autoCreateGithubIssue` is on) or set later via the plugin's "Set GitHub issue URL" command. While working, treat it as a one-way mirror: you may comment on, label, or reference the GH issue, but do **not** close it manually — the plugin closes it atomically during `op-resolve` (see below). If the user asks "is the GitHub issue still open?", check live state with `gh issue view <url>` rather than inferring from the op status.
+
+---
+
+## Verb: resolve
+
+`/op:resolve` (or run at the tail of `work`).
+
+1. **Write the `## Summary` section** in the issue body (shipped behavior, PR link, `<sha7> <subject>` commits, follow-ups) via `obsidian op-set-section issue=<PREFIX>-<N> name=Summary content="…"` before the confirmation pause. The verb only touches `## Summary`, leaving frontmatter and every other section untouched. Show its diff in the resolution preview. Replace the italic placeholder if still present; reconcile with any existing prose rather than overwriting.
+2. **Always pause for explicit user confirmation before mutating vault or repo** — even in auto mode. Show the planned transition:
+   - Source → target: `Projects/<slug>/ISSUES/<filename>` → `…/RESOLVED ISSUES/<filename>` — include the issue's current `obsidian://` link so the user can click through and verify before approving
+
+   - Frontmatter: `status` → `resolved` (or `wontfix`), `resolved` → `<today>`
+   - TASKS to trash (list each path)
+   - `commits:` status: "set" / "empty" — surface either as a fact; whether to back-fill is the project's call
+   - Any project-specific resolve actions (release, version bump, deploy) — only if the project's policy calls for them; otherwise omit
+   - GitHub issue: if `github_issue:` is set and `closeGithubIssueOnResolve` is on, note that the plugin will run `gh issue close` on the URL as part of `op-resolve` — do **not** close it yourself beforehand
+3. **`commits:` back-fill is optional and project-driven.** If the project's policy is to record shipped commits on the issue and `commits:` is empty, offer to back-fill from `git log` (referencing the issue id) via `op-append-commit`. If the project doesn't track commits this way — or doesn't have a code repo — skip this step.
+4. **Project-specific release/version steps run here, if the project has any.** If the project's policy ties resolve to a release or version bump, follow the project's `CLAUDE.md` (or equivalent) for the procedure. The schema reserves `version:` on the issue for recording the release identifier shipped, but *when* and *how* to set it is the project's call. Meta-only projects with no release artifact skip this step entirely.
+5. `obsidian op-resolve issue=<PREFIX>-<N>` (or `status=wontfix`). The plugin moves the file, sets `status` and `resolved:`, and trashes linked TASKS atomically. If the issue has a `github_issue:` URL and `closeGithubIssueOnResolve` is on, the plugin also runs `gh issue close` on it — check `githubClosed` / `githubCloseError` in the JSON response. **DOCS are never touched.**
+6. Report: external changes (URLs, commands run, including the linked GH issue if it was auto-closed), vault changes (paths from the JSON response — include the `obsidian://` link for the **post-move** `RESOLVED ISSUES/…` path so the user can open the resolved note directly), and any manual follow-ups (e.g. retrying `gh issue close` manually if `githubCloseError` is set).
+
+---
+
+## Cross-project surfaces
+
+`Projects/all-projects.base` and `Projects/All Projects.md` aggregate every project — leave them alone when scaffolding/cleaning. New projects land in them automatically via the `project` frontmatter key.
+
+## DOCS folder: superpowers symlink
+
+Projects with a code repo keep `DOCS/superpowers/` as a symlink into `<repo>/docs/superpowers/`. Vault-only docs (logs, prompt libraries) live directly in `DOCS/` alongside the symlink. One-time setup:
+
+```bash
+mkdir -p <vault>/Projects/<slug>/DOCS
+ln -s <repo>/docs/superpowers <vault>/Projects/<slug>/DOCS/superpowers
+obsidian eval code='(async()=>{const a=app.vault.adapter;const base="Projects/<slug>/DOCS/superpowers";for(const sub of ["plans","specs","research","testing"]){await a.reconcileFolderCreation(base+"/"+sub, base+"/"+sub);}})()'
+```
+
+Repo-tracked docs (`doc_type: plan|spec|adr|runbook`) → `DOCS/superpowers/{plans,specs,…}/`. Vault-only docs → `DOCS/` directly. Meta-only projects keep a plain `DOCS/` folder, no symlink.

--- a/plugins/op-obsidian/src/types/markdown.d.ts
+++ b/plugins/op-obsidian/src/types/markdown.d.ts
@@ -1,0 +1,4 @@
+declare module "*.md" {
+  const content: string;
+  export default content;
+}

--- a/plugins/op-obsidian/src/types/markdown.d.ts
+++ b/plugins/op-obsidian/src/types/markdown.d.ts
@@ -1,3 +1,9 @@
+// Declare all *.md imports as default-export strings.
+// esbuild's `loader: { ".md": "text" }` and the vitest "md-as-text" transform
+// both serialise the file content the same way (JSON.stringify). Only
+// explicitly-imported .md files are bundled — no wildcard scanning occurs.
+// The README.md under src/iterm/proto/ is NOT imported anywhere; it is purely
+// a documentation file and will never be included in the artifact.
 declare module "*.md" {
   const content: string;
   export default content;

--- a/plugins/op-obsidian/src/uriHandlers.ts
+++ b/plugins/op-obsidian/src/uriHandlers.ts
@@ -16,6 +16,7 @@ import type { SetFlowResult, Flow, Complexity } from "./setFlow";
 import type { ResolveArgs, ResolveStatus } from "./resolve";
 import type { ApplyLinkResult, LinkCheckResult, MigrateLinksResult } from "./links";
 import type { GetWorkflowResult } from "./workflow";
+import { getSkill } from "./skill";
 
 export interface UriHandlerDeps {
   store: { issues(): IssueEntry[] };
@@ -288,6 +289,20 @@ export async function handleOpGetWorkflowUri(
     project: res.project,
     path: res.path,
     exists: res.exists,
+    content: res.content,
+    size: res.size,
+  };
+}
+
+export async function handleOpGetSkillUri(
+  _deps: UriHandlerDeps,
+  params: Record<string, string>,
+): Promise<UriResponsePayload> {
+  const res = getSkill(params.name ?? "");
+  return {
+    ok: true,
+    command: "op-get-skill",
+    name: res.name,
     content: res.content,
     size: res.size,
   };

--- a/plugins/op-obsidian/tsconfig.json
+++ b/plugins/op-obsidian/tsconfig.json
@@ -13,6 +13,6 @@
     "strictNullChecks": true,
     "lib": ["DOM", "ES2022"]
   },
-  "include": ["src/**/*.ts"],
+  "include": ["src/**/*.ts", "src/**/*.d.ts"],
   "exclude": ["src/**/*.test.ts"]
 }

--- a/plugins/op-obsidian/vitest.config.ts
+++ b/plugins/op-obsidian/vitest.config.ts
@@ -1,0 +1,19 @@
+import { readFileSync } from "node:fs";
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  plugins: [
+    {
+      name: "md-as-text",
+      enforce: "pre",
+      transform(_code, id) {
+        if (!id.endsWith(".md")) return null;
+        const raw = readFileSync(id, "utf8");
+        return {
+          code: `export default ${JSON.stringify(raw)};`,
+          map: null,
+        };
+      },
+    },
+  ],
+});

--- a/plugins/op/.claude-plugin/plugin.json
+++ b/plugins/op/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "op",
   "description": "Obsidian Projects workflow — schema, slash commands, and agent skill for running a Jira-lite issue tracker inside an Obsidian vault.",
-  "version": "0.61.0",
+  "version": "0.61.1",
   "author": {
     "name": "Eugene Archibald"
   },

--- a/plugins/op/.claude-plugin/plugin.json
+++ b/plugins/op/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "op",
   "description": "Obsidian Projects workflow — schema, slash commands, and agent skill for running a Jira-lite issue tracker inside an Obsidian vault.",
-  "version": "0.60.1",
+  "version": "0.61.0",
   "author": {
     "name": "Eugene Archibald"
   },

--- a/plugins/op/skills/op/SKILL.md
+++ b/plugins/op/skills/op/SKILL.md
@@ -3,227 +3,41 @@ name: op
 description: Run the Obsidian Projects workflow — scaffold new projects, create/work/resolve issues, and maintain schema-conformant notes in an Obsidian vault that follows the Projects schema. Use whenever the user invokes /op:* commands or references an Obsidian project by ID prefix (e.g. JB-3, TMB-9, OP-11).
 ---
 
-# Obsidian Projects (op) workflow
+# Obsidian Projects (op) — zero-order guidance
 
-You are operating on an Obsidian vault that uses the **Projects schema** — a Jira-lite issue tracker where each project is a folder under `Projects/` and each issue/task/doc is a markdown note with structured frontmatter. Schema details live in [`reference/schema.md`](reference/schema.md); read it on first use or when frontmatter shape comes up.
+This is a **stub**. The canonical operating manual lives **inside** the `op-obsidian` plugin and ships with every plugin release; pull it with `obsidian op-get-skill` once per session and follow the body it returns. That keeps the skill stable while the workflow logic evolves with the plugin.
 
-## Scope of this skill
+## Zero-order rules — apply before fetching anything
 
-This skill manages **vault state and the issue schema** only — folder layout, frontmatter shape, ID numbering, status transitions, atomic resolve, the `op-*` command surface as capabilities. **It does not define a development workflow.** Whether you work straight to main, require PRs, run a multi-stage feature → integration → dev → main pipeline, use git worktrees, bump versions on every issue, or never bump versions at all is the **project's** decision, documented in that project's own `CLAUDE.md` (or equivalent). The skill stays out of the way.
+1. **Probe the plugin once per session and cache the result.** Every `op-*` action goes through it; without the plugin you cannot operate.
 
-The frontmatter fields `commits:`, `pr:`, `version:`, and `github_issue:` are **optional capabilities** the skill exposes for projects that want them. Whether and when to populate them is project policy. If your project's `CLAUDE.md` says nothing about commit tracking, branching, or release cadence, treat those concerns as out of scope for the skill — do what the project tells you, and if the project says nothing, ask the user rather than inventing a convention.
-
-All vault mutations go through the **`op-obsidian`** plugin. Probe once per session and cache the result:
-
-```bash
-obsidian eval code='({enabled: app.plugins.enabledPlugins.has("op-obsidian"), version: app.plugins.plugins["op-obsidian"]?.manifest?.version})'
-```
-
-If the plugin is missing or disabled, **stop and ask the user to install/enable it** rather than improvising with raw `obsidian` CLI primitives — the plugin owns filename sanitization, ID numbering, frontmatter shape, atomic move-and-trash on resolve, and the JSON response payload. For emergencies where the user can't enable it, [`reference/cli-gotchas.md`](reference/cli-gotchas.md) documents the raw-CLI fallbacks (including the read-append-rewrite recipe for appending to `commits:` without `op-append-commit`).
-
-**Delegating vault/CLI work.** This plugin ships an `obsidian-ops-specialist` subagent. When you're a coding agent working an issue and the next step is a raw Obsidian CLI call, a vault introspection, or a mutation the plugin owns, prefer delegating it via the Agent tool (`subagent_type: obsidian-ops-specialist`) over running the CLI yourself. The specialist knows the CLI gotchas, the op-obsidian dispatch surface, and keeps vault-side behavior consistent with this skill's lifecycle rules. You still own the skill's invariants — the specialist executes, you orchestrate.
-
-Run `obsidian vault` once to learn the active vault name and path; cache both.
-
-**Target the vault explicitly on every CLI call.** The `obsidian` CLI accepts a top-level `vault=<name>` argument that routes the command at that named vault regardless of which Obsidian window is currently focused — e.g. `obsidian vault=Agent-Vault eval code='app.vault.getName()'`. Use it. Without it, the CLI binds to whichever vault happens to be the active window at that moment, which is a race when more than one agent (or the user) can switch focus between calls. The form is `vault=<name>` (key=value), **not** `--vault <name>`; `obsidian help` documents it as the only top-level option. See [`reference/cli-gotchas.md`](reference/cli-gotchas.md) for the canonical worked example.
-
-## Link back to the issue note
-
-Whenever you surface a vault path to the user — post-action summaries, the "may I resolve?" confirmation pause, any step that mentions an issue or seed note — pair the path with a clickable `obsidian://` URI so the user can jump straight to the note without copy-pasting.
-
-- Cache the vault **name** (not just the path) from the first `obsidian vault` call — it's the first tab-separated column on the `path\t…` line (e.g. `Agent-Vault`).
-- Canonical URI: `obsidian://open?vault=<vault-name>&file=<vault-relative-path-without-.md>`.
-- Source of truth for the vault-relative path: the plugin's JSON payload at `Projects/_scratch/op-last-response.md`. Prefer it over reconstructing paths by hand.
-- Encoding: URI-encode the vault name if it contains spaces; for the file component, `encodeURIComponent` is safest but you may leave `/` unescaped for readability — Obsidian accepts either. Strip the trailing `.md`. `#` and `?` in filenames **must** be percent-encoded (`%23`, `%3F`) or the URI parses wrong.
-- Render alongside the path so terminal users still see something useful:
-
-  ```
-  path: Projects/obsidian-projects/ISSUES/OP-102 ….md
-  [Open in Obsidian](obsidian://open?vault=Agent-Vault&file=Projects%2Fobsidian-projects%2FISSUES%2FOP-102%20…)
-  ```
-
-Example: `obsidian://open?vault=Agent-Vault&file=Projects%2Fobsidian-projects%2FISSUES%2FOP-102%20Update%20agent%20guidance%20…`
-
----
-
-## Plugin commands
-
-All `op-*` commands take `key=value` arguments (not `--flag`). Each prints a one-line summary to stdout and writes a full JSON payload to `Projects/_scratch/op-last-response.md` — read that note for structured fields (paths, trashed-task list, etc.).
-
-| Command | Required | Optional | Effect |
-| :--- | :--- | :--- | :--- |
-| `op-scaffold` | `slug`, `prefix` | `repo_path`, `title`, `priority`, `scope`, `scope_mode` | creates `Projects/<slug>/<slug>.base` + `STATUS.md`; writes `repo_path:` (absolute path only) if given; seeds `<PREFIX>-1` if `title` given. `scope_mode=bullets\|body` matches `op-new` semantics |
-| `op-new` | `project`, `title` | `priority`, `scope`, `scope_mode`, `github_issue` | creates next-N issue with sanitized filename and schema-conformant frontmatter. Default `scope_mode=bullets` splits `scope=` on newlines and wraps each line as `- [ ]`; rejects payloads containing `## ` H2s or code fences (would be flattened). Pass `scope_mode=body` to write `scope=` verbatim under `## Scope` (bullets, paragraphs, code fences allowed; H2s still rejected since they would terminate the section). When the plugin's `autoCreateGithubIssue` setting is on and no `github_issue` is passed, also runs `gh issue create` in the project's `repo_path` and writes the URL to `github_issue:` |
-| `op-work` | `issue` | `agent`, `agent_session` (alias: `session`), `force` | sets `status: in-progress`; creates the initial TASKS note. Optional params: `agent=` records the working agent id; `agent_session=` adds an opaque per-session id. If a different agent or session is already registered, returns `conflict` in the JSON payload and refuses to write (pass `force=true` to override). Force-overwriting a different agent without supplying `agent_session=` clears the stale session from the previous agent. |
-| `op-append-commit` | `issue`, `sha`, `subject` | — | idempotent append to issue's `commits:` list |
-| `op-set-pr` | `issue`, `url` | — | sets scalar `pr:` |
-| `op-get-workflow` | `project` | — | reads `Projects/<project>/WORKFLOW.md` (the project's SDLC policy, optional). Returns `{exists, path, content, size}`. Read-only. |
-| `op-edit-workflow` | `project` | — | launches an agent in tmux to interview the user and author/refine `Projects/<project>/WORKFLOW.md`. Window naming `op-workflow-<slug>` keeps it distinct from issue sessions. The session has full edit capability but is bounded to writing the workflow file (no `op-work` / `op-resolve` / version bump). |
-| `op-set-scope` | `issue`, `scope` | `mode=scope\|body` | default `mode=scope` replaces the issue body's `## Scope` section (appends it if missing); payload is markdown without H2 headings. `mode=body` replaces the entire body content after the optional `# Title` heading; payload may include H2s. Use this when you genuinely want to rewrite Scope or the whole body — not for routine Plan/Notes/Summary edits, where `op-set-section` is safer (it scopes to one section). |
-| `op-set-evaluation` | `issue`, `evaluation` | — | replace (or append if missing) the issue body's `## Initial Evaluation` section. Frontmatter, the `# Title`, and every other H2 section are preserved; payload must not contain a bare `## ` H2 (would terminate the section). Use this when an evaluate-mode agent persists its output — it's section-scoped and won't clobber `## Plan`, `## Notes`, or `## Summary`. |
-| `op-set-section` | `issue`, `name`, `content` | `append=true` | replace (or, with `append=true`, extend) the issue body's `## <name>` section. `name` must be one of `Plan`, `Notes`, `Summary`. Frontmatter, the `# Title`, and any other H2 sections are preserved; payload must not contain its own `## ` H2 (would terminate the section). Preferred path for the Plan/Notes/Summary writes the workflow does on every issue — including the racy `### <ID>.<N>` block append under `## Notes` as tasks complete. |
-| `op-set-link` | `issue`, `relation`, `target` | — | writes both sides of an inter-issue link atomically. Plugin owns the inverse — agents MUST NOT touch link frontmatter directly. Relations: `parent` / `children` (many-to-one), `depends_on` / `depended_on_by` (many-to-many), `related_to` (symmetric). |
-| `op-remove-link` | `issue`, `relation`, `target` | — | removes both sides of a link. Idempotent. |
-| `op-link-check` | — | `repair=true` | walks every issue, reports any one-sided link drift (`missing-inverse` / `dangling-target`); with `repair=true` reconciles drift by re-applying links. |
-| `op-migrate-links` | — | — | one-shot rewrite of legacy `parent_issue` / `subissues` to canonical `parent` / `children`. Idempotent. |
-| `op-resolve` (or `op-close-current-issue`) | `issue` (or `path`) | `status=wontfix` | sets `status: resolved`, writes `resolved: <today>`, moves into `RESOLVED ISSUES/`, trashes linked TASKS — atomically. When `closeGithubIssueOnResolve` is on and the issue has a `github_issue:` URL, also runs `gh issue close` on it; the JSON response reports `githubClosed` / `githubCloseError` |
-
-`scope` is a single value containing newline-separated bullets. To pass richer markdown (paragraphs, sub-bullets, code fences) for the issue's `## Scope` section, set `scope_mode=body` and the payload is written verbatim. H2 headings (`## ...`) are rejected in either mode because they would terminate the Scope section.
-
-**URI senders (`obsidian://op-new?…`):** Obsidian's protocol parser is `Record<string, string>` and last-wins, so repeated `scope=a&scope=b` keys collapse to only the last value. Pack multi-value lists into a single `scope=` param using `%0A` (newline) or `,` as the delimiter; the plugin's `collectRepeated` helper splits on either. Spaces and `+`: the parser uses `decodeURIComponent`, which leaves `+` untouched — but the plugin normalizes `+` → space at the dispatch boundary to match `URLSearchParams.toString()` semantics. To preserve a literal `+`, encode it as `%2B`.
-
-Prefix → slug is **not** a plugin command — scan `Projects/*/STATUS.md` directly and read the `prefix:` frontmatter to disambiguate. Do not use `obsidian search` for this (it misreads `prefix:` as a query operator). **Legacy fallback:** if no `STATUS.md` declares that prefix (pre-`prefix:`-field projects, or the file is missing), scan `Projects/*/ISSUES/<PREFIX>-*.md` and `Projects/*/RESOLVED ISSUES/<PREFIX>-*.md` filenames instead and infer the slug from the parent folder. If still no match, stop and ask the user for the slug, then write `prefix:` into that project's `STATUS.md` before continuing so the next lookup is deterministic.
-
----
-
-## Verb: scaffold
-
-`/op:scaffold <slug> <PREFIX> [<title>]`
-
-1. Validate `slug` (lowercase + hyphens, `Projects/<slug>/` doesn't already exist).
-2. If the project has a code repo, ask the user for its absolute path (e.g. `/Users/you/Projects/<slug>`) and pass it as `repo_path=`. The plugin writes it to `STATUS.md` frontmatter, where `op:open-agent` reads it to set the agent's working directory and skip the working-dir modal. Must be absolute — no `~`, no vault-relative. Skip this prompt for meta-only projects with no repo.
-3. Run `obsidian op-scaffold slug=<slug> prefix=<PREFIX> [repo_path=/abs/path] [title="…"] [priority=med] [scope="bullet 1\nbullet 2"]`.
-4. Report `projectFolder`, `basePath`, `statusPath`, and `seedPath` (if any) from the JSON response — and include the `obsidian://` link for `seedPath` if it was created. Suggest `/op:new <slug>` next.
-
----
-
-## Verb: new
-
-`/op:new <project-or-prefix> [description]`
-
-1. Resolve `project-or-prefix` to a slug (folder match, else prefix scan over STATUS.md).
-2. Gather scope by description length:
-   - **None** → ask interactively for title, priority (default `med`), optional scope bullets.
-   - **Brief** (description ≤ 140 chars, single line) → propose title, priority guess, 2–5 bullet checklist; confirm.
-   - **Detailed** (> 140 chars, or multi-line regardless of length) → propose title, priority, summary paragraph + checklist; preserve any explicit acceptance criteria verbatim; confirm.
-   - **If unsure** (borderline length, ambiguous structure) → treat as detailed and surface the ambiguity in the confirm step rather than guessing silently.
-3. **Always pause for explicit user confirmation before mutating vault or repo** — even in auto mode. Issue creation is a commitment artifact.
-4. Run `obsidian op-new project=<slug> title="<title>" priority=<low|med|high> [scope="bullet 1\nbullet 2"]`. For multi-paragraph scope or scope with code fences/sub-bullets, add `scope_mode=body` so the payload is written verbatim under `## Scope` instead of being wrapped per-line as `- [ ]`. Bullets-mode payloads must not contain `## ` H2s or code fences — the plugin rejects them rather than mangle the body.
-5. Report the new id and path, and include the `obsidian://` link for the new issue note so the user can open it in one click; suggest `/op:issue <PREFIX>-<N>`.
-
----
-
-## Verb: work
-
-`/op:issue <project-or-prefix> [<N-or-ID>]`
-
-### Pick the issue
-
-Accepts `slug N`, `slug PREFIX-N`, `PREFIX N`, `PREFIX-N`, or just `slug`/`PREFIX` (auto-pick). Without N, prefer the lowest-numbered `in-progress`, else the lowest-numbered `open`. Multiple matches → stop and ask.
-
-### Start
-
-1. `obsidian op-work issue=<PREFIX>-<N> agent=<your-agent-id> [agent_session=<session-id>]`. The `agent` value is your runtime's identity (`claude`, `codex`, `gemini`, `copilot`, …) — pass the literal id, not the model name. The `agent_session` value should be a stable per-session identifier from your runtime; for Claude Code use `$CLAUDE_SESSION_ID` (exported in hook environments and via `--env`), and for other runtimes use whatever equivalent your harness exposes. Omit `agent_session=` if no stable id is available.
-
-   Read the JSON payload at `Projects/_scratch/op-last-response.md` after the call:
-   - `registered: true` and no `conflict` → you own the issue, proceed.
-   - `alreadyHeld: true` → idempotent re-entry, proceed.
-   - `conflict: { agent?, session? }` → another agent (or another session) is already registered. **Stop and ask the user** whether to take over — never pass `force=true` on your own. If they confirm, retry with `force=true`.
-
-   Emit a one-line ack with the issue's `obsidian://` link so the user can open the note while you write `## Plan`.
-2. **Check for a project workflow.** Read `Projects/<slug>/WORKFLOW.md` if it exists — that's the project's authoritative SDLC policy (branching, version cadence, PR rules, commit-to-issue mapping). Programmatic access: `obsidian op-get-workflow project=<slug>` returns `{exists, path, content}`. If absent, the project has no opinion — ask the user when policy ambiguity comes up; if the user wants to author one, the **`op: edit project workflow (WORKFLOW.md)`** palette command (or `obsidian op-edit-workflow project=<slug>`) launches an agent dedicated to that. (When you're launched via `op:open-agent`, the kickoff prompt already inlines the workflow text up to a configurable cap; use the CLI when you need the full file or want to verify.)
-3. If the body is empty or one line, scope is ambiguous — state your interpretation and confirm before implementing, even in auto mode.
-4. Reconcile scope vs. current repo/vault state — skip items already done; flag drift between the schema and observed reality.
-5. **Write the `## Plan` section now** (approach, key decisions, files to touch, risks) via `obsidian op-set-section issue=<PREFIX>-<N> name=Plan content="…"`. The verb scopes the rewrite to `## Plan` only — frontmatter, `## Scope`, `## Tasks`, `## Notes`, `## Summary`, and any other sections are untouched. Reconcile, don't overwrite: if the section already has user or prior-agent content, read the file first (`obsidian read`) and pass the merged Plan as `content=` rather than blowing existing prose away. Replace the italic placeholder if still present.
-6. The plugin creates the first TASKS note for you. For additional logical subtasks, create more TASKS notes (`obsidian create` is fine for these auxiliary notes — they're trashed at resolve).
-7. **Mirror every TASK note into a `## Tasks` checklist in the issue body.** After creating the TASK notes (planned upfront, or fix-up tasks discovered mid-session), append a line to the issue body's `## Tasks` section for each one:
-
-   ```markdown
-   ## Tasks
-
-   - [ ] <ISSUE-ID>.<N> — <task title>
+   ```bash
+   obsidian eval code='({enabled: app.plugins.enabledPlugins.has("op-obsidian"), version: app.plugins.plugins["op-obsidian"]?.manifest?.version})'
    ```
 
-   Reconcile rather than overwrite: if the section already exists (prior session, completed task, user-authored entry), preserve existing entries (`- [completed]` / `- [x]`) and append any new tasks not already listed. Mark entries `- [completed]` when the corresponding TASK note flips to `status: completed`. The body checklist is the durable record — TASK notes are trashed at resolve, the issue body isn't.
+   If `enabled` is `false` or the eval throws, **stop and ask the user to install/enable `op-obsidian`** before going further. Do not improvise with raw `obsidian` CLI primitives — the plugin owns filename sanitization, ID numbering, frontmatter shape, atomic move-and-trash on resolve, and the JSON response payload at `Projects/_scratch/op-last-response.md`.
 
-   When a TASK note flips to `status: completed`, also **append a `### <ISSUE-ID>.<N> — <title>` block under `## Notes`** recording what was done and any deviations from the plan. Use `obsidian op-set-section issue=<ISSUE-ID> name=Notes content="### <ISSUE-ID>.<N> — <title>\n\n…" append=true` — `append=true` extends the section instead of replacing it, which is the racy read-append-rewrite path the verb was built for. Idempotent at the agent level: before appending, check the current Notes section (`obsidian read`); if a block with the same `### <ISSUE-ID>.<N>` heading already exists, call `op-set-section name=Notes content="…"` (no `append=true`) with the merged Notes content to update in place rather than duplicating.
-8. Confirm before any action affecting shared systems (push, release, deploy, external API).
+2. **Always work in a git worktree** when an issue spans more than a one-line edit, especially when the issue was *delegated* to you by another agent. The delegating agent may still hold the main checkout open; editing it directly risks branch, build, and vault-sync conflicts. The project's own `CLAUDE.md` may make this rule absolute — read it.
 
-**Reconcile rule for legacy issues.** If the issue body is missing any of `## Plan`, `## Notes`, or `## Summary`, insert the missing sections in canonical order (`Scope → Plan → Tasks → Notes → Summary`) before writing. Never modify user-authored prose in other sections.
+3. **Cache the active vault name and target it explicitly on every CLI call.** `obsidian vault` returns the active vault's name and path — cache both. Then prepend `vault=<name>` to every `obsidian` invocation (e.g. `obsidian vault=Agent-Vault op-work issue=…`) so the call routes deterministically regardless of which Obsidian window is focused. Without it, the CLI binds to whichever vault happens to be active at the moment of the call, which races against window switches by other agents or the user. The form is `vault=<name>` (key=value), **not** `--vault <name>`.
 
-### Tracking refs (capabilities, not policy)
+## Fetching the full manual
 
-The plugin exposes two capabilities for recording git artifacts on an issue:
-
-```bash
-# Append a commit ref (idempotent; safe to call repeatedly)
-obsidian op-append-commit issue=<PREFIX>-<N> sha=<sha7> subject=<subject>
-
-# Set the PR URL on an issue
-obsidian op-set-pr issue=<PREFIX>-<N> url=<pr-url>
-```
-
-**When and whether to call these is project policy** — the project's `CLAUDE.md` decides whether `commits:` is mirrored 1:1 to commits, batch-filled at resolve, or never populated at all; whether PRs are required or skipped; whether commit subjects must reference the issue id. If the project says nothing, ask the user rather than inventing a cadence.
-
-For diagnostic detail on what to do when these calls fail (git not a repo, missing id, plugin unreachable mid-session), see [`reference/cli-gotchas.md`](reference/cli-gotchas.md).
-
-### Linking issues
-
-Issue-to-issue links live as plugin-managed frontmatter fields. **Never write `parent`, `children`, `depends_on`, `depended_on_by`, or `related_to` directly** — call `op-set-link` / `op-remove-link` and let the plugin maintain both sides. Direct frontmatter edits are tolerated for human convenience but `op-link-check` will flag the drift.
-
-Canonical relations and call shape:
+Once the plugin is confirmed enabled, fetch the operating manual:
 
 ```bash
-# X is a child of umbrella Y (many-to-one)
-obsidian op-set-link issue=OP-95 relation=parent target=OP-92
-
-# Equivalent from the umbrella side (same effect — plugin writes both)
-obsidian op-set-link issue=OP-92 relation=children target=OP-95
-
-# X blocks on Y (many-to-many)
-obsidian op-set-link issue=OP-X relation=depends_on target=OP-Y
-
-# X and Y are related (symmetric)
-obsidian op-set-link issue=OP-X relation=related_to target=OP-Y
-
-# Remove a link (idempotent)
-obsidian op-remove-link issue=OP-95 relation=parent target=OP-92
-
-# Audit the entire vault for one-sided drift
-obsidian op-link-check                # report-only
-obsidian op-link-check repair=true    # reconcile drift in place
+obsidian op-get-skill            # writes the body to Projects/_scratch/op-last-response.md
 ```
 
-Resolved-folder issues are valid link targets — a parent→child link must remain valid after the child resolves and moves into `RESOLVED ISSUES/`. The plugin's resolver looks at both folders.
+Read the `content` field from that JSON payload (or pass `name=skill` explicitly — currently the only recognized name; case-insensitive). The body covers: the full `op-*` command surface (`scaffold`, `new`, `work`, `append-commit`, `set-pr`, `set-scope`, `resolve`, …), each verb's lifecycle rules (Plan/Notes/Summary/Tasks reconciliation, GitHub issue mirroring, `commits:` back-fill, semver bumping, `obsidian://` link rendering), and the cross-project surfaces (`all-projects.base`, DOCS folder layout).
 
-When you discover a parent/child relationship mid-session, set the link with `op-set-link` and append a one-line note in the issue's `## Notes` block — don't paste a bare wikilink.
+If `op-get-skill` is unrecognized, the installed plugin predates this command. Tell the user to update `op-obsidian` (`>= 0.61.0`) — do **not** fall back to running raw CLI mutations from memory.
 
-If the issue has a `github_issue:` frontmatter field, it mirrors a GitHub issue. The URL may have been populated automatically at `op-new` time (when `autoCreateGithubIssue` is on) or set later via the plugin's "Set GitHub issue URL" command. While working, treat it as a one-way mirror: you may comment on, label, or reference the GH issue, but do **not** close it manually — the plugin closes it atomically during `op-resolve` (see below). If the user asks "is the GitHub issue still open?", check live state with `gh issue view <url>` rather than inferring from the op status.
+## References (kept in this skill folder)
 
----
+- [`reference/schema.md`](reference/schema.md) — frontmatter shape, status enum, relation names. Read on first use or when frontmatter shape comes up.
+- [`reference/cli-gotchas.md`](reference/cli-gotchas.md) — raw-CLI fallbacks for emergencies when the plugin is unavailable (e.g. read-append-rewrite for `commits:`).
 
-## Verb: resolve
+## Why this is a stub
 
-`/op:resolve` (or run at the tail of `work`).
-
-1. **Write the `## Summary` section** in the issue body (shipped behavior, PR link, `<sha7> <subject>` commits, follow-ups) via `obsidian op-set-section issue=<PREFIX>-<N> name=Summary content="…"` before the confirmation pause. The verb only touches `## Summary`, leaving frontmatter and every other section untouched. Show its diff in the resolution preview. Replace the italic placeholder if still present; reconcile with any existing prose rather than overwriting.
-2. **Always pause for explicit user confirmation before mutating vault or repo** — even in auto mode. Show the planned transition:
-   - Source → target: `Projects/<slug>/ISSUES/<filename>` → `…/RESOLVED ISSUES/<filename>` — include the issue's current `obsidian://` link so the user can click through and verify before approving
-
-   - Frontmatter: `status` → `resolved` (or `wontfix`), `resolved` → `<today>`
-   - TASKS to trash (list each path)
-   - `commits:` status: "set" / "empty" — surface either as a fact; whether to back-fill is the project's call
-   - Any project-specific resolve actions (release, version bump, deploy) — only if the project's policy calls for them; otherwise omit
-   - GitHub issue: if `github_issue:` is set and `closeGithubIssueOnResolve` is on, note that the plugin will run `gh issue close` on the URL as part of `op-resolve` — do **not** close it yourself beforehand
-3. **`commits:` back-fill is optional and project-driven.** If the project's policy is to record shipped commits on the issue and `commits:` is empty, offer to back-fill from `git log` (referencing the issue id) via `op-append-commit`. If the project doesn't track commits this way — or doesn't have a code repo — skip this step.
-4. **Project-specific release/version steps run here, if the project has any.** If the project's policy ties resolve to a release or version bump, follow the project's `CLAUDE.md` (or equivalent) for the procedure. The schema reserves `version:` on the issue for recording the release identifier shipped, but *when* and *how* to set it is the project's call. Meta-only projects with no release artifact skip this step entirely.
-5. `obsidian op-resolve issue=<PREFIX>-<N>` (or `status=wontfix`). The plugin moves the file, sets `status` and `resolved:`, and trashes linked TASKS atomically. If the issue has a `github_issue:` URL and `closeGithubIssueOnResolve` is on, the plugin also runs `gh issue close` on it — check `githubClosed` / `githubCloseError` in the JSON response. **DOCS are never touched.**
-6. Report: external changes (URLs, commands run, including the linked GH issue if it was auto-closed), vault changes (paths from the JSON response — include the `obsidian://` link for the **post-move** `RESOLVED ISSUES/…` path so the user can open the resolved note directly), and any manual follow-ups (e.g. retrying `gh issue close` manually if `githubCloseError` is set).
-
----
-
-## Cross-project surfaces
-
-`Projects/all-projects.base` and `Projects/All Projects.md` aggregate every project — leave them alone when scaffolding/cleaning. New projects land in them automatically via the `project` frontmatter key.
-
-## DOCS folder: superpowers symlink
-
-Projects with a code repo keep `DOCS/superpowers/` as a symlink into `<repo>/docs/superpowers/`. Vault-only docs (logs, prompt libraries) live directly in `DOCS/` alongside the symlink. One-time setup:
-
-```bash
-mkdir -p <vault>/Projects/<slug>/DOCS
-ln -s <repo>/docs/superpowers <vault>/Projects/<slug>/DOCS/superpowers
-obsidian eval code='(async()=>{const a=app.vault.adapter;const base="Projects/<slug>/DOCS/superpowers";for(const sub of ["plans","specs","research","testing"]){await a.reconcileFolderCreation(base+"/"+sub, base+"/"+sub);}})()'
-```
-
-Repo-tracked docs (`doc_type: plan|spec|adr|runbook`) → `DOCS/superpowers/{plans,specs,…}/`. Vault-only docs → `DOCS/` directly. Meta-only projects keep a plain `DOCS/` folder, no symlink.
+Historically the operating manual lived inline in this file, and every workflow tweak required editing the skill, re-syncing the Claude Code plugin cache, and rolling new agent sessions. The manual now lives in `plugins/op-obsidian/src/skill/manual.md` and is bundled into the plugin at build time. A plugin release is the only artifact that needs to ship; this stub stays put.


### PR DESCRIPTION
## Summary

- The 227-line operating manual moves into the plugin and is bundled at build time via esbuild's `.md` text loader; the on-disk `plugins/op/skills/op/SKILL.md` becomes a ~30-line zero-order stub that points agents at `obsidian op-get-skill` for the body. Future workflow tweaks ship with a plugin release; the skill markdown stops being a constantly-edited document.
- New `op-get-skill` CLI verb + `obsidian://op-get-skill` URI handler. Optional `name=` param (currently only `"skill"` is recognized); unknown names fail loudly with the valid options listed.
- Bumped to 0.61.0 (minor — additive verb, no removed surface).

## Why

Per OP-144: every workflow tweak previously required editing the skill markdown, re-syncing the Claude Code plugin cache, and rolling agent sessions. Encapsulating the manual into a plugin verb decouples skill churn from the operational manual: a plugin release is the only artifact that needs to ship.

## Design notes

- **Source of truth**: `plugins/op-obsidian/src/skill/manual.md` (canonical, bundled at build time). The on-disk `SKILL.md` is intentionally lean.
- **Bundling**: esbuild `loader: { ".md": "text" }` inlines markdown as default-export string. TS gets a `*.md` module declaration via `src/types/markdown.d.ts`. Vitest doesn't honor esbuild loaders — added a `vitest.config.ts` with a tiny inline transform plugin that does the same thing at test time.
- **Pure handler**: `getSkill(name)` in `src/skill.ts` returns `{name, content, size}`; whitespace/empty defaults to `"skill"`; unknown name throws with the expected list. Tested in `src/skill.test.ts`.
- **Wiring**: handler registered next to `op-get-workflow` in `main.ts` (CLI), `uriHandlers.ts` (pure URI body), `cliHandlers.ts` (parser).
- **Stub**: SKILL.md keeps the must-read-before-anything rules (plugin probe, worktree rule, active-vault cache) inline so an agent can always perform the probe before fetching the body. Includes fallback guidance for when `op-get-skill` is unrecognized (old plugin → tell user to update; do NOT improvise raw CLI mutations).
- **References preserved**: `reference/schema.md` and `reference/cli-gotchas.md` stay where they were — they're already references and don't churn.

## Test plan

- [x] `npx vitest run` → 739/739 pass (4 new in `skill.test.ts`)
- [x] `node scripts/bump-version.mjs minor` → 0.61.0 across all three JSONs; build succeeded; `main.js` fresher than `manifest.json`
- [x] Mechanical: `grep` confirms `manual.md` content + `op-get-skill` wiring inside `main.js`
- [x] `node scripts/dev-sync.mjs` → installed + reloaded into OP-Test
- [x] Live CLI: `obsidian op-get-skill` returns `op-get-skill: skill (25412 chars)`; payload at `Projects/_scratch/op-last-response.md` has `ok:true, command, name:"skill", content, size:25412`; content begins with the SKILL frontmatter, ends with the DOCS/meta-only line
- [x] `obsidian op-get-skill name=skill` matches default
- [x] `obsidian op-get-skill name=nope` fails loudly: `unknown name "nope" (expected one of skill)` — no orphan crash
- [x] URI variant: `obsidian://op-get-skill?name=skill` → identical payload

🤖 Generated with [Claude Code](https://claude.com/claude-code)