### PR TITLE
OP-194: generic {{var}} renderer + pluginVarRegistry + WorkflowDiagnostic

### DIFF
--- a/plugins/op-obsidian/manifest.json
+++ b/plugins/op-obsidian/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "op-obsidian",
   "name": "Obsidian Projects (op)",
-  "version": "0.61.8",
+  "version": "0.62.0",
   "minAppVersion": "1.5.0",
   "description": "Jira-lite issue tracker for Obsidian vaults — deterministic commands backing the op workflow.",
   "author": "Eugene Archibald",

--- a/plugins/op-obsidian/package.json
+++ b/plugins/op-obsidian/package.json
@@ -1,6 +1,6 @@
 {
   "name": "op-obsidian",
-  "version": "0.61.8",
+  "version": "0.62.0",
   "description": "Obsidian plugin that owns the deterministic half of the op workflow.",
   "main": "main.js",
   "scripts": {

--- a/plugins/op-obsidian/src/agentProfiles.ts
+++ b/plugins/op-obsidian/src/agentProfiles.ts
@@ -1,3 +1,5 @@
+import { renderTemplate } from "./renderTemplate";
+
 export type AgentId = "claude" | "gemini" | "copilot";
 
 export const AGENT_IDS: AgentId[] = ["claude", "gemini", "copilot"];
@@ -244,7 +246,13 @@ export function mergeProfile(id: AgentId, overlay?: ProfileOverlay): AgentProfil
 }
 
 export function renderSkillTrigger(profile: AgentProfile, issueId: string): string {
-  return profile.skillTrigger.replace(/\{\{id\}\}/g, issueId);
+  // Delegates to the generic `renderTemplate` so every prompt-shaping
+  // surface goes through one code path with one diagnostic contract. The
+  // shipped trigger strings only reference `{{id}}` today, so a partial
+  // context with just `{ id, agent }` is sufficient. Diagnostics are
+  // discarded here; 1d's composer will plumb them through to the dry-run /
+  // settings surfaces.
+  return renderTemplate(profile.skillTrigger, { id: issueId, agent: profile.id }).text;
 }
 
 export function launchFlagsFor(profile: AgentProfile, mode: AgentLaunchMode): string[] {

--- a/plugins/op-obsidian/src/pluginVarRegistry.test.ts
+++ b/plugins/op-obsidian/src/pluginVarRegistry.test.ts
@@ -182,6 +182,18 @@ describe("PLUGIN_VAR_REGISTRY", () => {
       expect(PLUGIN_VAR_REGISTRY.parent.compute(minimal)).toBe(PARENT_NONE_SENTINEL);
       expect(PLUGIN_VAR_REGISTRY.parent.compute({ ...minimal, parent: "OP-2" })).toBe("OP-2");
     });
+
+    it("{{parent}} returns undefined (not the sentinel) when parent slot is missing from a Partial ctx", () => {
+      // parent is required (string | null) in a full RenderContext, but in a
+      // Partial<RenderContext> the slot may simply be absent (undefined).
+      // undefined means "caller didn't provide the parent field at all" — the
+      // renderer treats that as missing-var, not as a confirmed top-level issue.
+      // null is the explicit signal that the issue has no parent; only that
+      // triggers the sentinel.
+      const noParentSlot: Partial<typeof minimal> = { ...minimal };
+      delete (noParentSlot as Partial<typeof noParentSlot>).parent;
+      expect(PLUGIN_VAR_REGISTRY.parent.compute(noParentSlot)).toBeUndefined();
+    });
   });
 });
 

--- a/plugins/op-obsidian/src/pluginVarRegistry.test.ts
+++ b/plugins/op-obsidian/src/pluginVarRegistry.test.ts
@@ -1,0 +1,263 @@
+import { describe, expect, it } from "vitest";
+import {
+  PARENT_NONE_SENTINEL,
+  PLUGIN_VAR_REGISTRY,
+  buildRenderContext,
+  type LaunchContext,
+  type RenderContext,
+} from "./pluginVarRegistry";
+import { BASE_PROFILES } from "./agentProfiles";
+import type { IssueEntry } from "./types";
+
+const FIXTURE_CTX: RenderContext = {
+  id: "OP-194",
+  title: "Generic {{var}} renderer + context builder",
+  project: "obsidian-projects",
+  status: "in-progress",
+  priority: "high",
+  parent: "OP-184",
+  pr_url: "https://github.com/earchibald/obsidian-projects/pull/232",
+  github_issue: "https://github.com/earchibald/obsidian-projects/issues/232",
+  repo_path: "/Users/me/Projects/obsidian-projects",
+  vault_path: "/Users/me/work/Agent-Vault",
+  vault_name: "Agent-Vault",
+  branch: "worktree-OP-194",
+  today: "2026-04-26",
+  agent: "claude",
+  model: "claude-opus-4-7",
+  mode: "implement",
+};
+
+const FIXTURE_ENTRY: IssueEntry = {
+  path: "Projects/obsidian-projects/ISSUES/OP-194.md",
+  type: "issue",
+  id: "OP-194",
+  project: "obsidian-projects",
+  status: "in-progress",
+  priority: "high",
+  created: "2026-04-26",
+  assignee: "earchibald",
+  pr: "https://github.com/earchibald/obsidian-projects/pull/232",
+  githubIssue: "https://github.com/earchibald/obsidian-projects/issues/232",
+  agent: "claude",
+  title: "Generic {{var}} renderer + context builder",
+  resolvedFolder: false,
+};
+
+describe("PLUGIN_VAR_REGISTRY", () => {
+  it("declares an entry for every required always-on var (OP-194 acceptance criterion)", () => {
+    const required = [
+      "id",
+      "title",
+      "project",
+      "status",
+      "priority",
+      "parent",
+      "repo_path",
+      "vault_path",
+      "vault_name",
+      "branch",
+      "pr_url",
+      "github_issue",
+      "today",
+      "agent",
+      "model",
+      "mode",
+    ];
+    for (const name of required) {
+      expect(PLUGIN_VAR_REGISTRY[name], `missing registry entry for {{${name}}}`).toBeDefined();
+    }
+  });
+
+  it("each entry's name field matches its key (no key/name drift)", () => {
+    for (const [key, entry] of Object.entries(PLUGIN_VAR_REGISTRY)) {
+      expect(entry.name).toBe(key);
+    }
+  });
+
+  it("each entry has a non-empty description and example", () => {
+    for (const [name, entry] of Object.entries(PLUGIN_VAR_REGISTRY)) {
+      expect(entry.description.length, `${name}.description`).toBeGreaterThan(0);
+      expect(entry.example.length, `${name}.example`).toBeGreaterThan(0);
+    }
+  });
+
+  describe("compute() against a fully populated fixture", () => {
+    const cases: Array<[string, string]> = [
+      ["id", FIXTURE_CTX.id],
+      ["title", FIXTURE_CTX.title],
+      ["project", FIXTURE_CTX.project],
+      ["status", FIXTURE_CTX.status],
+      ["priority", FIXTURE_CTX.priority!],
+      ["parent", FIXTURE_CTX.parent as string],
+      ["pr_url", FIXTURE_CTX.pr_url!],
+      ["github_issue", FIXTURE_CTX.github_issue!],
+      ["repo_path", FIXTURE_CTX.repo_path!],
+      ["vault_path", FIXTURE_CTX.vault_path],
+      ["vault_name", FIXTURE_CTX.vault_name],
+      ["branch", FIXTURE_CTX.branch!],
+      ["today", FIXTURE_CTX.today],
+      ["agent", FIXTURE_CTX.agent],
+      ["model", FIXTURE_CTX.model!],
+      ["mode", FIXTURE_CTX.mode],
+    ];
+
+    for (const [name, expected] of cases) {
+      it(`{{${name}}} resolves to the expected fixture value`, () => {
+        expect(PLUGIN_VAR_REGISTRY[name].compute(FIXTURE_CTX)).toBe(expected);
+      });
+    }
+  });
+
+  describe("parent sentinel", () => {
+    it("returns the literal parent id when present", () => {
+      expect(PLUGIN_VAR_REGISTRY.parent.compute({ ...FIXTURE_CTX, parent: "OP-184" })).toBe("OP-184");
+    });
+
+    it("returns PARENT_NONE_SENTINEL when parent is null (top-level issue)", () => {
+      expect(PLUGIN_VAR_REGISTRY.parent.compute({ ...FIXTURE_CTX, parent: null })).toBe(
+        PARENT_NONE_SENTINEL,
+      );
+    });
+
+    it("the sentinel string lives in the registry export — consumers reference one source", () => {
+      // If this check is ever made to pass by hardcoding the prose, that's the bug
+      // the test is here to prevent. The sentinel's prose must come from the
+      // exported constant, not be re-typed at the assertion site.
+      expect(PARENT_NONE_SENTINEL).toBe("(none — this is a top-level issue)");
+      expect(PLUGIN_VAR_REGISTRY.parent.compute({ ...FIXTURE_CTX, parent: null })).toBe(
+        PARENT_NONE_SENTINEL,
+      );
+    });
+
+    it("the sentinel describes what 'no parent' means in prose, not an empty string", () => {
+      // Defensive: protects against a refactor that sets the sentinel to "" or "—".
+      expect(PARENT_NONE_SENTINEL.length).toBeGreaterThan(10);
+      expect(PARENT_NONE_SENTINEL).toMatch(/top-level/i);
+    });
+  });
+
+  describe("optional-field fallthrough", () => {
+    const minimal: RenderContext = {
+      id: "OP-1",
+      title: "t",
+      project: "p",
+      status: "open",
+      parent: null,
+      vault_path: "/v",
+      vault_name: "V",
+      today: "2026-04-26",
+      agent: "claude",
+      mode: "implement",
+    };
+
+    it.each([
+      "priority",
+      "pr_url",
+      "github_issue",
+      "repo_path",
+      "branch",
+      "model",
+    ] as const)("{{%s}} returns undefined when ctx slot is undefined", (name) => {
+      expect(PLUGIN_VAR_REGISTRY[name].compute(minimal)).toBeUndefined();
+    });
+
+    it.each([
+      "id",
+      "title",
+      "project",
+      "status",
+      "vault_path",
+      "vault_name",
+      "today",
+      "agent",
+      "mode",
+    ] as const)("{{%s}} returns a string for a required field even on a minimal ctx", (name) => {
+      const v = PLUGIN_VAR_REGISTRY[name].compute(minimal);
+      expect(typeof v).toBe("string");
+      expect(v).not.toBe("");
+    });
+
+    it("{{parent}} always returns a string (sentinel or id) — never undefined", () => {
+      expect(PLUGIN_VAR_REGISTRY.parent.compute(minimal)).toBe(PARENT_NONE_SENTINEL);
+      expect(PLUGIN_VAR_REGISTRY.parent.compute({ ...minimal, parent: "OP-2" })).toBe("OP-2");
+    });
+  });
+});
+
+describe("buildRenderContext", () => {
+  const launch: LaunchContext = {
+    mode: "implement",
+    model: "claude-opus-4-7",
+    branch: "worktree-OP-194",
+    repo_path: "/Users/me/Projects/obsidian-projects",
+    vault_path: "/Users/me/work/Agent-Vault",
+    vault_name: "Agent-Vault",
+    today: "2026-04-26",
+    parent: "OP-184",
+  };
+
+  it("flattens IssueEntry + AgentProfile + LaunchContext into a RenderContext", () => {
+    const ctx = buildRenderContext({
+      entry: FIXTURE_ENTRY,
+      profile: BASE_PROFILES.claude,
+      launch,
+    });
+    expect(ctx).toMatchObject({
+      id: "OP-194",
+      title: FIXTURE_ENTRY.title,
+      project: "obsidian-projects",
+      status: "in-progress",
+      priority: "high",
+      parent: "OP-184",
+      pr_url: FIXTURE_ENTRY.pr,
+      github_issue: FIXTURE_ENTRY.githubIssue,
+      repo_path: launch.repo_path,
+      vault_path: launch.vault_path,
+      vault_name: launch.vault_name,
+      branch: launch.branch,
+      today: launch.today,
+      agent: "claude",
+      model: launch.model,
+      mode: launch.mode,
+    });
+  });
+
+  it("threads parent: null through to the RenderContext for top-level issues", () => {
+    const ctx = buildRenderContext({
+      entry: FIXTURE_ENTRY,
+      profile: BASE_PROFILES.claude,
+      launch: { ...launch, parent: null },
+    });
+    expect(ctx.parent).toBeNull();
+  });
+
+  it("maps IssueEntry.pr → pr_url and IssueEntry.githubIssue → github_issue", () => {
+    const ctx = buildRenderContext({
+      entry: FIXTURE_ENTRY,
+      profile: BASE_PROFILES.claude,
+      launch,
+    });
+    expect(ctx.pr_url).toBe(FIXTURE_ENTRY.pr);
+    expect(ctx.github_issue).toBe(FIXTURE_ENTRY.githubIssue);
+  });
+
+  it("uses AgentProfile.id as the agent value (not the binary or label)", () => {
+    const ctx = buildRenderContext({
+      entry: FIXTURE_ENTRY,
+      profile: BASE_PROFILES.gemini,
+      launch,
+    });
+    expect(ctx.agent).toBe("gemini");
+  });
+
+  it("does no I/O — pure assembly given the inputs", () => {
+    // Tautological-feeling test, but it pins the contract: the function does
+    // not reach for a clock, vault, or filesystem. Any future regression that
+    // adds an `await` or a `new Date()` will be caught by static signature
+    // (sync return) and by the property: same inputs → same output.
+    const a = buildRenderContext({ entry: FIXTURE_ENTRY, profile: BASE_PROFILES.claude, launch });
+    const b = buildRenderContext({ entry: FIXTURE_ENTRY, profile: BASE_PROFILES.claude, launch });
+    expect(a).toEqual(b);
+  });
+});

--- a/plugins/op-obsidian/src/pluginVarRegistry.ts
+++ b/plugins/op-obsidian/src/pluginVarRegistry.ts
@@ -1,0 +1,248 @@
+import type { AgentProfile } from "./agentProfiles";
+import type { IssueEntry } from "./types";
+
+// Always-on plugin vars surfaced to workflow-module templates. This file is
+// the single source of truth: adding a new always-on var is one entry here,
+// and every UI surface (renderer, autocomplete, settings reference panel,
+// op-list-vars CLI, generated reference docs) reads from this registry. No
+// duplication.
+//
+// OP-181 plan §"Variable templating" — these vars live exclusively at the
+// Launch-override scope (level 4): they are computed per-launch from the
+// launch context and shadow any same-named lower-precedence value. User vars
+// (`{{vars.<name>}}`) are a separate namespace handled by 1b/1c/1d.
+
+/**
+ * Sentinel string emitted when an issue has no `parent:` frontmatter. Lives
+ * in the registry (not duplicated at every callsite) so every surface that
+ * renders a parent reference reads the same prose. Designed to be readable
+ * inline — agents see prose-readable text rather than an empty string or an
+ * unrendered `{{parent}}` token. Spec: OP-181 plan §"Variable templating".
+ */
+export const PARENT_NONE_SENTINEL = "(none — this is a top-level issue)";
+
+/**
+ * Flat record of every value any plugin-var entry might compute over.
+ * Required fields are always present given a typed `RenderContext`; optional
+ * fields are `undefined` when the issue or environment doesn't supply them
+ * (e.g., a freshly created issue has no `branch`, no `pr_url`).
+ *
+ * This is the contract between `buildRenderContext` (assembly) and
+ * `PluginVar.compute` (lookup) — keep changes here in lockstep with the
+ * `PLUGIN_VAR_REGISTRY` entries below.
+ */
+export interface RenderContext {
+  // Issue identity
+  id: string;
+  title: string;
+  project: string;
+  status: string;
+  priority?: string;
+
+  // Issue links
+  /** `null` when the issue has no parent — registry returns `PARENT_NONE_SENTINEL`. */
+  parent: string | null;
+  pr_url?: string;
+  github_issue?: string;
+
+  // Repo / vault
+  repo_path?: string;
+  vault_path: string;
+  vault_name: string;
+  branch?: string;
+
+  // Run context
+  /** ISO `YYYY-MM-DD` — caller is responsible for formatting; pure-fn doesn't reach for `Date`. */
+  today: string;
+  agent: string;
+  model?: string;
+  mode: string;
+}
+
+/**
+ * One entry per always-on var. `compute(ctx)` returns the rendered string,
+ * or `undefined` if the value isn't available — the renderer leaves the token
+ * verbatim and emits a `missing-var` diagnostic in that case (the verbatim
+ * fallback is a soft failure, never a silent corruption).
+ *
+ * `ctx` is typed `Partial<RenderContext>` so callers with a fragment of the
+ * full context (legacy callsites mid-migration, or unit tests of a single
+ * field) can still resolve what they have. Full-context callers see no
+ * spurious diagnostics because every field is populated.
+ */
+export interface PluginVar {
+  name: string;
+  /** One-line, prose, suitable for a settings reference panel and `op-list-vars`. */
+  description: string;
+  /** Concrete example string — for tooltips / autocomplete previews / docs. */
+  example: string;
+  compute: (ctx: Partial<RenderContext>) => string | undefined;
+}
+
+/**
+ * Canonical registry. Map order is the order entries appear in `op-list-vars`
+ * and the settings reference panel — keep grouped by concern (identity →
+ * links → repo/vault → run context) for readability.
+ */
+export const PLUGIN_VAR_REGISTRY: Readonly<Record<string, PluginVar>> = Object.freeze({
+  // Issue identity
+  id: {
+    name: "id",
+    description: "The issue's canonical id (e.g., OP-194).",
+    example: "OP-194",
+    compute: (ctx) => ctx.id,
+  },
+  title: {
+    name: "title",
+    description: "The issue's title from its frontmatter.",
+    example: "Generic {{var}} renderer + context builder",
+    compute: (ctx) => ctx.title,
+  },
+  project: {
+    name: "project",
+    description: "The project slug the issue belongs to.",
+    example: "obsidian-projects",
+    compute: (ctx) => ctx.project,
+  },
+  status: {
+    name: "status",
+    description: "The issue's lifecycle status (open, in-progress, blocked, resolved, wontfix).",
+    example: "in-progress",
+    compute: (ctx) => ctx.status,
+  },
+  priority: {
+    name: "priority",
+    description: "The issue's priority (low, med, high) — undefined if not set.",
+    example: "high",
+    compute: (ctx) => ctx.priority,
+  },
+
+  // Issue links
+  parent: {
+    name: "parent",
+    description:
+      "The parent issue id from frontmatter, or the sentinel '(none — this is a top-level issue)' when no parent is set.",
+    example: "OP-184",
+    compute: (ctx) => (ctx.parent === null ? PARENT_NONE_SENTINEL : ctx.parent),
+  },
+  pr_url: {
+    name: "pr_url",
+    description: "The pull-request URL once the issue has one — undefined before the PR opens.",
+    example: "https://github.com/earchibald/obsidian-projects/pull/232",
+    compute: (ctx) => ctx.pr_url,
+  },
+  github_issue: {
+    name: "github_issue",
+    description: "The mirrored GitHub issue URL when the issue is GH-linked — undefined when local-only.",
+    example: "https://github.com/earchibald/obsidian-projects/issues/232",
+    compute: (ctx) => ctx.github_issue,
+  },
+
+  // Repo / vault
+  repo_path: {
+    name: "repo_path",
+    description: "Absolute path to the project's code repository — undefined for meta-only projects.",
+    example: "/Users/you/Projects/obsidian-projects",
+    compute: (ctx) => ctx.repo_path,
+  },
+  vault_path: {
+    name: "vault_path",
+    description: "Absolute path to the active Obsidian vault.",
+    example: "/Users/you/work/Agent-Vault",
+    compute: (ctx) => ctx.vault_path,
+  },
+  vault_name: {
+    name: "vault_name",
+    description: "Display name of the active Obsidian vault.",
+    example: "Agent-Vault",
+    compute: (ctx) => ctx.vault_name,
+  },
+  branch: {
+    name: "branch",
+    description:
+      "The git branch the agent is operating on — undefined before the worktree exists or for meta-only projects.",
+    example: "worktree-OP-194",
+    compute: (ctx) => ctx.branch,
+  },
+
+  // Run context
+  today: {
+    name: "today",
+    description: "Today's date in ISO YYYY-MM-DD form, computed by the launching surface.",
+    example: "2026-04-26",
+    compute: (ctx) => ctx.today,
+  },
+  agent: {
+    name: "agent",
+    description: "The agent id launching this session (claude, gemini, copilot).",
+    example: "claude",
+    compute: (ctx) => ctx.agent,
+  },
+  model: {
+    name: "model",
+    description: "The resolved model id for this launch — undefined if the agent has no per-launch model selection.",
+    example: "claude-opus-4-7",
+    compute: (ctx) => ctx.model,
+  },
+  mode: {
+    name: "mode",
+    description: "The launch mode (evaluate, plan, implement, review, finalize).",
+    example: "implement",
+    compute: (ctx) => ctx.mode,
+  },
+});
+
+/**
+ * Per-launch context that `buildRenderContext` does not derive from the issue
+ * note or the agent profile. Caller (1d's composition layer) reads vault and
+ * repo state once and threads it through; the pure-fn boundary stays clean.
+ *
+ * `parent: string | null` — caller reads the issue's `parent:` frontmatter
+ * and supplies `null` for top-level issues so the registry can emit the
+ * sentinel.
+ */
+export interface LaunchContext {
+  mode: string;
+  model?: string;
+  branch?: string;
+  repo_path?: string;
+  vault_path: string;
+  vault_name: string;
+  /** ISO YYYY-MM-DD. */
+  today: string;
+  /** `null` for top-level issues — registry will substitute the sentinel. */
+  parent: string | null;
+}
+
+/**
+ * Pure assembly: flatten an issue + agent profile + launch context into the
+ * `RenderContext` that the renderer and downstream surfaces consume.
+ *
+ * No I/O. No vault reads. No clock reads. Every value comes from arguments —
+ * call this exactly once per launch and reuse the result.
+ */
+export function buildRenderContext(args: {
+  entry: IssueEntry;
+  profile: AgentProfile;
+  launch: LaunchContext;
+}): RenderContext {
+  const { entry, profile, launch } = args;
+  return {
+    id: entry.id,
+    title: entry.title,
+    project: entry.project,
+    status: entry.status,
+    priority: entry.priority,
+    parent: launch.parent,
+    pr_url: entry.pr,
+    github_issue: entry.githubIssue,
+    repo_path: launch.repo_path,
+    vault_path: launch.vault_path,
+    vault_name: launch.vault_name,
+    branch: launch.branch,
+    today: launch.today,
+    agent: profile.id,
+    model: launch.model,
+    mode: launch.mode,
+  };
+}

--- a/plugins/op-obsidian/src/pluginVarRegistry.ts
+++ b/plugins/op-obsidian/src/pluginVarRegistry.ts
@@ -120,8 +120,7 @@ export const PLUGIN_VAR_REGISTRY: Readonly<Record<string, PluginVar>> = Object.f
   // Issue links
   parent: {
     name: "parent",
-    description:
-      "The parent issue id from frontmatter, or the sentinel '(none — this is a top-level issue)' when no parent is set.",
+    description: `The parent issue id from frontmatter, or \`${PARENT_NONE_SENTINEL}\` when no parent is set.`,
     example: "OP-184",
     compute: (ctx) => (ctx.parent === null ? PARENT_NONE_SENTINEL : ctx.parent),
   },

--- a/plugins/op-obsidian/src/renderTemplate.test.ts
+++ b/plugins/op-obsidian/src/renderTemplate.test.ts
@@ -61,6 +61,48 @@ describe("renderTemplate", () => {
     });
   });
 
+  describe("regex edge cases", () => {
+    it("{{ {{id}} }} — outer braces don't match (content starts with {), inner {{id}} is substituted", () => {
+      const r = renderTemplate("{{ {{id}} }}", FULL_CTX);
+      expect(r.text).toBe("{{ OP-194 }}");
+      expect(r.diagnostics).toEqual([]);
+    });
+
+    it("{{}} — empty braces don't match the token shape, left verbatim, no diagnostic", () => {
+      const r = renderTemplate("{{}}", FULL_CTX);
+      expect(r.text).toBe("{{}}");
+      expect(r.diagnostics).toEqual([]);
+    });
+
+    it("{{ }} — whitespace-only braces don't match (no identifier), left verbatim, no diagnostic", () => {
+      const r = renderTemplate("{{ }}", FULL_CTX);
+      expect(r.text).toBe("{{ }}");
+      expect(r.diagnostics).toEqual([]);
+    });
+
+    it("{{\nid\n}} — newlines inside braces match (\\s* includes \\n)", () => {
+      // Intentional: \s* allows newlines in multi-line template strings.
+      const r = renderTemplate("{{\nid\n}}", FULL_CTX);
+      expect(r.text).toBe("OP-194");
+      expect(r.diagnostics).toEqual([]);
+    });
+
+    it("{{ id — unclosed braces left verbatim, no crash", () => {
+      const r = renderTemplate("{{ id", FULL_CTX);
+      expect(r.text).toBe("{{ id");
+      expect(r.diagnostics).toEqual([]);
+    });
+
+    it("{{github-issue}} — hyphen not in token charset, left verbatim, no diagnostic", () => {
+      // The token name must match [a-zA-Z_][a-zA-Z0-9_]*. A hyphen breaks the
+      // match before }}, so the token is not recognised at all — no spurious
+      // missing-var diagnostic is emitted for it.
+      const r = renderTemplate("{{github-issue}}", FULL_CTX);
+      expect(r.text).toBe("{{github-issue}}");
+      expect(r.diagnostics).toEqual([]);
+    });
+  });
+
   describe("missing-var diagnostics", () => {
     it("leaves an unknown-name token verbatim and emits one missing-var diagnostic", () => {
       const r = renderTemplate("Hello {{notavar}}!", FULL_CTX);
@@ -126,6 +168,22 @@ describe("renderTemplate", () => {
       expect(second.text).toBe(first.text);
       expect(second.diagnostics).toEqual([]);
     });
+
+    it("known limitation: a resolved value containing {{…}} shapes is NOT a fixed point", () => {
+      // If ctx.title = "Use {{id}} in prose", the first pass substitutes {{title}}
+      // and produces "Use {{id}} in prose". The second pass then resolves {{id}},
+      // producing "Use OP-194 in prose". The two outputs differ — single-pass
+      // rendering is the intended contract; callers control whether extra passes
+      // are needed. The verbatim fallback still prevents silent corruption.
+      const ctx = { ...FULL_CTX, title: "Use {{id}} in prose" };
+      const first = renderTemplate("{{title}}", ctx);
+      expect(first.text).toBe("Use {{id}} in prose");
+      expect(first.diagnostics).toEqual([]);
+
+      const second = renderTemplate(first.text, ctx);
+      expect(second.text).toBe("Use OP-194 in prose");
+      expect(second.text).not.toBe(first.text); // not a fixed point
+    });
   });
 
   describe("parent sentinel propagation", () => {
@@ -163,5 +221,15 @@ describe("renderSkillTrigger (refactored to delegate to renderTemplate)", () => 
   it("substitutes every occurrence of {{id}} (matches legacy /\\{\\{id\\}\\}/g semantics)", () => {
     const profile = { ...BASE_PROFILES.claude, skillTrigger: "{{id}} {{id}} {{id}}" };
     expect(renderSkillTrigger(profile, "X-1")).toBe("X-1 X-1 X-1");
+  });
+
+  it("issueId containing $& is inserted literally (callback-based replace; legacy string replace would have expanded it)", () => {
+    // String.prototype.replace(regex, string) expands $& as the matched text.
+    // The callback form — which renderTemplate uses — returns the value directly,
+    // so $& in an issue id is safe and produces the exact id in the output.
+    const profile = { ...BASE_PROFILES.claude, skillTrigger: "{{id}}" };
+    expect(renderSkillTrigger(profile, "$&")).toBe("$&");
+    expect(renderSkillTrigger(profile, "$'")).toBe("$'");
+    expect(renderSkillTrigger(profile, "$`")).toBe("$`");
   });
 });

--- a/plugins/op-obsidian/src/renderTemplate.test.ts
+++ b/plugins/op-obsidian/src/renderTemplate.test.ts
@@ -1,0 +1,167 @@
+import { describe, expect, it } from "vitest";
+import { renderTemplate } from "./renderTemplate";
+import { PARENT_NONE_SENTINEL, type RenderContext } from "./pluginVarRegistry";
+import { BASE_PROFILES, renderSkillTrigger } from "./agentProfiles";
+
+const FULL_CTX: RenderContext = {
+  id: "OP-194",
+  title: "Generic var renderer",
+  project: "obsidian-projects",
+  status: "in-progress",
+  priority: "high",
+  parent: "OP-184",
+  pr_url: "https://example.test/pr/1",
+  github_issue: "https://example.test/issue/1",
+  repo_path: "/repo",
+  vault_path: "/vault",
+  vault_name: "Vault",
+  branch: "worktree-OP-194",
+  today: "2026-04-26",
+  agent: "claude",
+  model: "claude-opus-4-7",
+  mode: "implement",
+};
+
+describe("renderTemplate", () => {
+  describe("basic substitution", () => {
+    it("substitutes a single token", () => {
+      const r = renderTemplate("Issue {{id}}", FULL_CTX);
+      expect(r.text).toBe("Issue OP-194");
+      expect(r.diagnostics).toEqual([]);
+    });
+
+    it("substitutes multiple tokens in one pass", () => {
+      const r = renderTemplate("{{id}} on branch {{branch}} for project {{project}}", FULL_CTX);
+      expect(r.text).toBe("OP-194 on branch worktree-OP-194 for project obsidian-projects");
+      expect(r.diagnostics).toEqual([]);
+    });
+
+    it("substitutes the same token multiple times", () => {
+      const r = renderTemplate("{{id}}/{{id}}/{{id}}", FULL_CTX);
+      expect(r.text).toBe("OP-194/OP-194/OP-194");
+      expect(r.diagnostics).toEqual([]);
+    });
+
+    it("tolerates whitespace inside braces", () => {
+      const r = renderTemplate("{{ id }} and {{   branch   }}", FULL_CTX);
+      expect(r.text).toBe("OP-194 and worktree-OP-194");
+      expect(r.diagnostics).toEqual([]);
+    });
+
+    it("passes literal text through untouched", () => {
+      const r = renderTemplate("no tokens here, just prose.", FULL_CTX);
+      expect(r.text).toBe("no tokens here, just prose.");
+      expect(r.diagnostics).toEqual([]);
+    });
+
+    it("does not touch single-brace expressions", () => {
+      const r = renderTemplate("{ not a token } and {also not}", FULL_CTX);
+      expect(r.text).toBe("{ not a token } and {also not}");
+      expect(r.diagnostics).toEqual([]);
+    });
+  });
+
+  describe("missing-var diagnostics", () => {
+    it("leaves an unknown-name token verbatim and emits one missing-var diagnostic", () => {
+      const r = renderTemplate("Hello {{notavar}}!", FULL_CTX);
+      expect(r.text).toBe("Hello {{notavar}}!");
+      expect(r.diagnostics).toHaveLength(1);
+      expect(r.diagnostics[0]).toMatchObject({
+        code: "missing-var",
+        severity: "warning",
+        varName: "notavar",
+      });
+    });
+
+    it("leaves a known-but-undefined-in-ctx token verbatim and emits a missing-var diagnostic", () => {
+      const r = renderTemplate("Branch: {{branch}}", { id: "OP-1" });
+      expect(r.text).toBe("Branch: {{branch}}");
+      expect(r.diagnostics).toHaveLength(1);
+      expect(r.diagnostics[0]).toMatchObject({
+        code: "missing-var",
+        severity: "warning",
+        varName: "branch",
+      });
+    });
+
+    it("emits one diagnostic per token occurrence (not per unique name)", () => {
+      const r = renderTemplate("{{notavar}} and {{notavar}} again", FULL_CTX);
+      expect(r.text).toBe("{{notavar}} and {{notavar}} again");
+      expect(r.diagnostics).toHaveLength(2);
+      for (const d of r.diagnostics) {
+        expect(d.code).toBe("missing-var");
+        expect(d.varName).toBe("notavar");
+      }
+    });
+
+    it("mixes resolved and missing in one pass", () => {
+      const r = renderTemplate("{{id}} - {{nope}} - {{branch}}", FULL_CTX);
+      expect(r.text).toBe("OP-194 - {{nope}} - worktree-OP-194");
+      expect(r.diagnostics).toHaveLength(1);
+      expect(r.diagnostics[0].varName).toBe("nope");
+    });
+
+    it("ignores tokens whose name doesn't match the conservative shape (e.g., dotted vars.x)", () => {
+      // 1b/1c handle the `vars.<name>` namespace separately. The 1a renderer
+      // treats it as non-matching text — no substitution, no diagnostic.
+      const r = renderTemplate("custom: {{vars.x}}", FULL_CTX);
+      expect(r.text).toBe("custom: {{vars.x}}");
+      expect(r.diagnostics).toEqual([]);
+    });
+  });
+
+  describe("idempotency", () => {
+    it("feeding the renderer's output back produces the same text and diagnostics", () => {
+      const first = renderTemplate("{{id}} - {{nope}} - {{branch}}", FULL_CTX);
+      const second = renderTemplate(first.text, FULL_CTX);
+      expect(second.text).toBe(first.text);
+      // The missing-var token is still in the text and re-emits the same warning.
+      expect(second.diagnostics).toHaveLength(1);
+      expect(second.diagnostics[0].varName).toBe("nope");
+    });
+
+    it("a fully resolved string is a fixed point of the renderer", () => {
+      const first = renderTemplate("Issue {{id}} on {{branch}}", FULL_CTX);
+      const second = renderTemplate(first.text, FULL_CTX);
+      expect(second.text).toBe(first.text);
+      expect(second.diagnostics).toEqual([]);
+    });
+  });
+
+  describe("parent sentinel propagation", () => {
+    it("renders the sentinel string into the output when ctx.parent is null", () => {
+      const r = renderTemplate("Parent: {{parent}}", { ...FULL_CTX, parent: null });
+      expect(r.text).toBe(`Parent: ${PARENT_NONE_SENTINEL}`);
+      expect(r.diagnostics).toEqual([]);
+    });
+
+    it("renders the literal parent id when ctx.parent is a string", () => {
+      const r = renderTemplate("Parent: {{parent}}", { ...FULL_CTX, parent: "OP-184" });
+      expect(r.text).toBe("Parent: OP-184");
+      expect(r.diagnostics).toEqual([]);
+    });
+  });
+});
+
+describe("renderSkillTrigger (refactored to delegate to renderTemplate)", () => {
+  it("renders {{id}} for the claude base profile (byte-identical to legacy regex output)", () => {
+    expect(renderSkillTrigger(BASE_PROFILES.claude, "OP-194")).toBe("/op:issue OP-194");
+  });
+
+  it("renders {{id}} for the gemini base profile", () => {
+    expect(renderSkillTrigger(BASE_PROFILES.gemini, "OP-7")).toBe(
+      'Please call activate_skill for the "op" skill, then resume work on OP-7.',
+    );
+  });
+
+  it("renders {{id}} for the copilot base profile", () => {
+    expect(renderSkillTrigger(BASE_PROFILES.copilot, "OP-42")).toBe(
+      "Use the `op` skill to resume work on OP-42.",
+    );
+  });
+
+  it("substitutes every occurrence of {{id}} (matches legacy /\\{\\{id\\}\\}/g semantics)", () => {
+    const profile = { ...BASE_PROFILES.claude, skillTrigger: "{{id}} {{id}} {{id}}" };
+    expect(renderSkillTrigger(profile, "X-1")).toBe("X-1 X-1 X-1");
+  });
+});

--- a/plugins/op-obsidian/src/renderTemplate.ts
+++ b/plugins/op-obsidian/src/renderTemplate.ts
@@ -8,15 +8,26 @@ import type { WorkflowDiagnostic } from "./workflowDiagnostic";
 // same diagnostic contract.
 //
 // Token shape: `{{ name }}` — name is `[a-zA-Z_][a-zA-Z0-9_]*`. Whitespace
-// inside the braces is allowed and trimmed. Tokens that don't match this
-// shape (e.g., `{{ foo-bar }}`, `{{vars.x}}`) are left verbatim by this pass
-// — 1b/1c handle the `vars.<name>` namespace separately.
+// inside the braces is allowed and trimmed (including newlines, since `\s*`
+// matches `\n`). Tokens that don't match this shape (e.g., `{{ foo-bar }}`,
+// `{{vars.x}}`, `{{}}`) are left verbatim by this pass — 1b/1c handle the
+// `vars.<name>` namespace separately.
 //
 // Resolution: looks up `name` in `PLUGIN_VAR_REGISTRY`; calls `compute(ctx)`.
 // On `undefined` (compute returned undefined) or unknown name (no registry
 // entry), the token is left verbatim and a `missing-var` diagnostic is
 // recorded. Verbatim fallback is a soft failure — never silently corrupts a
 // prompt with empty strings, never throws on a typo'd name.
+//
+// Idempotency: the renderer is a fixed point for *fully-resolved* strings —
+// re-rendering a string whose every substitution produced a value with no
+// `{{...}}`-shaped substrings leaves text and diagnostics unchanged. If a
+// resolved value itself contains `{{name}}`-shaped text (e.g., a title like
+// "Use {{id}} in prose"), the next pass will attempt to resolve those inner
+// tokens. This is intentional: `{{title}}` is replaced in the first pass;
+// the caller controls whether to run additional passes. Single-pass rendering
+// is the common case; the verbatim fallback guards against partial expansion
+// producing a silently-garbled output.
 
 export interface RenderResult {
   text: string;

--- a/plugins/op-obsidian/src/renderTemplate.ts
+++ b/plugins/op-obsidian/src/renderTemplate.ts
@@ -1,0 +1,66 @@
+import { PLUGIN_VAR_REGISTRY, type RenderContext } from "./pluginVarRegistry";
+import type { WorkflowDiagnostic } from "./workflowDiagnostic";
+
+// Generic `{{var}}` template renderer. Pure function — no I/O, no clock, no
+// vault reads. Replaces the ad-hoc `\{\{id\}\}` regex `renderSkillTrigger`
+// used to carry, so every prompt-shaping callsite (skill-trigger today,
+// composed-module bodies in 1d) goes through the same code path with the
+// same diagnostic contract.
+//
+// Token shape: `{{ name }}` — name is `[a-zA-Z_][a-zA-Z0-9_]*`. Whitespace
+// inside the braces is allowed and trimmed. Tokens that don't match this
+// shape (e.g., `{{ foo-bar }}`, `{{vars.x}}`) are left verbatim by this pass
+// — 1b/1c handle the `vars.<name>` namespace separately.
+//
+// Resolution: looks up `name` in `PLUGIN_VAR_REGISTRY`; calls `compute(ctx)`.
+// On `undefined` (compute returned undefined) or unknown name (no registry
+// entry), the token is left verbatim and a `missing-var` diagnostic is
+// recorded. Verbatim fallback is a soft failure — never silently corrupts a
+// prompt with empty strings, never throws on a typo'd name.
+
+export interface RenderResult {
+  text: string;
+  diagnostics: WorkflowDiagnostic[];
+}
+
+const TOKEN_RE = /\{\{\s*([a-zA-Z_][a-zA-Z0-9_]*)\s*\}\}/g;
+
+/**
+ * Render a template string against a context. Accepts `Partial<RenderContext>`
+ * so callers that only have a fragment of the full context (e.g., the legacy
+ * `renderSkillTrigger` callsite, which only knows the issue id and agent)
+ * can still render — fields the ctx doesn't supply are treated as undefined
+ * by `PluginVar.compute`, which surfaces a `missing-var` diagnostic and
+ * leaves the token verbatim. Full-context callers (1d's composer) will pass
+ * a full `RenderContext` and see no spurious diagnostics.
+ */
+export function renderTemplate(text: string, ctx: Partial<RenderContext>): RenderResult {
+  const diagnostics: WorkflowDiagnostic[] = [];
+
+  const next = text.replace(TOKEN_RE, (match, rawName: string) => {
+    const name = rawName.trim();
+    const entry = PLUGIN_VAR_REGISTRY[name];
+    if (!entry) {
+      diagnostics.push({
+        code: "missing-var",
+        severity: "warning",
+        message: `Unknown variable {{${name}}} — left verbatim. Add an entry to pluginVarRegistry.ts (always-on var) or declare it as a user var (vars.${name}).`,
+        varName: name,
+      });
+      return match;
+    }
+    const value = entry.compute(ctx);
+    if (value === undefined) {
+      diagnostics.push({
+        code: "missing-var",
+        severity: "warning",
+        message: `Variable {{${name}}} resolved to undefined for this context — left verbatim.`,
+        varName: name,
+      });
+      return match;
+    }
+    return value;
+  });
+
+  return { text: next, diagnostics };
+}

--- a/plugins/op-obsidian/src/workflowDiagnostic.ts
+++ b/plugins/op-obsidian/src/workflowDiagnostic.ts
@@ -29,3 +29,21 @@ export interface WorkflowDiagnostic {
   /** Code-specific extras (e.g., `bad-model` carries `{ allowedAliases, … }`). */
   extra?: Record<string, unknown>;
 }
+
+/**
+ * Exhaustiveness helper for switch statements over `WorkflowDiagnosticCode`.
+ * Place in the `default` branch so TypeScript raises a compile error when a
+ * new code is added to the union but not handled by the switch.
+ *
+ * @example
+ * function describeCode(code: WorkflowDiagnosticCode): string {
+ *   switch (code) {
+ *     case "missing-var": return "…";
+ *     // …
+ *     default: return assertNeverCode(code);
+ *   }
+ * }
+ */
+export function assertNeverCode(x: never): never {
+  throw new Error(`Unhandled WorkflowDiagnosticCode: ${JSON.stringify(x)}`);
+}

--- a/plugins/op-obsidian/src/workflowDiagnostic.ts
+++ b/plugins/op-obsidian/src/workflowDiagnostic.ts
@@ -1,0 +1,31 @@
+// Unified diagnostic record for the workflow-modules engine. Every error and
+// warning the system emits — bad model spec, missing var, unknown module id,
+// schema-version mismatch, import collision, malformed frontmatter, intra-scope
+// collision — is a `WorkflowDiagnostic`. One shape, every surface.
+//
+// OP-194 (1a) declares the full union here and only emits `missing-var`. 1b/1c
+// add emit sites for the remaining codes; the type itself is stable from this
+// point on so consumers can pattern-match without breakage.
+
+export type WorkflowDiagnosticCode =
+  | "bad-model"
+  | "missing-var"
+  | "unknown-module"
+  | "schema-mismatch"
+  | "import-collision"
+  | "intra-scope-collision"
+  | "malformed-frontmatter";
+
+export type WorkflowDiagnosticSeverity = "error" | "warning" | "info";
+
+export interface WorkflowDiagnostic {
+  code: WorkflowDiagnosticCode;
+  severity: WorkflowDiagnosticSeverity;
+  /** Human-readable, prose, no jargon. Surfaces verbatim in the formatter. */
+  message: string;
+  stepId?: string;
+  moduleId?: string;
+  varName?: string;
+  /** Code-specific extras (e.g., `bad-model` carries `{ allowedAliases, … }`). */
+  extra?: Record<string, unknown>;
+}

--- a/plugins/op/.claude-plugin/plugin.json
+++ b/plugins/op/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "op",
   "description": "Obsidian Projects workflow — schema, slash commands, and agent skill for running a Jira-lite issue tracker inside an Obsidian vault.",
-  "version": "0.61.8",
+  "version": "0.62.0",
   "author": {
     "name": "Eugene Archibald"
   },


### PR DESCRIPTION
## Summary

Foundation for the workflow-modules engine (parent: OP-184; grandparent: OP-181). Pure-fn only, no vault IO — the loader is 1b, composition is 1d.

- **`workflowDiagnostic.ts`** — declares the full `WorkflowDiagnostic` union from OP-181 plan §"Unified diagnostic record" (`bad-model | missing-var | unknown-module | schema-mismatch | import-collision | intra-scope-collision | malformed-frontmatter`). 1a only emits `missing-var`; 1b/1c add emit sites without re-editing the union shape.
- **`pluginVarRegistry.ts`** — single source of truth for the 16 always-on plugin vars (`id, title, project, status, priority, parent, repo_path, vault_path, vault_name, branch, pr_url, github_issue, today, agent, model, mode`). Each entry: `{ name, description, example, compute(ctx) }`. `PARENT_NONE_SENTINEL = "(none — this is a top-level issue)"` lives here so every consumer references one source. `buildRenderContext({ entry, profile, launch })` flattens `IssueEntry + AgentProfile + LaunchContext` into a typed `RenderContext`. No I/O, no clock reads.
- **`renderTemplate.ts`** — generic `{{var}}` pure renderer. Token shape `{{ \s* [a-zA-Z_][a-zA-Z0-9_]* \s* }}`, registry-driven resolution. Unknown name or undefined compute → leaves the token verbatim and emits `WorkflowDiagnostic { code: "missing-var", varName }`. Verbatim fallback is the explicit safety contract: never silently corrupts a prompt with empty strings, never throws on a typo.
- **`agentProfiles.ts:renderSkillTrigger`** — refactored to delegate to `renderTemplate`. Public signature preserved; output byte-identical for every shipped trigger string (asserted in tests).

Bumps `op-obsidian` to `0.62.0` (minor — additive infrastructure; no user-visible behavior change yet).

## Test plan

- [x] `npm test` in `plugins/op-obsidian/` — 836 tests pass across 60 files. The one pre-existing `iTermPrefs.test.ts` infra failure reproduces on the unmodified branch tip; unrelated.
- [x] Targeted run of new + adjacent files: 84 / 84 passing (`pluginVarRegistry.test.ts`, `renderTemplate.test.ts`, `agentProfiles.test.ts`).
- [x] `node scripts/bump-version.mjs minor` — manifest, package.json, plugin.json all at 0.62.0; build green.
- [x] `node scripts/dev-sync.mjs` — copied into OP-Test; plugin reloaded clean.
- [x] OP-Test smoke probe — plugin loaded at v0.62.0, all 39 commands registered, no console errors.

### Test coverage highlights

- Every required always-on var has an entry (acceptance criterion).
- `parent` returns the literal id when present, `PARENT_NONE_SENTINEL` when null. The sentinel is sourced from the registry export — re-typing the prose at the assertion site would defeat the test.
- `renderTemplate`: single / multi / repeated tokens, whitespace-tolerant braces, mixed resolved + missing in one pass, idempotency (rendering the renderer's own output is a fixed point for fully resolved strings), `{{vars.<name>}}` shape ignored (left for 1b/1c), parent sentinel propagation through the renderer.
- `renderSkillTrigger` byte-equivalence asserted for `claude`, `gemini`, `copilot` profiles plus a synthetic `{{id}} {{id}} {{id}}` profile (matches legacy `/g` semantics).

## Out of scope (handled by sibling issues)

- Module file schema, frontmatter parser, loader → OP-195 (1b).
- Workflow file schema, `modelRegistry`, `extends:` inheritance, legacy fallback ladder → OP-196 (1c).
- IO loader (`loadModuleSources`), composer split (`composeWorkflow`), `RelaySession`, `launchHeadlessSubtask` rename → OP-197 (1d).
- The `{{vars.<name>}}` user-var namespace and precedence resolution → 1b/1d.

🤖 Generated with [Claude Code](https://claude.com/claude-code)