### PR TITLE
OP-178: kill view session when agent's window is unlinked

### DIFF
--- a/plugins/op-obsidian/manifest.json
+++ b/plugins/op-obsidian/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "op-obsidian",
   "name": "Obsidian Projects (op)",
-  "version": "0.61.5",
+  "version": "0.61.6",
   "minAppVersion": "1.5.0",
   "description": "Jira-lite issue tracker for Obsidian vaults — deterministic commands backing the op workflow.",
   "author": "Eugene Archibald",

--- a/plugins/op-obsidian/manifest.json
+++ b/plugins/op-obsidian/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "op-obsidian",
   "name": "Obsidian Projects (op)",
-  "version": "0.61.4",
+  "version": "0.61.5",
   "minAppVersion": "1.5.0",
   "description": "Jira-lite issue tracker for Obsidian vaults — deterministic commands backing the op workflow.",
   "author": "Eugene Archibald",

--- a/plugins/op-obsidian/package.json
+++ b/plugins/op-obsidian/package.json
@@ -1,6 +1,6 @@
 {
   "name": "op-obsidian",
-  "version": "0.61.5",
+  "version": "0.61.6",
   "description": "Obsidian plugin that owns the deterministic half of the op workflow.",
   "main": "main.js",
   "scripts": {

--- a/plugins/op-obsidian/package.json
+++ b/plugins/op-obsidian/package.json
@@ -1,6 +1,6 @@
 {
   "name": "op-obsidian",
-  "version": "0.61.4",
+  "version": "0.61.5",
   "description": "Obsidian plugin that owns the deterministic half of the op workflow.",
   "main": "main.js",
   "scripts": {

--- a/plugins/op-obsidian/src/orchestrator.test.ts
+++ b/plugins/op-obsidian/src/orchestrator.test.ts
@@ -163,4 +163,35 @@ describe("buildViewScript", () => {
       `exec '/opt/homebrew/bin/tmux' attach -t 'view-OP-172' \\; select-window -t 'view-OP-172':'OP-172'`,
     );
   });
+
+  // OP-178: the per-pane view session inherits the parent op-agents-N
+  // session's window list, so the agent's `/quit` would otherwise leave the
+  // iTerm pane attached and silently switched to a sibling agent's window.
+  // The hook kills the view session when the agent's specific window is
+  // unlinked, so the iTerm pane closes cleanly.
+  it("installs a window-unlinked hook on the view session that kills it when the agent's window dies", () => {
+    const out = buildViewScript(baseArgs);
+    expect(out).toContain(
+      `'/opt/homebrew/bin/tmux' set-hook -t '=view-OP-172' window-unlinked 'if-shell -F '\\''#{==:#{hook_window_name},OP-172}'\\'' '\\''kill-session -t =view-OP-172'\\'''`,
+    );
+  });
+
+  it("installs the hook after new-session and before exec attach", () => {
+    const out = buildViewScript(baseArgs);
+    const newSessionIdx = out.indexOf("new-session -d -s 'view-OP-172'");
+    const hookIdx = out.indexOf("set-hook -t '=view-OP-172'");
+    const execIdx = out.indexOf("exec '/opt/homebrew/bin/tmux' attach");
+    expect(newSessionIdx).toBeGreaterThan(-1);
+    expect(hookIdx).toBeGreaterThan(newSessionIdx);
+    expect(execIdx).toBeGreaterThan(hookIdx);
+  });
+
+  it("scopes the hook to the agent's specific window name so sibling deaths leave this view alone", () => {
+    const out = buildViewScript({ ...baseArgs, issueId: "OP-178", tmuxWindow: "OP-178" });
+    // The format predicate compares the unlinked window's name to *this*
+    // pane's agent window — siblings unlinking on the shared window list
+    // won't match and the if-shell branch won't fire.
+    expect(out).toContain(`#{==:#{hook_window_name},OP-178}`);
+    expect(out).toContain(`kill-session -t =view-OP-178`);
+  });
 });

--- a/plugins/op-obsidian/src/orchestrator.test.ts
+++ b/plugins/op-obsidian/src/orchestrator.test.ts
@@ -176,14 +176,26 @@ describe("buildViewScript", () => {
     );
   });
 
-  it("installs the hook after new-session and before exec attach", () => {
+  it("installs the hook after new-session and before exec attach, with race guard in between", () => {
     const out = buildViewScript(baseArgs);
     const newSessionIdx = out.indexOf("new-session -d -s 'view-OP-172'");
     const hookIdx = out.indexOf("set-hook -t '=view-OP-172'");
+    const raceGuardIdx = out.indexOf("select-window -t '=view-OP-172':'OP-172'");
     const execIdx = out.indexOf("exec '/opt/homebrew/bin/tmux' attach");
     expect(newSessionIdx).toBeGreaterThan(-1);
     expect(hookIdx).toBeGreaterThan(newSessionIdx);
-    expect(execIdx).toBeGreaterThan(hookIdx);
+    expect(raceGuardIdx).toBeGreaterThan(hookIdx);
+    expect(execIdx).toBeGreaterThan(raceGuardIdx);
+  });
+
+  // OP-178 race guard: agent window dies between new-session and set-hook
+  // while sibling windows keep the session alive. The hook is installed but
+  // will never fire (window already gone), so we kill the session immediately.
+  it("emits a race guard that kills the view session when the agent window is already gone", () => {
+    const out = buildViewScript(baseArgs);
+    expect(out).toContain(
+      `'/opt/homebrew/bin/tmux' select-window -t '=view-OP-172':'OP-172' 2>/dev/null || { '/opt/homebrew/bin/tmux' kill-session -t '=view-OP-172' 2>/dev/null || true; }`,
+    );
   });
 
   it("scopes the hook to the agent's specific window name so sibling deaths leave this view alone", () => {

--- a/plugins/op-obsidian/src/orchestrator.ts
+++ b/plugins/op-obsidian/src/orchestrator.ts
@@ -311,18 +311,29 @@ export function buildViewScript({
   issueTitle,
 }: BuildViewArgs): string {
   const tmux = shSingleQuote(tmuxBinary);
+  const groupSessName = `view-${issueId}`;
   const sess = shSingleQuote(tmuxSession);
-  const groupSess = shSingleQuote(`view-${issueId}`);
+  const groupSess = shSingleQuote(groupSessName);
+  const groupSessTarget = shSingleQuote(`=${groupSessName}`);
   const win = shSingleQuote(tmuxWindow);
   const tabName = shSingleQuote(oscSafe(issueId));
   const windowTitle = shSingleQuote(
     oscSafe(issueTitle && issueTitle.length > 0 ? issueTitle : issueId),
   );
+  // OP-178: the per-pane grouped session shares its window list with the
+  // parent op-agents-N session. When the agent's window is unlinked (e.g. on
+  // /quit) tmux silently switches the attached client to the next window —
+  // typically a sibling agent — so the iTerm pane lingers as a duplicate
+  // viewer. The hook below kills the view session when the unlinked window
+  // is *this* pane's agent window; tmux then detaches the client, the bash
+  // `exec tmux attach` returns, and the iTerm pane closes.
+  const hookCmd = `if-shell -F '#{==:#{hook_window_name},${tmuxWindow}}' 'kill-session -t =${groupSessName}'`;
   const lines = [
     "#!/bin/bash",
     "set -e",
     `export PATH="/opt/homebrew/bin:/usr/local/bin:$HOME/.local/bin:$HOME/bin:$PATH"`,
     `${tmux} new-session -d -s ${groupSess} -t ${sess} 2>/dev/null || true`,
+    `${tmux} set-hook -t ${groupSessTarget} window-unlinked ${shSingleQuote(hookCmd)}`,
     `printf '\\033]1;%s\\007' ${tabName}`,
     `printf '\\033]2;%s\\007' ${windowTitle}`,
     `exec ${tmux} attach -t ${groupSess} \\; select-window -t ${groupSess}:${win}`,

--- a/plugins/op-obsidian/src/orchestrator.ts
+++ b/plugins/op-obsidian/src/orchestrator.ts
@@ -333,7 +333,15 @@ export function buildViewScript({
     "set -e",
     `export PATH="/opt/homebrew/bin:/usr/local/bin:$HOME/.local/bin:$HOME/bin:$PATH"`,
     `${tmux} new-session -d -s ${groupSess} -t ${sess} 2>/dev/null || true`,
-    `${tmux} set-hook -t ${groupSessTarget} window-unlinked ${shSingleQuote(hookCmd)}`,
+    // OP-178: make set-hook non-fatal so a session-already-gone race (agent
+    // crashed before this script reached set-hook) doesn't show an error
+    // before the subsequent exec-attach also fails and the pane closes.
+    `${tmux} set-hook -t ${groupSessTarget} window-unlinked ${shSingleQuote(hookCmd)} 2>/dev/null || true`,
+    // OP-178 race guard: if the agent window died between new-session and
+    // set-hook while sibling windows kept the session alive, the hook is now
+    // installed but will never fire (window already gone). Kill the session
+    // immediately so exec-attach never runs and the pane closes cleanly.
+    `${tmux} select-window -t ${groupSessTarget}:${win} 2>/dev/null || { ${tmux} kill-session -t ${groupSessTarget} 2>/dev/null || true; }`,
     `printf '\\033]1;%s\\007' ${tabName}`,
     `printf '\\033]2;%s\\007' ${windowTitle}`,
     `exec ${tmux} attach -t ${groupSess} \\; select-window -t ${groupSess}:${win}`,

--- a/plugins/op/.claude-plugin/plugin.json
+++ b/plugins/op/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "op",
   "description": "Obsidian Projects workflow — schema, slash commands, and agent skill for running a Jira-lite issue tracker inside an Obsidian vault.",
-  "version": "0.61.4",
+  "version": "0.61.5",
   "author": {
     "name": "Eugene Archibald"
   },

--- a/plugins/op/.claude-plugin/plugin.json
+++ b/plugins/op/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "op",
   "description": "Obsidian Projects workflow — schema, slash commands, and agent skill for running a Jira-lite issue tracker inside an Obsidian vault.",
-  "version": "0.61.5",
+  "version": "0.61.6",
   "author": {
     "name": "Eugene Archibald"
   },


### PR DESCRIPTION
## Summary

- Each iTerm pane attaches to a per-pane *grouped* tmux session `view-<issueId>` whose window list is shared with the parent `op-agents-N` session. When the agent's window dies (`/quit`, `kill-window`, etc.) tmux silently switches the attached client to the next window in the shared list — typically a sibling agent's window — so the iTerm pane lingers as a duplicate viewer of another agent's session and macOS shifts focus back to Obsidian (issue OP-178).
- Install a `set-hook -t =view-<issueId> window-unlinked …` in `buildViewScript` that, when the unlinked window matches *this* pane's agent window (`#{==:#{hook_window_name},<windowName>}`), runs `kill-session -t =view-<issueId>`. tmux destroys the view session → the iTerm-attached client is detached → `exec tmux attach` returns → bash exits → iTerm pane closes (default profile behavior).
- Hook target uses the `=name` exact-match prefix so it can't accidentally prefix-match into a sibling `view-…` session, per WORKFLOW.md "tmux experimentation" rules.

## Why this is safe

- The legacy `terminalLaunch.ts` path (`tmux -CC attach`) is untouched — iTerm's tmux integration mode already closes tabs cleanly when their tmux window dies.
- The hook gates on `#{hook_window_name}`, so sibling agent deaths fired on the shared window list don't kill this view.
- `set-hook` overwrites by default — re-attach to an existing view session re-installs the same hook idempotently.

## Test plan

- [x] `npx vitest run src/orchestrator.test.ts` — new assertions cover hook line emission, ordering (after `new-session`, before `exec attach`), and per-window scoping
- [x] Full op-obsidian suite green (`npx vitest run` — 772 tests)
- [x] `node scripts/bump-version.mjs patch` — lockstep bump to `0.61.5` + production build OK
- [x] `node scripts/dev-sync.mjs` + smoke test in OP-Test (plugin loaded, 39 commands registered, dev:console clean)
- [ ] Reviewer: walk through the bash-quoting of the hook string — `shSingleQuote` of a tmux command string with embedded single-quoted format predicate

## Adversarial review request

@copilot please pressure-test:

1. **Quoting correctness.** The bash line is `tmux set-hook -t '=view-OP-178' window-unlinked '<hookCmd>'` where `<hookCmd>` is `shSingleQuote("if-shell -F '#{==:#{hook_window_name},OP-178}' 'kill-session -t =view-OP-178'")`. Confirm the `'\''` escape sequence survives both bash dequoting and tmux's command-string parser, and that tmux receives exactly one argument with the inner single quotes still grouping the format predicate and the kill-session subcommand.
2. **Sibling-pane isolation.** When two agents (`OP-A`, `OP-B`) share an `op-agents-1` session and `OP-A` exits, the `window-unlinked` hook fires on every session that has it set — including `view-OP-B`. The format predicate `#{==:#{hook_window_name},OP-B}` should evaluate false in that fire and leave `view-OP-B` alone. Trace whether that is in fact how `#{hook_window_name}` resolves on the *receiving* session (vs. always reflecting the originating session).
3. **Re-attach idempotence.** When a user closes the iTerm pane and re-launches the same issue, `new-session … 2>/dev/null || true` no-ops because the view session already exists; `set-hook` re-runs and overwrites the previous hook. Confirm this is safe (no append-mode side-effect, no stale hook left behind from a prior issue id reusing the same session — though same-id reuse is the only path here).
4. **Race: agent dies before hook is installed.** The bash script runs `new-session`, then `set-hook`, then `printf … exec tmux attach`. If the agent's window is already dead when set-hook runs (e.g. agent crashed before pane attached), what happens? Does `set-hook` succeed against a session whose only window is gone? Does the hook fire retroactively on the next event?
5. **Manual `tmux unlink-window` from the user.** Per the issue body "if the user manually unlinks the agent's window via tmux keybindings, the hook still fires — same end state as a clean /quit, which is correct." Verify.
6. **Cleanup symmetry with `agentSessionCleanup.ts`.** That module also tears down view sessions. Does the new hook race or double-kill against it?

🤖 Generated with [Claude Code](https://claude.com/claude-code)