### PR TITLE
OP-175: route scripts via vault=OP-Test; relax active-window assertion

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,7 +19,7 @@ Always, in order:
    ```bash
    node scripts/dev-sync.mjs
    ```
-   The script hardcodes `~/Documents/OP-Test/OP-Test/.obsidian/plugins/op-obsidian/` as the target. It currently still asserts OP-Test is the active Obsidian window before mutating (an internal `obsidian plugin:reload` call would otherwise hit whichever window happens to be focused — switch to the OP-Test window, then re-run if the assertion fires) and rejects any path containing `Agent-Vault` (belt-and-suspenders against muscle-memory mistakes — Agent-Vault is BRAT-only, see below). Never `rm -rf` the dest — `data.json` (user settings) lives there; `dev-sync.mjs` only overwrites `main.js` and `manifest.json`.
+   The script hardcodes `~/Documents/OP-Test/OP-Test/.obsidian/plugins/op-obsidian/` as the target. It asserts OP-Test is **open** in Obsidian (any window — focus is not required since OP-175 routes every internal CLI call via `vault=OP-Test`) and rejects any path containing `Agent-Vault` (belt-and-suspenders against muscle-memory mistakes — Agent-Vault is BRAT-only, see below). Never `rm -rf` the dest — `data.json` (user settings) lives there; `dev-sync.mjs` only overwrites `main.js` and `manifest.json`.
 
 3. **Reload the plugin.** `dev-sync.mjs` handles this: it tries `obsidian plugin:reload id=op-obsidian` first and falls back to the `loadManifests + enablePluginAndSave` recipe on first-install (when Obsidian hasn't scanned the new folder yet). No separate manual step needed.
 
@@ -55,13 +55,13 @@ Never skip these steps, even for "trivial" changes — untested plugin builds sh
 
 ## OP-Test vault: the sole dev sync target
 
-The **OP-Test** vault at `~/Documents/OP-Test/OP-Test/` is a clean-room test vault — separate from your day-to-day Agent-Vault — used to verify the plugin's behavior in a vault that has no project state, no settings carry-over, and no other plugins. **OP-Test is the only vault that receives dev syncs from this repo.** `node scripts/dev-sync.mjs` enforces this: it asserts OP-Test is the active Obsidian window before mutating, and refuses any target path containing `Agent-Vault`.
+The **OP-Test** vault at `~/Documents/OP-Test/OP-Test/` is a clean-room test vault — separate from your day-to-day Agent-Vault — used to verify the plugin's behavior in a vault that has no project state, no settings carry-over, and no other plugins. **OP-Test is the only vault that receives dev syncs from this repo.** `node scripts/dev-sync.mjs` enforces this: it asserts the OP-Test vault is open in Obsidian before mutating, routes every internal CLI call via `vault=OP-Test` (OP-175 — focus is not required), and refuses any target path containing `Agent-Vault`.
 
 **Do not install op-obsidian into OP-Test via BRAT.** We're the plugin's authors and the dev build is on disk; BRAT adds GitHub-release latency and doesn't carry uncommitted work. Use `dev-sync.mjs` instead — it handles the file copy, the first-install enable recipe, and subsequent reloads.
 
 **Target OP-Test on every CLI call: `obsidian vault=OP-Test …`.** The `obsidian` CLI accepts a top-level `vault=<name>` argument that routes the command at the named vault regardless of which window is currently focused (`obsidian help` documents it). Use it on every call in this repo's smoke tests, settings probes, and any ad-hoc CLI dispatch — it removes the focused-window race entirely and means you don't need to hand-verify focus before each command. The form is `vault=<name>` (key=value), not `--vault <name>`; see [`reference/cli-gotchas.md`](plugins/op/skills/op/reference/cli-gotchas.md) "Per-call vault targeting" for the full pattern.
 
-The `dev-sync.mjs` / `reset-test-vault.mjs` / `build-seeds.mjs` scripts still assert OP-Test is the active vault as defense in depth — their internal `obsidian plugin:reload` calls don't yet pass `vault=OP-Test`, so the assertion is the safety net. Switch the OP-Test window into focus and re-run if a script aborts with that error. Re-running `obsidian vault` (no args) after a window switch confirms which vault is active.
+The `dev-sync.mjs` / `reset-test-vault.mjs` / `build-seeds.mjs` scripts assert the OP-Test vault is open in Obsidian as defense in depth — they probe via `obsidian vault=OP-Test eval code='app.vault.getName()'` and abort with "Open the OP-Test vault in Obsidian (any window — focus is no longer required) and re-run" on miss. Since OP-175 every internal CLI call inside these scripts is routed via `vault=OP-Test`, so OP-Test does not need to be the focused window — opening the vault in any Obsidian window is enough.
 
 ## Resetting between scenarios
 
@@ -72,7 +72,7 @@ node scripts/reset-test-vault.mjs <seed>
 # valid seeds: empty | scaffolded | mid-flow | github-linked | multi-project
 ```
 
-The script asserts OP-Test is the active vault, runs `git reset --hard seed/<name> && git clean -fd` inside OP-Test, then reloads op-obsidian so Obsidian re-reads the vault state. The seed ladder itself is built (and rebuilt) by `node scripts/build-seeds.mjs` — re-runnable so seeds stay in sync as the plugin's scaffolding behavior evolves.
+The script asserts the OP-Test vault is open in Obsidian (focus not required since OP-175), runs `git reset --hard seed/<name> && git clean -fd` inside OP-Test, then reloads op-obsidian so Obsidian re-reads the vault state. The seed ladder itself is built (and rebuilt) by `node scripts/build-seeds.mjs` — re-runnable so seeds stay in sync as the plugin's scaffolding behavior evolves.
 
 ## Agent-Vault is BRAT-only
 

--- a/plugins/op-obsidian/manifest.json
+++ b/plugins/op-obsidian/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "op-obsidian",
   "name": "Obsidian Projects (op)",
-  "version": "0.61.2",
+  "version": "0.61.3",
   "minAppVersion": "1.5.0",
   "description": "Jira-lite issue tracker for Obsidian vaults — deterministic commands backing the op workflow.",
   "author": "Eugene Archibald",

--- a/plugins/op-obsidian/package.json
+++ b/plugins/op-obsidian/package.json
@@ -1,6 +1,6 @@
 {
   "name": "op-obsidian",
-  "version": "0.61.2",
+  "version": "0.61.3",
   "description": "Obsidian plugin that owns the deterministic half of the op workflow.",
   "main": "main.js",
   "scripts": {

--- a/plugins/op/.claude-plugin/plugin.json
+++ b/plugins/op/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "op",
   "description": "Obsidian Projects workflow — schema, slash commands, and agent skill for running a Jira-lite issue tracker inside an Obsidian vault.",
-  "version": "0.61.2",
+  "version": "0.61.3",
   "author": {
     "name": "Eugene Archibald"
   },

--- a/scripts/build-seeds.mjs
+++ b/scripts/build-seeds.mjs
@@ -8,7 +8,8 @@
 //   node scripts/build-seeds.mjs
 //
 // Preconditions:
-//   - OP-Test is the active Obsidian vault.
+//   - OP-Test is open in Obsidian (any window — focus is not required since
+//     OP-175; calls route via `vault=OP-Test` explicitly).
 //   - OP-Test git working tree is clean (commit/stash any untracked work first).
 //   - `seed/empty` tag exists OR HEAD is the desired empty baseline (the
 //     script tags HEAD as seed/empty if the tag is absent on first run).
@@ -29,7 +30,7 @@ import { join } from "node:path";
 
 import {
   OP_TEST_VAULT,
-  assertActiveVaultIsOpTest,
+  assertOpTestVaultOpen,
   fail,
   runGit,
   runObsidian,
@@ -40,7 +41,7 @@ const FIXTURE_CLONE_PATH = join(homedir(), "Documents/OP-Test", FIXTURE_REPO_NAM
 const FIXTURE_DESCRIPTION =
   "Disposable fixture repo for op-obsidian functional testing — no production use.";
 
-assertActiveVaultIsOpTest();
+assertOpTestVaultOpen();
 assertCleanTree();
 ensureBaselineTag();
 

--- a/scripts/dev-sync.mjs
+++ b/scripts/dev-sync.mjs
@@ -9,7 +9,9 @@
 //
 // Hardcoded target: ~/Documents/OP-Test/OP-Test/.obsidian/plugins/op-obsidian/
 // No env-var override — Agent-Vault is BRAT-only and must never receive a
-// dev sync. Active-vault and Agent-Vault guards both fire to enforce this.
+// dev sync. The OP-Test-open assertion + the Agent-Vault path-segment guard
+// + explicit `vault=OP-Test` routing on every CLI call (OP-175) jointly
+// enforce this; no Obsidian window needs to be focused on OP-Test.
 
 import { copyFileSync, existsSync, mkdirSync, statSync } from "node:fs";
 import { dirname, join, relative } from "node:path";
@@ -17,8 +19,8 @@ import { fileURLToPath } from "node:url";
 
 import {
   OP_TEST_PLUGIN_DEST,
-  assertActiveVaultIsOpTest,
   assertNotAgentVault,
+  assertOpTestVaultOpen,
   fail,
   runObsidian,
 } from "./lib/op-test.mjs";
@@ -28,7 +30,7 @@ const root = join(here, "..");
 const pluginSrc = join(root, "plugins/op-obsidian");
 const filesToCopy = ["main.js", "manifest.json"];
 
-assertActiveVaultIsOpTest();
+assertOpTestVaultOpen();
 assertNotAgentVault(OP_TEST_PLUGIN_DEST);
 
 for (const f of filesToCopy) {

--- a/scripts/lib/op-test.mjs
+++ b/scripts/lib/op-test.mjs
@@ -65,7 +65,7 @@ export function assertOpTestVaultOpen() {
         `\nOpen the OP-Test vault in Obsidian (any window — focus is no longer required) and re-run.`,
     );
   }
-  if (!stdout.includes(OP_TEST_VAULT_NAME)) {
+  if (!stdout.startsWith(`=> ${OP_TEST_VAULT_NAME}`)) {
     fail(
       `OP-Test probe returned an unexpected payload — refusing to proceed.\n` +
         `  out: ${stdout || "(empty)"}\n`,

--- a/scripts/lib/op-test.mjs
+++ b/scripts/lib/op-test.mjs
@@ -1,17 +1,24 @@
-// Shared helpers for OP-Test test-vault scripts (OP-147).
+// Shared helpers for OP-Test test-vault scripts (OP-147, OP-175).
 //
 // Single source of truth for:
 //   - the OP-Test vault path (no env-var override)
-//   - the active-vault assertion against the running Obsidian window
+//   - the OP-Test-open assertion (vault registered + reachable, not necessarily focused)
 //   - thin wrappers around `obsidian` CLI and `git` so error reporting stays
 //     consistent across dev-sync / build-seeds / reset-test-vault.
+//
+// All `obsidian` CLI calls go through `runObsidian`, which prepends
+// `vault=OP-Test` so routing is explicit per-call (OP-171/OP-175). This means
+// no script in this directory cares which Obsidian window is currently
+// focused — it will always hit OP-Test. Callers that need a different vault
+// should use spawnSync directly.
 
-import { realpathSync, existsSync } from "node:fs";
+import { existsSync, realpathSync } from "node:fs";
 import { spawnSync } from "node:child_process";
 import { homedir } from "node:os";
 import { join, sep } from "node:path";
 
 export const OP_TEST_VAULT = join(homedir(), "Documents/OP-Test/OP-Test");
+export const OP_TEST_VAULT_NAME = "OP-Test";
 export const OP_TEST_PLUGIN_DEST = join(
   OP_TEST_VAULT,
   ".obsidian/plugins/op-obsidian",
@@ -22,81 +29,73 @@ export function fail(msg) {
   process.exit(1);
 }
 
-// Resolve a filesystem path through realpath if it exists; otherwise return
-// the input unchanged. Also strips any trailing path separator so that
-// "/a/b/" and "/a/b" compare equal (guards against `obsidian vault` emitting
-// a trailing slash on some CLI versions).
-export function resolvePath(p) {
-  let resolved;
-  try {
-    resolved = realpathSync(p);
-  } catch {
-    resolved = p;
-  }
-  // Strip trailing separator(s). realpathSync normalises on most platforms but
-  // raw CLI-returned paths may not have been through it.
-  while (resolved.length > 1 && resolved.endsWith(sep)) {
-    resolved = resolved.slice(0, -1);
-  }
-  return resolved;
-}
-
-// `obsidian vault` prints a tab-separated key/value table:
-//   name<TAB>Agent-Vault
-//   path<TAB>/Users/.../Agent-Vault
-// Returns { name, path } or throws if the CLI is missing or returns no path.
-export function readActiveVault() {
-  const r = spawnSync("obsidian", ["vault"], { encoding: "utf8" });
-  if (r.error) {
-    fail(`obsidian CLI not found on PATH (${r.error.message}). Install obsidian-cli first.`);
-  }
-  if (r.status !== 0) {
-    fail(
-      `\`obsidian vault\` failed (exit ${r.status}). Is the Obsidian app running with a vault open?\n${r.stderr || r.stdout}`,
-    );
-  }
-  const lines = r.stdout.split("\n").filter(Boolean);
-  const fields = {};
-  for (const line of lines) {
-    const idx = line.indexOf("\t");
-    if (idx === -1) continue;
-    fields[line.slice(0, idx).trim()] = line.slice(idx + 1).trim();
-  }
-  if (!fields.path) {
-    fail(`\`obsidian vault\` returned no path field. Raw output:\n${r.stdout}`);
-  }
-  return { name: fields.name ?? "", path: fields.path };
-}
-
-// Refuse to proceed unless the active Obsidian window is OP-Test.
-// Resolves both sides through realpath so symlinked vault dirs still match.
-export function assertActiveVaultIsOpTest() {
+// Refuse to proceed unless the OP-Test vault is registered with the running
+// Obsidian app and reachable via `vault=OP-Test`. Does NOT require OP-Test to
+// be the focused window — `runObsidian` routes every call explicitly.
+//
+// Probe: `obsidian vault=OP-Test eval code='app.vault.getName()'`. The CLI
+// returns exit 0 in both the hit and miss cases on the versions we ship
+// against, so we parse stdout instead of trusting the exit code:
+//   hit  → stdout starts with "=> OP-Test"
+//   miss → stdout is "Vault not found."
+export function assertOpTestVaultOpen() {
   if (!existsSync(OP_TEST_VAULT)) {
     fail(
       `OP-Test vault is missing at ${OP_TEST_VAULT}.\n` +
         `Create the directory and run \`git init\` inside it before re-running.`,
     );
   }
-  const expected = resolvePath(OP_TEST_VAULT);
-  const active = readActiveVault();
-  const actual = resolvePath(active.path);
-  if (actual !== expected) {
+  const r = spawnSync(
+    "obsidian",
+    [`vault=${OP_TEST_VAULT_NAME}`, "eval", "code=app.vault.getName()"],
+    { encoding: "utf8" },
+  );
+  if (r.error) {
+    fail(`obsidian CLI not found on PATH (${r.error.message}). Install obsidian-cli first.`);
+  }
+  const stdout = (r.stdout || "").trim();
+  const stderr = (r.stderr || "").trim();
+  if (r.status !== 0 || /vault not found/i.test(stdout)) {
     fail(
-      `Active Obsidian vault is not OP-Test.\n` +
-        `  expected: ${expected}\n` +
-        `  active:   ${actual} (${active.name || "unnamed"})\n\n` +
-        `Activate the OP-Test window in Obsidian and re-run (these scripts call \`obsidian plugin:reload\` internally without \`vault=OP-Test\`, so they still require the OP-Test window to be focused).`,
+      `OP-Test vault is not open in Obsidian.\n` +
+        `  probe: obsidian vault=${OP_TEST_VAULT_NAME} eval code='app.vault.getName()'\n` +
+        `  exit:  ${r.status}\n` +
+        `  out:   ${stdout || "(empty)"}\n` +
+        (stderr ? `  err:   ${stderr}\n` : "") +
+        `\nOpen the OP-Test vault in Obsidian (any window — focus is no longer required) and re-run.`,
     );
   }
-  return { vaultPath: actual, vaultName: active.name };
+  if (!stdout.includes(OP_TEST_VAULT_NAME)) {
+    fail(
+      `OP-Test probe returned an unexpected payload — refusing to proceed.\n` +
+        `  out: ${stdout || "(empty)"}\n`,
+    );
+  }
+  return { vaultName: OP_TEST_VAULT_NAME, vaultPath: OP_TEST_VAULT };
+}
+
+// Resolve through realpath if the path exists; strip trailing separator. Used
+// only by `assertNotAgentVault` so the path-segment check sees the canonical
+// form even when the caller passed a symlinked or trailing-slashed path.
+function resolvePath(p) {
+  let resolved;
+  try {
+    resolved = realpathSync(p);
+  } catch {
+    resolved = p;
+  }
+  while (resolved.length > 1 && resolved.endsWith(sep)) {
+    resolved = resolved.slice(0, -1);
+  }
+  return resolved;
 }
 
 // Belt-and-suspenders: refuse any path whose resolved form has "Agent-Vault"
 // as a distinct path segment. A substring match would accidentally block
 // legitimately-named paths such as ~/old-Agent-Vault-archive/. Conversely,
-// a renamed Agent-Vault wouldn't be caught here — the active-vault assertion
-// is the primary guard; this one only catches muscle-memory copy-paste errors
-// that wire a different target path.
+// a renamed Agent-Vault wouldn't be caught here — the OP-Test-open assertion
+// + the explicit `vault=OP-Test` routing are the primary guards; this one
+// catches muscle-memory copy-paste errors that wire a different target path.
 export function assertNotAgentVault(targetPath) {
   const resolved = resolvePath(targetPath);
   const parts = resolved.split(sep);
@@ -108,12 +107,18 @@ export function assertNotAgentVault(targetPath) {
   }
 }
 
+// Run the `obsidian` CLI with `vault=OP-Test` prepended so the call is
+// routed at OP-Test regardless of which Obsidian window is currently focused
+// (OP-175). All scripts in this directory exclusively target OP-Test, so the
+// prepend is unconditional. If a future caller needs a different vault, use
+// spawnSync directly rather than threading an opt-out through here.
 export function runObsidian(args, { allowFail = false } = {}) {
-  const r = spawnSync("obsidian", args, { encoding: "utf8" });
+  const fullArgs = [`vault=${OP_TEST_VAULT_NAME}`, ...args];
+  const r = spawnSync("obsidian", fullArgs, { encoding: "utf8" });
   if (r.error) fail(`obsidian CLI not found: ${r.error.message}`);
   if (r.status !== 0 && !allowFail) {
     fail(
-      `\`obsidian ${args.join(" ")}\` failed (exit ${r.status})\n` +
+      `\`obsidian ${fullArgs.join(" ")}\` failed (exit ${r.status})\n` +
         `${r.stderr || ""}\n${r.stdout || ""}`.trim(),
     );
   }

--- a/scripts/reset-test-vault.mjs
+++ b/scripts/reset-test-vault.mjs
@@ -11,7 +11,7 @@
 
 import {
   OP_TEST_VAULT,
-  assertActiveVaultIsOpTest,
+  assertOpTestVaultOpen,
   fail,
   runGit,
   runObsidian,
@@ -42,7 +42,7 @@ if (!VALID_SEEDS.has(bare)) {
 }
 const tag = `seed/${bare}`;
 
-assertActiveVaultIsOpTest();
+assertOpTestVaultOpen();
 
 const tagCheck = runGit(["rev-parse", "--verify", `refs/tags/${tag}`], {
   allowFail: true,


### PR DESCRIPTION
## Summary

- Centralize `vault=OP-Test` routing at `scripts/lib/op-test.mjs:runObsidian` so dev-sync / reset-test-vault / build-seeds no longer require the OP-Test Obsidian window to be focused — every internal CLI call now routes explicitly.
- Replace `assertActiveVaultIsOpTest()` (path-compare against focused window) with `assertOpTestVaultOpen()` — probes `obsidian vault=OP-Test eval code=app.vault.getName()` and parses stdout (CLI returns exit 0 on miss, so we look for `Vault not found.`). Error message says "Open the OP-Test vault in Obsidian (any window — focus is no longer required)".
- Update CLAUDE.md (3 sites) to drop the "switch to OP-Test window" guidance.
- Patch bump 0.61.2 → 0.61.3 (lockstep across manifest.json / package.json / plugin.json) — internal dev-script fix, no plugin runtime change, no public surface change.

Closes OP-175.

## Test plan

- [x] Build green via `node scripts/bump-version.mjs 0.61.3` (esbuild + freshness assertion).
- [x] Smoke-test with Agent-Vault focused (`open obsidian://open?vault=Agent-Vault`):
  - `dev-sync.mjs` copied artifacts to OP-Test and reloaded the plugin; verified plugin version in OP-Test flipped to 0.61.3.
  - `reset-test-vault.mjs invalid-seed` → seed-validation error (no assertion involvement).
  - `reset-test-vault.mjs empty` → passed assertion, failed at expected `Seed tag seed/empty does not exist`.
  - `build-seeds.mjs` → passed assertion, failed at expected `OP-Test working tree is not clean`.
- [x] Probe behavior empirically verified: `obsidian vault=OP-Test eval code=app.vault.getName()` returns exit 0 + stdout `=> OP-Test` on hit; `obsidian vault=NonExistentVault eval ...` returns exit 0 + stdout `Vault not found.` on miss.

## Note

Pre-existing lockfile desync: `plugins/op-obsidian/package.json` lists `protobufjs-cli@^2.0.1` but `package-lock.json` has no entry for it (re-introduced after OP-170 dropped it). Out of scope here — `npm install --no-package-lock` worked around it locally for the build step. Worth a follow-up issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)