### PR TITLE
OP-174: auto-publish op-obsidian release on push to main

### DIFF
--- a/.github/workflows/op-obsidian-release.yml
+++ b/.github/workflows/op-obsidian-release.yml
@@ -19,11 +19,16 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          fetch-tags: true
 
       - name: Read manifest version
         id: version
         run: |
           version=$(jq -r .version plugins/op-obsidian/manifest.json)
+          if [[ -z "$version" || "$version" == "null" ]]; then
+            echo "ERROR: could not read a valid version from plugins/op-obsidian/manifest.json" >&2
+            exit 1
+          fi
           echo "version=$version" >> "$GITHUB_OUTPUT"
           echo "tag=op-obsidian-v$version" >> "$GITHUB_OUTPUT"
 

--- a/.github/workflows/op-obsidian-release.yml
+++ b/.github/workflows/op-obsidian-release.yml
@@ -2,38 +2,78 @@ name: Release op-obsidian
 
 on:
   push:
-    tags:
-      - "op-obsidian-v*"
+    branches:
+      - main
 
 permissions:
   contents: write
 
+concurrency:
+  group: op-obsidian-release
+  cancel-in-progress: false
+
 jobs:
-  build:
+  release:
     runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: plugins/op-obsidian
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Read manifest version
+        id: version
+        run: |
+          version=$(jq -r .version plugins/op-obsidian/manifest.json)
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+          echo "tag=op-obsidian-v$version" >> "$GITHUB_OUTPUT"
+
+      - name: Skip if tag already exists
+        id: guard
+        env:
+          TAG: ${{ steps.version.outputs.tag }}
+        run: |
+          if git rev-parse --verify --quiet "refs/tags/$TAG" >/dev/null; then
+            echo "Tag $TAG already exists; nothing to release."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
 
       - name: Setup Node
+        if: steps.guard.outputs.skip == 'false'
         uses: actions/setup-node@v4
         with:
           node-version: "20"
 
       - name: Install
-        run: npm install
+        if: steps.guard.outputs.skip == 'false'
+        working-directory: plugins/op-obsidian
+        run: npm ci
 
       - name: Build
+        if: steps.guard.outputs.skip == 'false'
+        working-directory: plugins/op-obsidian
         run: npm run build
 
+      - name: Create and push tag
+        if: steps.guard.outputs.skip == 'false'
+        env:
+          TAG: ${{ steps.version.outputs.tag }}
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git tag "$TAG"
+          git push origin "$TAG"
+
       - name: Create release
+        if: steps.guard.outputs.skip == 'false'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          TAG: ${{ github.ref_name }}
+          TAG: ${{ steps.version.outputs.tag }}
+          VERSION: ${{ steps.version.outputs.version }}
         run: |
           gh release create "$TAG" \
-            --title "$TAG" \
-            --notes "op-obsidian $TAG" \
-            main.js manifest.json
+            --title "op-obsidian v$VERSION" \
+            --generate-notes \
+            plugins/op-obsidian/main.js \
+            plugins/op-obsidian/manifest.json


### PR DESCRIPTION
## Summary

- Reshape `.github/workflows/op-obsidian-release.yml` from tag-triggered to push-to-main triggered with self-tagging.
- Idempotency: `git rev-parse --verify --quiet refs/tags/op-obsidian-v<version>` guards every subsequent step. Non-bumping pushes to main run the workflow but no-op cleanly.
- Build path: `actions/checkout@v4` (`fetch-depth: 0`) → `setup-node@v4` (node 20) → `npm ci` + `npm run build` in `plugins/op-obsidian/` → tag + push at the workflow commit → `gh release create --generate-notes` attaching `main.js` + `manifest.json`.
- `concurrency.group: op-obsidian-release` serializes runs against the tag-creation race.
- Doc update: vault `Projects/obsidian-projects/WORKFLOW.md` now has a `## Releases (op-obsidian)` section describing the auto-publish flow. (Vault-only doc, not part of this diff.)

Issue: OP-174. Pre-existing release `op-obsidian-v0.61.2` is on GitHub, so the post-merge run of this PR will hit the tag-exists guard and exit clean — the next version-bumping merge after this lands is the first end-to-end exercise.

## Test plan

- [ ] CI: workflow YAML parses (Actions tab shows the new run for this PR's merge).
- [ ] Post-merge run logs show `Tag op-obsidian-v0.61.2 already exists; nothing to release.` and skip the build/release steps.
- [ ] Next version-bumping PR merged after this lands produces a fresh `op-obsidian-v<new>` release with `main.js` + `manifest.json` attached and auto-generated notes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)