### PR TITLE
OP-182: document non-iTerm terminals as second-class and untested

### DIFF
--- a/plugins/op-obsidian/README.md
+++ b/plugins/op-obsidian/README.md
@@ -96,9 +96,17 @@ Per-project repo paths (slug → absolute path). Overridden by a `repo_path:` in
 
 ### Terminal
 
-- **Terminal app** — `Terminal` (plain tmux) or `iTerm` (`tmux -CC` control mode). All agents share one tmux session (`op-agents`), one window per issue, so agents survive the terminal closing (reattach with `tmux attach -t op-agents`).
+**Supported terminals.** macOS only. Three tiers:
+
+- **iTerm — primary, daily-driver.** All agent-launch UX (tmux `-CC` control mode, the layout orchestrator, non-activating background launch via `open -ga`, recommended-prefs nudges, AppleScript automation) is built and tested against iTerm. Pick this unless you have a reason not to.
+- **Terminal.app — second-class fallback.** Works via plain tmux: each launch writes a launch script and `open -a Terminal`s it. No orchestrator, no `-CC` integration (each new Terminal window opens its own tmux client and mirrors the shared session), no background launch (Terminal has no equivalent non-activating cold-start), no pane layouts. Functional, but a degraded experience — only use it if iTerm isn't an option.
+- **Other terminals (Kitty, Alacritty, Ghostty, WezTerm, …) — not supported.** The dropdown is hardcoded to `Terminal | iTerm`; nothing else has been tested. If one of these is your default terminal, op still routes via `open -a Terminal` or iTerm — your preferred terminal is bypassed entirely. Adding support is not on the roadmap.
+
+Settings:
+
+- **Terminal app** — `Terminal` or `iTerm` (see tiers above). All agents share one tmux session (`op-agents`), one window per issue, so agents survive the terminal closing (reattach with `tmux attach -t op-agents`).
 - **tmux binary** — absolute path. Obsidian's `PATH` omits `/opt/homebrew/bin`, so bare `tmux` fails on Apple Silicon brew installs; set `/opt/homebrew/bin/tmux` or `/usr/local/bin/tmux` explicitly.
-- **iTerm window placement** — new tab in front window vs. new window.
+- **iTerm window placement** — new tab in front window vs. new window. iTerm only.
 
 ### iTerm layout orchestrator
 

--- a/plugins/op-obsidian/manifest.json
+++ b/plugins/op-obsidian/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "op-obsidian",
   "name": "Obsidian Projects (op)",
-  "version": "0.61.6",
+  "version": "0.61.7",
   "minAppVersion": "1.5.0",
   "description": "Jira-lite issue tracker for Obsidian vaults — deterministic commands backing the op workflow.",
   "author": "Eugene Archibald",

--- a/plugins/op-obsidian/package.json
+++ b/plugins/op-obsidian/package.json
@@ -1,6 +1,6 @@
 {
   "name": "op-obsidian",
-  "version": "0.61.6",
+  "version": "0.61.7",
   "description": "Obsidian plugin that owns the deterministic half of the op workflow.",
   "main": "main.js",
   "scripts": {

--- a/plugins/op-obsidian/src/settings.ts
+++ b/plugins/op-obsidian/src/settings.ts
@@ -408,7 +408,7 @@ export class OpSettingsTab extends PluginSettingTab {
     new Setting(containerEl)
       .setName("Terminal app")
       .setDesc(
-        "All agents share a single tmux session (`op-agents`), one window per issue (window name = issue id). Agents survive the terminal closing — reattach with `tmux attach -t op-agents`. iTerm uses tmux control mode (`tmux -CC`); Terminal.app uses plain tmux.",
+        "iTerm is the primary, daily-driver terminal — orchestrator, tmux `-CC` control mode, background launch and AppleScript paths all assume it. Terminal.app is a second-class fallback (plain tmux via `open -a Terminal`; no orchestrator, no `-CC`, no background launch). Other terminals (Kitty, Alacritty, Ghostty, WezTerm, …) are not supported; op still routes through Terminal.app or iTerm regardless of your default terminal. All agents share a single tmux session (`op-agents`), one window per issue (window name = issue id). Agents survive the terminal closing — reattach with `tmux attach -t op-agents`.",
       )
       .addDropdown((d) =>
         d

--- a/plugins/op/.claude-plugin/plugin.json
+++ b/plugins/op/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "op",
   "description": "Obsidian Projects workflow — schema, slash commands, and agent skill for running a Jira-lite issue tracker inside an Obsidian vault.",
-  "version": "0.61.6",
+  "version": "0.61.7",
   "author": {
     "name": "Eugene Archibald"
   },


### PR DESCRIPTION
## Summary
- README "Terminal" section now spells out three tiers: **iTerm** (primary daily-driver), **Terminal.app** (second-class fallback), **other terminals** (Kitty/Alacritty/Ghostty/WezTerm — not supported, op routes through one of the two regardless).
- Settings tab "Terminal app" tooltip mirrors the same tiering so users see it without leaving the dropdown.
- Docs and one tooltip string only — no behavior change.

Tracks op issue OP-182. Closes #218.

## Test plan
- [x] `node scripts/bump-version.mjs patch` → 0.61.7, build green.
- [x] `node scripts/dev-sync.mjs` → reload op-obsidian in OP-Test.
- [x] Probe rendered Settings tab via `app.setting.openTabById("op-obsidian")` — Terminal-app row found, description starts "iTerm is the primary, daily-driver terminal —…".
- [x] `obsidian vault=OP-Test dev:console` → no errors after reload + settings render.

🤖 Generated with [Claude Code](https://claude.com/claude-code)