### PR TITLE
OP-195: workflow-module schema + loader + typed VarDecl parser

### DIFF
--- a/docs/specs/workflow-module-schema.md
+++ b/docs/specs/workflow-module-schema.md
@@ -65,10 +65,12 @@ generic {{var}} template engine from OP-194.
 - **`project`** (string) — restricts a global module to a specific project
   slug. Per-project modules already live under their slug, so they don't need
   this field; if set, the value should match the enclosing slug or the module
-  is filtered out at load time.
+  is filtered out at load time. An empty or whitespace-only value (`project:
+  ""`) is silently treated as absent — the field is ignored and the module
+  applies to all projects.
 - **`agent`** (string) — restricts the module to a specific agent id
   (`claude`, `gemini`, `copilot`, custom). Loader doesn't filter on this
-  today; consumers may apply it.
+  today; consumers may apply it. Same empty-string rule as `project`.
 - **`order`** (integer, default `0`) — sort key within a scope.
 - **`vars`** (list of `VarDecl`) — see below.
 
@@ -101,6 +103,12 @@ The first `=` splits name from default value. The empty-default form
 caller must supply a value"; empty-default means "the default is the empty
 string".
 
+**Value whitespace is preserved verbatim.** `bar=  hi  ` yields a default
+of `"  hi  "` (two leading spaces, two trailing). If your intent is "empty
+default", write `bar=` (no trailing space). Spaces inside the name
+segment (before `=`) are trimmed, but spaces in the value segment
+(after `=`) are not.
+
 #### YAML auto-coercion gotcha
 
 YAML coerces some bare scalars to non-string types — most commonly ISO dates
@@ -125,6 +133,18 @@ vars:
 `name:` is required and must be a non-empty string. `default:` and
 `description:` are optional and must be strings. Unknown keys are tolerated
 (forward-compat for future fields like `enum:` or `required:`).
+
+**Watch out for typos.** `defualt:` vs `default:` won't emit an error —
+unknown keys are silently accepted. If a default value appears to be
+ignored, double-check the key spelling.
+
+### Var name identifiers
+
+Variable names are not validated against an identifier regex at parse time.
+However, the OP-194 renderer uses `[a-zA-Z_][a-zA-Z0-9_]*` to match
+`{{var}}` placeholders — names containing hyphens or starting with a digit
+will parse and load successfully but will **not** be expanded by the renderer.
+Use names that match `[a-zA-Z_][a-zA-Z0-9_]*` for full compatibility.
 
 ### Duplicate names
 

--- a/docs/specs/workflow-module-schema.md
+++ b/docs/specs/workflow-module-schema.md
@@ -1,0 +1,185 @@
+# Workflow Module Schema
+
+Status: shipped in OP-195 (1b of OP-184). Composition (1d/OP-197) consumes
+loaded modules; this doc covers the file format and load behavior only.
+
+## What a module is
+
+A workflow module is a markdown file whose frontmatter declares a partition of
+the composed workflow — typically a step (or set of steps) that should be
+spliced into a larger workflow at a named scope. Composition stitches modules
+together; **this doc covers the file format only**, not how composition works.
+
+## Where modules live
+
+| Location | Path | Applies to |
+| :--- | :--- | :--- |
+| Global | `Projects/_op-modules/<id>.md` | Every project. |
+| Per-project | `Projects/<slug>/MODULES/<id>.md` | Only project `<slug>`. |
+
+`<id>` is the module id. **The filename basename must match the `id:`
+frontmatter field exactly.** A file named `review-and-merge.md` must declare
+`id: review-and-merge`. Mismatches emit `malformed-frontmatter` diagnostics
+and the module is dropped.
+
+Files outside these two layouts are ignored — including subdirectories. A
+file at `Projects/_op-modules/sub/foo.md` is **not** loaded.
+
+## Frontmatter contract
+
+```yaml
+---
+id: review-and-merge       # required, must match the filename basename
+title: "Review and merge"  # required
+type: workflow-module      # required, exact literal
+scope: pre-commit          # required string — partition key for collision check
+project: obsidian-projects # optional — restrict to one project (slug)
+agent: claude              # optional — restrict to one agent id
+order: 10                  # optional integer (default 0) — sort key within a scope
+vars:                      # optional list of VarDecl
+  - foo                    # bare
+  - bar=baz                # default-shorthand
+  - qux=                   # explicit empty default (distinct from bare)
+  - { name: pkg, default: op-obsidian, description: "Package name" }
+---
+
+# Module body (prose / template)
+
+The body is opaque to OP-195 — composition (1d) renders it through the
+generic {{var}} template engine from OP-194.
+```
+
+### Required fields
+
+- **`id`** (string) — module id, must match the filename basename.
+- **`title`** (string) — human-readable title.
+- **`type`** (literal `workflow-module`) — anything else is ignored by the
+  loader.
+- **`scope`** (string) — partition key. Two modules at the same scope that
+  declare the same variable name trigger an `intra-scope-collision`
+  diagnostic. The set of valid scope names is open-ended; conventions emerge
+  with the workflow surfaces 1d wires up.
+
+### Optional fields
+
+- **`project`** (string) — restricts a global module to a specific project
+  slug. Per-project modules already live under their slug, so they don't need
+  this field; if set, the value should match the enclosing slug or the module
+  is filtered out at load time.
+- **`agent`** (string) — restricts the module to a specific agent id
+  (`claude`, `gemini`, `copilot`, custom). Loader doesn't filter on this
+  today; consumers may apply it.
+- **`order`** (integer, default `0`) — sort key within a scope.
+- **`vars`** (list of `VarDecl`) — see below.
+
+## `vars:` declarations
+
+Each entry in `vars:` is a single `VarDecl`. Three shapes:
+
+### Bare
+
+```yaml
+vars:
+  - pkg
+```
+
+Just a variable name. The composer (1d) must satisfy this from a higher-
+precedence source, or it surfaces a diagnostic.
+
+### Default-shorthand
+
+```yaml
+vars:
+  - bar=baz       # default value "baz"
+  - qux=          # default value "" (empty string — explicit)
+  - expr=a=b=c    # only the FIRST = splits; value is "a=b=c"
+  - due=2026-04-25  # value is the string "2026-04-25"
+```
+
+The first `=` splits name from default value. The empty-default form
+(`name=`) is intentionally distinct from the bare form: bare means "the
+caller must supply a value"; empty-default means "the default is the empty
+string".
+
+#### YAML auto-coercion gotcha
+
+YAML coerces some bare scalars to non-string types — most commonly ISO dates
+to `Date`. The shorthand form sidesteps this because the `=` keeps the entry
+parse-as-string. **A bare** `- 2026-04-25` **becomes a `Date` and is
+rejected** with a diagnostic that points at the offending entry. Quote the
+value (`'2026-04-25'`) or use the shorthand (`name=2026-04-25`) to keep it as
+a string.
+
+The same rule applies inside object form: `default: 2026-04-25` (no quotes)
+is a `Date` and is rejected; `default: '2026-04-25'` is fine.
+
+### Object form
+
+```yaml
+vars:
+  - name: pkg
+    default: op-obsidian
+    description: Package name to install
+```
+
+`name:` is required and must be a non-empty string. `default:` and
+`description:` are optional and must be strings. Unknown keys are tolerated
+(forward-compat for future fields like `enum:` or `required:`).
+
+### Duplicate names
+
+Two entries declaring the same `name` within one module is a
+`malformed-frontmatter` diagnostic. The first declaration wins; later
+duplicates are dropped from the module's loaded `vars`.
+
+## Diagnostics
+
+| Code | When | Severity |
+| :--- | :--- | :--- |
+| `malformed-frontmatter` | Missing/wrong-type required field, id-vs-filename mismatch, invalid `VarDecl`, duplicate var name within one module, vars list isn't an array, or YAML coerced a value to a non-string type. | error |
+| `intra-scope-collision` | Two or more modules at the same `scope:` declare the same variable name (after per-project shadowing). | error |
+
+Diagnostics carry `moduleId` (the module's id), `varName` (when applicable),
+and `extra.path` (the source file path). The composer (1d) surfaces them
+verbatim through the unified diagnostic stream.
+
+## Shadowing
+
+A per-project module shadows a same-id global module. **Only the per-project
+copy is loaded; the global is discarded silently** — no diagnostic.
+
+This is by design: a project can override or disable a shipped global module
+by adding a same-id file under `Projects/<slug>/MODULES/`. **Watch out** —
+this can be surprising. If a global module appears to have stopped applying
+to one project, check whether that project has a same-id file shadowing it.
+
+A future settings UI (out of scope here) may surface the shadowing relationship
+visually so users don't have to spelunk the filesystem.
+
+## Loading order
+
+The IO loader (`loadModules` in `plugins/op-obsidian/src/workflowModule.ts`):
+
+1. Walks every markdown file under `Projects/`.
+2. Buckets each file as global (matching `Projects/_op-modules/<id>.md`,
+   one level deep) or per-project (matching `Projects/<slug>/MODULES/<id>.md`,
+   one level deep below `MODULES/`).
+3. Reads each file's frontmatter via Obsidian's `metadataCache`. Files with
+   missing or invalid frontmatter emit `malformed-frontmatter` diagnostics
+   and are dropped.
+4. Applies shadowing — per-project copies overwrite same-id globals.
+5. Optionally filters by `opts.project` (drops globals carrying a `project:`
+   field that doesn't match the requested slug).
+6. Runs intra-scope collision validation across the surviving set.
+
+The loader returns `{ modules, diagnostics }`; composition (1d) consumes both.
+
+## What's NOT in this issue
+
+- Composition: how modules combine into a workflow per `scope` and `order`.
+  See OP-197 (1d).
+- Workflow file schema, `extends:`, `modelRegistry`, legacy `WORKFLOW.md`
+  fallback. See OP-196 (1c).
+- User-var resolution (`{{vars.<name>}}` in templates). The OP-194 renderer
+  ignores the `vars.` namespace; 1d wires the loaded `VarDecl[]` into the
+  render context.

--- a/plugins/op-obsidian/manifest.json
+++ b/plugins/op-obsidian/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "op-obsidian",
   "name": "Obsidian Projects (op)",
-  "version": "0.63.0",
+  "version": "0.63.1",
   "minAppVersion": "1.5.0",
   "description": "Jira-lite issue tracker for Obsidian vaults — deterministic commands backing the op workflow.",
   "author": "Eugene Archibald",

--- a/plugins/op-obsidian/manifest.json
+++ b/plugins/op-obsidian/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "op-obsidian",
   "name": "Obsidian Projects (op)",
-  "version": "0.62.0",
+  "version": "0.63.0",
   "minAppVersion": "1.5.0",
   "description": "Jira-lite issue tracker for Obsidian vaults — deterministic commands backing the op workflow.",
   "author": "Eugene Archibald",

--- a/plugins/op-obsidian/package.json
+++ b/plugins/op-obsidian/package.json
@@ -1,6 +1,6 @@
 {
   "name": "op-obsidian",
-  "version": "0.63.0",
+  "version": "0.63.1",
   "description": "Obsidian plugin that owns the deterministic half of the op workflow.",
   "main": "main.js",
   "scripts": {

--- a/plugins/op-obsidian/package.json
+++ b/plugins/op-obsidian/package.json
@@ -1,6 +1,6 @@
 {
   "name": "op-obsidian",
-  "version": "0.62.0",
+  "version": "0.63.0",
   "description": "Obsidian plugin that owns the deterministic half of the op workflow.",
   "main": "main.js",
   "scripts": {

--- a/plugins/op-obsidian/src/workflowDiagnostic.ts
+++ b/plugins/op-obsidian/src/workflowDiagnostic.ts
@@ -26,7 +26,25 @@ export interface WorkflowDiagnostic {
   stepId?: string;
   moduleId?: string;
   varName?: string;
-  /** Code-specific extras (e.g., `bad-model` carries `{ allowedAliases, … }`). */
+  /**
+   * Code-specific structured payload. Consumers MUST use these fields rather
+   * than parsing `message` — the message is for human display only and may be
+   * reformatted without notice.
+   *
+   * Guaranteed keys by code:
+   *   - `malformed-frontmatter` (from `parseModule` / `parseVarDecls`):
+   *       - `path` (string) — vault-relative source file path (always present)
+   *       - `field` (string) — frontmatter field name (present when the error
+   *         is a scalar-field violation; absent for id-mismatch and
+   *         vars-list errors)
+   *       - `expected` (string) — human description of the expected type/value
+   *         (present when `field` is present; for id-mismatch: the expected id)
+   *       - `actual` (string) — `describe(value)` of the bad value (same
+   *         presence rule as `expected`)
+   *   - `intra-scope-collision`:
+   *       - `scope` (string) — the scope key where the collision occurred
+   *       - `moduleIds` (string[]) — sorted ids of the colliding modules
+   */
   extra?: Record<string, unknown>;
 }
 

--- a/plugins/op-obsidian/src/workflowModule.test.ts
+++ b/plugins/op-obsidian/src/workflowModule.test.ts
@@ -126,6 +126,32 @@ describe("loadModules — shadowing", () => {
     const r = loadModules(app);
     expect(r.modules.map((m) => m.id).sort()).toEqual(["a", "b"]);
   });
+
+  it("bucketing is order-independent: mixed globals and per-project files in any order", () => {
+    // Exercises the loop over getMarkdownFiles() with many files interleaved —
+    // result must be identical regardless of which order the vault returns them.
+    const files: FakeFile[] = [
+      { path: "Projects/_op-modules/g1.md", frontmatter: moduleFm({ id: "g1", title: "Global 1" }) },
+      { path: "Projects/alpha/MODULES/p1.md", frontmatter: moduleFm({ id: "p1", title: "Alpha p1" }) },
+      { path: "Projects/_op-modules/g2.md", frontmatter: moduleFm({ id: "g2", title: "Global 2" }) },
+      { path: "Projects/beta/MODULES/p2.md", frontmatter: moduleFm({ id: "p2", title: "Beta p2" }) },
+      // g1 is shadowed by a per-project copy from beta:
+      { path: "Projects/beta/MODULES/g1.md", frontmatter: moduleFm({ id: "g1", title: "Beta override of g1" }) },
+      // Noise: out-of-band files that must be ignored
+      { path: "Projects/alpha/ISSUES/OP-1.md", frontmatter: moduleFm({ id: "OP-1" }) },
+      { path: "Projects/_op-modules/sub/deep.md", frontmatter: moduleFm({ id: "deep" }) },
+    ];
+    const r = loadModules(fakeApp(files));
+    // 4 unique ids: g1 (shadowed to beta), g2, p1, p2
+    expect(r.modules).toHaveLength(4);
+    const byId = Object.fromEntries(r.modules.map((m) => [m.id, m]));
+    expect(byId["g1"].title).toBe("Beta override of g1");
+    expect(byId["g1"].source.kind).toBe("project");
+    expect(byId["g2"].source.kind).toBe("global");
+    expect(byId["p1"].source).toMatchObject({ kind: "project", projectSlug: "alpha" });
+    expect(byId["p2"].source).toMatchObject({ kind: "project", projectSlug: "beta" });
+    expect(r.diagnostics).toEqual([]);
+  });
 });
 
 describe("loadModules — project filter", () => {

--- a/plugins/op-obsidian/src/workflowModule.test.ts
+++ b/plugins/op-obsidian/src/workflowModule.test.ts
@@ -1,0 +1,226 @@
+import { describe, it, expect, vi } from "vitest";
+
+vi.mock("obsidian", () => {
+  class TFile {
+    path = "";
+    basename = "";
+    name = "";
+  }
+  return { TFile };
+});
+
+import { TFile } from "obsidian";
+import { loadModules } from "./workflowModule";
+
+interface FakeFile {
+  path: string;
+  frontmatter: Record<string, unknown> | null;
+}
+
+function makeFile(path: string): TFile {
+  const basename = path.split("/").pop()!.replace(/\.md$/, "");
+  const f = new TFile();
+  Object.assign(f, { path, basename, name: `${basename}.md` });
+  return f;
+}
+
+function fakeApp(files: FakeFile[]) {
+  const tfiles = files.map((f) => ({ tfile: makeFile(f.path), fm: f.frontmatter }));
+  const app = {
+    vault: {
+      getMarkdownFiles: () => tfiles.map((x) => x.tfile),
+    },
+    metadataCache: {
+      getFileCache: (file: TFile) => {
+        const hit = tfiles.find((x) => x.tfile === file);
+        return hit && hit.fm ? { frontmatter: hit.fm } : null;
+      },
+    },
+  };
+  return app as any;
+}
+
+const moduleFm = (over: Record<string, unknown> = {}) => ({
+  type: "workflow-module",
+  title: "Sample",
+  scope: "pre-commit",
+  ...over,
+});
+
+describe("loadModules — path bucketing", () => {
+  it("loads global modules from Projects/_op-modules/<id>.md", () => {
+    const app = fakeApp([
+      { path: "Projects/_op-modules/sample.md", frontmatter: moduleFm({ id: "sample" }) },
+    ]);
+    const r = loadModules(app);
+    expect(r.modules).toHaveLength(1);
+    expect(r.modules[0].source).toEqual({ kind: "global", path: "Projects/_op-modules/sample.md" });
+    expect(r.diagnostics).toEqual([]);
+  });
+
+  it("loads per-project modules from Projects/<slug>/MODULES/<id>.md", () => {
+    const app = fakeApp([
+      {
+        path: "Projects/obsidian-projects/MODULES/build.md",
+        frontmatter: moduleFm({ id: "build" }),
+      },
+    ]);
+    const r = loadModules(app);
+    expect(r.modules).toHaveLength(1);
+    expect(r.modules[0].source).toEqual({
+      kind: "project",
+      path: "Projects/obsidian-projects/MODULES/build.md",
+      projectSlug: "obsidian-projects",
+    });
+  });
+
+  it("ignores files outside the module directories", () => {
+    const app = fakeApp([
+      {
+        path: "Projects/obsidian-projects/ISSUES/OP-1.md",
+        frontmatter: moduleFm({ id: "OP-1" }),
+      },
+      { path: "Projects/_scratch/foo.md", frontmatter: moduleFm({ id: "foo" }) },
+      {
+        path: "Projects/obsidian-projects/MODULES/sub/nested.md",
+        frontmatter: moduleFm({ id: "nested" }),
+      },
+      {
+        path: "Projects/_op-modules/sub/nested.md",
+        frontmatter: moduleFm({ id: "nested" }),
+      },
+    ]);
+    const r = loadModules(app);
+    expect(r.modules).toEqual([]);
+    expect(r.diagnostics).toEqual([]);
+  });
+});
+
+describe("loadModules — shadowing", () => {
+  it("per-project module shadows same-id global silently", () => {
+    const app = fakeApp([
+      {
+        path: "Projects/_op-modules/lint.md",
+        frontmatter: moduleFm({ id: "lint", title: "Global lint" }),
+      },
+      {
+        path: "Projects/obsidian-projects/MODULES/lint.md",
+        frontmatter: moduleFm({ id: "lint", title: "Project lint" }),
+      },
+    ]);
+    const r = loadModules(app);
+    expect(r.modules).toHaveLength(1);
+    expect(r.modules[0].title).toBe("Project lint");
+    expect(r.modules[0].source.kind).toBe("project");
+    expect(r.diagnostics).toEqual([]);
+  });
+
+  it("does not shadow a different-id pair", () => {
+    const app = fakeApp([
+      { path: "Projects/_op-modules/a.md", frontmatter: moduleFm({ id: "a" }) },
+      {
+        path: "Projects/obsidian-projects/MODULES/b.md",
+        frontmatter: moduleFm({ id: "b" }),
+      },
+    ]);
+    const r = loadModules(app);
+    expect(r.modules.map((m) => m.id).sort()).toEqual(["a", "b"]);
+  });
+});
+
+describe("loadModules — project filter", () => {
+  it("drops globals whose project: doesn't match opts.project", () => {
+    const app = fakeApp([
+      {
+        path: "Projects/_op-modules/all.md",
+        frontmatter: moduleFm({ id: "all" }),
+      },
+      {
+        path: "Projects/_op-modules/match.md",
+        frontmatter: moduleFm({ id: "match", project: "obsidian-projects" }),
+      },
+      {
+        path: "Projects/_op-modules/other.md",
+        frontmatter: moduleFm({ id: "other", project: "different-project" }),
+      },
+    ]);
+    const r = loadModules(app, { project: "obsidian-projects" });
+    expect(r.modules.map((m) => m.id).sort()).toEqual(["all", "match"]);
+  });
+
+  it("keeps modules without a project: field regardless of filter", () => {
+    const app = fakeApp([
+      { path: "Projects/_op-modules/lint.md", frontmatter: moduleFm({ id: "lint" }) },
+    ]);
+    const r = loadModules(app, { project: "anything" });
+    expect(r.modules).toHaveLength(1);
+  });
+
+  it("no filter → keeps all modules including those with project:", () => {
+    const app = fakeApp([
+      {
+        path: "Projects/_op-modules/match.md",
+        frontmatter: moduleFm({ id: "match", project: "obsidian-projects" }),
+      },
+    ]);
+    const r = loadModules(app);
+    expect(r.modules).toHaveLength(1);
+  });
+});
+
+describe("loadModules — diagnostics", () => {
+  it("emits malformed-frontmatter for module files with no frontmatter", () => {
+    const app = fakeApp([{ path: "Projects/_op-modules/empty.md", frontmatter: null }]);
+    const r = loadModules(app);
+    expect(r.modules).toEqual([]);
+    expect(r.diagnostics).toHaveLength(1);
+    expect(r.diagnostics[0].code).toBe("malformed-frontmatter");
+  });
+
+  it("emits malformed-frontmatter when type is not workflow-module", () => {
+    const app = fakeApp([
+      {
+        path: "Projects/_op-modules/skill.md",
+        frontmatter: { type: "skill", id: "skill", title: "x", scope: "x" },
+      },
+    ]);
+    const r = loadModules(app);
+    expect(r.modules).toEqual([]);
+    expect(r.diagnostics).toHaveLength(1);
+  });
+
+  it("propagates intra-scope-collision after shadowing", () => {
+    const app = fakeApp([
+      {
+        path: "Projects/_op-modules/a.md",
+        frontmatter: moduleFm({ id: "a", scope: "pre-commit", vars: ["pkg"] }),
+      },
+      {
+        path: "Projects/_op-modules/b.md",
+        frontmatter: moduleFm({ id: "b", scope: "pre-commit", vars: ["pkg"] }),
+      },
+    ]);
+    const r = loadModules(app);
+    const collisions = r.diagnostics.filter((d) => d.code === "intra-scope-collision");
+    expect(collisions).toHaveLength(1);
+    expect(collisions[0].varName).toBe("pkg");
+  });
+
+  it("collision check runs against post-shadowing module set", () => {
+    // Global `a` and project `a` both declare `pkg` at scope=pre-commit. After
+    // shadowing, only the project copy survives — no collision.
+    const app = fakeApp([
+      {
+        path: "Projects/_op-modules/a.md",
+        frontmatter: moduleFm({ id: "a", vars: ["pkg"] }),
+      },
+      {
+        path: "Projects/obsidian-projects/MODULES/a.md",
+        frontmatter: moduleFm({ id: "a", vars: ["pkg"] }),
+      },
+    ]);
+    const r = loadModules(app);
+    const collisions = r.diagnostics.filter((d) => d.code === "intra-scope-collision");
+    expect(collisions).toEqual([]);
+  });
+});

--- a/plugins/op-obsidian/src/workflowModule.ts
+++ b/plugins/op-obsidian/src/workflowModule.ts
@@ -1,0 +1,143 @@
+import { App, TFile } from "obsidian";
+import {
+  parseModule,
+  validateIntraScopeCollisions,
+  type ModuleSource,
+  type WorkflowModule,
+} from "./workflowModulePure";
+import type { WorkflowDiagnostic } from "./workflowDiagnostic";
+
+// Workflow-module IO loader. Walks the vault, parses each module file via the
+// pure layer (workflowModulePure.ts), applies per-project shadowing of global
+// modules, and runs intra-scope collision validation. Composition (resolving
+// vars across scopes, applying user values) is OP-197 (1d).
+//
+// Module locations:
+//   - Global:      Projects/_op-modules/<id>.md
+//   - Per-project: Projects/<slug>/MODULES/<id>.md
+//
+// A per-project module of the same id shadows the global. Shadowing is silent
+// — no diagnostic — because it's intentional behavior. The schema doc calls
+// this out so users don't lose hours wondering why a global module went quiet.
+
+export type {
+  ModuleSource,
+  ParseModuleArgs,
+  ParseModuleResult,
+  ParseVarDeclResult,
+  ParseVarDeclsResult,
+  VarDecl,
+  WorkflowModule,
+} from "./workflowModulePure";
+export {
+  parseModule,
+  parseVarDecl,
+  parseVarDecls,
+  validateIntraScopeCollisions,
+} from "./workflowModulePure";
+
+const PROJECTS_ROOT = "Projects/";
+const GLOBAL_MODULES_DIR = "Projects/_op-modules/";
+const PER_PROJECT_MODULES_INFIX = "/MODULES/";
+
+export interface LoadModulesOptions {
+  /**
+   * If set, drop modules whose `project:` frontmatter is non-empty and doesn't
+   * match this slug. Per-project modules (`Projects/<slug>/MODULES/`) are
+   * always restricted to their own slug regardless of this option — only
+   * globals carrying an explicit `project:` field participate in this filter.
+   */
+  project?: string;
+}
+
+export interface LoadModulesResult {
+  modules: WorkflowModule[];
+  diagnostics: WorkflowDiagnostic[];
+}
+
+/**
+ * Discover and load every workflow module visible in the vault. Pure logic
+ * lives in `workflowModulePure.ts`; this function is the IO seam.
+ *
+ * Steps:
+ *   1. Walk every markdown file in `Projects/`.
+ *   2. Bucket each file as global or per-project based on its path.
+ *   3. Read frontmatter via `app.metadataCache` and call `parseModule`.
+ *   4. Apply shadowing: per-project modules win over same-id globals.
+ *   5. Optionally filter by `opts.project`.
+ *   6. Run intra-scope collision validation.
+ *
+ * Caller responsibility: invoke after `workspace.onLayoutReady` so
+ * `metadataCache` has resolved frontmatter for newly-opened vaults. Earlier
+ * calls may surface spurious `malformed-frontmatter` diagnostics for files
+ * whose cache hasn't populated yet.
+ */
+export function loadModules(app: App, opts: LoadModulesOptions = {}): LoadModulesResult {
+  type Bucket = { file: TFile; id: string; source: ModuleSource };
+
+  const globals: Bucket[] = [];
+  const perProject: Bucket[] = [];
+
+  for (const file of app.vault.getMarkdownFiles()) {
+    const path = file.path;
+    if (!path.startsWith(PROJECTS_ROOT)) continue;
+
+    const id = file.basename;
+
+    if (path.startsWith(GLOBAL_MODULES_DIR)) {
+      // Global modules live exactly one directory deep below GLOBAL_MODULES_DIR.
+      const rel = path.slice(GLOBAL_MODULES_DIR.length);
+      if (rel.includes("/")) continue;
+      globals.push({ file, id, source: { kind: "global", path } });
+      continue;
+    }
+
+    const moduleIdx = path.indexOf(PER_PROJECT_MODULES_INFIX);
+    if (moduleIdx === -1) continue;
+    const beforeInfix = path.slice(0, moduleIdx);
+    const slugStart = beforeInfix.lastIndexOf("/");
+    if (slugStart === -1) continue;
+    const slug = beforeInfix.slice(slugStart + 1);
+    if (!slug || beforeInfix !== `${PROJECTS_ROOT.slice(0, -1)}/${slug}`) continue;
+    const afterInfix = path.slice(moduleIdx + PER_PROJECT_MODULES_INFIX.length);
+    if (afterInfix.includes("/")) continue;
+    perProject.push({
+      file,
+      id,
+      source: { kind: "project", path, projectSlug: slug },
+    });
+  }
+
+  const diagnostics: WorkflowDiagnostic[] = [];
+  const byId = new Map<string, WorkflowModule>();
+
+  // Load globals first; per-project copies overwrite by id below.
+  for (const bucket of globals) {
+    const r = parseFile(app, bucket);
+    diagnostics.push(...r.diagnostics);
+    if (r.module) byId.set(r.module.id, r.module);
+  }
+  for (const bucket of perProject) {
+    const r = parseFile(app, bucket);
+    diagnostics.push(...r.diagnostics);
+    if (r.module) byId.set(r.module.id, r.module); // shadows any same-id global
+  }
+
+  let modules = Array.from(byId.values());
+
+  if (opts.project) {
+    modules = modules.filter((m) => !m.project || m.project === opts.project);
+  }
+
+  diagnostics.push(...validateIntraScopeCollisions(modules));
+
+  return { modules, diagnostics };
+}
+
+function parseFile(
+  app: App,
+  bucket: { file: TFile; id: string; source: ModuleSource },
+): { module: WorkflowModule | null; diagnostics: WorkflowDiagnostic[] } {
+  const fm = app.metadataCache.getFileCache(bucket.file)?.frontmatter ?? null;
+  return parseModule({ id: bucket.id, frontmatter: fm, source: bucket.source });
+}

--- a/plugins/op-obsidian/src/workflowModulePure.test.ts
+++ b/plugins/op-obsidian/src/workflowModulePure.test.ts
@@ -136,6 +136,14 @@ describe("parseVarDecl — malformed", () => {
     expect(r.diagnostics[0].code).toBe("malformed-frontmatter");
   });
 
+  it("= only (no name, no value)", () => {
+    // eqIdx=0, rawName="" → empty name → malformed.  Verify no off-by-one
+    // that would let name="" slip through as a valid bare.
+    const r = parseVarDecl("=");
+    expect(r.decl).toBeNull();
+    expect(r.diagnostics[0].code).toBe("malformed-frontmatter");
+  });
+
   it("=value (empty name)", () => {
     const r = parseVarDecl("=value");
     expect(r.decl).toBeNull();
@@ -267,6 +275,26 @@ describe("parseVarDecls — list-level", () => {
     }
   });
 
+  it("bare x beats empty-default x= on duplicate (first-wins, not most-specific)", () => {
+    // `["x", "x="]` → bare is first, empty-default is duplicate → bare wins.
+    // The composer (1d) must satisfy a bare from a higher-precedence source;
+    // the empty-default would have supplied "". First-wins is the documented
+    // rule; there is no "more-specific wins" tie-break.
+    const r = parseVarDecls(["x", "x="]);
+    expect(r.decls).toEqual([{ kind: "bare", name: "x" }]);
+    expect(r.diagnostics).toHaveLength(1);
+    expect(r.diagnostics[0].code).toBe("malformed-frontmatter");
+    expect(r.diagnostics[0].varName).toBe("x");
+  });
+
+  it("empty-default x= beats bare x on duplicate when empty-default is listed first", () => {
+    // Symmetry check: whichever appears first in the list wins.
+    const r = parseVarDecls(["x=", "x"]);
+    expect(r.decls).toEqual([{ kind: "default", name: "x", value: "" }]);
+    expect(r.diagnostics).toHaveLength(1);
+    expect(r.diagnostics[0].varName).toBe("x");
+  });
+
   it("string + object mix preserves order", () => {
     const r = parseVarDecls([
       "first",
@@ -361,6 +389,18 @@ describe("parseModule", () => {
     expect(r.diagnostics[0].extra?.actual).toBe("different");
   });
 
+  it("rejects id missing entirely from frontmatter (not just wrong value)", () => {
+    // Delete `id` so it is absent — different code path from an id mismatch.
+    const fm = { ...fmBase() };
+    delete fm.id;
+    const r = parseModule({ id: "sample", frontmatter: fm, source: GLOBAL_SOURCE });
+    expect(r.module).toBeNull();
+    expect(r.diagnostics[0].code).toBe("malformed-frontmatter");
+    // Should surface a clear "field: id" payload so consumers can distinguish
+    // this from an id-mismatch.
+    expect(r.diagnostics[0].extra?.field).toBe("id");
+  });
+
   it("rejects missing title / scope", () => {
     const r1 = parseModule({
       id: "sample",
@@ -396,6 +436,41 @@ describe("parseModule", () => {
     expect(r.module?.project).toBeUndefined();
     expect(r.module?.agent).toBeUndefined();
     expect(r.module?.order).toBe(0);
+  });
+
+  it("project: '' is treated as absent (not a hard-fail)", () => {
+    // Authors sometimes write `project: ""` to mean "no restriction".
+    // The loader must not hard-fail the module for this — treat it as absent.
+    const r = parseModule({
+      id: "sample",
+      frontmatter: fmBase({ project: "" }),
+      source: GLOBAL_SOURCE,
+    });
+    expect(r.module).not.toBeNull();
+    expect(r.module?.project).toBeUndefined();
+    expect(r.diagnostics).toEqual([]);
+  });
+
+  it("agent: '' is treated as absent (not a hard-fail)", () => {
+    const r = parseModule({
+      id: "sample",
+      frontmatter: fmBase({ agent: "" }),
+      source: GLOBAL_SOURCE,
+    });
+    expect(r.module).not.toBeNull();
+    expect(r.module?.agent).toBeUndefined();
+    expect(r.diagnostics).toEqual([]);
+  });
+
+  it("project: non-string (e.g. 42) is still a hard-fail", () => {
+    const r = parseModule({
+      id: "sample",
+      frontmatter: fmBase({ project: 42 }),
+      source: GLOBAL_SOURCE,
+    });
+    expect(r.module).toBeNull();
+    expect(r.diagnostics[0].code).toBe("malformed-frontmatter");
+    expect(r.diagnostics[0].extra?.field).toBe("project");
   });
 
   it("vars-level diagnostics do not disqualify the module", () => {

--- a/plugins/op-obsidian/src/workflowModulePure.test.ts
+++ b/plugins/op-obsidian/src/workflowModulePure.test.ts
@@ -1,0 +1,487 @@
+import { describe, expect, it } from "vitest";
+import {
+  parseModule,
+  parseVarDecl,
+  parseVarDecls,
+  validateIntraScopeCollisions,
+  type ModuleSource,
+  type VarDecl,
+  type WorkflowModule,
+} from "./workflowModulePure";
+
+const GLOBAL_SOURCE: ModuleSource = {
+  kind: "global",
+  path: "Projects/_op-modules/sample.md",
+};
+const PROJECT_SOURCE: ModuleSource = {
+  kind: "project",
+  path: "Projects/obsidian-projects/MODULES/sample.md",
+  projectSlug: "obsidian-projects",
+};
+
+describe("parseVarDecl — string forms", () => {
+  type Case = {
+    name: string;
+    input: string;
+    expected: VarDecl;
+  };
+  const cases: Case[] = [
+    { name: "bare name", input: "foo", expected: { kind: "bare", name: "foo" } },
+    { name: "bare name trims surrounding whitespace", input: "  foo  ", expected: { kind: "bare", name: "foo" } },
+    {
+      name: "name=VALUE shorthand",
+      input: "bar=baz",
+      expected: { kind: "default", name: "bar", value: "baz" },
+    },
+    {
+      name: "empty default (name=)",
+      input: "qux=",
+      expected: { kind: "default", name: "qux", value: "" },
+    },
+    {
+      name: "name=VALUE preserves =-in-value (only first = splits)",
+      input: "expr=a=b=c",
+      expected: { kind: "default", name: "expr", value: "a=b=c" },
+    },
+    {
+      name: "value preserves leading/trailing whitespace",
+      input: "label= hi ",
+      expected: { kind: "default", name: "label", value: " hi " },
+    },
+    {
+      name: "value preserves quotes verbatim — we do not unwrap",
+      input: 'pkg="op-obsidian"',
+      expected: { kind: "default", name: "pkg", value: '"op-obsidian"' },
+    },
+    {
+      name: "YAML auto-coerced types: name=2026-04-25 stays string",
+      // This is the canonical 1b test: when YAML keeps `name=2026-04-25` as a
+      // string (because the `=` makes it ambiguous), the parser must split on
+      // `=` and emit a string value — never a Date object. The Date-rejection
+      // path is covered separately by the `wrong-type` table below.
+      input: "due=2026-04-25",
+      expected: { kind: "default", name: "due", value: "2026-04-25" },
+    },
+    {
+      name: "name with spaces: spaces inside the name are preserved (caller's problem)",
+      input: "first name=Ada",
+      expected: { kind: "default", name: "first name", value: "Ada" },
+    },
+  ];
+  for (const c of cases) {
+    it(c.name, () => {
+      const r = parseVarDecl(c.input);
+      expect(r.diagnostics).toEqual([]);
+      expect(r.decl).toEqual(c.expected);
+    });
+  }
+});
+
+describe("parseVarDecl — object forms", () => {
+  it("name only", () => {
+    const r = parseVarDecl({ name: "pkg" });
+    expect(r.diagnostics).toEqual([]);
+    expect(r.decl).toEqual({ kind: "object", name: "pkg" });
+  });
+
+  it("name + default + description", () => {
+    const r = parseVarDecl({ name: "pkg", default: "op-obsidian", description: "Package name" });
+    expect(r.diagnostics).toEqual([]);
+    expect(r.decl).toEqual({
+      kind: "object",
+      name: "pkg",
+      default: "op-obsidian",
+      description: "Package name",
+    });
+  });
+
+  it("name + description (no default)", () => {
+    const r = parseVarDecl({ name: "verbose", description: "Toggle verbose output" });
+    expect(r.diagnostics).toEqual([]);
+    expect(r.decl).toEqual({
+      kind: "object",
+      name: "verbose",
+      description: "Toggle verbose output",
+    });
+  });
+
+  it("default of empty string is preserved", () => {
+    const r = parseVarDecl({ name: "x", default: "" });
+    expect(r.diagnostics).toEqual([]);
+    expect(r.decl).toEqual({ kind: "object", name: "x", default: "" });
+  });
+
+  it("trims whitespace from name", () => {
+    const r = parseVarDecl({ name: "  pkg  " });
+    expect(r.decl).toEqual({ kind: "object", name: "pkg" });
+  });
+
+  it("unknown keys are tolerated (forward-compat)", () => {
+    const r = parseVarDecl({ name: "pkg", futureField: 42 });
+    expect(r.diagnostics).toEqual([]);
+    expect(r.decl).toEqual({ kind: "object", name: "pkg" });
+  });
+});
+
+describe("parseVarDecl — malformed", () => {
+  it("empty string", () => {
+    const r = parseVarDecl("");
+    expect(r.decl).toBeNull();
+    expect(r.diagnostics[0].code).toBe("malformed-frontmatter");
+  });
+
+  it("whitespace-only string", () => {
+    const r = parseVarDecl("   ");
+    expect(r.decl).toBeNull();
+    expect(r.diagnostics[0].code).toBe("malformed-frontmatter");
+  });
+
+  it("=value (empty name)", () => {
+    const r = parseVarDecl("=value");
+    expect(r.decl).toBeNull();
+    expect(r.diagnostics[0].code).toBe("malformed-frontmatter");
+  });
+
+  it("whitespace-name= (whitespace-only name)", () => {
+    const r = parseVarDecl("   =value");
+    expect(r.decl).toBeNull();
+    expect(r.diagnostics[0].code).toBe("malformed-frontmatter");
+  });
+
+  it("number", () => {
+    const r = parseVarDecl(42);
+    expect(r.decl).toBeNull();
+    expect(r.diagnostics[0].code).toBe("malformed-frontmatter");
+  });
+
+  it("boolean", () => {
+    const r = parseVarDecl(true);
+    expect(r.decl).toBeNull();
+    expect(r.diagnostics[0].code).toBe("malformed-frontmatter");
+  });
+
+  it("Date (YAML auto-coerced ISO date)", () => {
+    // If YAML sees a bare `- 2026-04-25` (no `=`, no quotes), it auto-coerces
+    // to a Date. The parser must reject and surface a clear hint that the
+    // user should quote the value to keep it as a string.
+    const r = parseVarDecl(new Date("2026-04-25"));
+    expect(r.decl).toBeNull();
+    expect(r.diagnostics).toHaveLength(1);
+    expect(r.diagnostics[0].code).toBe("malformed-frontmatter");
+    expect(r.diagnostics[0].message).toMatch(/Date/);
+  });
+
+  it("null", () => {
+    const r = parseVarDecl(null);
+    expect(r.decl).toBeNull();
+    expect(r.diagnostics[0].code).toBe("malformed-frontmatter");
+  });
+
+  it("array", () => {
+    const r = parseVarDecl(["foo"]);
+    expect(r.decl).toBeNull();
+    expect(r.diagnostics[0].code).toBe("malformed-frontmatter");
+  });
+
+  it("object missing name", () => {
+    const r = parseVarDecl({ default: "x" });
+    expect(r.decl).toBeNull();
+    expect(r.diagnostics[0].code).toBe("malformed-frontmatter");
+  });
+
+  it("object name is empty string", () => {
+    const r = parseVarDecl({ name: "" });
+    expect(r.decl).toBeNull();
+    expect(r.diagnostics[0].code).toBe("malformed-frontmatter");
+  });
+
+  it("object name is whitespace-only", () => {
+    const r = parseVarDecl({ name: "   " });
+    expect(r.decl).toBeNull();
+    expect(r.diagnostics[0].code).toBe("malformed-frontmatter");
+  });
+
+  it("object name is non-string", () => {
+    const r = parseVarDecl({ name: 42 });
+    expect(r.decl).toBeNull();
+    expect(r.diagnostics[0].code).toBe("malformed-frontmatter");
+  });
+
+  it("object default is a Date (YAML auto-coerced)", () => {
+    const r = parseVarDecl({ name: "due", default: new Date("2026-04-25") });
+    expect(r.decl).toBeNull();
+    expect(r.diagnostics[0].code).toBe("malformed-frontmatter");
+    expect(r.diagnostics[0].message).toMatch(/Date/);
+    expect(r.diagnostics[0].varName).toBe("due");
+  });
+
+  it("object default is a number", () => {
+    const r = parseVarDecl({ name: "n", default: 42 });
+    expect(r.decl).toBeNull();
+    expect(r.diagnostics[0].code).toBe("malformed-frontmatter");
+    expect(r.diagnostics[0].varName).toBe("n");
+  });
+
+  it("object description is non-string", () => {
+    const r = parseVarDecl({ name: "n", description: 7 });
+    expect(r.decl).toBeNull();
+    expect(r.diagnostics[0].code).toBe("malformed-frontmatter");
+    expect(r.diagnostics[0].varName).toBe("n");
+  });
+});
+
+describe("parseVarDecls — list-level", () => {
+  it("undefined / null → empty list, no diagnostics", () => {
+    expect(parseVarDecls(undefined)).toEqual({ decls: [], diagnostics: [] });
+    expect(parseVarDecls(null)).toEqual({ decls: [], diagnostics: [] });
+  });
+
+  it("non-array (string) → diagnostic, empty list", () => {
+    const r = parseVarDecls("foo");
+    expect(r.decls).toEqual([]);
+    expect(r.diagnostics).toHaveLength(1);
+    expect(r.diagnostics[0].code).toBe("malformed-frontmatter");
+  });
+
+  it("empty array → empty list, no diagnostics", () => {
+    expect(parseVarDecls([])).toEqual({ decls: [], diagnostics: [] });
+  });
+
+  it("mixed valid + invalid → keeps valid, emits diagnostics for invalid", () => {
+    const r = parseVarDecls(["foo", 42, "bar=baz", { name: "" }]);
+    expect(r.decls).toEqual([
+      { kind: "bare", name: "foo" },
+      { kind: "default", name: "bar", value: "baz" },
+    ]);
+    expect(r.diagnostics).toHaveLength(2);
+    expect(r.diagnostics.every((d) => d.code === "malformed-frontmatter")).toBe(true);
+  });
+
+  it("duplicate-name-within-one-module → keeps first, emits diagnostic for each duplicate", () => {
+    const r = parseVarDecls(["foo", "foo=bar", { name: "foo", description: "third" }]);
+    expect(r.decls).toEqual([{ kind: "bare", name: "foo" }]);
+    expect(r.diagnostics).toHaveLength(2);
+    for (const d of r.diagnostics) {
+      expect(d.code).toBe("malformed-frontmatter");
+      expect(d.varName).toBe("foo");
+    }
+  });
+
+  it("string + object mix preserves order", () => {
+    const r = parseVarDecls([
+      "first",
+      { name: "second", description: "two" },
+      "third=3",
+    ]);
+    expect(r.decls).toEqual([
+      { kind: "bare", name: "first" },
+      { kind: "object", name: "second", description: "two" },
+      { kind: "default", name: "third", value: "3" },
+    ]);
+    expect(r.diagnostics).toEqual([]);
+  });
+});
+
+describe("parseModule", () => {
+  function fmBase(over: Record<string, unknown> = {}): Record<string, unknown> {
+    return {
+      id: "sample",
+      title: "Sample",
+      type: "workflow-module",
+      scope: "pre-commit",
+      ...over,
+    };
+  }
+
+  it("happy path — all required fields", () => {
+    const r = parseModule({ id: "sample", frontmatter: fmBase(), source: GLOBAL_SOURCE });
+    expect(r.diagnostics).toEqual([]);
+    expect(r.module).toEqual({
+      id: "sample",
+      title: "Sample",
+      scope: "pre-commit",
+      project: undefined,
+      agent: undefined,
+      order: 0,
+      vars: [],
+      source: GLOBAL_SOURCE,
+    });
+  });
+
+  it("populates optional fields", () => {
+    const r = parseModule({
+      id: "sample",
+      frontmatter: fmBase({
+        project: "obsidian-projects",
+        agent: "claude",
+        order: 10,
+        vars: ["foo", "bar=baz"],
+      }),
+      source: PROJECT_SOURCE,
+    });
+    expect(r.diagnostics).toEqual([]);
+    expect(r.module).toMatchObject({
+      project: "obsidian-projects",
+      agent: "claude",
+      order: 10,
+      vars: [
+        { kind: "bare", name: "foo" },
+        { kind: "default", name: "bar", value: "baz" },
+      ],
+    });
+  });
+
+  it("rejects missing frontmatter", () => {
+    const r = parseModule({ id: "sample", frontmatter: null, source: GLOBAL_SOURCE });
+    expect(r.module).toBeNull();
+    expect(r.diagnostics[0].code).toBe("malformed-frontmatter");
+    expect(r.diagnostics[0].extra?.path).toBe(GLOBAL_SOURCE.path);
+  });
+
+  it("rejects wrong type", () => {
+    const r = parseModule({
+      id: "sample",
+      frontmatter: { ...fmBase(), type: "issue" },
+      source: GLOBAL_SOURCE,
+    });
+    expect(r.module).toBeNull();
+    expect(r.diagnostics).toHaveLength(1);
+    expect(r.diagnostics[0].message).toMatch(/workflow-module/);
+  });
+
+  it("rejects id mismatch (filename vs frontmatter id)", () => {
+    const r = parseModule({
+      id: "sample",
+      frontmatter: fmBase({ id: "different" }),
+      source: GLOBAL_SOURCE,
+    });
+    expect(r.module).toBeNull();
+    expect(r.diagnostics[0].code).toBe("malformed-frontmatter");
+    expect(r.diagnostics[0].extra?.expected).toBe("sample");
+    expect(r.diagnostics[0].extra?.actual).toBe("different");
+  });
+
+  it("rejects missing title / scope", () => {
+    const r1 = parseModule({
+      id: "sample",
+      frontmatter: fmBase({ title: undefined }),
+      source: GLOBAL_SOURCE,
+    });
+    expect(r1.module).toBeNull();
+
+    const r2 = parseModule({
+      id: "sample",
+      frontmatter: fmBase({ scope: "" }),
+      source: GLOBAL_SOURCE,
+    });
+    expect(r2.module).toBeNull();
+  });
+
+  it("rejects non-integer order", () => {
+    const r = parseModule({
+      id: "sample",
+      frontmatter: fmBase({ order: 1.5 }),
+      source: GLOBAL_SOURCE,
+    });
+    expect(r.module).toBeNull();
+    expect(r.diagnostics[0].extra?.field).toBe("order");
+  });
+
+  it("treats absent project/agent/order as defaults (not errors)", () => {
+    const r = parseModule({
+      id: "sample",
+      frontmatter: fmBase(),
+      source: GLOBAL_SOURCE,
+    });
+    expect(r.module?.project).toBeUndefined();
+    expect(r.module?.agent).toBeUndefined();
+    expect(r.module?.order).toBe(0);
+  });
+
+  it("vars-level diagnostics do not disqualify the module", () => {
+    const r = parseModule({
+      id: "sample",
+      frontmatter: fmBase({ vars: ["valid", 42, "another"] }),
+      source: GLOBAL_SOURCE,
+    });
+    expect(r.module).not.toBeNull();
+    expect(r.module?.vars).toEqual([
+      { kind: "bare", name: "valid" },
+      { kind: "bare", name: "another" },
+    ]);
+    expect(r.diagnostics.length).toBeGreaterThan(0);
+    expect(r.diagnostics.every((d) => d.code === "malformed-frontmatter")).toBe(true);
+    // Vars diagnostics carry the moduleId + path injected by parseModule.
+    expect(r.diagnostics[0].moduleId).toBe("sample");
+    expect(r.diagnostics[0].extra?.path).toBe(GLOBAL_SOURCE.path);
+  });
+});
+
+describe("validateIntraScopeCollisions", () => {
+  function module(
+    id: string,
+    scope: string,
+    varNames: string[],
+    source: ModuleSource = GLOBAL_SOURCE,
+  ): WorkflowModule {
+    return {
+      id,
+      title: id,
+      scope,
+      project: undefined,
+      agent: undefined,
+      order: 0,
+      vars: varNames.map((n) => ({ kind: "bare", name: n })),
+      source,
+    };
+  }
+
+  it("no collisions when all (scope, varName) pairs are unique", () => {
+    const diags = validateIntraScopeCollisions([
+      module("a", "pre-commit", ["x", "y"]),
+      module("b", "pre-commit", ["z"]),
+      module("c", "pre-merge", ["x"]),
+    ]);
+    expect(diags).toEqual([]);
+  });
+
+  it("flags collision across two modules at the same scope", () => {
+    const diags = validateIntraScopeCollisions([
+      module("a", "pre-commit", ["x"]),
+      module("b", "pre-commit", ["x"]),
+    ]);
+    expect(diags).toHaveLength(1);
+    expect(diags[0].code).toBe("intra-scope-collision");
+    expect(diags[0].varName).toBe("x");
+    expect(diags[0].extra?.scope).toBe("pre-commit");
+    expect(diags[0].extra?.moduleIds).toEqual(["a", "b"]);
+  });
+
+  it("flags 3-way collision and lists module ids in stable order", () => {
+    const diags = validateIntraScopeCollisions([
+      module("c", "pre-commit", ["x"]),
+      module("a", "pre-commit", ["x"]),
+      module("b", "pre-commit", ["x"]),
+    ]);
+    expect(diags).toHaveLength(1);
+    expect(diags[0].extra?.moduleIds).toEqual(["a", "b", "c"]);
+  });
+
+  it("does not collide across different scopes", () => {
+    const diags = validateIntraScopeCollisions([
+      module("a", "pre-commit", ["x"]),
+      module("b", "post-commit", ["x"]),
+    ]);
+    expect(diags).toEqual([]);
+  });
+
+  it("emits one diagnostic per colliding var, not per module", () => {
+    const diags = validateIntraScopeCollisions([
+      module("a", "pre-commit", ["x", "y"]),
+      module("b", "pre-commit", ["x", "y"]),
+    ]);
+    expect(diags).toHaveLength(2);
+    const names = diags.map((d) => d.varName).sort();
+    expect(names).toEqual(["x", "y"]);
+  });
+});

--- a/plugins/op-obsidian/src/workflowModulePure.ts
+++ b/plugins/op-obsidian/src/workflowModulePure.ts
@@ -352,11 +352,13 @@ export function parseModule(args: ParseModuleArgs): ParseModuleResult {
   if (Object.prototype.hasOwnProperty.call(frontmatter, "project")) {
     const v = frontmatter.project;
     if (v !== undefined && v !== null) {
-      if (typeof v !== "string" || v.length === 0) {
+      if (typeof v !== "string") {
         diagnostics.push(invalidFieldDiag(path, id, "project", v, "non-empty string"));
-      } else {
+      } else if (v.trim().length > 0) {
         project = v;
       }
+      // empty / whitespace-only string is silently treated as absent — authors
+      // sometimes write `project: ""` to mean "no restriction"; honour that intent.
     }
   }
 
@@ -364,11 +366,12 @@ export function parseModule(args: ParseModuleArgs): ParseModuleResult {
   if (Object.prototype.hasOwnProperty.call(frontmatter, "agent")) {
     const v = frontmatter.agent;
     if (v !== undefined && v !== null) {
-      if (typeof v !== "string" || v.length === 0) {
+      if (typeof v !== "string") {
         diagnostics.push(invalidFieldDiag(path, id, "agent", v, "non-empty string"));
-      } else {
+      } else if (v.trim().length > 0) {
         agent = v;
       }
+      // empty / whitespace-only string treated as absent (same reasoning as project).
     }
   }
 

--- a/plugins/op-obsidian/src/workflowModulePure.ts
+++ b/plugins/op-obsidian/src/workflowModulePure.ts
@@ -1,0 +1,476 @@
+import type { WorkflowDiagnostic } from "./workflowDiagnostic";
+
+// Workflow-module schema, types, and pure parsers. OP-195 (1b) of the OP-184
+// umbrella. No I/O, no Obsidian imports — every input flows in via arguments.
+//
+// A workflow module is a markdown file whose frontmatter declares a partition
+// of the composed workflow. Files live in either of two places:
+//
+//   - Global:      Projects/_op-modules/<id>.md
+//   - Per-project: Projects/<slug>/MODULES/<id>.md
+//
+// A per-project module of the same id shadows the global (per-project wins, no
+// merge). The IO loader in `workflowModule.ts` walks the vault and applies
+// shadowing; this module owns shape decisions only.
+//
+// Frontmatter contract:
+//
+//   ---
+//   id: review-and-merge       # required, must match the source filename basename
+//   title: "Review and merge"  # required
+//   type: workflow-module      # required, exact literal
+//   scope: pre-commit          # required string — partition key for collision check
+//   project: obsidian-projects # optional — restrict to one project (slug)
+//   agent: claude              # optional — restrict to one agent id
+//   order: 10                  # optional integer (default 0) — sort key within a scope
+//   vars:                      # optional list of VarDecl
+//     - foo                    # bare
+//     - bar=baz                # default-shorthand
+//     - qux=                   # explicit empty default (distinct from bare)
+//     - { name: pkg, default: op-obsidian, description: "Package name" }
+//   ---
+//
+// Composition (resolving variables across scopes, applying user values, etc.)
+// is OP-197 (1d). This file ships load-and-validate primitives.
+
+/**
+ * Typed declaration of a single variable consumed by a workflow module.
+ *
+ * - `bare` — the module names a variable but supplies no default. Caller (1d's
+ *   composer) must satisfy it from a higher-precedence source or surface a
+ *   diagnostic.
+ * - `default` — the module supplies a default value as a string. Empty-string
+ *   default (`name=`) is intentional and distinct from `bare`.
+ * - `object` — full form with optional default and optional one-line
+ *   description. Description surfaces in settings UIs and the future
+ *   `op-list-vars` CLI.
+ */
+export type VarDecl =
+  | { kind: "bare"; name: string }
+  | { kind: "default"; name: string; value: string }
+  | { kind: "object"; name: string; default?: string; description?: string };
+
+/** Where a loaded module came from. Carried on `WorkflowModule` for diagnostics + shadowing. */
+export type ModuleSource =
+  | { kind: "global"; path: string }
+  | { kind: "project"; path: string; projectSlug: string };
+
+/** Parsed and validated module. */
+export interface WorkflowModule {
+  id: string;
+  title: string;
+  scope: string;
+  project?: string;
+  agent?: string;
+  /** Integer sort key within a scope. Default 0 when frontmatter omits it. */
+  order: number;
+  vars: VarDecl[];
+  source: ModuleSource;
+}
+
+/**
+ * Result of parsing a single var declaration. `decl` is `null` only when a
+ * `malformed-frontmatter` diagnostic is also returned — caller should drop the
+ * entry but keep walking the rest of the list.
+ */
+export interface ParseVarDeclResult {
+  decl: VarDecl | null;
+  diagnostics: WorkflowDiagnostic[];
+}
+
+/**
+ * Parse a single var declaration from raw YAML-decoded input. Pure function.
+ *
+ * String-input rules:
+ *   - No `=` → `{ kind: "bare", name }` after trimming the surrounding
+ *     whitespace from the name. Empty/whitespace-only string → diagnostic.
+ *   - First `=` splits into `name` and `value`. ONLY the FIRST `=` splits —
+ *     `name=foo=bar` yields name="name", value="foo=bar".
+ *   - Empty `name` (`=value`) → diagnostic (malformed-frontmatter).
+ *   - Empty `value` (`name=`) → `{ kind: "default", name, value: "" }`. The
+ *     trailing `=` is the user's explicit signal "default-of-empty-string"
+ *     and is preserved verbatim (distinct from `bare`).
+ *
+ * Object-input rules:
+ *   - `name` is required and must be a non-empty string.
+ *   - `default` if present must be a string (Date/number → diagnostic).
+ *   - `description` if present must be a string.
+ *   - Unknown keys are tolerated (forward-compat for future fields).
+ *
+ * Anything else (number, boolean, Date, null, array) → diagnostic.
+ *
+ * The caller (`parseVarDecls`) attaches `moduleId` to diagnostics this function
+ * emits — this function is decoupled from module identity so it can be unit-
+ * tested in isolation.
+ */
+export function parseVarDecl(raw: unknown): ParseVarDeclResult {
+  if (typeof raw === "string") {
+    return parseStringVarDecl(raw);
+  }
+  if (raw && typeof raw === "object" && !Array.isArray(raw) && !(raw instanceof Date)) {
+    return parseObjectVarDecl(raw as Record<string, unknown>);
+  }
+  return {
+    decl: null,
+    diagnostics: [
+      {
+        code: "malformed-frontmatter",
+        severity: "error",
+        message: `Invalid var declaration: expected string or object, got ${describe(raw)}.`,
+      },
+    ],
+  };
+}
+
+function parseStringVarDecl(raw: string): ParseVarDeclResult {
+  const eqIdx = raw.indexOf("=");
+  if (eqIdx === -1) {
+    const name = raw.trim();
+    if (!name) {
+      return {
+        decl: null,
+        diagnostics: [
+          {
+            code: "malformed-frontmatter",
+            severity: "error",
+            message: `Invalid var declaration: empty string.`,
+          },
+        ],
+      };
+    }
+    return { decl: { kind: "bare", name }, diagnostics: [] };
+  }
+
+  const rawName = raw.slice(0, eqIdx);
+  const value = raw.slice(eqIdx + 1);
+  const name = rawName.trim();
+  if (!name) {
+    return {
+      decl: null,
+      diagnostics: [
+        {
+          code: "malformed-frontmatter",
+          severity: "error",
+          message: `Invalid var declaration: empty name in ${JSON.stringify(raw)}.`,
+        },
+      ],
+    };
+  }
+  return { decl: { kind: "default", name, value }, diagnostics: [] };
+}
+
+function parseObjectVarDecl(obj: Record<string, unknown>): ParseVarDeclResult {
+  const rawName = obj.name;
+  if (typeof rawName !== "string" || rawName.trim().length === 0) {
+    return {
+      decl: null,
+      diagnostics: [
+        {
+          code: "malformed-frontmatter",
+          severity: "error",
+          message: `Invalid var declaration: object form requires a non-empty string \`name\` (got ${describe(rawName)}).`,
+        },
+      ],
+    };
+  }
+  const name = rawName.trim();
+
+  const decl: { kind: "object"; name: string; default?: string; description?: string } = {
+    kind: "object",
+    name,
+  };
+  const diagnostics: WorkflowDiagnostic[] = [];
+
+  if (Object.prototype.hasOwnProperty.call(obj, "default")) {
+    const def = obj.default;
+    if (typeof def !== "string") {
+      diagnostics.push({
+        code: "malformed-frontmatter",
+        severity: "error",
+        message: `Invalid var declaration ${JSON.stringify(name)}: \`default\` must be a string (got ${describe(def)}). Quote the value in YAML to keep it as a string.`,
+        varName: name,
+      });
+    } else {
+      decl.default = def;
+    }
+  }
+
+  if (Object.prototype.hasOwnProperty.call(obj, "description")) {
+    const desc = obj.description;
+    if (typeof desc !== "string") {
+      diagnostics.push({
+        code: "malformed-frontmatter",
+        severity: "error",
+        message: `Invalid var declaration ${JSON.stringify(name)}: \`description\` must be a string (got ${describe(desc)}).`,
+        varName: name,
+      });
+    } else {
+      decl.description = desc;
+    }
+  }
+
+  if (diagnostics.length > 0) return { decl: null, diagnostics };
+  return { decl, diagnostics: [] };
+}
+
+export interface ParseVarDeclsResult {
+  decls: VarDecl[];
+  diagnostics: WorkflowDiagnostic[];
+}
+
+/**
+ * Parse a `vars:` list. Accepts unknown — undefined / missing field is fine
+ * (returns empty list, no diagnostics). Anything that isn't an array (string,
+ * scalar, object) → one `malformed-frontmatter` diagnostic and an empty list.
+ *
+ * Duplicate names within one module emit a `malformed-frontmatter` diagnostic
+ * per duplicate (with `varName` set to the colliding name); the second
+ * occurrence is dropped from the returned list. The first wins.
+ */
+export function parseVarDecls(rawVars: unknown): ParseVarDeclsResult {
+  if (rawVars === undefined || rawVars === null) {
+    return { decls: [], diagnostics: [] };
+  }
+  if (!Array.isArray(rawVars)) {
+    return {
+      decls: [],
+      diagnostics: [
+        {
+          code: "malformed-frontmatter",
+          severity: "error",
+          message: `\`vars\` must be a list (got ${describe(rawVars)}).`,
+        },
+      ],
+    };
+  }
+
+  const decls: VarDecl[] = [];
+  const seen = new Set<string>();
+  const diagnostics: WorkflowDiagnostic[] = [];
+
+  for (const entry of rawVars) {
+    const result = parseVarDecl(entry);
+    diagnostics.push(...result.diagnostics);
+    if (!result.decl) continue;
+    if (seen.has(result.decl.name)) {
+      diagnostics.push({
+        code: "malformed-frontmatter",
+        severity: "error",
+        message: `Duplicate var \`${result.decl.name}\` declared more than once in this module — keeping the first declaration, dropping later ones.`,
+        varName: result.decl.name,
+      });
+      continue;
+    }
+    seen.add(result.decl.name);
+    decls.push(result.decl);
+  }
+
+  return { decls, diagnostics };
+}
+
+export interface ParseModuleArgs {
+  /** Filename basename without `.md`. parseModule asserts it equals `frontmatter.id`. */
+  id: string;
+  frontmatter: Record<string, unknown> | null | undefined;
+  source: ModuleSource;
+}
+
+export interface ParseModuleResult {
+  module: WorkflowModule | null;
+  diagnostics: WorkflowDiagnostic[];
+}
+
+/**
+ * Parse one module from its filename basename, frontmatter, and source. Pure.
+ *
+ * Returns `module: null` (with diagnostics) when the frontmatter is missing,
+ * not a `workflow-module` type, or fails core validation (id mismatch, missing
+ * required field, wrong scalar type). Returns a populated `WorkflowModule`
+ * when validation succeeds — even if `vars` parsing emitted per-entry
+ * diagnostics; bad var entries are dropped from `module.vars` but the module
+ * itself is still loadable.
+ */
+export function parseModule(args: ParseModuleArgs): ParseModuleResult {
+  const { id, frontmatter, source } = args;
+  const diagnostics: WorkflowDiagnostic[] = [];
+  const path = source.path;
+
+  if (!frontmatter || typeof frontmatter !== "object") {
+    return {
+      module: null,
+      diagnostics: [
+        {
+          code: "malformed-frontmatter",
+          severity: "error",
+          message: `${path}: missing or empty frontmatter — workflow modules require frontmatter with \`type: workflow-module\`.`,
+          moduleId: id,
+          extra: { path },
+        },
+      ],
+    };
+  }
+
+  if (frontmatter.type !== "workflow-module") {
+    return {
+      module: null,
+      diagnostics: [
+        {
+          code: "malformed-frontmatter",
+          severity: "error",
+          message: `${path}: \`type\` must be \`workflow-module\` (got ${describe(frontmatter.type)}).`,
+          moduleId: id,
+          extra: { path },
+        },
+      ],
+    };
+  }
+
+  const fmId = frontmatter.id;
+  if (typeof fmId !== "string" || fmId.length === 0) {
+    diagnostics.push(invalidFieldDiag(path, id, "id", fmId, "non-empty string"));
+  } else if (fmId !== id) {
+    diagnostics.push({
+      code: "malformed-frontmatter",
+      severity: "error",
+      message: `${path}: frontmatter \`id\` (${JSON.stringify(fmId)}) must match the filename basename (${JSON.stringify(id)}).`,
+      moduleId: id,
+      extra: { path, expected: id, actual: fmId },
+    });
+  }
+
+  const title = frontmatter.title;
+  if (typeof title !== "string" || title.length === 0) {
+    diagnostics.push(invalidFieldDiag(path, id, "title", title, "non-empty string"));
+  }
+
+  const scope = frontmatter.scope;
+  if (typeof scope !== "string" || scope.length === 0) {
+    diagnostics.push(invalidFieldDiag(path, id, "scope", scope, "non-empty string"));
+  }
+
+  let project: string | undefined;
+  if (Object.prototype.hasOwnProperty.call(frontmatter, "project")) {
+    const v = frontmatter.project;
+    if (v !== undefined && v !== null) {
+      if (typeof v !== "string" || v.length === 0) {
+        diagnostics.push(invalidFieldDiag(path, id, "project", v, "non-empty string"));
+      } else {
+        project = v;
+      }
+    }
+  }
+
+  let agent: string | undefined;
+  if (Object.prototype.hasOwnProperty.call(frontmatter, "agent")) {
+    const v = frontmatter.agent;
+    if (v !== undefined && v !== null) {
+      if (typeof v !== "string" || v.length === 0) {
+        diagnostics.push(invalidFieldDiag(path, id, "agent", v, "non-empty string"));
+      } else {
+        agent = v;
+      }
+    }
+  }
+
+  let order = 0;
+  if (Object.prototype.hasOwnProperty.call(frontmatter, "order")) {
+    const v = frontmatter.order;
+    if (v !== undefined && v !== null) {
+      if (typeof v !== "number" || !Number.isInteger(v)) {
+        diagnostics.push(invalidFieldDiag(path, id, "order", v, "integer"));
+      } else {
+        order = v;
+      }
+    }
+  }
+
+  const varsResult = parseVarDecls(frontmatter.vars);
+  for (const d of varsResult.diagnostics) {
+    diagnostics.push({ ...d, moduleId: id, extra: { ...(d.extra ?? {}), path } });
+  }
+
+  // Hard-fail diagnostics (missing/invalid required fields, id mismatch) make
+  // the module unusable. The check is "did any diagnostic so far signal a
+  // structural problem" — vars-only diagnostics don't disqualify the module.
+  const hardFail =
+    diagnostics.length > varsResult.diagnostics.length
+      ? diagnostics.slice(0, diagnostics.length - varsResult.diagnostics.length)
+      : [];
+  if (hardFail.length > 0) {
+    return { module: null, diagnostics };
+  }
+
+  const module: WorkflowModule = {
+    id,
+    title: title as string,
+    scope: scope as string,
+    project,
+    agent,
+    order,
+    vars: varsResult.decls,
+    source,
+  };
+  return { module, diagnostics };
+}
+
+/**
+ * Detect cross-module variable collisions within a single scope.
+ *
+ * For each `(scope, varName)` pair declared by 2+ modules in the input, emit
+ * one `intra-scope-collision` diagnostic naming all colliding module ids in
+ * stable order (by module id). Pure — caller decides which modules are in
+ * scope (after shadowing, after project filtering).
+ */
+export function validateIntraScopeCollisions(modules: WorkflowModule[]): WorkflowDiagnostic[] {
+  // Group declared var names by (scope, varName) → moduleIds.
+  const groups = new Map<string, { scope: string; varName: string; moduleIds: string[] }>();
+  for (const m of modules) {
+    for (const v of m.vars) {
+      const key = `${m.scope} ${v.name}`;
+      const existing = groups.get(key);
+      if (existing) {
+        existing.moduleIds.push(m.id);
+      } else {
+        groups.set(key, { scope: m.scope, varName: v.name, moduleIds: [m.id] });
+      }
+    }
+  }
+
+  const diagnostics: WorkflowDiagnostic[] = [];
+  for (const { scope, varName, moduleIds } of groups.values()) {
+    if (moduleIds.length < 2) continue;
+    const sorted = [...moduleIds].sort();
+    diagnostics.push({
+      code: "intra-scope-collision",
+      severity: "error",
+      message: `Variable \`${varName}\` declared by multiple modules at scope \`${scope}\`: ${sorted.map((s) => `\`${s}\``).join(", ")}.`,
+      varName,
+      extra: { scope, moduleIds: sorted },
+    });
+  }
+  return diagnostics;
+}
+
+function describe(v: unknown): string {
+  if (v === null) return "null";
+  if (v === undefined) return "undefined";
+  if (v instanceof Date) return `Date(${v.toISOString()}) — quote the value in YAML to keep it as a string`;
+  if (Array.isArray(v)) return "array";
+  return typeof v;
+}
+
+function invalidFieldDiag(
+  path: string,
+  id: string,
+  field: string,
+  value: unknown,
+  expected: string,
+): WorkflowDiagnostic {
+  return {
+    code: "malformed-frontmatter",
+    severity: "error",
+    message: `${path}: \`${field}\` must be a ${expected} (got ${describe(value)}).`,
+    moduleId: id,
+    extra: { path, field, expected, actual: describe(value) },
+  };
+}

--- a/plugins/op/.claude-plugin/plugin.json
+++ b/plugins/op/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "op",
   "description": "Obsidian Projects workflow — schema, slash commands, and agent skill for running a Jira-lite issue tracker inside an Obsidian vault.",
-  "version": "0.63.0",
+  "version": "0.63.1",
   "author": {
     "name": "Eugene Archibald"
   },

--- a/plugins/op/.claude-plugin/plugin.json
+++ b/plugins/op/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "op",
   "description": "Obsidian Projects workflow — schema, slash commands, and agent skill for running a Jira-lite issue tracker inside an Obsidian vault.",
-  "version": "0.62.0",
+  "version": "0.63.0",
   "author": {
     "name": "Eugene Archibald"
   },


### PR DESCRIPTION
## Summary

- Pure-fn shape: `parseVarDecl` / `parseVarDecls` / `parseModule` / `validateIntraScopeCollisions` in `workflowModulePure.ts` — no Obsidian imports, no IO. Three `VarDecl` shapes (`bare`, `default`, `object`) with table-driven coverage of every edge from the issue scope.
- Thin IO seam in `workflowModule.ts`: `loadModules(app, opts?)` walks `Projects/_op-modules/` and `Projects/<slug>/MODULES/`, applies per-project shadowing, optional project filter, runs intra-scope collision validation.
- Diagnostics: `malformed-frontmatter` for invalid declarations (wrong type, id-vs-filename mismatch, non-string fields, YAML-coerced Date, duplicate var name within one module); `intra-scope-collision` after shadowing.
- Schema reference: `docs/specs/workflow-module-schema.md` — single source for users authoring modules; covers shadowing surprise, YAML auto-coercion gotcha, diagnostic table.
- Bumps op-obsidian `0.62.0 → 0.63.0` (minor — additive infra; no user-visible behavior change yet).

No composition. No `extends:`. No `modelRegistry`. No legacy `WORKFLOW.md` fallback. All deferred to 1c/1d (OP-196/OP-197).

## Test plan

- [x] 51 pure tests in `workflowModulePure.test.ts` covering: bare names, name=VALUE shorthand, name= (empty default), name=VALUE with `=`-in-value, quoted values, YAML-coerced types stay strings, Date rejection, object form with description, missing names, duplicate-name-within-one-module, parseModule happy path + every required-field rejection, vars-level diagnostics don't disqualify the module, intra-scope-collision (2-way, 3-way, no-cross-scope, one-per-var).
- [x] 12 IO tests in `workflowModule.test.ts` covering: path bucketing, ignoring out-of-band files, per-project shadowing of same-id globals, project filter behavior, malformed-frontmatter on bad files, collision check runs against post-shadowing set.
- [x] Full suite: 916 / 916 passing (the 1 failing suite is `iTermPrefs.test.ts` — pre-existing infra issue with `obsidian` package resolution in vitest, also failing on unmodified main; unrelated to this PR; documented in OP-194).

🤖 Generated with [Claude Code](https://claude.com/claude-code)