### PR TITLE
OP-176: drop protobufjs-cli devDep, add PR-time lockfile sanity check

### DIFF
--- a/.github/workflows/op-obsidian-pr-checks.yml
+++ b/.github/workflows/op-obsidian-pr-checks.yml
@@ -1,0 +1,26 @@
+name: op-obsidian PR checks
+
+on:
+  pull_request:
+    paths:
+      - "plugins/op-obsidian/**"
+      - ".github/workflows/op-obsidian-pr-checks.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  lockfile-sync:
+    name: Lockfile sync (npm ci)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: npm ci (strict lockfile check)
+        working-directory: plugins/op-obsidian
+        run: npm ci

--- a/.github/workflows/op-obsidian-pr-checks.yml
+++ b/.github/workflows/op-obsidian-pr-checks.yml
@@ -2,25 +2,47 @@ name: op-obsidian PR checks
 
 on:
   pull_request:
-    paths:
-      - "plugins/op-obsidian/**"
-      - ".github/workflows/op-obsidian-pr-checks.yml"
 
 permissions:
   contents: read
 
 jobs:
   lockfile-sync:
-    name: Lockfile sync (npm ci)
+    name: Lockfile sync (npm ci --dry-run)
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      # Detect whether this PR touches op-obsidian files.  The job always
+      # runs so it can be registered as a required status check without
+      # blocking unrelated PRs (path-filtered `on:` triggers show as
+      # "Expected" / pending in required-checks UX; step-level `if:` shows
+      # as skipped / neutral, which counts as passing).
+      - name: Detect op-obsidian changes
+        id: op_changes
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          if git diff --name-only "$BASE_SHA" "$HEAD_SHA" \
+               | grep -qE '^plugins/op-obsidian/|^\.github/workflows/op-obsidian-pr-checks\.yml$'; then
+            echo "relevant=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "relevant=false" >> "$GITHUB_OUTPUT"
+          fi
 
       - name: Setup Node
+        if: steps.op_changes.outputs.relevant == 'true'
         uses: actions/setup-node@v4
         with:
           node-version: "20"
 
-      - name: npm ci (strict lockfile check)
+      # --dry-run reports what npm ci would install / remove without
+      # downloading packages; it still enforces strict lockfile consistency,
+      # which is the only thing we need to verify here.
+      - name: npm ci --dry-run (strict lockfile check)
+        if: steps.op_changes.outputs.relevant == 'true'
         working-directory: plugins/op-obsidian
-        run: npm ci
+        run: npm ci --dry-run

--- a/.github/workflows/op-obsidian-release.yml
+++ b/.github/workflows/op-obsidian-release.yml
@@ -53,7 +53,19 @@ jobs:
       - name: Install
         if: steps.guard.outputs.skip == 'false'
         working-directory: plugins/op-obsidian
-        run: npm ci
+        run: |
+          if ! npm ci; then
+            {
+              echo "## ❌ \`npm ci\` failed — lockfile out of sync"
+              echo ""
+              echo "**Likely cause:** \`plugins/op-obsidian/package.json\` was edited without"
+              echo "regenerating \`package-lock.json\`."
+              echo ""
+              echo "**Fix:** run \`npm install\` in \`plugins/op-obsidian/\` and commit the"
+              echo "updated \`package-lock.json\` before merging."
+            } >> "$GITHUB_STEP_SUMMARY"
+            exit 1
+          fi
 
       - name: Build
         if: steps.guard.outputs.skip == 'false'

--- a/plugins/op-obsidian/manifest.json
+++ b/plugins/op-obsidian/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "op-obsidian",
   "name": "Obsidian Projects (op)",
-  "version": "0.61.3",
+  "version": "0.61.4",
   "minAppVersion": "1.5.0",
   "description": "Jira-lite issue tracker for Obsidian vaults — deterministic commands backing the op workflow.",
   "author": "Eugene Archibald",

--- a/plugins/op-obsidian/package.json
+++ b/plugins/op-obsidian/package.json
@@ -1,6 +1,6 @@
 {
   "name": "op-obsidian",
-  "version": "0.61.3",
+  "version": "0.61.4",
   "description": "Obsidian plugin that owns the deterministic half of the op workflow.",
   "main": "main.js",
   "scripts": {
@@ -22,7 +22,6 @@
     "builtin-modules": "^3.3.0",
     "esbuild": "^0.20.0",
     "obsidian": "latest",
-    "protobufjs-cli": "^2.0.1",
     "tslib": "^2.6.2",
     "typescript": "^5.3.0",
     "vitest": "^4.1.4"

--- a/plugins/op/.claude-plugin/plugin.json
+++ b/plugins/op/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "op",
   "description": "Obsidian Projects workflow — schema, slash commands, and agent skill for running a Jira-lite issue tracker inside an Obsidian vault.",
-  "version": "0.61.3",
+  "version": "0.61.4",
   "author": {
     "name": "Eugene Archibald"
   },


### PR DESCRIPTION
## Summary

- **Root cause.** OP-144 (#199 / `f5d2813`) re-added `protobufjs-cli@^2.0.1` to `plugins/op-obsidian/package.json` without regenerating `package-lock.json`. OP-170 (#198 / `8adac50`) had removed it from both files; only the package.json side was reverted. `npm ci` in `.github/workflows/op-obsidian-release.yml` is strict about lockfile sync, so the release workflow has failed on every push to main since OP-173 (`cffa6f6`) — manifest is at 0.61.3 on main but the latest published release is `op-obsidian-v0.61.2`. Failing run: https://github.com/earchibald/obsidian-projects/actions/runs/24949197127.
- **Fix (OP-170 alignment).** Re-remove `protobufjs-cli` from `plugins/op-obsidian/package.json`. The CLI is invoked on-demand via `npx --package=protobufjs-cli@2 -- pbjs/pbts` for vendored proto regeneration only (see `plugins/op-obsidian/src/iterm/proto/README.md`); keeping it out of devDeps avoids the deprecated `inflight` transitive without affecting build, runtime, or tests. The runtime `protobufjs` dep stays.
- **Guardrail.** New `.github/workflows/op-obsidian-pr-checks.yml` runs `npm ci` on PRs that touch `plugins/op-obsidian/`, so future package.json edits without a matching lockfile update fail at PR time instead of post-merge in the release workflow.
- **Version.** Patch bump 0.61.3 → 0.61.4 so the next push to main publishes a build that actually has the lockfile fix. (Re-running release for `cffa6f6` would publish 0.61.3 from a still-broken tree.)

Verified locally: `npm ci --dry-run` against the corrected `package.json` succeeds with no errors. Built via `bump-version.mjs`, synced to OP-Test, plugin reports 0.61.4 with a clean console.

## Test plan

- [x] `npm ci --dry-run` in `plugins/op-obsidian/` passes against the trimmed `package.json`
- [x] `bump-version.mjs` runs `npm run build` and asserts `main.js` is fresher than `manifest.json`
- [x] `dev-sync.mjs` to OP-Test, plugin reloads to 0.61.4, console clean
- [ ] After merge: confirm `Release op-obsidian` workflow on main succeeds at the Install step and publishes `op-obsidian-v0.61.4`
- [ ] After merge: confirm the new PR checks workflow runs against this PR (it won't on this PR itself since the workflow file is being added in the same PR — first opportunity to exercise it is the next op-obsidian PR)

@copilot please pressure-test:
- Could the lockfile still be out of sync with the trimmed `package.json`? Run `npm ci --dry-run` mentally against the diff — any package the lockfile lists but `package.json` no longer requires? Any deps the runtime `protobufjs` needs that were only being pulled in transitively via `protobufjs-cli`?
- The new PR-checks workflow uses `paths:` filters. Does the `paths:` syntax skip the job entirely (status: skipped) for unrelated PRs, or does GitHub's required-checks UX treat skipped paths-filtered jobs as failing? If the latter, recommend the `paths-ignore` inversion or a no-op job that always reports success.
- The workflow runs `npm ci` (the same install the release workflow does). Would `npm ci --dry-run` be safer or faster, or does dry-run skip the lockfile-strict check we want?
- Is there a way for the release workflow to fail more gracefully on this class of drift in the future (e.g. surface the missing-package list in the job summary instead of buried log lines)?
- The `inflight` deprecation that drove OP-170 — does the trimmed devDeps tree still pull it in transitively (e.g. via `vitest` or `esbuild`)? `npm ls inflight` after `npm ci` would tell.