### PR TITLE
OP-177: prefix iTerm tab/window/session labels with the issue ID

### DIFF
--- a/plugins/op-obsidian/manifest.json
+++ b/plugins/op-obsidian/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "op-obsidian",
   "name": "Obsidian Projects (op)",
-  "version": "0.61.7",
+  "version": "0.61.8",
   "minAppVersion": "1.5.0",
   "description": "Jira-lite issue tracker for Obsidian vaults — deterministic commands backing the op workflow.",
   "author": "Eugene Archibald",

--- a/plugins/op-obsidian/package.json
+++ b/plugins/op-obsidian/package.json
@@ -1,6 +1,6 @@
 {
   "name": "op-obsidian",
-  "version": "0.61.7",
+  "version": "0.61.8",
   "description": "Obsidian plugin that owns the deterministic half of the op workflow.",
   "main": "main.js",
   "scripts": {

--- a/plugins/op-obsidian/src/orchestrator.test.ts
+++ b/plugins/op-obsidian/src/orchestrator.test.ts
@@ -1,6 +1,11 @@
 import { describe, it, expect } from "vitest";
 
-import { buildViewScript, firstEmptyCell, pruneDeadSessionSlots } from "./orchestrator";
+import {
+  buildViewScript,
+  firstEmptyCell,
+  labelWithId,
+  pruneDeadSessionSlots,
+} from "./orchestrator";
 import type { RegistryData, WindowState } from "./layout/registry";
 
 function makeReg(win: WindowState, surfaces: RegistryData["surfaces"] = {}): RegistryData {
@@ -104,31 +109,46 @@ describe("buildViewScript", () => {
     issueTitle: "research - can we actually name iterm2 tmux windows",
   };
 
-  it("emits OSC 1 (tab/icon name) with the issueId before exec", () => {
+  it("emits OSC 1 (tab/icon name) with `<id> <title>` before exec", () => {
     const out = buildViewScript(baseArgs);
-    expect(out).toContain(`printf '\\033]1;%s\\007' 'OP-172'`);
+    expect(out).toContain(
+      `printf '\\033]1;%s\\007' 'OP-172 research - can we actually name iterm2 tmux windows'`,
+    );
     const oscIdx = out.indexOf(`printf '\\033]1;`);
     const execIdx = out.indexOf("exec");
     expect(oscIdx).toBeGreaterThan(-1);
     expect(execIdx).toBeGreaterThan(oscIdx);
   });
 
-  it("emits OSC 2 (window title) with the issueTitle when present", () => {
+  it("emits OSC 2 (window title) with `<id> <title>` when title present", () => {
     const out = buildViewScript(baseArgs);
     expect(out).toContain(
-      `printf '\\033]2;%s\\007' 'research - can we actually name iterm2 tmux windows'`,
+      `printf '\\033]2;%s\\007' 'OP-172 research - can we actually name iterm2 tmux windows'`,
     );
   });
 
-  it("falls back to issueId for OSC 2 when issueTitle is empty", () => {
+  it("falls back to bare issueId for both OSC 1 and OSC 2 when issueTitle is empty", () => {
     const out = buildViewScript({ ...baseArgs, issueTitle: "" });
+    expect(out).toContain(`printf '\\033]1;%s\\007' 'OP-172'`);
     expect(out).toContain(`printf '\\033]2;%s\\007' 'OP-172'`);
   });
 
-  it("falls back to issueId for OSC 2 when issueTitle is missing", () => {
+  it("falls back to bare issueId for both OSC 1 and OSC 2 when issueTitle is missing", () => {
     const { issueTitle, ...rest } = baseArgs;
     const out = buildViewScript(rest);
+    expect(out).toContain(`printf '\\033]1;%s\\007' 'OP-172'`);
     expect(out).toContain(`printf '\\033]2;%s\\007' 'OP-172'`);
+  });
+
+  it("does not double-prefix when issueTitle already starts with the issueId (basename fallback)", () => {
+    const out = buildViewScript({
+      ...baseArgs,
+      issueTitle: "OP-172 research - can we actually name iterm2 tmux windows",
+    });
+    expect(out).toContain(
+      `printf '\\033]1;%s\\007' 'OP-172 research - can we actually name iterm2 tmux windows'`,
+    );
+    expect(out).not.toContain("OP-172 OP-172");
   });
 
   it("does not enable tmux set-titles forwarding (OP-103 regression guard)", () => {
@@ -142,8 +162,10 @@ describe("buildViewScript", () => {
       ...baseArgs,
       issueTitle: "evil\x1b]0;injected\x07title",
     });
-    // Control chars stripped → only safe text survives in the OSC 2 payload
-    expect(out).toContain(`printf '\\033]2;%s\\007' 'evil]0;injectedtitle'`);
+    // Control chars stripped → only safe text survives in the (combined) payload
+    expect(out).toContain(
+      `printf '\\033]2;%s\\007' 'OP-172 evil]0;injectedtitle'`,
+    );
   });
 
   it("strips control characters (ESC, BEL) from issueId in OSC 1 payload", () => {
@@ -151,7 +173,9 @@ describe("buildViewScript", () => {
       ...baseArgs,
       issueId: "OP\x1b-172",
     });
-    expect(out).toContain(`printf '\\033]1;%s\\007' 'OP-172'`);
+    expect(out).toContain(
+      `printf '\\033]1;%s\\007' 'OP-172 research - can we actually name iterm2 tmux windows'`,
+    );
   });
 
   it("creates the per-pane grouped session and attaches with select-window", () => {
@@ -205,5 +229,26 @@ describe("buildViewScript", () => {
     // won't match and the if-shell branch won't fire.
     expect(out).toContain(`#{==:#{hook_window_name},OP-178}`);
     expect(out).toContain(`kill-session -t =view-OP-178`);
+  });
+});
+
+describe("labelWithId", () => {
+  it("prefixes the title with the issueId", () => {
+    expect(labelWithId("OP-177", "iterm tmux windows…")).toBe("OP-177 iterm tmux windows…");
+  });
+
+  it("returns bare issueId when title is empty/missing", () => {
+    expect(labelWithId("OP-177", "")).toBe("OP-177");
+    expect(labelWithId("OP-177", undefined)).toBe("OP-177");
+  });
+
+  it("does not double-prefix when title already starts with `<id> `", () => {
+    expect(labelWithId("OP-177", "OP-177 iterm tmux windows…")).toBe(
+      "OP-177 iterm tmux windows…",
+    );
+  });
+
+  it("returns the title as-is when it equals the issueId", () => {
+    expect(labelWithId("OP-177", "OP-177")).toBe("OP-177");
   });
 });

--- a/plugins/op-obsidian/src/orchestrator.test.ts
+++ b/plugins/op-obsidian/src/orchestrator.test.ts
@@ -168,6 +168,21 @@ describe("buildViewScript", () => {
     );
   });
 
+  it("does not double-prefix when issueTitle has a control char between id and separator (dedup bypass guard)", () => {
+    // BEL injected between the id and the space would have bypassed the old
+    // startsWith check before oscSafe was moved before labelWithId.
+    const out = buildViewScript({
+      ...baseArgs,
+      issueTitle: "OP-172\x07 research - can we actually name iterm2 tmux windows",
+    });
+    // After oscSafe strips \x07 the title becomes "OP-172 research …" which
+    // starts with the id — dedup fires and no double-prefix is emitted.
+    expect(out).toContain(
+      `printf '\\033]1;%s\\007' 'OP-172 research - can we actually name iterm2 tmux windows'`,
+    );
+    expect(out).not.toContain("OP-172 OP-172");
+  });
+
   it("strips control characters (ESC, BEL) from issueId in OSC 1 payload", () => {
     const out = buildViewScript({
       ...baseArgs,
@@ -245,6 +260,18 @@ describe("labelWithId", () => {
   it("does not double-prefix when title already starts with `<id> `", () => {
     expect(labelWithId("OP-177", "OP-177 iterm tmux windows…")).toBe(
       "OP-177 iterm tmux windows…",
+    );
+  });
+
+  it("does not double-prefix when title starts with `<id>:` (colon separator)", () => {
+    expect(labelWithId("OP-177", "OP-177: iterm tmux windows…")).toBe(
+      "OP-177: iterm tmux windows…",
+    );
+  });
+
+  it("does not double-prefix when title starts with `<id> -` (dash separator)", () => {
+    expect(labelWithId("OP-177", "OP-177 - iterm tmux windows…")).toBe(
+      "OP-177 - iterm tmux windows…",
     );
   });
 

--- a/plugins/op-obsidian/src/orchestrator.ts
+++ b/plugins/op-obsidian/src/orchestrator.ts
@@ -308,7 +308,11 @@ interface BuildViewArgs {
 // "OP-177 iterm tmux windows…") so the visible label always carries the
 // ID. Falls back to bare `<issueId>` when title is empty/missing.
 // `labelWithId` skips the prefix when the title already starts with the
-// id (basename fallback in `IssueStore.parseIssue` — fm.title missing).
+// id (basename fallback in `IssueStore.parseIssue` — fm.title missing),
+// including colon/dash-separated forms ("OP-177: …", "OP-177 - …").
+// `oscSafe` is applied to id and title *before* `labelWithId` so the dedup
+// check operates on stripped values — a control char injected between the
+// id and its separator cannot bypass the guard.
 export function buildViewScript({
   tmuxBinary,
   tmuxSession,
@@ -322,7 +326,11 @@ export function buildViewScript({
   const groupSess = shSingleQuote(groupSessName);
   const groupSessTarget = shSingleQuote(`=${groupSessName}`);
   const win = shSingleQuote(tmuxWindow);
-  const label = oscSafe(labelWithId(issueId, issueTitle));
+  // Strip control chars from raw inputs BEFORE the dedup check so that a
+  // control char injected between the id and its separator (e.g. "OP-177\x07
+  // title") cannot bypass `labelWithId`'s prefix guard.  The result is
+  // already OSC-safe — no second pass needed.
+  const label = labelWithId(oscSafe(issueId), issueTitle !== undefined ? oscSafe(issueTitle) : undefined);
   const tabName = shSingleQuote(label);
   const windowTitle = shSingleQuote(label);
   // OP-178: the per-pane grouped session shares its window list with the
@@ -460,14 +468,17 @@ function oscSafe(s: string): string {
 }
 
 // Build a visible label of the form `<issueId> <issueTitle>` for tab/window
-// titles. When the title already starts with `<issueId>` (basename fallback
-// path in `IssueStore.parseIssue` — fm.title missing) skip the prefix to
-// avoid `OP-177 OP-177 …`. Falls back to bare `<issueId>` for empty title.
+// titles. When the title already starts with `<issueId>` followed by any
+// non-word character — space ("OP-177 title"), colon ("OP-177: title"), dash
+// ("OP-177 - title"), etc. — skip the prefix to avoid "OP-177 OP-177: …".
+// Also skips when the title equals the id exactly (basename with no suffix).
+// Falls back to bare `<issueId>` for empty/missing title.
 export function labelWithId(issueId: string, issueTitle?: string): string {
   if (!issueTitle || issueTitle.length === 0) return issueId;
-  if (issueTitle === issueId || issueTitle.startsWith(`${issueId} `)) {
-    return issueTitle;
-  }
+  // Escape regex metacharacters in the id (e.g. the literal `-` in "OP-177").
+  const escapedId = issueId.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  // Match id followed by any non-word char (space, colon, dash…) OR end-of-string.
+  if (new RegExp(`^${escapedId}(?:\\W|$)`).test(issueTitle)) return issueTitle;
   return `${issueId} ${issueTitle}`;
 }
 

--- a/plugins/op-obsidian/src/orchestrator.ts
+++ b/plugins/op-obsidian/src/orchestrator.ts
@@ -85,7 +85,7 @@ export async function orchestrateLaunch(
   // Re-launching an existing issue: if the session still exists in iTerm,
   // just select it. Otherwise fall through to fresh assignment — the user
   // likely closed the pane, and the issueId → session mapping is stale.
-  const sessionTitle = args.issueTitle && args.issueTitle.length > 0 ? args.issueTitle : args.issueId;
+  const sessionTitle = labelWithId(args.issueId, args.issueTitle);
   const existing = reg.surfaces[args.issueId];
   if (existing && (await sessionExists(existing.sessionId))) {
     await selectSession(existing.sessionId);
@@ -295,14 +295,20 @@ interface BuildViewArgs {
   issueTitle?: string;
 }
 
-// OP-172: emit BOTH OSC 1 (icon/tab name = issue id) and OSC 2 (window title =
-// issue title) before `exec tmux attach`. Without OSC 1 the iTerm session-name
-// slot was being auto-set to the running command name ("tmux"), so every pane
-// label read "tmux" — `setSessionName` lands on iTerm's profile-name slot,
-// which is a different field from what the tab label tracks. OSC 1 pins the
-// tab label to `<issueId>` per-pane; tmux without `set-titles on` does not
-// re-emit OSC 1/2 across pane focus changes, so this stays sticky and avoids
-// the OP-103 regression where a focused pane's id leaked to the window title.
+// OP-172: emit BOTH OSC 1 (icon/tab name) and OSC 2 (window title) before
+// `exec tmux attach`. Without OSC 1 the iTerm session-name slot was being
+// auto-set to the running command name ("tmux"), so every pane label read
+// "tmux" — `setSessionName` lands on iTerm's profile-name slot, which is
+// a different field from what the tab label tracks. tmux without
+// `set-titles on` does not re-emit OSC 1/2 across pane focus changes, so
+// this stays sticky and avoids the OP-103 regression where a focused
+// pane's id leaked to the window title.
+//
+// OP-177: both payloads are `<issueId> <issueTitle>` (e.g.
+// "OP-177 iterm tmux windows…") so the visible label always carries the
+// ID. Falls back to bare `<issueId>` when title is empty/missing.
+// `labelWithId` skips the prefix when the title already starts with the
+// id (basename fallback in `IssueStore.parseIssue` — fm.title missing).
 export function buildViewScript({
   tmuxBinary,
   tmuxSession,
@@ -316,10 +322,9 @@ export function buildViewScript({
   const groupSess = shSingleQuote(groupSessName);
   const groupSessTarget = shSingleQuote(`=${groupSessName}`);
   const win = shSingleQuote(tmuxWindow);
-  const tabName = shSingleQuote(oscSafe(issueId));
-  const windowTitle = shSingleQuote(
-    oscSafe(issueTitle && issueTitle.length > 0 ? issueTitle : issueId),
-  );
+  const label = oscSafe(labelWithId(issueId, issueTitle));
+  const tabName = shSingleQuote(label);
+  const windowTitle = shSingleQuote(label);
   // OP-178: the per-pane grouped session shares its window list with the
   // parent op-agents-N session. When the agent's window is unlinked (e.g. on
   // /quit) tmux silently switches the attached client to the next window —
@@ -452,6 +457,18 @@ function shSingleQuote(s: string): string {
 // terminate or inject into an OSC sequence payload.
 function oscSafe(s: string): string {
   return s.replace(/[\x00-\x1f\x7f]/g, "");
+}
+
+// Build a visible label of the form `<issueId> <issueTitle>` for tab/window
+// titles. When the title already starts with `<issueId>` (basename fallback
+// path in `IssueStore.parseIssue` — fm.title missing) skip the prefix to
+// avoid `OP-177 OP-177 …`. Falls back to bare `<issueId>` for empty title.
+export function labelWithId(issueId: string, issueTitle?: string): string {
+  if (!issueTitle || issueTitle.length === 0) return issueId;
+  if (issueTitle === issueId || issueTitle.startsWith(`${issueId} `)) {
+    return issueTitle;
+  }
+  return `${issueId} ${issueTitle}`;
 }
 
 // iTerm's `create window with default profile command "..."` takes a bash

--- a/plugins/op/.claude-plugin/plugin.json
+++ b/plugins/op/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "op",
   "description": "Obsidian Projects workflow — schema, slash commands, and agent skill for running a Jira-lite issue tracker inside an Obsidian vault.",
-  "version": "0.61.7",
+  "version": "0.61.8",
   "author": {
     "name": "Eugene Archibald"
   },


### PR DESCRIPTION
## Summary

- iTerm tab/window labels and the pane subtitle now show `<issueId> <issueTitle>` (e.g. `OP-177 iterm tmux windows…`) instead of just the title (or just the id on the tab). Resolves the gap where the description was visible but the issue ID was nowhere on screen.
- New `labelWithId` helper in `orchestrator.ts` is defensive against `IssueStore.parseIssue`'s basename-fallback branch (line 177: `title: str(fm.title) ?? file.basename`) — when the title already starts with `<id> `, the prefix is skipped so we don't render `OP-177 OP-177 …`.
- The tmux window name is **not** touched — it remains the bare `<id>`, since `staleAgentBadges`, the prep script's `grep -Fxq` window probe, and the view script's `select-window -t` all key off it.
- Patch bump (0.61.4 → 0.61.5). Closes the linked GH issue automatically on resolve via the plugin's `closeGithubIssueOnResolve` setting.

Follow-up filed as **OP-179** (parent-suffix `[Parent: ABC-123]` when an issue has a parent) — out of scope here because it needs a new `parent:` frontmatter field, schema doc update, and launch-args plumbing.

## Test plan

- [x] `npx vitest run src/orchestrator.test.ts` — 19/19 passing (4 new `labelWithId` cases + updated `buildViewScript` assertions for the combined OSC 1/OSC 2 payload, fallback-to-bare-id when title empty/missing, no-double-prefix guard, control-char stripping over the concatenated label).
- [x] `node scripts/dev-sync.mjs` to OP-Test → plugin reloaded clean (version 0.61.5 confirmed loaded; no console errors).
- [ ] Manual: launch an OP-Test agent and verify the iTerm tab reads `OP-N <title>` (left to reviewer / smoke pass on local).

## Adversarial review pressure-test prompts

@copilot please pressure-test:
1. **Double-prefix corner cases.** What if `issueTitle` starts with the id but with a separator other than space (e.g. `OP-177:`, `OP-177 - …`)? Does `startsWith(\`\${id} \`)` miss those and render `OP-177 OP-177: …`? Acceptable trade-off, or should the regex be looser?
2. **Control-char injection.** `oscSafe` runs **after** `labelWithId`, so a `\x07` in `issueId` (extremely unlikely but parsed from frontmatter) gets stripped before reaching the OSC payload. But does `labelWithId`'s `startsWith` check happen on the raw (unstripped) values, allowing a control-char in the title to bypass the dedup? Verify the call order in `buildViewScript`.
3. **Tmux identity invariant.** Confirm no caller of `tmuxWindowName(issueId)` accidentally consumes the visible label instead — search for any string concat that mixes `tmuxWindow` (from `OrchestrateResult`) with the new combined label.
4. **Setting iTerm's session-name slot.** `setSessionName(sessionId, sessionTitle)` is now called with the combined label. Does iTerm truncate or sanitize this differently from the OSC 1/OSC 2 payloads? Specifically the existing-issue re-launch path (`orchestrator.ts:88-108`) — if a user previously launched OP-N when the title was bare and now relaunches after this PR, will the WS-driven name update overwrite the stale label, or is there a cache that would leave the stale label visible?

🤖 Generated with [Claude Code](https://claude.com/claude-code)