### PR TITLE
OP-171: doc obsidian CLI vault=<name> for explicit per-call routing

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,34 +15,34 @@ Always, in order:
    1. `cd plugins/op-obsidian && npm ci` (or `npm install` if no lockfile — but op-obsidian has one).
    2. Re-run with the **literal version** that's now in the JSON files, e.g. `node scripts/bump-version.mjs 0.37.3` — **not** `patch`/`minor`/`major`, which would compound the bump. The script idempotently re-runs the build step against the version already on disk.
 
-2. **Sync into the OP-Test vault.** Activate the OP-Test Obsidian window first (the `obsidian` CLI binds to the active window — there is no per-vault flag), then:
+2. **Sync into the OP-Test vault.**
    ```bash
    node scripts/dev-sync.mjs
    ```
-   The script hardcodes `~/Documents/OP-Test/OP-Test/.obsidian/plugins/op-obsidian/` as the target. It refuses to run unless OP-Test is the active vault, and it explicitly rejects any path containing `Agent-Vault` (belt-and-suspenders against muscle-memory mistakes — Agent-Vault is BRAT-only, see below). Never `rm -rf` the dest — `data.json` (user settings) lives there; `dev-sync.mjs` only overwrites `main.js` and `manifest.json`.
+   The script hardcodes `~/Documents/OP-Test/OP-Test/.obsidian/plugins/op-obsidian/` as the target. It currently still asserts OP-Test is the active Obsidian window before mutating (an internal `obsidian plugin:reload` call would otherwise hit whichever window happens to be focused — switch to the OP-Test window, then re-run if the assertion fires) and rejects any path containing `Agent-Vault` (belt-and-suspenders against muscle-memory mistakes — Agent-Vault is BRAT-only, see below). Never `rm -rf` the dest — `data.json` (user settings) lives there; `dev-sync.mjs` only overwrites `main.js` and `manifest.json`.
 
 3. **Reload the plugin.** `dev-sync.mjs` handles this: it tries `obsidian plugin:reload id=op-obsidian` first and falls back to the `loadManifests + enablePluginAndSave` recipe on first-install (when Obsidian hasn't scanned the new folder yet). No separate manual step needed.
 
-4. **Smoke test** per the `obsidian-plugin-creator:obsidian-plugin-creator` skill §9 (with OP-Test still the active vault):
+4. **Smoke test** per the `obsidian-plugin-creator:obsidian-plugin-creator` skill §9. Pass `vault=OP-Test` on every CLI call so the command routes at OP-Test regardless of which window is focused (see [`reference/cli-gotchas.md`](plugins/op/skills/op/reference/cli-gotchas.md) "Per-call vault targeting"):
    ```bash
-   obsidian dev:debug on
-   obsidian dev:console clear
-   # exercise the commands you just changed via obsidian eval / executeCommandById
-   obsidian dev:console   # expect no errors
+   obsidian vault=OP-Test dev:debug on
+   obsidian vault=OP-Test dev:console clear
+   # exercise the commands you just changed via obsidian vault=OP-Test eval / executeCommandById
+   obsidian vault=OP-Test dev:console   # expect no errors
    ```
-   Also spot-check the plugin instance: `obsidian eval code='app.plugins.plugins["op-obsidian"]'` should return a live object with your commands registered.
+   Also spot-check the plugin instance: `obsidian vault=OP-Test eval code='app.plugins.plugins["op-obsidian"]'` should return a live object with your commands registered.
 
-5. **Smoke-test Settings UIs.** When the change touches the op-obsidian Settings tab — Project order, working dirs, agent overlays, flow chaining, GitHub integration — `executeCommandById` won't reach it. Use `app.setting.openTabById` to render the tab synchronously and assert against the live DOM:
+5. **Smoke-test Settings UIs.** When the change touches the op-obsidian Settings tab — Project order, working dirs, agent overlays, flow chaining, GitHub integration — `executeCommandById` won't reach it. Use `app.setting.openTabById` to render the tab synchronously and assert against the live DOM. Pass `vault=OP-Test` on every call:
 
    ```bash
    # Daily-group rows (Default agent / Terminal / Sidebar tab / Onboarding / Hotkey preset) — visible from open:
-   obsidian eval code='(()=>{ app.setting.open(); app.setting.openTabById("op-obsidian"); return document.querySelectorAll(".op-settings__group--daily .setting-item").length; })()'
+   obsidian vault=OP-Test eval code='(()=>{ app.setting.open(); app.setting.openTabById("op-obsidian"); return document.querySelectorAll(".op-settings__group--daily .setting-item").length; })()'
 
    # Advanced subsections (each is its own collapsible) — count the wrappers:
-   obsidian eval code='(()=>{ app.setting.open(); app.setting.openTabById("op-obsidian"); return document.querySelectorAll(".op-settings__group--advanced .op-collapsible").length; })()'
+   obsidian vault=OP-Test eval code='(()=>{ app.setting.open(); app.setting.openTabById("op-obsidian"); return document.querySelectorAll(".op-settings__group--advanced .op-collapsible").length; })()'
 
    # Project-order drag rows: post-OP-164 they live INSIDE the "Working directories & project order" collapsible, which starts collapsed. Expand it first by clicking the header, then count:
-   obsidian eval code='(()=>{ app.setting.open(); app.setting.openTabById("op-obsidian"); document.querySelector("[data-op-section=\"workingDirs\"] .op-collapsible__header").click(); return document.querySelectorAll(".op-project-order__item").length; })()'
+   obsidian vault=OP-Test eval code='(()=>{ app.setting.open(); app.setting.openTabById("op-obsidian"); document.querySelector("[data-op-section=\"workingDirs\"] .op-collapsible__header").click(); return document.querySelectorAll(".op-project-order__item").length; })()'
    ```
 
    Returns synchronously — no `await` needed. Use it to verify drag-row count, `draggable=true` flags, prefix badges, reset-button presence, etc. without touching the GUI. Worked example: after a change to the "Project order" section, the count above should equal the number of discovered projects (one `.op-project-order__item` per project). Swap the selector for the section you actually changed.
@@ -59,7 +59,9 @@ The **OP-Test** vault at `~/Documents/OP-Test/OP-Test/` is a clean-room test vau
 
 **Do not install op-obsidian into OP-Test via BRAT.** We're the plugin's authors and the dev build is on disk; BRAT adds GitHub-release latency and doesn't carry uncommitted work. Use `dev-sync.mjs` instead — it handles the file copy, the first-install enable recipe, and subsequent reloads.
 
-**One CLI-target caveat.** The `obsidian` CLI binds to whichever Obsidian window is currently active — switching from another vault to OP-Test (or vice versa) changes which vault `obsidian vault`, `obsidian eval`, and the `op-*` dispatch verbs target. Re-run `obsidian vault` after any window switch to confirm you're operating on the vault you think you are. There's no per-vault flag; activate the right window first. `dev-sync.mjs` (and the other OP-Test scripts) check this for you and abort with a clear error if the active vault isn't OP-Test.
+**Target OP-Test on every CLI call: `obsidian vault=OP-Test …`.** The `obsidian` CLI accepts a top-level `vault=<name>` argument that routes the command at the named vault regardless of which window is currently focused (`obsidian help` documents it). Use it on every call in this repo's smoke tests, settings probes, and any ad-hoc CLI dispatch — it removes the focused-window race entirely and means you don't need to hand-verify focus before each command. The form is `vault=<name>` (key=value), not `--vault <name>`; see [`reference/cli-gotchas.md`](plugins/op/skills/op/reference/cli-gotchas.md) "Per-call vault targeting" for the full pattern.
+
+The `dev-sync.mjs` / `reset-test-vault.mjs` / `build-seeds.mjs` scripts still assert OP-Test is the active vault as defense in depth — their internal `obsidian plugin:reload` calls don't yet pass `vault=OP-Test`, so the assertion is the safety net. Switch the OP-Test window into focus and re-run if a script aborts with that error. Re-running `obsidian vault` (no args) after a window switch confirms which vault is active.
 
 ## Resetting between scenarios
 

--- a/plugins/op-obsidian/manifest.json
+++ b/plugins/op-obsidian/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "op-obsidian",
   "name": "Obsidian Projects (op)",
-  "version": "0.60.0",
+  "version": "0.60.1",
   "minAppVersion": "1.5.0",
   "description": "Jira-lite issue tracker for Obsidian vaults — deterministic commands backing the op workflow.",
   "author": "Eugene Archibald",

--- a/plugins/op-obsidian/package.json
+++ b/plugins/op-obsidian/package.json
@@ -1,6 +1,6 @@
 {
   "name": "op-obsidian",
-  "version": "0.60.0",
+  "version": "0.60.1",
   "description": "Obsidian plugin that owns the deterministic half of the op workflow.",
   "main": "main.js",
   "scripts": {

--- a/plugins/op/.claude-plugin/plugin.json
+++ b/plugins/op/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "op",
   "description": "Obsidian Projects workflow — schema, slash commands, and agent skill for running a Jira-lite issue tracker inside an Obsidian vault.",
-  "version": "0.60.0",
+  "version": "0.60.1",
   "author": {
     "name": "Eugene Archibald"
   },

--- a/plugins/op/agents/obsidian-ops-specialist.md
+++ b/plugins/op/agents/obsidian-ops-specialist.md
@@ -44,8 +44,10 @@ When a delegated task involves editing files in a code repository, follow that p
 ## Sanity-check the vault and plugin once per task
 
 ```bash
-obsidian vault   # active vault name + path
-obsidian eval code='({enabled: app.plugins.enabledPlugins.has("op-obsidian"), version: app.plugins.plugins["op-obsidian"]?.manifest?.version})'
+obsidian vault   # list registered vaults; cache the name of the one you're targeting
+obsidian vault=<name> eval code='({enabled: app.plugins.enabledPlugins.has("op-obsidian"), version: app.plugins.plugins["op-obsidian"]?.manifest?.version})'
 ```
+
+Always pass `vault=<name>` on every CLI call — the top-level flag routes the command at that named vault regardless of which Obsidian window is currently active. Without it the CLI binds to whichever window happens to be focused, which is a race when other agents or the user can switch windows between calls. See the op skill's [`reference/cli-gotchas.md`](../skills/op/reference/cli-gotchas.md) for the full worked example.
 
 If op-obsidian is missing or disabled, surface that to the calling agent and stop — don't improvise with raw CLI when the plugin owns the invariant.

--- a/plugins/op/skills/op/SKILL.md
+++ b/plugins/op/skills/op/SKILL.md
@@ -23,7 +23,9 @@ If the plugin is missing or disabled, **stop and ask the user to install/enable 
 
 **Delegating vault/CLI work.** This plugin ships an `obsidian-ops-specialist` subagent. When you're a coding agent working an issue and the next step is a raw Obsidian CLI call, a vault introspection, or a mutation the plugin owns, prefer delegating it via the Agent tool (`subagent_type: obsidian-ops-specialist`) over running the CLI yourself. The specialist knows the CLI gotchas, the op-obsidian dispatch surface, and keeps vault-side behavior consistent with this skill's lifecycle rules. You still own the skill's invariants — the specialist executes, you orchestrate.
 
-Run `obsidian vault` once to learn the active vault path; cache it.
+Run `obsidian vault` once to learn the active vault name and path; cache both.
+
+**Target the vault explicitly on every CLI call.** The `obsidian` CLI accepts a top-level `vault=<name>` argument that routes the command at that named vault regardless of which Obsidian window is currently focused — e.g. `obsidian vault=Agent-Vault eval code='app.vault.getName()'`. Use it. Without it, the CLI binds to whichever vault happens to be the active window at that moment, which is a race when more than one agent (or the user) can switch focus between calls. The form is `vault=<name>` (key=value), **not** `--vault <name>`; `obsidian help` documents it as the only top-level option. See [`reference/cli-gotchas.md`](reference/cli-gotchas.md) for the canonical worked example.
 
 ## Link back to the issue note
 

--- a/plugins/op/skills/op/reference/cli-gotchas.md
+++ b/plugins/op/skills/op/reference/cli-gotchas.md
@@ -2,6 +2,17 @@
 
 Quirks of the raw `obsidian` CLI that matter when the `op-obsidian` plugin is unavailable and you have to fall back to primitives.
 
+## Per-call vault targeting — `vault=<name>`
+
+The `obsidian` CLI accepts `vault=<name>` as a top-level argument that routes the command at that named vault regardless of which Obsidian window is currently active. Use it on every call — without it, the CLI binds to whichever vault happens to have window focus at that moment, which is a race whenever another agent (or the user) might switch windows between calls.
+
+```bash
+obsidian vault=OP-Test eval code='app.vault.getName()'   # => OP-Test
+obsidian vault=Agent-Vault op-work issue=OP-42           # routes at Agent-Vault even if OP-Test is focused
+```
+
+Form is `vault=<name>` (key=value), **not** `--vault <name>`; `obsidian help` lists it as the only top-level option. Quote names with spaces: `vault="My Vault"`. Vault names are matched against the names registered in Obsidian's vault list (visible via `obsidian vault` with no arguments) — not paths.
+
 ## `obsidian search` can't query `prefix:`
 
 `obsidian search query="prefix: <PREFIX>"` fails with `Error: Operator "prefix" not recognized` — the CLI parses a leading `<word>:` as a search operator, colliding with frontmatter keys. For prefix → slug lookups, scan `Projects/*/STATUS.md` frontmatter directly.

--- a/scripts/lib/op-test.mjs
+++ b/scripts/lib/op-test.mjs
@@ -85,7 +85,7 @@ export function assertActiveVaultIsOpTest() {
       `Active Obsidian vault is not OP-Test.\n` +
         `  expected: ${expected}\n` +
         `  active:   ${actual} (${active.name || "unnamed"})\n\n` +
-        `Activate the OP-Test window in Obsidian (the OP-Test vault must be the focused window — there is no per-vault CLI flag), then re-run.`,
+        `Activate the OP-Test window in Obsidian and re-run (these scripts call \`obsidian plugin:reload\` internally without \`vault=OP-Test\`, so they still require the OP-Test window to be focused).`,
     );
   }
   return { vaultPath: actual, vaultName: active.name };


### PR DESCRIPTION
## Summary

Replace "activate the right Obsidian window first; there is no per-vault flag" guidance across the op skill, its CLI gotchas reference, the obsidian-ops-specialist agent, and CLAUDE.md with the canonical form `obsidian vault=<name> <verb>`.

The flag is documented in `obsidian help` and verified end-to-end:

```
$ obsidian vault                        # active vault is Agent-Vault
name  Agent-Vault
$ obsidian vault=OP-Test eval code='app.vault.getName()'
=> OP-Test                              # routes at OP-Test regardless
```

Eliminates a focused-window race that bites multi-agent sessions: the CLI otherwise binds to whichever window is active at call time, so an unrelated focus switch between calls would silently re-target.

## Files touched

- `plugins/op/skills/op/SKILL.md` — extended the `obsidian vault` cache paragraph with explicit `vault=<name>` guidance
- `plugins/op/skills/op/reference/cli-gotchas.md` — new "Per-call vault targeting" section as the single-source worked example
- `plugins/op/agents/obsidian-ops-specialist.md` — per-task sanity check now uses `vault=<name>`
- `CLAUDE.md` — §2 (sync), §4 (smoke test), §5 (settings probes), §"OP-Test … sole dev sync target" all use `vault=OP-Test`

## Scope notes

- `scripts/dev-sync.mjs`, `reset-test-vault.mjs`, `build-seeds.mjs` still assert OP-Test as the active vault as defense in depth — their internal `obsidian plugin:reload` calls don't yet pass `vault=OP-Test`. CLAUDE.md now flags this as a follow-up rather than an active footgun.
- WORKFLOW.md re-checked: no "active window" / vault-targeting guidance to update.

## Test plan

- [x] `obsidian vault=OP-Test eval code='app.vault.getName()'` → `OP-Test` (with Agent-Vault active)
- [x] `obsidian vault=OP-Test eval code='({enabled, version})'` → `enabled: true, version: 0.60.1`
- [x] Documented Settings smoke-test snippet (`.op-settings__group--daily .setting-item` count) returns `5` via `vault=OP-Test`
- [x] `bump-version.mjs` green (manifest/package/plugin.json all 0.60.1; build verified `main.js` fresher than `manifest.json`)

## Adversarial review

This is a docs change that modifies agent behavior (the recommended CLI form), so per WORKFLOW.md it does not meet bypass criterion #4 ("pure-prose clarification"). Requesting Copilot review with these pressure-test prompts in a follow-up comment:

- Does any updated snippet still leak the old "active window" framing?
- Are there scripts or CI hooks that would break if a future PR drops the active-vault assertion in `lib/op-test.mjs`?
- Does the cli-gotchas worked example accurately describe what `obsidian help` advertises (form, scope, vault name vs. path matching)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)