### PR TITLE
OP-183: document gemini and copilot as second-class and untested

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,8 +17,18 @@ Both components read and write the same schema. You can drive the vault entirely
 - **`op-obsidian` plugin** (`plugins/op-obsidian/`) — The Obsidian community plugin.
   - **Sidebar view** — Open, in-flight, and resolved issue tabs.
   - **Command palette** — Native Obsidian commands for every workflow step.
-  - **Agent orchestration** — Launching Claude/Gemini/etc. in tmux windows directly from an issue note.
+  - **Agent orchestration** — Launching Claude (and, on a best-effort basis, Gemini or Copilot — see below) in tmux windows directly from an issue note.
 - **Marketplace** — `.claude-plugin/marketplace.json` at repo root.
+
+### Supported AI runtimes
+
+The agent-orchestration code paths recognize three runtimes — `claude`, `gemini`, and `copilot` — but they are not equally supported:
+
+- **Claude (Claude Code)** — primary supported runtime. The `op` skill, the slash commands, the smoke-test scripts, and the orchestration tests are all developed and exercised against Claude Code.
+- **Gemini CLI** — second-class, untested. Profile entries, hook installers, and dispatch code exist but no part of the dev workflow runs against Gemini, the launch flags and prompt preambles are unverified, and the PreToolUse worktree guard has not been validated end-to-end against a live Gemini install.
+- **Copilot CLI** — second-class, untested. Same caveat as Gemini, plus a known gap: Copilot CLI has no PreToolUse hook surface, so the worktree-enforcement guard does **not** apply to Copilot sessions even when the setting is on. The SessionEnd hook file path (`~/.copilot/hooks.json`) is best-effort from docs and has not been verified against a live Copilot install.
+
+Picking Gemini or Copilot in **Settings → Default agent** is allowed and the plugin will dispatch them, but you are exercising untested code paths. If you hit a problem, switching back to Claude is the supported recovery path. Patches that improve Gemini/Copilot support are welcome — start by adding a smoke-test recipe before changing dispatch code.
 
 ## Getting Started
 

--- a/plugins/op-obsidian/manifest.json
+++ b/plugins/op-obsidian/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "op-obsidian",
   "name": "Obsidian Projects (op)",
-  "version": "0.61.6",
+  "version": "0.61.7",
   "minAppVersion": "1.5.0",
   "description": "Jira-lite issue tracker for Obsidian vaults — deterministic commands backing the op workflow.",
   "author": "Eugene Archibald",

--- a/plugins/op-obsidian/package.json
+++ b/plugins/op-obsidian/package.json
@@ -1,6 +1,6 @@
 {
   "name": "op-obsidian",
-  "version": "0.61.6",
+  "version": "0.61.7",
   "description": "Obsidian plugin that owns the deterministic half of the op workflow.",
   "main": "main.js",
   "scripts": {

--- a/plugins/op-obsidian/src/agentProfiles.ts
+++ b/plugins/op-obsidian/src/agentProfiles.ts
@@ -178,6 +178,11 @@ export const BASE_PROFILES: Readonly<Record<AgentId, AgentProfile>> = Object.fre
     finalizePromptPreamble: DEFAULT_FINALIZE_PREAMBLE,
     skillTrigger: "/op:issue {{id}}",
   },
+  // Second-class, untested. The dispatch code accepts gemini/copilot but no
+  // part of this repo's dev workflow or test suite exercises them — launch
+  // flags, prompt preambles, hook-install paths, and skill-trigger phrasing
+  // are all best-effort defaults that have not been validated against a live
+  // install. See README "Supported AI runtimes" for user-facing framing.
   gemini: {
     id: "gemini",
     label: "Gemini CLI",

--- a/plugins/op-obsidian/src/settings.ts
+++ b/plugins/op-obsidian/src/settings.ts
@@ -114,7 +114,7 @@ const ADVANCED_SECTIONS: ReadonlyArray<{
     id: "worktreeEnforcement",
     title: "Agent worktree enforcement",
     blurb:
-      "Opt-in PreToolUse hook (Claude Code + Gemini) that blocks Edit/Write on the main checkout for op-launched sessions.",
+      "Opt-in PreToolUse hook that blocks Edit/Write on the main checkout for op-launched sessions. Verified on Claude Code; the Gemini install path is best-effort and untested. Copilot CLI has no PreToolUse surface, so this guard does not apply to Copilot sessions.",
   },
   {
     id: "flowChaining",
@@ -392,7 +392,7 @@ export class OpSettingsTab extends PluginSettingTab {
     new Setting(containerEl)
       .setName("Default agent")
       .setDesc(
-        "Agent launched by “op: open agent for issue” when no override is given — e.g. claude, gemini, codex. The picker only appears when this agent isn't detected on PATH, or “Always prompt for agent” is on.",
+        "Agent launched by “op: open agent for issue” when no override is given. Only claude is supported and exercised end-to-end; gemini and copilot are second-class, untested scaffolding — see the project README's “Supported AI runtimes” section. The picker only appears when this agent isn't detected on PATH, or “Always prompt for agent” is on.",
       )
       .addDropdown((d) => {
         for (const id of AGENT_IDS) d.addOption(id, id);
@@ -1209,7 +1209,7 @@ export class OpSettingsTab extends PluginSettingTab {
     new Setting(containerEl)
       .setName("Enforce worktree for delegated agents")
       .setDesc(
-        "Block edits on the main checkout for op-launched sessions. PreToolUse hook (Claude Code + Gemini); Copilot CLI is skipped (no pre-tool gate). Changes take effect on the next agent session. Override per-session with OP_ALLOW_MAIN_EDIT=1.",
+        "Block edits on the main checkout for op-launched sessions. PreToolUse hook — verified on Claude Code; the Gemini install path is best-effort and untested. Copilot CLI is skipped (no pre-tool gate). Changes take effect on the next agent session. Override per-session with OP_ALLOW_MAIN_EDIT=1.",
       )
       .addToggle((t) =>
         t.setValue(s.agents.enforceWorktree).onChange(async (v) => {
@@ -1348,7 +1348,7 @@ export class OpSettingsTab extends PluginSettingTab {
     );
     addTerm(
       "Worktree enforcement",
-      "An opt-in PreToolUse hook (Claude Code + Gemini only) that blocks Edit/Write on the main checkout for op-launched agents. Agents must `git worktree add` or export `OP_ALLOW_MAIN_EDIT=1` to override.",
+      "An opt-in PreToolUse hook that blocks Edit/Write on the main checkout for op-launched agents. Verified on Claude Code; the Gemini install path is best-effort and untested. Copilot CLI has no PreToolUse surface and is not gated. Agents must `git worktree add` or export `OP_ALLOW_MAIN_EDIT=1` to override.",
     );
   }
 

--- a/plugins/op-obsidian/src/skill/manual.md
+++ b/plugins/op-obsidian/src/skill/manual.md
@@ -113,7 +113,7 @@ Accepts `slug N`, `slug PREFIX-N`, `PREFIX N`, `PREFIX-N`, or just `slug`/`PREFI
 
 ### Start
 
-1. `obsidian op-work issue=<PREFIX>-<N> agent=<your-agent-id> [agent_session=<session-id>]`. The `agent` value is your runtime's identity (`claude`, `codex`, `gemini`, `copilot`, …) — pass the literal id, not the model name. The `agent_session` value should be a stable per-session identifier from your runtime; for Claude Code use `$CLAUDE_SESSION_ID` (exported in hook environments and via `--env`), and for other runtimes use whatever equivalent your harness exposes. Omit `agent_session=` if no stable id is available.
+1. `obsidian op-work issue=<PREFIX>-<N> agent=<your-agent-id> [agent_session=<session-id>]`. The `agent` value is your runtime's identity (`claude`, `codex`, `gemini`, `copilot`, …) — pass the literal id, not the model name. Only `claude` is exercised in this repo's dev workflow and tests; `gemini` and `copilot` are second-class scaffolding (the dispatch code accepts them but no part of the workflow has been validated against a live install — see the README's "Supported AI runtimes" section). The `agent_session` value should be a stable per-session identifier from your runtime; for Claude Code use `$CLAUDE_SESSION_ID` (exported in hook environments and via `--env`), and for other runtimes use whatever equivalent your harness exposes. Omit `agent_session=` if no stable id is available.
 
    Read the JSON payload at `Projects/_scratch/op-last-response.md` after the call:
    - `registered: true` and no `conflict` → you own the issue, proceed.

--- a/plugins/op/.claude-plugin/plugin.json
+++ b/plugins/op/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "op",
   "description": "Obsidian Projects workflow — schema, slash commands, and agent skill for running a Jira-lite issue tracker inside an Obsidian vault.",
-  "version": "0.61.6",
+  "version": "0.61.7",
   "author": {
     "name": "Eugene Archibald"
   },

--- a/plugins/op/skills/op/reference/schema.md
+++ b/plugins/op/skills/op/reference/schema.md
@@ -43,7 +43,7 @@ commits:                 # optional; short-sha + subject, appended during work
   - <sha7> <subject>
 pr:                      # optional; PR or MR URL if one exists
 github_issue:            # optional; direct mapping to a GitHub issue URL
-agent:                   # optional; agent runtime currently working the issue (e.g. claude, codex, gemini, copilot)
+agent:                   # optional; agent runtime currently working the issue (e.g. claude, codex, gemini, copilot — only `claude` is exercised in this repo's dev/test workflow; gemini/copilot are accepted but untested)
 agent_session:           # optional; opaque per-session id paired with `agent:` — used by op-work for conflict detection
 version:                 # optional; semver string of the release that shipped this issue, set at resolve
 flow:                    # optional; current stage of the multi-mode workflow (evaluate → planning → implementation → review → finalization → done)
@@ -76,7 +76,7 @@ Why: keeps the project key visible in file lists and makes wikilinks from TASKS 
 
 **GitHub issue mapping.** `github_issue:` is an optional URL pointing at a GitHub issue that mirrors this op issue. Set manually via the plugin's "Set GitHub issue URL" command, auto-populated at creation time when the `autoCreateGithubIssue` plugin setting is on (runs `gh issue create` in the project's repo), or passed in at creation. When `closeGithubIssueOnResolve` is on, resolving the op issue runs `gh issue close` on the linked URL.
 
-**Agent registration.** `agent:` records the runtime currently working the issue (`claude`, `codex`, `gemini`, `copilot`, …); `agent_session:` is an opaque per-session id the agent passes to `op-work` (e.g. `$CLAUDE_SESSION_ID`). Both are written by `obsidian op-work agent=<id> agent_session=<sid>` and act as a soft lock — if another agent or session is already registered, `op-work` returns a `conflict` in its JSON payload and refuses to overwrite unless `force=true`. Skill agents must surface a conflict to the user rather than auto-forcing. The fields are also written by the plugin's `op:open-agent` UI when launching, and cleared by `op-resolve`.
+**Agent registration.** `agent:` records the runtime currently working the issue (`claude`, `codex`, `gemini`, `copilot`, …); `agent_session:` is an opaque per-session id the agent passes to `op-work` (e.g. `$CLAUDE_SESSION_ID`). Both are written by `obsidian op-work agent=<id> agent_session=<sid>` and act as a soft lock — if another agent or session is already registered, `op-work` returns a `conflict` in its JSON payload and refuses to overwrite unless `force=true`. Skill agents must surface a conflict to the user rather than auto-forcing. The fields are also written by the plugin's `op:open-agent` UI when launching, and cleared by `op-resolve`. Note: `gemini` and `copilot` are accepted by the dispatch code but are second-class and untested in this repo's dev workflow — only `claude` is exercised end-to-end. See the project README's "Supported AI runtimes" section.
 
 **Version.** `version:` is **optional**. It records the release identifier (e.g. `0.1.7`) that shipped this issue, when the project tracks releases on issues. *When* and *how* to set it — patch/minor/major classification, lockstep across multiple version files, whether to bump per issue at all — is owned by the project, not by this skill. See the project's own `CLAUDE.md` (or equivalent) for the policy. Meta-only projects without a release artifact leave the field unset.
 


### PR DESCRIPTION
## Summary

Documentation-only change clarifying that the agent-orchestration code paths recognize three runtimes (`claude`, `gemini`, `copilot`) but only Claude is exercised end-to-end.

- `README.md` — new **Supported AI runtimes** subsection: Claude is the primary supported runtime; Gemini/Copilot are second-class scaffolding (with the Copilot-no-PreToolUse-gate caveat called out explicitly).
- `plugins/op-obsidian/src/skill/manual.md` — agent= paragraph notes only claude is exercised; gemini/copilot are accepted but untested.
- `plugins/op-obsidian/src/settings.ts` — Default-agent dropdown description, worktree-enforcement toggle, glossary advanced-section blurb, and worktree-enforcement section header all updated.
- `plugins/op-obsidian/src/agentProfiles.ts` — header comment on the gemini/copilot profile entries.
- `plugins/op/skills/op/reference/schema.md` — `agent:` field comment + Agent registration paragraph mirror the manual.
- Patch bump: `0.61.6` → `0.61.7` (lockstep across the three version files via `bump-version.mjs`).

## Adversarial AI review — bypass rationale

Per WORKFLOW.md "Adversarial AI review before merge", this diff meets all 7 bypass criteria:

1. **No runtime behavior change** — only description copy and prose. The `gemini`/`copilot` AGENT_IDS, profiles, hooks, and dispatch paths are unchanged.
2. **No control flow changes** — no added/removed branches, loops, or exception handling.
3. **No new dependencies** — no new imports, packages, API calls, or env vars.
4. **No public surface change** — no new/removed CLI param, URI handler, slash command, palette command, frontmatter field, schema field, settings tab field, or exported function signature. Settings tab field text is updated; the field itself is not.
5. **No security or permission impact** — no auth, hooks, command execution, file-write, vault trash/move, or GitHub integration touched.
6. **Reversible in one commit** — single squash, no entanglement.
7. **Single concern** — one logical area (documenting runtime support tiers).

The version bump itself is a docs-shipped patch with no behavior change in `main.js` (string changes only).

## Test plan

- [x] `npm run build` (via `bump-version.mjs`) — green
- [x] `node scripts/dev-sync.mjs` — synced to OP-Test, plugin reloaded clean
- [x] OP-Test settings tab smoke test: 5 daily rows, 8 advanced collapsibles, Default-agent description renders the new copy
- [x] `npm test` — 773/773 tests pass (1 unrelated pre-existing suite-load failure in `iTermPrefs.test.ts`, untouched by this PR)
- [x] Console clean after smoke probes