### PR TITLE
OP-196: workflow file schema + modelRegistry + extends inheritance + legacy fallback

### DIFF
--- a/docs/specs/workflow-file-schema.md
+++ b/docs/specs/workflow-file-schema.md
@@ -1,0 +1,260 @@
+# Workflow File Schema
+
+Status: shipped in OP-196 (1c of OP-184). Composition (1d/OP-197) consumes the
+loaded workflow; this doc covers the file format, the `extends:` inheritance
+rule, the model registry, and the legacy-fallback ladder. Module composition
+itself lives in [`workflow-module-schema.md`](./workflow-module-schema.md).
+
+## What a workflow file is
+
+A workflow file is the per-project description of *what gets injected, by
+which agent, at which step*. It declares:
+
+- **Defaults**: the agent and model used when a step doesn't override them.
+- **Steps**: an ordered list of named stages — `kickoff`, `review`,
+  `finalize`, etc. Each step references a list of module ids (defined in
+  [workflow modules](./workflow-module-schema.md)) that supply its content
+  and variable declarations. A step may override the default agent or model.
+- **Inheritance**: an optional `extends:` pointer to a parent workflow file
+  (typically a global default at `Projects/_op-workflow.md`). Parent steps
+  apply unless the child repeats a `step:` id, in which case the child's
+  step replaces the parent's at that slot.
+
+## Where workflow files live
+
+| Location | Path | Applies to |
+| :--- | :--- | :--- |
+| Per-project | `Projects/<slug>/WORKFLOW.md` | Project `<slug>`. |
+| Global default | `Projects/_op-workflow.md` (by convention) | Any project that names it via `extends:`. |
+
+The loader doesn't auto-merge globals — a project must opt in by declaring
+`extends:` explicitly. This is intentional: an unnamed global is invisible to
+authors editing the per-project file.
+
+## Frontmatter contract
+
+```yaml
+---
+type: workflow                        # required, exact literal
+schema: 1                             # required integer; locks the contract
+project: obsidian-projects            # required string (project slug)
+default_agent: claude                 # list-or-scalar
+default_model: opus                   # list-or-scalar-or-keyed-map
+extends: Projects/_op-workflow.md     # optional, vault-relative; one level only
+steps:                                # required (in modern shape)
+  - step: kickoff                     # required, unique within the workflow
+    modules: [orient, identify-issue] # list of module ids; may be empty
+    agent: claude                     # optional override (list-or-scalar)
+    model: opus                       # optional override (list-or-scalar-or-keyed-map)
+  - step: review
+    modules: [review-and-merge]
+---
+
+# Markdown body is opaque commentary today. The synthetic legacy-kickoff step
+# is the only path that attaches body content to a workflow programmatically.
+```
+
+### `type` and `schema`
+
+`type` is the literal `workflow`. `schema` is an integer locking the format
+version. **This loader supports `schema: 1` only.** Files declaring
+`schema: 2` (or any other value) emit `schema-mismatch` and are dropped —
+future versions will be added with explicit migration paths.
+
+### `project`
+
+The project slug. Must be a non-empty string. If it disagrees with the
+file's enclosing folder name (`Projects/<slug>/`), the loader emits a
+warning-severity `malformed-frontmatter` diagnostic and uses the folder
+name. The warning is intentional: the folder is canonical, but a
+mistyped `project:` field is a useful breadcrumb when copying a workflow
+between projects.
+
+### `default_agent` (list-or-scalar)
+
+Accepts:
+
+- A scalar string: `default_agent: claude`. Equivalent to `[claude]`.
+- A list of strings: `default_agent: [claude, gemini]`. The launch context
+  picks one at runtime.
+
+Empty input, whitespace-only entries, or non-string entries emit
+`malformed-frontmatter` and the workflow is dropped.
+
+Lists deduplicate while preserving order. `[claude, claude, gemini]` becomes
+`[claude, gemini]`.
+
+### `default_model` (list-or-scalar-or-keyed-map)
+
+Accepts three shapes:
+
+- **Scalar** — `default_model: opus`. Applies to every agent in the
+  surrounding agent list. Internally normalised to `{ kind: "all", values: ["opus"] }`.
+- **List** — `default_model: [opus, sonnet]`. Same semantics: applies to every
+  agent, with multiple alternatives. The launch context picks one.
+- **Keyed map (per-agent)** — `default_model: { claude: opus, gemini: pro }`.
+  Each value is itself a list-or-scalar. Internally normalised to
+  `{ kind: "perAgent", perAgent: { claude: ["opus"], gemini: ["pro"] } }`.
+
+Empty maps, empty lists, and non-string values emit
+`malformed-frontmatter`. A keyed map referencing an agent absent from
+`default_agent` emits a warning-severity diagnostic — the agent might still
+work at runtime via a step-level override, but more often it's a typo.
+
+### `extends:` (optional, one level only)
+
+Points at another workflow file (vault-relative path). The loader reads the
+parent, parses it the same way, and merges:
+
+- **Defaults**: shallow merge. Child wins on per-key collisions. Empty child
+  defaults (`default_agent: []`, `default_model: { kind: "all", values: [] }`)
+  fall through to the parent.
+- **Steps**: child step ids replace parent steps at the parent's slot. Child
+  steps with new ids append in their original order. The merged step list
+  preserves parent order for inherited slots and child order for new slots.
+
+**One level only.** A parent file declaring its own `extends:` emits a
+warning-severity `schema-mismatch` and the grandparent is ignored. Author
+intent is rarely "deep chain"; v1 lock is conservative.
+
+### `steps:` (required)
+
+A list of step records. Each record:
+
+- **`step` (required)** — unique step id within the workflow. Non-empty
+  string. Duplicate ids: first wins, second emits `malformed-frontmatter`.
+- **`modules` (required, may be empty)** — list of module ids the step
+  composes from. Module resolution lives in
+  [`workflow-module-schema.md`](./workflow-module-schema.md). Module ids are
+  trimmed and deduplicated.
+- **`agent` (optional)** — list-or-scalar override. Same semantics as
+  `default_agent`.
+- **`model` (optional)** — list-or-scalar-or-keyed-map override. Same
+  semantics as `default_model`.
+
+A step that supplies neither `agent:` nor `model:` inherits both from the
+workflow's defaults. The model-validation pass skips inherit-only steps —
+the `<defaults>` pass already validated that pair.
+
+## Model registry
+
+Model names are validated against a per-agent registry, keyed by agent id.
+Each agent has:
+
+- **`aliases`** — a map from bare alias (e.g. `opus`, `sonnet`, `haiku`) to
+  the canonical versioned id (e.g. `claude-opus-4-7`). Aliases are the
+  ergonomic shorthand a workflow file author writes.
+- **`versioned`** — a set of canonical ids accepted as-is. Versioned ids pin
+  to a specific point release; aliases float forward as we update the
+  registry.
+
+A model name validates if it appears as an alias key OR as a versioned id
+for the relevant agent. Resolution returns the canonical versioned id in
+both cases.
+
+| Agent | Aliases | Canonical examples |
+| :--- | :--- | :--- |
+| `claude` | `opus` → `claude-opus-4-7`<br>`sonnet` → `claude-sonnet-4-6`<br>`haiku` → `claude-haiku-4-5-20251001` | `claude-opus-4-7`, `claude-sonnet-4-6`, `claude-opus-4-6` |
+| `gemini` | `pro` → `gemini-2.5-pro`<br>`flash` → `gemini-2.5-flash` | `gemini-2.5-pro`, `gemini-2.5-flash` |
+| `copilot` | `default` → `gpt-5` | `gpt-5`, `gpt-4.1` |
+
+Adding a new model:
+
+- **New ergonomic alias**: add `name → canonicalId` to `aliases` *and* add
+  `canonicalId` to `versioned` (the alias must resolve to a known versioned
+  id — `validateRegistryShape()` enforces this).
+- **New pinned version**: add it to `versioned` only.
+- **New agent**: add a top-level entry. The pure registry doesn't enforce
+  the agent id against `agentProfiles.AgentId`; that's a separate runtime
+  concern.
+
+### `BadModelSpec`
+
+When validation fails, the loader emits a `WorkflowDiagnostic` with
+`code: "bad-model"`. The `extra` field carries a `BadModelSpec` payload:
+
+```ts
+{
+  stepId: string;          // step id, or "<defaults>" for top-level default_model
+  badName: string;
+  agent: string;
+  allowedAliases: string[];   // sorted
+  allowedVersioned: string[]; // sorted
+}
+```
+
+Surfaces consuming the diagnostic stream (e.g. the recovery dialog at OP-184
+§3e) can render a "did you mean?" picker straight from these arrays.
+
+Unknown agent ids short-circuit to `bad-model` with **empty** `allowedAliases`
+and `allowedVersioned` — the empty arrays are the signal that the agent id
+itself is the typo.
+
+## Legacy WORKFLOW.md fallback ladder
+
+Many existing projects' `WORKFLOW.md` files predate the modern schema. To
+keep them working without forcing a flag-day migration, the loader applies a
+six-shape fallback ladder before declaring a file unparseable:
+
+| # | Trigger | Result |
+| :-- | :-- | :-- |
+| 1 | No frontmatter fence at all. | Synthetic workflow with one step `{ step: "kickoff", modules: [], legacyKickoffBody: <entire body> }`. `isLegacy: true`. |
+| 2 | Frontmatter fence present, no `type:` field. | Same as (1), with the body extracted post-fence. |
+| 3 | `type: workflow` but no `steps:` field. | Same as (1). Often appears mid-migration. |
+| 4 | `type: <not workflow>`. | Drop the file with `schema-mismatch` diagnostic. |
+| 5 | Frontmatter parses to `null` (e.g., empty fence `---\n---`). | Same as (1). |
+| 6 | Body contains inline `---` HRs after the frontmatter fence. | Modern parsing — fence-detection runs against the **first** `\n---` only. The HRs in the body are not mistaken for a frontmatter close. Logic matches `promptBuild.ts:stripFrontmatter` exactly. |
+
+Shape 6 is the only one that doesn't enter the legacy synthesizer — it's a
+modern workflow with HRs in its body. The fixture exists to lock the
+regression: a future refactor that swaps `indexOf("\n---", 3)` for greedy
+match would silently break shape-6 files.
+
+The loader emits a warning-severity `schema-mismatch` diagnostic for shapes
+1, 2, 3, 5 so users see "running in legacy compatibility mode" alongside the
+synth result. A separate diagnostic with severity `error` fires for shape 4.
+
+Migration: replace the legacy body with the modern frontmatter contract:
+
+```yaml
+---
+type: workflow
+schema: 1
+project: <your-slug>
+default_agent: claude
+default_model: opus
+steps:
+  - step: kickoff
+    modules: [<module-ids>]
+---
+```
+
+Then split the body into module files under `Projects/<slug>/MODULES/` (see
+[`workflow-module-schema.md`](./workflow-module-schema.md)). Run the loader
+once and inspect diagnostics — `bad-model` and `malformed-frontmatter` will
+flag any remaining gaps.
+
+## Diagnostics
+
+Every error and warning the loader emits is a `WorkflowDiagnostic`. Codes:
+
+| Code | Severity | When it fires |
+| :--- | :--- | :--- |
+| `schema-mismatch` | `error` | `type` field is missing or not `workflow`; `schema` is missing or not `1`; `extends:` resolves to a missing file. |
+| `schema-mismatch` | `warning` | Parsed via legacy fallback ladder (shapes 1, 2, 3, 5); parent file declares its own `extends:` (one-level rule). |
+| `malformed-frontmatter` | `error` | Required field missing or wrong shape; non-string entries in agent/model lists; non-object step record; duplicate step id. |
+| `malformed-frontmatter` | `warning` | `project` field disagrees with the file's enclosing folder slug; `default_model` keyed-map references an agent absent from `default_agent`. |
+| `bad-model` | `error` | A model name doesn't resolve to a known alias or versioned id for its agent. Carries `BadModelSpec` payload in `extra`. |
+
+The diagnostic stream is the primary surface for downstream recovery
+dialogs and CLI tools — consumers should pattern-match on `code` and
+`severity`, not on `message` (which may be reformatted).
+
+## What's not in this layer
+
+- **Composition** (resolving modules into step bodies, applying user-supplied
+  variables, ordering modules within a scope) — OP-197 (1d).
+- **Runtime injection** at agent launch — OP-198 (2a) and OP-199 (2b).
+- **Settings UI** for editing workflow files — OP-186 (3).
+- **Migration** of this project's own `WORKFLOW.md` into the modern shape —
+  OP-189.

--- a/plugins/op-obsidian/manifest.json
+++ b/plugins/op-obsidian/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "op-obsidian",
   "name": "Obsidian Projects (op)",
-  "version": "0.63.1",
+  "version": "0.64.0",
   "minAppVersion": "1.5.0",
   "description": "Jira-lite issue tracker for Obsidian vaults — deterministic commands backing the op workflow.",
   "author": "Eugene Archibald",

--- a/plugins/op-obsidian/package.json
+++ b/plugins/op-obsidian/package.json
@@ -1,6 +1,6 @@
 {
   "name": "op-obsidian",
-  "version": "0.63.1",
+  "version": "0.64.0",
   "description": "Obsidian plugin that owns the deterministic half of the op workflow.",
   "main": "main.js",
   "scripts": {

--- a/plugins/op-obsidian/src/__fixtures__/legacy-workflow/1-no-frontmatter.md
+++ b/plugins/op-obsidian/src/__fixtures__/legacy-workflow/1-no-frontmatter.md
@@ -1,0 +1,11 @@
+# Project workflow
+
+Always work in a git worktree. No exceptions — including one-line tweaks.
+
+## Branching
+
+Branches off `main`. PRs only.
+
+## Releases
+
+Tag a release after every merge.

--- a/plugins/op-obsidian/src/__fixtures__/legacy-workflow/2-no-type.md
+++ b/plugins/op-obsidian/src/__fixtures__/legacy-workflow/2-no-type.md
@@ -1,0 +1,12 @@
+---
+project: demo-project
+updated: 2026-04-25
+---
+
+# Project workflow
+
+Frontmatter present, but `type:` is missing. Should fall through to legacy-2.
+
+## Branching
+
+Standard PR-only flow.

--- a/plugins/op-obsidian/src/__fixtures__/legacy-workflow/3-no-steps.md
+++ b/plugins/op-obsidian/src/__fixtures__/legacy-workflow/3-no-steps.md
@@ -1,0 +1,17 @@
+---
+type: workflow
+schema: 1
+project: demo-project
+default_agent: claude
+default_model: opus
+---
+
+# Project workflow
+
+`type: workflow` is set but there's no `steps:` field. Should fall through to
+legacy-3 — the body becomes a synthetic kickoff step.
+
+## Notes
+
+This shape often appears mid-migration: an author has switched the type to
+`workflow` but hasn't decomposed the body into modules yet.

--- a/plugins/op-obsidian/src/__fixtures__/legacy-workflow/4-wrong-type.md
+++ b/plugins/op-obsidian/src/__fixtures__/legacy-workflow/4-wrong-type.md
@@ -1,0 +1,9 @@
+---
+type: project
+project: demo-project
+---
+
+# Not a workflow file
+
+`type: project` (or any other non-`workflow` value) means this file is not a
+workflow at all. Should be ignored with a `schema-mismatch` diagnostic.

--- a/plugins/op-obsidian/src/__fixtures__/legacy-workflow/5-null-frontmatter.md
+++ b/plugins/op-obsidian/src/__fixtures__/legacy-workflow/5-null-frontmatter.md
@@ -1,0 +1,7 @@
+---
+---
+
+# Project workflow
+
+Empty frontmatter fence — YAML parses to null. Should fall through to
+legacy-5 and produce a synthetic kickoff step containing this body.

--- a/plugins/op-obsidian/src/__fixtures__/legacy-workflow/6-body-fence.md
+++ b/plugins/op-obsidian/src/__fixtures__/legacy-workflow/6-body-fence.md
@@ -1,0 +1,29 @@
+---
+type: workflow
+schema: 1
+project: demo-project
+default_agent: claude
+default_model: opus
+steps:
+  - step: kickoff
+    modules: [orient]
+---
+
+# Project workflow
+
+A modern workflow whose body contains an inline `---` HR (and a second one).
+The fence-detection logic must run against the FIRST `\n---` only — these
+inline horizontal rules must NOT be mistaken for a frontmatter close.
+
+---
+
+## Section heading after HR
+
+Body content continues here. The classifier should still report `modern` and
+the parser should still find the `steps:` field.
+
+---
+
+## Another section after another HR
+
+More body content.

--- a/plugins/op-obsidian/src/modelRegistry.test.ts
+++ b/plugins/op-obsidian/src/modelRegistry.test.ts
@@ -1,0 +1,186 @@
+import { describe, it, expect } from "vitest";
+import {
+  MODEL_REGISTRY,
+  isKnownAgent,
+  knownAgents,
+  validateModelName,
+  validateRegistryShape,
+} from "./modelRegistry";
+
+describe("MODEL_REGISTRY shape", () => {
+  it("every alias resolves to a known versioned id for the same agent", () => {
+    expect(validateRegistryShape()).toEqual([]);
+  });
+
+  it("knows about claude, gemini, copilot at minimum", () => {
+    const ids = knownAgents();
+    expect(ids).toContain("claude");
+    expect(ids).toContain("gemini");
+    expect(ids).toContain("copilot");
+  });
+
+  it("returns sorted agent ids", () => {
+    const ids = knownAgents();
+    const sorted = [...ids].sort();
+    expect(ids).toEqual(sorted);
+  });
+
+  it("isKnownAgent returns true for registered agents", () => {
+    expect(isKnownAgent("claude")).toBe(true);
+    expect(isKnownAgent("gemini")).toBe(true);
+    expect(isKnownAgent("copilot")).toBe(true);
+  });
+
+  it("isKnownAgent returns false for unknown agents", () => {
+    expect(isKnownAgent("bard")).toBe(false);
+    expect(isKnownAgent("")).toBe(false);
+    expect(isKnownAgent("CLAUDE")).toBe(false); // case-sensitive
+  });
+
+  it("isKnownAgent trims input", () => {
+    expect(isKnownAgent("  claude  ")).toBe(true);
+  });
+});
+
+describe("validateModelName — claude aliases", () => {
+  it("resolves opus to canonical id", () => {
+    const r = validateModelName("claude", "opus", "step-1");
+    expect(r).toEqual({ ok: true, canonicalId: "claude-opus-4-7" });
+  });
+
+  it("resolves sonnet to canonical id", () => {
+    const r = validateModelName("claude", "sonnet", "step-1");
+    expect(r).toEqual({ ok: true, canonicalId: "claude-sonnet-4-6" });
+  });
+
+  it("resolves haiku to canonical id", () => {
+    const r = validateModelName("claude", "haiku", "step-1");
+    expect(r).toEqual({ ok: true, canonicalId: "claude-haiku-4-5-20251001" });
+  });
+});
+
+describe("validateModelName — claude versioned ids", () => {
+  it("accepts claude-opus-4-7 as-is", () => {
+    const r = validateModelName("claude", "claude-opus-4-7", "step-1");
+    expect(r).toEqual({ ok: true, canonicalId: "claude-opus-4-7" });
+  });
+
+  it("accepts claude-sonnet-4-6 as-is", () => {
+    const r = validateModelName("claude", "claude-sonnet-4-6", "step-1");
+    expect(r).toEqual({ ok: true, canonicalId: "claude-sonnet-4-6" });
+  });
+
+  it("accepts older pinned versions for users who pin", () => {
+    const r = validateModelName("claude", "claude-opus-4-6", "step-1");
+    expect(r).toEqual({ ok: true, canonicalId: "claude-opus-4-6" });
+  });
+});
+
+describe("validateModelName — gemini and copilot", () => {
+  it("resolves gemini pro alias", () => {
+    const r = validateModelName("gemini", "pro", "step-1");
+    expect(r).toEqual({ ok: true, canonicalId: "gemini-2.5-pro" });
+  });
+
+  it("accepts gemini versioned id", () => {
+    const r = validateModelName("gemini", "gemini-2.5-flash", "step-1");
+    expect(r).toEqual({ ok: true, canonicalId: "gemini-2.5-flash" });
+  });
+
+  it("resolves copilot default alias", () => {
+    const r = validateModelName("copilot", "default", "step-1");
+    expect(r).toEqual({ ok: true, canonicalId: "gpt-5" });
+  });
+
+  it("accepts copilot versioned id", () => {
+    const r = validateModelName("copilot", "gpt-4.1", "step-1");
+    expect(r).toEqual({ ok: true, canonicalId: "gpt-4.1" });
+  });
+});
+
+describe("validateModelName — bad names", () => {
+  it("rejects unknown alias for known agent with sorted allowed-arrays", () => {
+    const r = validateModelName("claude", "ultra", "step-1");
+    expect(r.ok).toBe(false);
+    if (r.ok) throw new Error("expected failure");
+    expect(r.bad.stepId).toBe("step-1");
+    expect(r.bad.badName).toBe("ultra");
+    expect(r.bad.agent).toBe("claude");
+    expect(r.bad.allowedAliases).toEqual(["haiku", "opus", "sonnet"]);
+    // Versioned list sorted lexicographically.
+    expect(r.bad.allowedVersioned).toEqual([...r.bad.allowedVersioned].sort());
+    expect(r.bad.allowedVersioned).toContain("claude-opus-4-7");
+  });
+
+  it("rejects gemini alias used against claude", () => {
+    const r = validateModelName("claude", "pro", "step-1");
+    expect(r.ok).toBe(false);
+  });
+
+  it("rejects unknown versioned id", () => {
+    const r = validateModelName("claude", "claude-opus-9-9", "step-1");
+    expect(r.ok).toBe(false);
+  });
+
+  it("rejects empty model name", () => {
+    const r = validateModelName("claude", "", "step-1");
+    expect(r.ok).toBe(false);
+    if (r.ok) throw new Error("expected failure");
+    expect(r.bad.badName).toBe("");
+    expect(r.bad.allowedAliases.length).toBeGreaterThan(0);
+  });
+});
+
+describe("validateModelName — unknown agent", () => {
+  it("returns bad-model with empty allowed-arrays", () => {
+    const r = validateModelName("bard", "ultra", "step-1");
+    expect(r.ok).toBe(false);
+    if (r.ok) throw new Error("expected failure");
+    expect(r.bad.agent).toBe("bard");
+    expect(r.bad.badName).toBe("ultra");
+    expect(r.bad.allowedAliases).toEqual([]);
+    expect(r.bad.allowedVersioned).toEqual([]);
+  });
+
+  it("empty agent id is treated as unknown", () => {
+    const r = validateModelName("", "opus", "step-1");
+    expect(r.ok).toBe(false);
+  });
+});
+
+describe("validateModelName — input hygiene", () => {
+  it("trims whitespace around the model name", () => {
+    const r = validateModelName("claude", "  opus  ", "step-1");
+    expect(r).toEqual({ ok: true, canonicalId: "claude-opus-4-7" });
+  });
+
+  it("trims whitespace around the agent id", () => {
+    const r = validateModelName("  claude  ", "opus", "step-1");
+    expect(r).toEqual({ ok: true, canonicalId: "claude-opus-4-7" });
+  });
+
+  it("preserves stepId verbatim (caller-controlled)", () => {
+    const r = validateModelName("claude", "ultra", "kickoff");
+    if (r.ok) throw new Error("expected failure");
+    expect(r.bad.stepId).toBe("kickoff");
+  });
+
+  it("uses '<defaults>' convention for top-level default_model", () => {
+    const r = validateModelName("claude", "ultra", "<defaults>");
+    if (r.ok) throw new Error("expected failure");
+    expect(r.bad.stepId).toBe("<defaults>");
+  });
+});
+
+describe("MODEL_REGISTRY — alias-vs-versioned contract", () => {
+  it("aliases and versioned can share a value but not a key", () => {
+    // It would be a bug if a bare alias also appeared in `versioned` —
+    // the registry treats `versioned` as canonical-id-shaped names. None of
+    // the seeded aliases (opus, sonnet, haiku, pro, flash, default) collide.
+    for (const reg of Object.values(MODEL_REGISTRY)) {
+      for (const alias of Object.keys(reg.aliases)) {
+        expect(reg.versioned.has(alias)).toBe(false);
+      }
+    }
+  });
+});

--- a/plugins/op-obsidian/src/modelRegistry.ts
+++ b/plugins/op-obsidian/src/modelRegistry.ts
@@ -1,0 +1,221 @@
+// Single source of truth for per-agent model validation. OP-196 (1c) of the
+// OP-184 umbrella. No I/O, no Obsidian imports.
+//
+// Each supported agent has a `{ aliases, versioned }` record:
+//
+//   - `aliases` maps a bare alias (e.g. "opus", "sonnet", "haiku") to its
+//     canonical versioned id (e.g. "claude-opus-4-7"). Aliases are the
+//     ergonomic shorthand a workflow file author writes.
+//   - `versioned` is the set of canonical ids accepted as-is. Versioned ids
+//     pin to a specific point release; aliases float forward as Anthropic ships
+//     newer model versions and we update the registry.
+//
+// A model name is valid for an agent if it appears as a key in `aliases` OR as
+// an entry in `versioned`. Resolving an alias yields its canonical id; a
+// versioned id resolves to itself.
+//
+// The registry is the seed for OP-196's `validateModelName`. It also drives
+// the recovery dialog OP-184 schedules at 3e: when validation fails, the
+// `BadModelSpec` payload carries `allowedAliases` and `allowedVersioned` so
+// the dialog can render an "did you mean?" picker without round-tripping
+// through this module.
+//
+// Adding a new model:
+//   - To add an ergonomic alias: add `name -> canonicalId` to `aliases` AND
+//     add `canonicalId` to `versioned` (the alias must resolve to a known
+//     versioned id).
+//   - To add a new pinned version: add it to `versioned` only.
+//   - To add a new agent: add a top-level entry. The pure registry doesn't
+//     enforce the agent id against `agentProfiles.AgentId` — that's a runtime
+//     concern, kept separate so this file stays Obsidian-free for vitest.
+
+/**
+ * Per-agent model registry. Opaque-by-design: callers should consume via the
+ * helpers in this module rather than reaching into the structure.
+ */
+export interface AgentModelRegistry {
+  /** Bare alias -> canonical versioned id. */
+  aliases: Record<string, string>;
+  /** Canonical versioned ids accepted as-is. */
+  versioned: Set<string>;
+}
+
+/**
+ * Validation result. `ok: true` returns the canonical id (alias resolved, or
+ * versioned id passed through). `ok: false` returns a structured `bad`
+ * payload — same shape as `WorkflowDiagnostic.extra` for `code: "bad-model"`,
+ * so callers can hand it directly to a diagnostic constructor.
+ */
+export type ValidateModelResult =
+  | { ok: true; canonicalId: string }
+  | { ok: false; bad: BadModelSpec };
+
+/**
+ * Structured payload for an invalid model name. Doubles as the typed surface
+ * for the OP-184 §3e recovery dialog and as the `extra` field of a
+ * `bad-model` `WorkflowDiagnostic`.
+ */
+export interface BadModelSpec {
+  /** Step id, or "<defaults>" when the bad spec was on top-level `default_model`. */
+  stepId: string;
+  /** The model name that failed validation. */
+  badName: string;
+  /** Agent id under which the name was checked. */
+  agent: string;
+  /** Sorted list of bare aliases the agent accepts. */
+  allowedAliases: string[];
+  /** Sorted list of canonical versioned ids the agent accepts. */
+  allowedVersioned: string[];
+}
+
+// Versioned ids are documented in the workspace system prompt:
+//   Opus 4.7    -> claude-opus-4-7
+//   Sonnet 4.6  -> claude-sonnet-4-6
+//   Haiku 4.5   -> claude-haiku-4-5-20251001
+//
+// Older 4.x and 5.x point releases are also accepted as-is for users who pin.
+// This list is conservative — adding a new pinned id is a one-line change.
+const CLAUDE_VERSIONED = new Set<string>([
+  "claude-opus-4-7",
+  "claude-opus-4-6",
+  "claude-opus-4-5",
+  "claude-sonnet-4-6",
+  "claude-sonnet-4-5",
+  "claude-haiku-4-5",
+  "claude-haiku-4-5-20251001",
+]);
+
+const GEMINI_VERSIONED = new Set<string>([
+  "gemini-2.5-pro",
+  "gemini-2.5-flash",
+  "gemini-2.0-pro",
+  "gemini-2.0-flash",
+]);
+
+const COPILOT_VERSIONED = new Set<string>([
+  "gpt-5",
+  "gpt-4.1",
+]);
+
+/**
+ * The canonical registry. Keys are agent ids. Aliases must resolve to a value
+ * present in `versioned` for the same agent — `validateRegistryShape` (used
+ * only in tests) checks this invariant.
+ */
+export const MODEL_REGISTRY: Record<string, AgentModelRegistry> = {
+  claude: {
+    aliases: {
+      opus: "claude-opus-4-7",
+      sonnet: "claude-sonnet-4-6",
+      haiku: "claude-haiku-4-5-20251001",
+    },
+    versioned: CLAUDE_VERSIONED,
+  },
+  gemini: {
+    aliases: {
+      pro: "gemini-2.5-pro",
+      flash: "gemini-2.5-flash",
+    },
+    versioned: GEMINI_VERSIONED,
+  },
+  copilot: {
+    aliases: {
+      default: "gpt-5",
+    },
+    versioned: COPILOT_VERSIONED,
+  },
+};
+
+/**
+ * Validate a model name against an agent's registry. Returns the canonical id
+ * on success, or a structured `BadModelSpec` payload on failure.
+ *
+ * Resolution order:
+ *   1. Exact match in `aliases` -> return its canonical id.
+ *   2. Exact match in `versioned` -> return as-is.
+ *   3. Otherwise -> bad-model with allowed-arrays sorted for stable output.
+ *
+ * Unknown agent id short-circuits to bad-model with empty allowed-arrays —
+ * the empty arrays signal "the agent itself isn't recognized" rather than
+ * "the agent has no models," which is impossible by construction.
+ *
+ * Trim is intentional: incoming names from YAML may carry trailing spaces if
+ * the author wrote `model: "opus "` deliberately or by accident. Trimming
+ * matches the lenient parsing the rest of the workflow-file pipeline does.
+ */
+export function validateModelName(
+  agent: string,
+  name: string,
+  stepId: string,
+): ValidateModelResult {
+  const trimmedName = (name ?? "").trim();
+  const trimmedAgent = (agent ?? "").trim();
+  const reg = MODEL_REGISTRY[trimmedAgent];
+  if (!reg) {
+    return {
+      ok: false,
+      bad: {
+        stepId,
+        badName: trimmedName,
+        agent: trimmedAgent,
+        allowedAliases: [],
+        allowedVersioned: [],
+      },
+    };
+  }
+  if (Object.prototype.hasOwnProperty.call(reg.aliases, trimmedName)) {
+    return { ok: true, canonicalId: reg.aliases[trimmedName] };
+  }
+  if (reg.versioned.has(trimmedName)) {
+    return { ok: true, canonicalId: trimmedName };
+  }
+  return {
+    ok: false,
+    bad: {
+      stepId,
+      badName: trimmedName,
+      agent: trimmedAgent,
+      allowedAliases: Object.keys(reg.aliases).sort(),
+      allowedVersioned: Array.from(reg.versioned).sort(),
+    },
+  };
+}
+
+/**
+ * Returns the list of agent ids the registry knows about, sorted. Useful for
+ * agent-id validation, settings UIs, and "did you mean?" prompts when the
+ * agent itself is the typo.
+ */
+export function knownAgents(): string[] {
+  return Object.keys(MODEL_REGISTRY).sort();
+}
+
+/**
+ * Does the registry contain an entry for this agent? Convenience over
+ * `MODEL_REGISTRY[id] != null` so callers don't need the import.
+ */
+export function isKnownAgent(agent: string): boolean {
+  return Object.prototype.hasOwnProperty.call(
+    MODEL_REGISTRY,
+    (agent ?? "").trim(),
+  );
+}
+
+/**
+ * Test-only invariant check: every alias must resolve to a known versioned id
+ * for the same agent. Exported so the test suite can assert it; not used at
+ * runtime.
+ */
+export function validateRegistryShape(): string[] {
+  const errors: string[] = [];
+  for (const [agent, reg] of Object.entries(MODEL_REGISTRY)) {
+    for (const [alias, canonicalId] of Object.entries(reg.aliases)) {
+      if (!reg.versioned.has(canonicalId)) {
+        errors.push(
+          `${agent}: alias "${alias}" -> "${canonicalId}" not in versioned set`,
+        );
+      }
+    }
+  }
+  return errors;
+}

--- a/plugins/op-obsidian/src/workflowFile.fixtures.test.ts
+++ b/plugins/op-obsidian/src/workflowFile.fixtures.test.ts
@@ -1,0 +1,142 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import {
+  classifyLegacy,
+  parseWorkflowFile,
+  stripWorkflowFrontmatter,
+  synthesizeLegacyWorkflow,
+} from "./workflowFilePure";
+
+// Fixture-driven coverage of the legacy WORKFLOW.md fallback ladder. The six
+// shapes from OP-196 scope live as real markdown files under
+// `src/__fixtures__/legacy-workflow/`. Each test reads its fixture from disk,
+// runs `classifyLegacy` (modelling what the IO layer would do with the
+// metadataCache frontmatter) and asserts the classification + synth output.
+//
+// Why fixtures vs. inline strings: fixtures are easy to eyeball as an author
+// debugging shape mismatches, and they exercise the same string-shape the
+// loader sees in the real vault (no escaping artifacts from JS literals).
+
+const FIXTURES_DIR = resolve(__dirname, "__fixtures__/legacy-workflow");
+
+function readFixture(name: string): string {
+  return readFileSync(resolve(FIXTURES_DIR, name), "utf8");
+}
+
+describe("legacy fallback fixtures", () => {
+  it("(1) 1-no-frontmatter.md classifies as legacy-1 and synthesises the body verbatim", () => {
+    const raw = readFixture("1-no-frontmatter.md");
+    const c = classifyLegacy(raw, undefined);
+    expect(c.shape).toBe("legacy-1");
+    expect(c.body).toBe(raw); // entire file becomes body — no fence to strip
+    const wf = synthesizeLegacyWorkflow({
+      path: "Projects/demo/WORKFLOW.md",
+      project: "demo",
+      body: c.body,
+      shape: c.shape,
+    });
+    expect(wf.steps[0].step).toBe("kickoff");
+    expect(wf.steps[0].legacyKickoffBody).toBe(raw);
+    expect(wf.source.isLegacy).toBe(true);
+  });
+
+  it("(2) 2-no-type.md classifies as legacy-2 (frontmatter without type field)", () => {
+    const raw = readFixture("2-no-type.md");
+    // Mirror what Obsidian's metadataCache would parse from the fixture's
+    // frontmatter: `project` + `updated`, no `type`.
+    const c = classifyLegacy(raw, { project: "demo-project", updated: "2026-04-25" });
+    expect(c.shape).toBe("legacy-2");
+    expect(c.body).toBe(stripWorkflowFrontmatter(raw));
+    // The body retains its leading blank line (the empty line after the
+    // closing fence in the fixture). Heading appears immediately after.
+    expect(c.body).toContain("# Project workflow");
+  });
+
+  it("(3) 3-no-steps.md classifies as legacy-3 (type: workflow without steps)", () => {
+    const raw = readFixture("3-no-steps.md");
+    const c = classifyLegacy(raw, {
+      type: "workflow",
+      schema: 1,
+      project: "demo-project",
+      default_agent: "claude",
+      default_model: "opus",
+    });
+    expect(c.shape).toBe("legacy-3");
+    expect(c.body).toBe(stripWorkflowFrontmatter(raw));
+  });
+
+  it("(4) 4-wrong-type.md classifies as legacy-4 — caller drops with schema-mismatch", () => {
+    const raw = readFixture("4-wrong-type.md");
+    const c = classifyLegacy(raw, { type: "project", project: "demo-project" });
+    expect(c.shape).toBe("legacy-4");
+    // synthesizeLegacyWorkflow refuses to handle this shape — caller must
+    // emit a schema-mismatch and return null instead. We assert the refusal.
+    expect(() =>
+      synthesizeLegacyWorkflow({
+        path: "Projects/demo/WORKFLOW.md",
+        project: "demo",
+        body: c.body,
+        shape: c.shape,
+      }),
+    ).toThrow(/not synthesisable/);
+  });
+
+  it("(5) 5-null-frontmatter.md classifies as legacy-5", () => {
+    const raw = readFixture("5-null-frontmatter.md");
+    // Empty fence: in Obsidian the metadataCache may return `undefined` (no
+    // cache entry) or `null`; the IO layer normalises to `null` when the file
+    // begins with a fence. Verify the null path lands at legacy-5.
+    const c = classifyLegacy(raw, null);
+    expect(c.shape).toBe("legacy-5");
+    expect(c.body).toContain("# Project workflow");
+  });
+
+  it("(6) 6-body-fence.md classifies as modern — fence-detection runs against first --- only", () => {
+    const raw = readFixture("6-body-fence.md");
+    const fm = {
+      type: "workflow",
+      schema: 1,
+      project: "demo-project",
+      default_agent: "claude",
+      default_model: "opus",
+      steps: [{ step: "kickoff", modules: ["orient"] }],
+    };
+    const c = classifyLegacy(raw, fm);
+    expect(c.shape).toBe("modern");
+    // Body retains the inline `---` HRs verbatim — the closing fence at the
+    // first occurrence is the only one consumed.
+    expect(c.body).toContain("Section heading after HR");
+    expect(c.body).toContain("Another section after another HR");
+    // And the modern parser produces a clean workflow with the declared step.
+    const r = parseWorkflowFile({
+      path: "Projects/demo/WORKFLOW.md",
+      project: "demo-project",
+      frontmatter: fm,
+    });
+    expect(r.workflow!.steps).toEqual([{ step: "kickoff", modules: ["orient"] }]);
+    expect(r.diagnostics).toEqual([]);
+  });
+});
+
+describe("legacy fixtures — round-trip via stripWorkflowFrontmatter", () => {
+  it("legacy-1 fixture: stripFrontmatter is the identity", () => {
+    const raw = readFixture("1-no-frontmatter.md");
+    expect(stripWorkflowFrontmatter(raw)).toBe(raw);
+  });
+
+  it("legacy-2 fixture: stripFrontmatter drops the fence", () => {
+    const raw = readFixture("2-no-type.md");
+    const body = stripWorkflowFrontmatter(raw);
+    expect(body).toContain("# Project workflow");
+    expect(body.includes("project: demo-project")).toBe(false); // frontmatter stripped
+  });
+
+  it("legacy-6 fixture: stripFrontmatter preserves inline --- HRs in body", () => {
+    const raw = readFixture("6-body-fence.md");
+    const body = stripWorkflowFrontmatter(raw);
+    // Two inline `---` HRs in the body must survive.
+    const hrCount = body.match(/^---$/gm)?.length ?? 0;
+    expect(hrCount).toBeGreaterThanOrEqual(2);
+  });
+});

--- a/plugins/op-obsidian/src/workflowFile.test.ts
+++ b/plugins/op-obsidian/src/workflowFile.test.ts
@@ -19,10 +19,19 @@ interface FakeFile {
   path: string;
   raw: string;
   /**
-   * `null` means the metadataCache call should return `{ frontmatter: null }`
-   * (matches Obsidian's behaviour for an empty fence in some scenarios). To
-   * model "no cache entry", use `undefined`. To model "no frontmatter at all",
-   * pair `raw: "no fence text"` with `undefined`.
+   * Models what `metadataCache.getFileCache(file)?.frontmatter` returns:
+   *
+   * - `undefined` (default): Obsidian has no cache entry for the file, or the
+   *   YAML between fences is empty / parses to a scalar. The IO loader sees
+   *   `undefined` for `fmCached`. This is the correct model for shape 1 (no
+   *   fence) and shape 5 (empty/null-YAML fence) — the two are distinguished
+   *   solely by whether `raw` starts with `---`.
+   * - `null`: a non-standard sentinel retained for defensive testing; Obsidian
+   *   never returns `null` for `frontmatter` (typed `FrontMatterCache | undefined`),
+   *   but the disambiguation code handles it correctly anyway.
+   * - A record: simulates a successfully-parsed frontmatter object (the loader
+   *   code strips Obsidian's injected `position` key, so it need not be present
+   *   in fixtures).
    */
   frontmatter?: Record<string, unknown> | null | undefined;
 }
@@ -178,13 +187,34 @@ describe("loadWorkflowFile — legacy fallback shapes", () => {
     expect((r.diagnostics[0].extra as Record<string, unknown>).actual).toBe("project");
   });
 
-  it("(5) frontmatter parses to null → legacy-5 synthetic step", async () => {
+  it("(5) frontmatter parses to null → legacy-5 synthetic step (models real Obsidian: getFileCache returns null)", async () => {
+    // Real Obsidian: for `---\n---` the YAML engine yields undefined, so
+    // `getFileCache(file)?.frontmatter` is `undefined`.  The fakeApp models
+    // this by returning `null` for getFileCache (no cache entry), which makes
+    // `fmCached = undefined` after the optional-chain.  The raw-starts-with-`---`
+    // check then maps it to `null` → shape 5.
     const raw = "---\n---\nbody after empty fence\n";
     const app = fakeApp([
       {
         path: "Projects/demo/WORKFLOW.md",
         raw,
-        frontmatter: null,
+        frontmatter: undefined, // getFileCache returns null → fmCached = undefined → fmInput = null
+      },
+    ]);
+    const r = await loadWorkflowFile(app, "demo");
+    expect(r.workflow!.source.isLegacy).toBe(true);
+    expect(r.workflow!.steps[0].legacyKickoffBody).toBe("body after empty fence\n");
+  });
+
+  it("(5-null) defensive: fmCached=null also routes to legacy-5", async () => {
+    // Obsidian never returns null for frontmatter, but the disambiguation code
+    // handles it correctly (null != undefined, so fmInput = null → shape 5).
+    const raw = "---\n---\nbody after empty fence\n";
+    const app = fakeApp([
+      {
+        path: "Projects/demo/WORKFLOW.md",
+        raw,
+        frontmatter: null, // getFileCache returns { frontmatter: null } → fmCached = null → fmInput = null
       },
     ]);
     const r = await loadWorkflowFile(app, "demo");
@@ -281,6 +311,31 @@ describe("loadWorkflowFile — extends inheritance", () => {
           d.message.includes("nested extends"),
       ),
     ).toBe(true);
+  });
+
+  it("self-reference: extends pointing at the same file emits schema-mismatch error (not 'nested extends')", async () => {
+    // A workflow that extends itself must not loop, and must get a clear
+    // "self-reference" diagnostic rather than the confusing "nested extends"
+    // warning that would fire if the guard were absent.
+    const selfRaw = modernRaw({
+      extends: "Projects/demo/WORKFLOW.md", // same path as the file itself
+    });
+    const app = fakeApp([
+      { path: "Projects/demo/WORKFLOW.md", raw: selfRaw.raw, frontmatter: selfRaw.fm },
+    ]);
+    const r = await loadWorkflowFile(app, "demo");
+    // The workflow still parses; the self-merge is skipped.
+    expect(r.workflow).not.toBeNull();
+    expect(
+      r.diagnostics.some(
+        (d) =>
+          d.code === "schema-mismatch" &&
+          d.severity === "error" &&
+          d.message.includes("self-reference"),
+      ),
+    ).toBe(true);
+    // Must NOT emit a "nested extends" warning (that's the wrong diagnosis).
+    expect(r.diagnostics.some((d) => d.message.includes("nested extends"))).toBe(false);
   });
 
   it("missing parent file emits schema-mismatch but child still loads", async () => {

--- a/plugins/op-obsidian/src/workflowFile.test.ts
+++ b/plugins/op-obsidian/src/workflowFile.test.ts
@@ -1,0 +1,389 @@
+import { describe, it, expect, vi } from "vitest";
+
+vi.mock("obsidian", () => {
+  class TFile {
+    path = "";
+    basename = "";
+    name = "";
+  }
+  return {
+    TFile,
+    normalizePath: (p: string) => p.replace(/\/+/g, "/").replace(/\/$/g, ""),
+  };
+});
+
+import { TFile } from "obsidian";
+import { loadWorkflowFile, mergeWorkflows, type WorkflowFile } from "./workflowFile";
+
+interface FakeFile {
+  path: string;
+  raw: string;
+  /**
+   * `null` means the metadataCache call should return `{ frontmatter: null }`
+   * (matches Obsidian's behaviour for an empty fence in some scenarios). To
+   * model "no cache entry", use `undefined`. To model "no frontmatter at all",
+   * pair `raw: "no fence text"` with `undefined`.
+   */
+  frontmatter?: Record<string, unknown> | null | undefined;
+}
+
+function makeFile(path: string): TFile {
+  const basename = path.split("/").pop()!.replace(/\.md$/, "");
+  const f = new TFile();
+  Object.assign(f, { path, basename, name: `${basename}.md` });
+  return f;
+}
+
+function fakeApp(files: FakeFile[]) {
+  const tfiles = files.map((f) => ({
+    tfile: makeFile(f.path),
+    raw: f.raw,
+    fm: f.frontmatter,
+  }));
+  return {
+    vault: {
+      getMarkdownFiles: () => tfiles.map((x) => x.tfile),
+      getAbstractFileByPath: (path: string) => {
+        const hit = tfiles.find((x) => x.tfile.path === path);
+        return hit ? hit.tfile : null;
+      },
+      read: async (file: TFile) => {
+        const hit = tfiles.find((x) => x.tfile === file);
+        if (!hit) throw new Error(`fakeApp: missing raw for ${file.path}`);
+        return hit.raw;
+      },
+    },
+    metadataCache: {
+      getFileCache: (file: TFile) => {
+        const hit = tfiles.find((x) => x.tfile === file);
+        if (!hit) return null;
+        if (hit.fm === undefined) return null; // no cache entry
+        return { frontmatter: hit.fm };
+      },
+    },
+  } as any;
+}
+
+const modernRaw = (over: Record<string, unknown> = {}) => {
+  const fm = {
+    type: "workflow",
+    schema: 1,
+    project: "demo",
+    default_agent: "claude",
+    default_model: "opus",
+    steps: [{ step: "kickoff", modules: ["orient"] }],
+    ...over,
+  };
+  // Build a minimal raw representation. The IO loader reads raw via
+  // `app.vault.read` to detect the leading fence; we just need the fence to
+  // be present so classification picks "modern" / "legacy-N" correctly.
+  return { fm, raw: "---\n# yaml omitted (parsed via metadataCache)\n---\nbody\n" };
+};
+
+// ---------------------------------------------------------------------------
+// loadWorkflowFile — happy path
+// ---------------------------------------------------------------------------
+
+describe("loadWorkflowFile — modern", () => {
+  it("loads a clean modern workflow with no extends", async () => {
+    const { fm, raw } = modernRaw();
+    const app = fakeApp([{ path: "Projects/demo/WORKFLOW.md", raw, frontmatter: fm }]);
+    const r = await loadWorkflowFile(app, "demo");
+    expect(r.workflow).not.toBeNull();
+    expect(r.diagnostics).toEqual([]);
+    expect(r.workflow!.steps).toHaveLength(1);
+    expect(r.workflow!.source.isLegacy).toBe(false);
+  });
+
+  it("returns null when the file doesn't exist", async () => {
+    const app = fakeApp([]);
+    const r = await loadWorkflowFile(app, "demo");
+    expect(r.workflow).toBeNull();
+    expect(r.diagnostics[0].code).toBe("schema-mismatch");
+    expect(r.diagnostics[0].message).toContain("not found");
+  });
+
+  it("returns an error for a blank project slug", async () => {
+    const app = fakeApp([]);
+    const r = await loadWorkflowFile(app, "  ");
+    expect(r.workflow).toBeNull();
+    expect(r.diagnostics[0].code).toBe("malformed-frontmatter");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// loadWorkflowFile — legacy fallback ladder (six shapes via raw input)
+// ---------------------------------------------------------------------------
+
+describe("loadWorkflowFile — legacy fallback shapes", () => {
+  it("(1) raw with no frontmatter fence → legacy-1 synthetic step", async () => {
+    const app = fakeApp([
+      {
+        path: "Projects/demo/WORKFLOW.md",
+        raw: "Just freeform workflow prose, no frontmatter.\n",
+        frontmatter: undefined,
+      },
+    ]);
+    const r = await loadWorkflowFile(app, "demo");
+    expect(r.workflow).not.toBeNull();
+    expect(r.workflow!.source.isLegacy).toBe(true);
+    expect(r.workflow!.steps).toHaveLength(1);
+    expect(r.workflow!.steps[0].step).toBe("kickoff");
+    expect(r.workflow!.steps[0].legacyKickoffBody).toBe(
+      "Just freeform workflow prose, no frontmatter.\n",
+    );
+    expect(r.diagnostics.some((d) => d.code === "schema-mismatch" && d.severity === "warning")).toBe(true);
+  });
+
+  it("(2) frontmatter present, no type field → legacy-2 synthetic step", async () => {
+    const raw = "---\nproject: demo\nupdated: 2026-04-25\n---\nbody content here\n";
+    const app = fakeApp([
+      {
+        path: "Projects/demo/WORKFLOW.md",
+        raw,
+        frontmatter: { project: "demo", updated: "2026-04-25" },
+      },
+    ]);
+    const r = await loadWorkflowFile(app, "demo");
+    expect(r.workflow!.source.isLegacy).toBe(true);
+    expect(r.workflow!.steps[0].legacyKickoffBody).toBe("body content here\n");
+  });
+
+  it("(3) type: workflow but no steps → legacy-3 synthetic step", async () => {
+    const raw = "---\ntype: workflow\nschema: 1\nproject: demo\n---\n# Body\ntext\n";
+    const app = fakeApp([
+      {
+        path: "Projects/demo/WORKFLOW.md",
+        raw,
+        frontmatter: { type: "workflow", schema: 1, project: "demo" },
+      },
+    ]);
+    const r = await loadWorkflowFile(app, "demo");
+    expect(r.workflow!.source.isLegacy).toBe(true);
+    expect(r.workflow!.steps[0].legacyKickoffBody).toBe("# Body\ntext\n");
+  });
+
+  it("(4) type: <other> → legacy-4 drop with schema-mismatch diagnostic", async () => {
+    const raw = "---\ntype: project\n---\nbody\n";
+    const app = fakeApp([
+      {
+        path: "Projects/demo/WORKFLOW.md",
+        raw,
+        frontmatter: { type: "project" },
+      },
+    ]);
+    const r = await loadWorkflowFile(app, "demo");
+    expect(r.workflow).toBeNull();
+    expect(r.diagnostics[0].code).toBe("schema-mismatch");
+    expect((r.diagnostics[0].extra as Record<string, unknown>).actual).toBe("project");
+  });
+
+  it("(5) frontmatter parses to null → legacy-5 synthetic step", async () => {
+    const raw = "---\n---\nbody after empty fence\n";
+    const app = fakeApp([
+      {
+        path: "Projects/demo/WORKFLOW.md",
+        raw,
+        frontmatter: null,
+      },
+    ]);
+    const r = await loadWorkflowFile(app, "demo");
+    expect(r.workflow!.source.isLegacy).toBe(true);
+    expect(r.workflow!.steps[0].legacyKickoffBody).toBe("body after empty fence\n");
+  });
+
+  it("(6) modern with body containing --- HR after fence → modern, fence-detection runs against first ---", async () => {
+    const raw =
+      "---\ntype: workflow\nschema: 1\nproject: demo\ndefault_agent: claude\ndefault_model: opus\nsteps: []\n---\n# Section\n\n---\n\nNot a frontmatter close — body HR.\n";
+    const app = fakeApp([
+      {
+        path: "Projects/demo/WORKFLOW.md",
+        raw,
+        frontmatter: {
+          type: "workflow",
+          schema: 1,
+          project: "demo",
+          default_agent: "claude",
+          default_model: "opus",
+          steps: [],
+        },
+      },
+    ]);
+    const r = await loadWorkflowFile(app, "demo");
+    expect(r.workflow).not.toBeNull();
+    expect(r.workflow!.source.isLegacy).toBe(false);
+    expect(r.workflow!.steps).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// loadWorkflowFile — extends inheritance
+// ---------------------------------------------------------------------------
+
+describe("loadWorkflowFile — extends inheritance", () => {
+  it("merges parent and child workflows (one level)", async () => {
+    const childRaw = modernRaw({
+      extends: "Projects/_op-workflow.md",
+      steps: [{ step: "review", modules: ["review-and-merge"] }],
+    });
+    const parentRaw = modernRaw({
+      project: "demo",
+      steps: [{ step: "kickoff", modules: ["orient"] }],
+    });
+    const app = fakeApp([
+      { path: "Projects/demo/WORKFLOW.md", raw: childRaw.raw, frontmatter: childRaw.fm },
+      { path: "Projects/_op-workflow.md", raw: parentRaw.raw, frontmatter: parentRaw.fm },
+    ]);
+    const r = await loadWorkflowFile(app, "demo");
+    expect(r.workflow).not.toBeNull();
+    expect(r.workflow!.steps.map((s) => s.step)).toEqual(["kickoff", "review"]);
+  });
+
+  it("child step overrides parent step with same id", async () => {
+    const childRaw = modernRaw({
+      extends: "Projects/_op-workflow.md",
+      steps: [{ step: "kickoff", modules: ["custom-orient"] }],
+    });
+    const parentRaw = modernRaw({
+      project: "demo",
+      steps: [
+        { step: "kickoff", modules: ["orient"] },
+        { step: "review", modules: ["review-and-merge"] },
+      ],
+    });
+    const app = fakeApp([
+      { path: "Projects/demo/WORKFLOW.md", raw: childRaw.raw, frontmatter: childRaw.fm },
+      { path: "Projects/_op-workflow.md", raw: parentRaw.raw, frontmatter: parentRaw.fm },
+    ]);
+    const r = await loadWorkflowFile(app, "demo");
+    expect(r.workflow!.steps).toHaveLength(2);
+    expect(r.workflow!.steps[0].modules).toEqual(["custom-orient"]); // child override
+    expect(r.workflow!.steps[1].step).toBe("review"); // parent preserved
+  });
+
+  it("emits schema-mismatch warning when parent declares its own extends (one-level rule)", async () => {
+    const childRaw = modernRaw({ extends: "Projects/_op-workflow.md" });
+    const parentRaw = modernRaw({
+      project: "demo",
+      extends: "Projects/_grandparent.md",
+    });
+    const app = fakeApp([
+      { path: "Projects/demo/WORKFLOW.md", raw: childRaw.raw, frontmatter: childRaw.fm },
+      { path: "Projects/_op-workflow.md", raw: parentRaw.raw, frontmatter: parentRaw.fm },
+    ]);
+    const r = await loadWorkflowFile(app, "demo");
+    expect(r.workflow).not.toBeNull();
+    expect(
+      r.diagnostics.some(
+        (d) =>
+          d.code === "schema-mismatch" &&
+          d.severity === "warning" &&
+          d.message.includes("nested extends"),
+      ),
+    ).toBe(true);
+  });
+
+  it("missing parent file emits schema-mismatch but child still loads", async () => {
+    const childRaw = modernRaw({ extends: "Projects/_missing.md" });
+    const app = fakeApp([
+      { path: "Projects/demo/WORKFLOW.md", raw: childRaw.raw, frontmatter: childRaw.fm },
+    ]);
+    const r = await loadWorkflowFile(app, "demo");
+    // Child's own workflow still parses; diagnostic surfaces the missing parent.
+    expect(r.workflow).not.toBeNull();
+    expect(
+      r.diagnostics.some(
+        (d) => d.code === "schema-mismatch" && d.message.includes("not found"),
+      ),
+    ).toBe(true);
+  });
+
+  it("child's defaults win over parent's", async () => {
+    const childRaw = modernRaw({
+      extends: "Projects/_op-workflow.md",
+      default_agent: "gemini",
+      default_model: "pro",
+    });
+    const parentRaw = modernRaw({
+      project: "demo",
+      default_agent: "claude",
+      default_model: "opus",
+    });
+    const app = fakeApp([
+      { path: "Projects/demo/WORKFLOW.md", raw: childRaw.raw, frontmatter: childRaw.fm },
+      { path: "Projects/_op-workflow.md", raw: parentRaw.raw, frontmatter: parentRaw.fm },
+    ]);
+    const r = await loadWorkflowFile(app, "demo");
+    expect(r.workflow!.defaultAgent).toEqual(["gemini"]);
+    expect(r.workflow!.defaultModel).toEqual({ kind: "all", values: ["pro"] });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// mergeWorkflows — pure
+// ---------------------------------------------------------------------------
+
+const wf = (over: Partial<WorkflowFile>): WorkflowFile => ({
+  source: { path: "child.md", project: "demo", isLegacy: false },
+  type: "workflow",
+  schema: 1,
+  project: "demo",
+  defaultAgent: ["claude"],
+  defaultModel: { kind: "all", values: ["opus"] },
+  extendsPath: null,
+  steps: [],
+  ...over,
+});
+
+describe("mergeWorkflows", () => {
+  it("preserves parent step order, appends child-only steps", () => {
+    const parent = wf({
+      steps: [
+        { step: "kickoff", modules: ["a"] },
+        { step: "review", modules: ["b"] },
+      ],
+    });
+    const child = wf({
+      source: { path: "child.md", project: "demo", isLegacy: false },
+      steps: [{ step: "finalize", modules: ["c"] }],
+    });
+    const merged = mergeWorkflows(parent, child);
+    expect(merged.steps.map((s) => s.step)).toEqual(["kickoff", "review", "finalize"]);
+  });
+
+  it("substitutes child override at the parent's slot, doesn't append duplicate", () => {
+    const parent = wf({
+      steps: [
+        { step: "kickoff", modules: ["a"] },
+        { step: "review", modules: ["b"] },
+      ],
+    });
+    const child = wf({
+      steps: [{ step: "review", modules: ["custom-b"] }],
+    });
+    const merged = mergeWorkflows(parent, child);
+    expect(merged.steps).toHaveLength(2);
+    expect(merged.steps[1].modules).toEqual(["custom-b"]);
+  });
+
+  it("falls back to parent defaults when child has empty agents/models", () => {
+    const parent = wf({
+      defaultAgent: ["claude"],
+      defaultModel: { kind: "all", values: ["opus"] },
+    });
+    const child = wf({
+      defaultAgent: [],
+      defaultModel: { kind: "all", values: [] },
+    });
+    const merged = mergeWorkflows(parent, child);
+    expect(merged.defaultAgent).toEqual(["claude"]);
+    expect(merged.defaultModel).toEqual({ kind: "all", values: ["opus"] });
+  });
+
+  it("merged source identifies as the child", () => {
+    const parent = wf({ source: { path: "parent.md", project: "demo", isLegacy: false } });
+    const child = wf({ source: { path: "child.md", project: "demo", isLegacy: false } });
+    const merged = mergeWorkflows(parent, child);
+    expect(merged.source).toEqual(child.source);
+  });
+});

--- a/plugins/op-obsidian/src/workflowFile.test.ts
+++ b/plugins/op-obsidian/src/workflowFile.test.ts
@@ -187,18 +187,20 @@ describe("loadWorkflowFile — legacy fallback shapes", () => {
     expect((r.diagnostics[0].extra as Record<string, unknown>).actual).toBe("project");
   });
 
-  it("(5) frontmatter parses to null → legacy-5 synthetic step (models real Obsidian: getFileCache returns null)", async () => {
-    // Real Obsidian: for `---\n---` the YAML engine yields undefined, so
-    // `getFileCache(file)?.frontmatter` is `undefined`.  The fakeApp models
-    // this by returning `null` for getFileCache (no cache entry), which makes
-    // `fmCached = undefined` after the optional-chain.  The raw-starts-with-`---`
-    // check then maps it to `null` → shape 5.
+  it("(5) frontmatter parses to null → legacy-5 synthetic step (fmCached=undefined via fakeApp)", async () => {
+    // Real Obsidian: for `---\n---` the YAML engine yields undefined for the
+    // fence content, so `getFileCache(file)?.frontmatter` is `undefined`.
+    // fakeApp models this by returning `null` from getFileCache when `frontmatter`
+    // is `undefined` in the fixture (simulating "no usable frontmatter"), which
+    // makes `getFileCache(file)?.frontmatter` evaluate to `undefined` via the
+    // optional chain.  The raw-starts-with-`---` check then maps fmCached=undefined
+    // to fmInput=null → shape 5.
     const raw = "---\n---\nbody after empty fence\n";
     const app = fakeApp([
       {
         path: "Projects/demo/WORKFLOW.md",
         raw,
-        frontmatter: undefined, // getFileCache returns null → fmCached = undefined → fmInput = null
+        frontmatter: undefined, // fakeApp returns null for getFileCache → null?.frontmatter = undefined = fmCached
       },
     ]);
     const r = await loadWorkflowFile(app, "demo");
@@ -207,14 +209,15 @@ describe("loadWorkflowFile — legacy fallback shapes", () => {
   });
 
   it("(5-null) defensive: fmCached=null also routes to legacy-5", async () => {
-    // Obsidian never returns null for frontmatter, but the disambiguation code
-    // handles it correctly (null != undefined, so fmInput = null → shape 5).
+    // Obsidian never returns null for frontmatter (typed FrontMatterCache | undefined),
+    // but the disambiguation code handles it gracefully (fmCached=null satisfies
+    // `!== undefined`, so fmInput = null → classifyLegacy(raw, null) → shape 5).
     const raw = "---\n---\nbody after empty fence\n";
     const app = fakeApp([
       {
         path: "Projects/demo/WORKFLOW.md",
         raw,
-        frontmatter: null, // getFileCache returns { frontmatter: null } → fmCached = null → fmInput = null
+        frontmatter: null, // fakeApp returns { frontmatter: null } → fmCached = null → fmInput = null
       },
     ]);
     const r = await loadWorkflowFile(app, "demo");

--- a/plugins/op-obsidian/src/workflowFile.ts
+++ b/plugins/op-obsidian/src/workflowFile.ts
@@ -1,0 +1,274 @@
+import { App, TFile, normalizePath } from "obsidian";
+import {
+  classifyLegacy,
+  parseWorkflowFile,
+  synthesizeLegacyWorkflow,
+  validateWorkflowModels,
+  type WorkflowFile,
+  type WorkflowStep,
+} from "./workflowFilePure";
+import type { WorkflowDiagnostic } from "./workflowDiagnostic";
+
+export type {
+  AgentSpec,
+  BadModelSpec,
+  LegacyClassification,
+  LegacyShape,
+  ModelSpec,
+  ParseAgentSpecResult,
+  ParseModelSpecResult,
+  ParseWorkflowArgs,
+  ParseWorkflowResult,
+  WorkflowFile,
+  WorkflowFileSource,
+  WorkflowStep,
+} from "./workflowFilePure";
+export {
+  classifyLegacy,
+  parseAgentSpec,
+  parseModelSpec,
+  parseWorkflowFile,
+  stripWorkflowFrontmatter,
+  synthesizeLegacyWorkflow,
+  validateWorkflowModels,
+} from "./workflowFilePure";
+
+const PROJECTS_ROOT = "Projects/";
+
+export interface LoadWorkflowResult {
+  /** Resolved + merged workflow, or `null` if the file couldn't be salvaged. */
+  workflow: WorkflowFile | null;
+  diagnostics: WorkflowDiagnostic[];
+}
+
+/**
+ * Load a project's `WORKFLOW.md`, applying:
+ *   - Legacy fallback ladder (six shapes — see `classifyLegacy`).
+ *   - One level of `extends:` inheritance against another workflow file
+ *     (typically `Projects/_op-workflow.md`). Transitive chains are NOT
+ *     followed — a parent's own `extends:` is ignored with a `schema-mismatch`
+ *     diagnostic.
+ *   - Model-name validation against `modelRegistry`.
+ *
+ * Pure logic (parsing, classification, merging) lives in `workflowFilePure.ts`.
+ * This function is the IO seam:
+ *
+ *   1. Read the file's raw content + frontmatter (via metadataCache).
+ *   2. Classify shape → modern or legacy-1..5.
+ *   3. Modern → `parseWorkflowFile`. Legacy 1/2/3/5 → `synthesizeLegacyWorkflow`.
+ *      Legacy 4 → emit `schema-mismatch` and return null.
+ *   4. If the modern workflow declared `extends:`, recursively load the parent
+ *      (one level only) and merge.
+ *   5. Run `validateWorkflowModels` on the final merged workflow.
+ *
+ * Caller responsibility: invoke after `workspace.onLayoutReady` so
+ * `metadataCache` has resolved frontmatter for the project's files. Earlier
+ * calls may surface spurious `malformed-frontmatter` diagnostics.
+ */
+export async function loadWorkflowFile(
+  app: App,
+  project: string,
+): Promise<LoadWorkflowResult> {
+  const slug = project.trim();
+  if (!slug) {
+    return {
+      workflow: null,
+      diagnostics: [
+        {
+          code: "malformed-frontmatter",
+          severity: "error",
+          message: "loadWorkflowFile: project slug is required.",
+          extra: { field: "project" },
+        },
+      ],
+    };
+  }
+  const path = normalizePath(`${PROJECTS_ROOT}${slug}/WORKFLOW.md`);
+  return loadAtPath(app, { path, project: slug, allowExtends: true });
+}
+
+interface LoadAtPathArgs {
+  path: string;
+  project: string;
+  /**
+   * When `false`, the loader rejects an `extends:` field on the loaded file
+   * with a `schema-mismatch` diagnostic. Used for the recursive call so we
+   * enforce the "one level only" v1 rule.
+   */
+  allowExtends: boolean;
+}
+
+async function loadAtPath(app: App, args: LoadAtPathArgs): Promise<LoadWorkflowResult> {
+  const file = app.vault.getAbstractFileByPath(args.path);
+  if (!(file instanceof TFile)) {
+    return {
+      workflow: null,
+      diagnostics: [
+        {
+          code: "schema-mismatch",
+          severity: "error",
+          message: `Workflow file not found: ${args.path}.`,
+          extra: { path: args.path, expected: "existing TFile", actual: "missing" },
+        },
+      ],
+    };
+  }
+  const raw = await app.vault.read(file);
+  // metadataCache.getFileCache(file)?.frontmatter:
+  //   - `undefined` when frontmatter is absent or YAML parsed to null
+  //   - the parsed object otherwise (`{}` for an empty fence)
+  // We disambiguate "no fence at all" from "fence with null/empty content"
+  // using the raw content's leading `---`.
+  const fmCached = app.metadataCache.getFileCache(file)?.frontmatter;
+  const fmInput: Record<string, unknown> | null | undefined = raw.startsWith("---")
+    ? fmCached === undefined
+      ? null
+      : fmCached
+    : undefined;
+
+  const classification = classifyLegacy(raw, fmInput);
+
+  // Legacy 1/2/3/5 — synthesize a workflow from the body.
+  if (
+    classification.shape === "legacy-1" ||
+    classification.shape === "legacy-2" ||
+    classification.shape === "legacy-3" ||
+    classification.shape === "legacy-5"
+  ) {
+    const workflow = synthesizeLegacyWorkflow({
+      path: args.path,
+      project: args.project,
+      body: classification.body,
+      shape: classification.shape,
+    });
+    return { workflow, diagnostics: [legacyShapeDiagnostic(args.path, classification.shape)] };
+  }
+
+  // Legacy 4 — wrong type. Drop the file with a schema-mismatch diagnostic.
+  if (classification.shape === "legacy-4") {
+    const actualType = (fmInput && typeof fmInput === "object" && !Array.isArray(fmInput))
+      ? (fmInput as Record<string, unknown>).type
+      : undefined;
+    return {
+      workflow: null,
+      diagnostics: [
+        {
+          code: "schema-mismatch",
+          severity: "error",
+          message: `${args.path}: type must be "workflow", got "${String(actualType)}".`,
+          extra: { path: args.path, field: "type", expected: "workflow", actual: String(actualType) },
+        },
+      ],
+    };
+  }
+
+  // Modern — hand off to the pure parser.
+  const parsed = parseWorkflowFile({
+    path: args.path,
+    project: args.project,
+    frontmatter: fmInput as Record<string, unknown>,
+  });
+  if (!parsed.workflow) {
+    return { workflow: null, diagnostics: parsed.diagnostics };
+  }
+
+  let workflow = parsed.workflow;
+  const diagnostics = [...parsed.diagnostics];
+
+  // extends: one level only. The recursive load forbids further extension.
+  if (workflow.extendsPath !== null) {
+    if (!args.allowExtends) {
+      diagnostics.push({
+        code: "schema-mismatch",
+        severity: "warning",
+        message: `${args.path}: nested extends is not supported (v1 allows one level only). Ignoring grandparent.`,
+        extra: { path: args.path, field: "extends", expected: "absent for parent files", actual: workflow.extendsPath },
+      });
+    } else {
+      const parentLoad = await loadAtPath(app, {
+        path: normalizePath(workflow.extendsPath),
+        project: args.project,
+        allowExtends: false,
+      });
+      diagnostics.push(...parentLoad.diagnostics);
+      if (parentLoad.workflow) {
+        workflow = mergeWorkflows(parentLoad.workflow, workflow);
+      }
+    }
+  }
+
+  // Validate models on the post-merge workflow.
+  diagnostics.push(...validateWorkflowModels(workflow));
+
+  return { workflow, diagnostics };
+}
+
+function legacyShapeDiagnostic(path: string, shape: string): WorkflowDiagnostic {
+  return {
+    code: "schema-mismatch",
+    severity: "warning",
+    message:
+      `${path}: parsed via legacy fallback (${shape}). Body wrapped into a synthetic kickoff step. ` +
+      `Migrate to the modern schema (\`type: workflow\`, \`schema: 1\`, \`steps: [...]\`) — see ` +
+      `docs/specs/workflow-file-schema.md.`,
+    extra: { path, field: "<file>", expected: "modern schema", actual: shape },
+  };
+}
+
+/**
+ * Shallow-merge a parent workflow with a child. Child wins on top-level
+ * collisions (`defaultAgent`, `defaultModel`, `extendsPath`). Steps are
+ * concatenated parent-first, child-second; a child step that repeats a
+ * parent's `step:` id replaces the parent entry by id (the merged step list
+ * preserves parent order for inherited steps and child order for new steps).
+ *
+ * `source` and `project` come from the child — the merged workflow identifies
+ * as the child file. `isLegacy` is OR'd: any legacy ancestor taints the chain.
+ *
+ * Pure: no IO, exposed for testability.
+ */
+export function mergeWorkflows(parent: WorkflowFile, child: WorkflowFile): WorkflowFile {
+  // Map child step ids for fast override lookup.
+  const childById = new Map<string, WorkflowStep>();
+  for (const s of child.steps) childById.set(s.step, s);
+
+  const mergedSteps: WorkflowStep[] = [];
+  const consumedChildIds = new Set<string>();
+
+  // Walk parent steps first; substitute child override when present.
+  for (const ps of parent.steps) {
+    const override = childById.get(ps.step);
+    if (override) {
+      mergedSteps.push(override);
+      consumedChildIds.add(ps.step);
+    } else {
+      mergedSteps.push(ps);
+    }
+  }
+  // Append remaining child-only steps in their original order.
+  for (const cs of child.steps) {
+    if (!consumedChildIds.has(cs.step)) mergedSteps.push(cs);
+  }
+
+  return {
+    source: child.source,
+    type: "workflow",
+    schema: 1,
+    project: child.project,
+    defaultAgent: child.defaultAgent.length > 0 ? child.defaultAgent : parent.defaultAgent,
+    defaultModel: defaultModelFallback(parent.defaultModel, child.defaultModel),
+    extendsPath: child.extendsPath, // child's `extends:` describes how it got here; preserved for surfacing
+    steps: mergedSteps,
+  };
+}
+
+function defaultModelFallback(
+  parent: WorkflowFile["defaultModel"],
+  child: WorkflowFile["defaultModel"],
+): WorkflowFile["defaultModel"] {
+  // Treat an empty `kind: "all"` list on the child as "child didn't supply
+  // a default" and fall through to the parent.
+  if (child.kind === "all" && child.values.length === 0) return parent;
+  if (child.kind === "perAgent" && Object.keys(child.perAgent).length === 0) return parent;
+  return child;
+}

--- a/plugins/op-obsidian/src/workflowFile.ts
+++ b/plugins/op-obsidian/src/workflowFile.ts
@@ -115,10 +115,16 @@ async function loadAtPath(app: App, args: LoadAtPathArgs): Promise<LoadWorkflowR
   }
   const raw = await app.vault.read(file);
   // metadataCache.getFileCache(file)?.frontmatter:
-  //   - `undefined` when frontmatter is absent or YAML parsed to null
-  //   - the parsed object otherwise (`{}` for an empty fence)
-  // We disambiguate "no fence at all" from "fence with null/empty content"
-  // using the raw content's leading `---`.
+  //   - `undefined` when the frontmatter fence is absent OR when the fence's
+  //     YAML content is empty / parses to a scalar (e.g. `---\n---`).
+  //     Obsidian's YAML engine yields `undefined` in both cases.
+  //   - A FrontMatterCache object (extends Record<string, any>, includes a
+  //     `position` key) when the fence contains parseable key-value YAML.
+  //
+  // We disambiguate "no fence at all" (shape 1) from "fence with empty/null
+  // YAML" (shape 5) using the raw content's leading `---`, mapping Obsidian's
+  // `undefined` → `null` so `classifyLegacy` can tell shape 1 from shape 5
+  // without inspecting the raw string a second time.
   const fmCached = app.metadataCache.getFileCache(file)?.frontmatter;
   const fmInput: Record<string, unknown> | null | undefined = raw.startsWith("---")
     ? fmCached === undefined
@@ -183,6 +189,18 @@ async function loadAtPath(app: App, args: LoadAtPathArgs): Promise<LoadWorkflowR
         severity: "warning",
         message: `${args.path}: nested extends is not supported (v1 allows one level only). Ignoring grandparent.`,
         extra: { path: args.path, field: "extends", expected: "absent for parent files", actual: workflow.extendsPath },
+      });
+    } else if (normalizePath(workflow.extendsPath) === args.path) {
+      // Self-reference: the file's `extends:` points at itself. Without this
+      // guard the recursive load would re-read the same file (with
+      // `allowExtends: false`), surface a misleading "nested extends" warning,
+      // and then merge the workflow with itself (an idempotent but confusing
+      // no-op). Emit a clear error and skip the merge.
+      diagnostics.push({
+        code: "schema-mismatch",
+        severity: "error",
+        message: `${args.path}: extends points at the same file (self-reference is not permitted). Ignoring.`,
+        extra: { path: args.path, field: "extends", expected: "a different file path", actual: workflow.extendsPath },
       });
     } else {
       const parentLoad = await loadAtPath(app, {

--- a/plugins/op-obsidian/src/workflowFilePure.test.ts
+++ b/plugins/op-obsidian/src/workflowFilePure.test.ts
@@ -1,0 +1,674 @@
+import { describe, it, expect } from "vitest";
+import {
+  classifyLegacy,
+  parseAgentSpec,
+  parseModelSpec,
+  parseWorkflowFile,
+  stripWorkflowFrontmatter,
+  synthesizeLegacyWorkflow,
+  validateWorkflowModels,
+  type WorkflowFile,
+} from "./workflowFilePure";
+
+const PATH = "Projects/demo/WORKFLOW.md";
+const PROJECT = "demo";
+
+const ctx = (over: Partial<{ field: string; optional: boolean }> = {}) => ({
+  path: PATH,
+  field: over.field ?? "default_agent",
+  optional: over.optional,
+});
+
+// ---------------------------------------------------------------------------
+// parseAgentSpec
+// ---------------------------------------------------------------------------
+
+describe("parseAgentSpec — scalar", () => {
+  it("wraps a scalar string", () => {
+    const r = parseAgentSpec("claude", ctx());
+    expect(r.value).toEqual(["claude"]);
+    expect(r.diagnostics).toEqual([]);
+  });
+
+  it("trims surrounding whitespace", () => {
+    const r = parseAgentSpec("  claude  ", ctx());
+    expect(r.value).toEqual(["claude"]);
+  });
+
+  it("rejects whitespace-only string", () => {
+    const r = parseAgentSpec("   ", ctx());
+    expect(r.value).toBeNull();
+    expect(r.diagnostics[0].code).toBe("malformed-frontmatter");
+  });
+
+  it("rejects empty string", () => {
+    const r = parseAgentSpec("", ctx());
+    expect(r.value).toBeNull();
+  });
+});
+
+describe("parseAgentSpec — list", () => {
+  it("accepts a list of strings", () => {
+    const r = parseAgentSpec(["claude", "gemini"], ctx());
+    expect(r.value).toEqual(["claude", "gemini"]);
+  });
+
+  it("trims and dedups while preserving order", () => {
+    const r = parseAgentSpec(["claude", " claude ", "gemini", "claude"], ctx());
+    expect(r.value).toEqual(["claude", "gemini"]);
+  });
+
+  it("silently drops blank entries", () => {
+    const r = parseAgentSpec(["claude", "", "  ", "gemini"], ctx());
+    expect(r.value).toEqual(["claude", "gemini"]);
+    expect(r.diagnostics).toEqual([]);
+  });
+
+  it("rejects mixed list with non-string entries", () => {
+    const r = parseAgentSpec(["claude", 1, true], ctx());
+    expect(r.value).toBeNull();
+    expect(r.diagnostics).toHaveLength(2);
+  });
+
+  it("rejects empty list", () => {
+    const r = parseAgentSpec([], ctx());
+    expect(r.value).toBeNull();
+    expect(r.diagnostics[0].code).toBe("malformed-frontmatter");
+  });
+});
+
+describe("parseAgentSpec — non-scalar non-list", () => {
+  it("rejects a plain object", () => {
+    const r = parseAgentSpec({ claude: "opus" }, ctx());
+    expect(r.value).toBeNull();
+  });
+
+  it("rejects a Date", () => {
+    const r = parseAgentSpec(new Date(), ctx());
+    expect(r.value).toBeNull();
+  });
+
+  it("rejects a number", () => {
+    const r = parseAgentSpec(42, ctx());
+    expect(r.value).toBeNull();
+  });
+
+  it("rejects a boolean", () => {
+    const r = parseAgentSpec(true, ctx());
+    expect(r.value).toBeNull();
+  });
+});
+
+describe("parseAgentSpec — optional", () => {
+  it("accepts undefined when optional", () => {
+    const r = parseAgentSpec(undefined, ctx({ optional: true }));
+    expect(r.value).toBeNull();
+    expect(r.diagnostics).toEqual([]);
+  });
+
+  it("accepts null when optional", () => {
+    const r = parseAgentSpec(null, ctx({ optional: true }));
+    expect(r.value).toBeNull();
+    expect(r.diagnostics).toEqual([]);
+  });
+
+  it("rejects undefined when not optional", () => {
+    const r = parseAgentSpec(undefined, ctx());
+    expect(r.value).toBeNull();
+    expect(r.diagnostics).toHaveLength(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// parseModelSpec
+// ---------------------------------------------------------------------------
+
+describe("parseModelSpec — scalar / list / per-agent map", () => {
+  it("scalar string -> kind:all with one value", () => {
+    const r = parseModelSpec("opus", ctx({ field: "default_model" }));
+    expect(r.value).toEqual({ kind: "all", values: ["opus"] });
+  });
+
+  it("trims a scalar string", () => {
+    const r = parseModelSpec("  opus  ", ctx({ field: "default_model" }));
+    expect(r.value).toEqual({ kind: "all", values: ["opus"] });
+  });
+
+  it("list of strings -> kind:all with values", () => {
+    const r = parseModelSpec(["opus", "sonnet"], ctx({ field: "default_model" }));
+    expect(r.value).toEqual({ kind: "all", values: ["opus", "sonnet"] });
+  });
+
+  it("list dedups while preserving order", () => {
+    const r = parseModelSpec(["opus", "opus", "sonnet"], ctx({ field: "default_model" }));
+    expect(r.value).toEqual({ kind: "all", values: ["opus", "sonnet"] });
+  });
+
+  it("plain object -> kind:perAgent with per-key list-or-scalar parsing", () => {
+    const r = parseModelSpec(
+      { claude: "opus", gemini: ["pro", "flash"] },
+      ctx({ field: "default_model" }),
+    );
+    expect(r.value).toEqual({
+      kind: "perAgent",
+      perAgent: { claude: ["opus"], gemini: ["pro", "flash"] },
+    });
+  });
+});
+
+describe("parseModelSpec — bad shapes", () => {
+  it("rejects empty list", () => {
+    const r = parseModelSpec([], ctx({ field: "default_model" }));
+    expect(r.value).toBeNull();
+  });
+
+  it("rejects empty per-agent object", () => {
+    const r = parseModelSpec({}, ctx({ field: "default_model" }));
+    expect(r.value).toBeNull();
+  });
+
+  it("rejects Date", () => {
+    const r = parseModelSpec(new Date(), ctx({ field: "default_model" }));
+    expect(r.value).toBeNull();
+  });
+
+  it("rejects number", () => {
+    const r = parseModelSpec(42, ctx({ field: "default_model" }));
+    expect(r.value).toBeNull();
+  });
+
+  it("propagates per-key failures and drops bad entries", () => {
+    const r = parseModelSpec(
+      { claude: "opus", gemini: 42 },
+      ctx({ field: "default_model" }),
+    );
+    // The valid entry survives, the bad one emits a diagnostic.
+    expect(r.value).toEqual({
+      kind: "perAgent",
+      perAgent: { claude: ["opus"] },
+    });
+    expect(r.diagnostics.length).toBeGreaterThan(0);
+  });
+
+  it("rejects per-agent map with empty key", () => {
+    const r = parseModelSpec({ "": "opus" }, ctx({ field: "default_model" }));
+    expect(r.value).toBeNull();
+  });
+});
+
+describe("parseModelSpec — optional", () => {
+  it("undefined returns null + no diagnostics when optional", () => {
+    const r = parseModelSpec(undefined, ctx({ field: "model", optional: true }));
+    expect(r.value).toBeNull();
+    expect(r.diagnostics).toEqual([]);
+  });
+
+  it("undefined returns null + 1 diagnostic when required", () => {
+    const r = parseModelSpec(undefined, ctx({ field: "default_model" }));
+    expect(r.value).toBeNull();
+    expect(r.diagnostics).toHaveLength(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// stripWorkflowFrontmatter — fence detection (shape 6)
+// ---------------------------------------------------------------------------
+
+describe("stripWorkflowFrontmatter", () => {
+  it("strips frontmatter fence", () => {
+    const raw = "---\ntype: workflow\n---\nbody\n";
+    expect(stripWorkflowFrontmatter(raw)).toBe("body\n");
+  });
+
+  it("returns input verbatim when no fence", () => {
+    const raw = "no fence here\n";
+    expect(stripWorkflowFrontmatter(raw)).toBe(raw);
+  });
+
+  it("matches FIRST closing fence — body HR is preserved (shape 6)", () => {
+    const raw = "---\ntype: workflow\n---\n# Title\n---\nhr-rule-after-frontmatter\n---\nmore\n";
+    const body = stripWorkflowFrontmatter(raw);
+    // Body retains the inline `---` lines verbatim; only the first closing
+    // fence at position 14ish is consumed.
+    expect(body).toBe("# Title\n---\nhr-rule-after-frontmatter\n---\nmore\n");
+  });
+
+  it("returns empty string when fence is unterminated", () => {
+    const raw = "---\ntype: workflow\nno-close-fence";
+    expect(stripWorkflowFrontmatter(raw)).toBe(raw);
+  });
+
+  it("returns empty string when content ends right after closing fence", () => {
+    const raw = "---\ntype: workflow\n---";
+    // `indexOf("\n---", 3)` finds the `\n---` before the closing fence.
+    // Then `indexOf("\n", end + 4)` looks past the closing `---` for the
+    // newline that bounds the body — there isn't one, so afterFence = -1
+    // and the function returns "" (matches promptBuild.ts:stripFrontmatter).
+    expect(stripWorkflowFrontmatter(raw)).toBe("");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// classifyLegacy — six shapes
+// ---------------------------------------------------------------------------
+
+describe("classifyLegacy — six shapes", () => {
+  it("(1) no frontmatter at all -> legacy-1", () => {
+    const c = classifyLegacy("Just some workflow prose.\n", undefined);
+    expect(c.shape).toBe("legacy-1");
+    expect(c.body).toBe("Just some workflow prose.\n");
+  });
+
+  it("(2) frontmatter present, no type field -> legacy-2", () => {
+    const raw = "---\nproject: demo\n---\nbody\n";
+    const c = classifyLegacy(raw, { project: "demo" });
+    expect(c.shape).toBe("legacy-2");
+    expect(c.body).toBe("body\n");
+  });
+
+  it("(3) type: workflow but no steps -> legacy-3", () => {
+    const raw = "---\ntype: workflow\nschema: 1\n---\nbody\n";
+    const c = classifyLegacy(raw, { type: "workflow", schema: 1 });
+    expect(c.shape).toBe("legacy-3");
+    expect(c.body).toBe("body\n");
+  });
+
+  it("(4) type: <other> -> legacy-4 (drop)", () => {
+    const raw = "---\ntype: project\n---\nbody\n";
+    const c = classifyLegacy(raw, { type: "project" });
+    expect(c.shape).toBe("legacy-4");
+  });
+
+  it("(5) frontmatter parses to null -> legacy-5", () => {
+    const raw = "---\n---\nbody\n";
+    const c = classifyLegacy(raw, null);
+    expect(c.shape).toBe("legacy-5");
+    expect(c.body).toBe("body\n");
+  });
+
+  it("(6) body contains --- after fence -> classifies as modern when type+steps present", () => {
+    const raw = "---\ntype: workflow\nschema: 1\nsteps: []\n---\n# Section\n---\nhr-after-frontmatter\n";
+    const c = classifyLegacy(raw, { type: "workflow", schema: 1, steps: [] });
+    expect(c.shape).toBe("modern");
+  });
+
+  it("(6) body --- is preserved in classification body output for legacy-3", () => {
+    const raw = "---\ntype: workflow\n---\n# Section\n---\nhr-after-frontmatter\n";
+    const c = classifyLegacy(raw, { type: "workflow" });
+    expect(c.shape).toBe("legacy-3");
+    expect(c.body).toBe("# Section\n---\nhr-after-frontmatter\n");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// synthesizeLegacyWorkflow
+// ---------------------------------------------------------------------------
+
+describe("synthesizeLegacyWorkflow", () => {
+  it("produces a synthetic kickoff step carrying the body verbatim", () => {
+    const wf = synthesizeLegacyWorkflow({
+      path: PATH,
+      project: PROJECT,
+      body: "the entire WORKFLOW.md body\n",
+      shape: "legacy-1",
+    });
+    expect(wf.source).toEqual({ path: PATH, project: PROJECT, isLegacy: true });
+    expect(wf.steps).toHaveLength(1);
+    expect(wf.steps[0]).toEqual({
+      step: "kickoff",
+      modules: [],
+      legacyKickoffBody: "the entire WORKFLOW.md body\n",
+    });
+    expect(wf.defaultAgent).toEqual([]);
+    expect(wf.defaultModel).toEqual({ kind: "all", values: [] });
+    expect(wf.extendsPath).toBeNull();
+  });
+
+  it("works for shapes 1, 2, 3, 5", () => {
+    for (const shape of ["legacy-1", "legacy-2", "legacy-3", "legacy-5"] as const) {
+      const wf = synthesizeLegacyWorkflow({ path: PATH, project: PROJECT, body: "x", shape });
+      expect(wf.steps[0].legacyKickoffBody).toBe("x");
+    }
+  });
+
+  it("throws for non-synthesisable shapes (defensive)", () => {
+    expect(() =>
+      synthesizeLegacyWorkflow({ path: PATH, project: PROJECT, body: "x", shape: "modern" }),
+    ).toThrow();
+    expect(() =>
+      synthesizeLegacyWorkflow({ path: PATH, project: PROJECT, body: "x", shape: "legacy-4" }),
+    ).toThrow();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// parseWorkflowFile — modern path
+// ---------------------------------------------------------------------------
+
+const modernFm = (over: Record<string, unknown> = {}) => ({
+  type: "workflow",
+  schema: 1,
+  project: PROJECT,
+  default_agent: "claude",
+  default_model: "opus",
+  steps: [
+    { step: "kickoff", modules: ["orient"] },
+  ],
+  ...over,
+});
+
+describe("parseWorkflowFile — happy path", () => {
+  it("parses a minimal modern workflow", () => {
+    const r = parseWorkflowFile({ path: PATH, project: PROJECT, frontmatter: modernFm() });
+    expect(r.workflow).not.toBeNull();
+    expect(r.diagnostics).toEqual([]);
+    const wf = r.workflow!;
+    expect(wf.type).toBe("workflow");
+    expect(wf.schema).toBe(1);
+    expect(wf.project).toBe(PROJECT);
+    expect(wf.defaultAgent).toEqual(["claude"]);
+    expect(wf.defaultModel).toEqual({ kind: "all", values: ["opus"] });
+    expect(wf.extendsPath).toBeNull();
+    expect(wf.steps).toHaveLength(1);
+    expect(wf.steps[0]).toEqual({ step: "kickoff", modules: ["orient"] });
+    expect(wf.source).toEqual({ path: PATH, project: PROJECT, isLegacy: false });
+  });
+
+  it("parses a step with agent + model overrides", () => {
+    const fm = modernFm({
+      steps: [
+        { step: "kickoff", modules: ["orient"], agent: "gemini", model: "flash" },
+      ],
+    });
+    const r = parseWorkflowFile({ path: PATH, project: PROJECT, frontmatter: fm });
+    expect(r.workflow!.steps[0].agent).toEqual(["gemini"]);
+    expect(r.workflow!.steps[0].model).toEqual({ kind: "all", values: ["flash"] });
+  });
+
+  it("parses a per-agent default_model", () => {
+    const fm = modernFm({
+      default_agent: ["claude", "gemini"],
+      default_model: { claude: "opus", gemini: "pro" },
+    });
+    const r = parseWorkflowFile({ path: PATH, project: PROJECT, frontmatter: fm });
+    expect(r.workflow!.defaultModel).toEqual({
+      kind: "perAgent",
+      perAgent: { claude: ["opus"], gemini: ["pro"] },
+    });
+  });
+
+  it("captures extends path verbatim", () => {
+    const fm = modernFm({ extends: "Projects/_op-workflow.md" });
+    const r = parseWorkflowFile({ path: PATH, project: PROJECT, frontmatter: fm });
+    expect(r.workflow!.extendsPath).toBe("Projects/_op-workflow.md");
+  });
+});
+
+describe("parseWorkflowFile — type / schema gates", () => {
+  it("emits schema-mismatch when type is missing", () => {
+    const fm = modernFm();
+    delete (fm as Record<string, unknown>).type;
+    const r = parseWorkflowFile({ path: PATH, project: PROJECT, frontmatter: fm });
+    expect(r.workflow).toBeNull();
+    expect(r.diagnostics[0].code).toBe("schema-mismatch");
+  });
+
+  it("emits schema-mismatch when type is wrong", () => {
+    const fm = modernFm({ type: "project" });
+    const r = parseWorkflowFile({ path: PATH, project: PROJECT, frontmatter: fm });
+    expect(r.workflow).toBeNull();
+    expect(r.diagnostics[0].code).toBe("schema-mismatch");
+  });
+
+  it("emits schema-mismatch when schema is wrong", () => {
+    const fm = modernFm({ schema: 2 });
+    const r = parseWorkflowFile({ path: PATH, project: PROJECT, frontmatter: fm });
+    expect(r.workflow).toBeNull();
+    expect(r.diagnostics[0].code).toBe("schema-mismatch");
+  });
+
+  it("emits schema-mismatch when schema is missing", () => {
+    const fm = modernFm();
+    delete (fm as Record<string, unknown>).schema;
+    const r = parseWorkflowFile({ path: PATH, project: PROJECT, frontmatter: fm });
+    expect(r.workflow).toBeNull();
+    expect(r.diagnostics[0].code).toBe("schema-mismatch");
+  });
+});
+
+describe("parseWorkflowFile — required fields", () => {
+  it("rejects missing project", () => {
+    const fm = modernFm();
+    delete (fm as Record<string, unknown>).project;
+    const r = parseWorkflowFile({ path: PATH, project: PROJECT, frontmatter: fm });
+    expect(r.workflow).toBeNull();
+  });
+
+  it("warns when project field disagrees with file slug but keeps the file slug", () => {
+    const fm = modernFm({ project: "other-slug" });
+    const r = parseWorkflowFile({ path: PATH, project: PROJECT, frontmatter: fm });
+    expect(r.workflow).not.toBeNull();
+    expect(r.workflow!.project).toBe(PROJECT);
+    expect(r.diagnostics.some((d) => d.code === "malformed-frontmatter" && d.severity === "warning")).toBe(true);
+  });
+
+  it("rejects missing default_agent", () => {
+    const fm = modernFm();
+    delete (fm as Record<string, unknown>).default_agent;
+    const r = parseWorkflowFile({ path: PATH, project: PROJECT, frontmatter: fm });
+    expect(r.workflow).toBeNull();
+  });
+
+  it("rejects missing default_model", () => {
+    const fm = modernFm();
+    delete (fm as Record<string, unknown>).default_model;
+    const r = parseWorkflowFile({ path: PATH, project: PROJECT, frontmatter: fm });
+    expect(r.workflow).toBeNull();
+  });
+
+  it("rejects missing steps", () => {
+    const fm = modernFm();
+    delete (fm as Record<string, unknown>).steps;
+    const r = parseWorkflowFile({ path: PATH, project: PROJECT, frontmatter: fm });
+    expect(r.workflow).toBeNull();
+  });
+
+  it("rejects steps that isn't an array", () => {
+    const fm = modernFm({ steps: { kickoff: ["orient"] } });
+    const r = parseWorkflowFile({ path: PATH, project: PROJECT, frontmatter: fm });
+    expect(r.workflow).toBeNull();
+  });
+});
+
+describe("parseWorkflowFile — step shape", () => {
+  it("rejects a step with missing step id", () => {
+    const fm = modernFm({ steps: [{ modules: ["orient"] }] });
+    const r = parseWorkflowFile({ path: PATH, project: PROJECT, frontmatter: fm });
+    expect(r.workflow).not.toBeNull(); // workflow still produced
+    expect(r.workflow!.steps).toHaveLength(0);
+    expect(r.diagnostics.some((d) => d.message.includes("steps[0].step"))).toBe(true);
+  });
+
+  it("treats missing modules as empty list", () => {
+    const fm = modernFm({ steps: [{ step: "kickoff" }] });
+    const r = parseWorkflowFile({ path: PATH, project: PROJECT, frontmatter: fm });
+    expect(r.workflow!.steps).toHaveLength(1);
+    expect(r.workflow!.steps[0].modules).toEqual([]);
+  });
+
+  it("rejects modules that isn't a list", () => {
+    const fm = modernFm({ steps: [{ step: "kickoff", modules: "orient" }] });
+    const r = parseWorkflowFile({ path: PATH, project: PROJECT, frontmatter: fm });
+    expect(r.workflow!.steps).toHaveLength(0);
+  });
+
+  it("dedups module ids while preserving order", () => {
+    const fm = modernFm({
+      steps: [{ step: "kickoff", modules: ["orient", "orient", "evaluate"] }],
+    });
+    const r = parseWorkflowFile({ path: PATH, project: PROJECT, frontmatter: fm });
+    expect(r.workflow!.steps[0].modules).toEqual(["orient", "evaluate"]);
+  });
+
+  it("rejects duplicate step ids — first wins, second emits diagnostic", () => {
+    const fm = modernFm({
+      steps: [
+        { step: "kickoff", modules: ["a"] },
+        { step: "kickoff", modules: ["b"] },
+      ],
+    });
+    const r = parseWorkflowFile({ path: PATH, project: PROJECT, frontmatter: fm });
+    expect(r.workflow!.steps).toHaveLength(1);
+    expect(r.workflow!.steps[0].modules).toEqual(["a"]);
+    expect(r.diagnostics.some((d) => d.message.includes("duplicate step id"))).toBe(true);
+  });
+
+  it("rejects a non-object step entry", () => {
+    const fm = modernFm({ steps: ["not a step"] });
+    const r = parseWorkflowFile({ path: PATH, project: PROJECT, frontmatter: fm });
+    expect(r.workflow!.steps).toHaveLength(0);
+  });
+
+  it("optional agent/model on a step are skipped silently when absent", () => {
+    const fm = modernFm({ steps: [{ step: "kickoff", modules: ["a"] }] });
+    const r = parseWorkflowFile({ path: PATH, project: PROJECT, frontmatter: fm });
+    expect(r.workflow!.steps[0].agent).toBeUndefined();
+    expect(r.workflow!.steps[0].model).toBeUndefined();
+    expect(r.diagnostics).toEqual([]);
+  });
+});
+
+describe("parseWorkflowFile — extends shape", () => {
+  it("rejects non-string extends", () => {
+    const fm = modernFm({ extends: 42 });
+    const r = parseWorkflowFile({ path: PATH, project: PROJECT, frontmatter: fm });
+    expect(r.workflow).toBeNull();
+  });
+
+  it("rejects empty-string extends", () => {
+    const fm = modernFm({ extends: "  " });
+    const r = parseWorkflowFile({ path: PATH, project: PROJECT, frontmatter: fm });
+    expect(r.workflow).toBeNull();
+  });
+
+  it("treats null extends as absent", () => {
+    const fm = modernFm({ extends: null });
+    const r = parseWorkflowFile({ path: PATH, project: PROJECT, frontmatter: fm });
+    expect(r.workflow!.extendsPath).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// parseWorkflowFile — frontmatter shape edges
+// ---------------------------------------------------------------------------
+
+describe("parseWorkflowFile — frontmatter edges", () => {
+  it("rejects null frontmatter", () => {
+    const r = parseWorkflowFile({ path: PATH, project: PROJECT, frontmatter: null });
+    expect(r.workflow).toBeNull();
+    expect(r.diagnostics[0].code).toBe("malformed-frontmatter");
+  });
+
+  it("rejects array frontmatter", () => {
+    const r = parseWorkflowFile({
+      path: PATH,
+      project: PROJECT,
+      frontmatter: [] as unknown as Record<string, unknown>,
+    });
+    expect(r.workflow).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// validateWorkflowModels
+// ---------------------------------------------------------------------------
+
+const goodWorkflow = (): WorkflowFile => ({
+  source: { path: PATH, project: PROJECT, isLegacy: false },
+  type: "workflow",
+  schema: 1,
+  project: PROJECT,
+  defaultAgent: ["claude"],
+  defaultModel: { kind: "all", values: ["opus"] },
+  extendsPath: null,
+  steps: [{ step: "kickoff", modules: ["orient"] }],
+});
+
+describe("validateWorkflowModels", () => {
+  it("emits no diagnostics for a clean workflow", () => {
+    expect(validateWorkflowModels(goodWorkflow())).toEqual([]);
+  });
+
+  it("emits bad-model for a typo in default_model with allowed-arrays in extra", () => {
+    const wf = goodWorkflow();
+    wf.defaultModel = { kind: "all", values: ["ultra"] };
+    const diags = validateWorkflowModels(wf);
+    expect(diags).toHaveLength(1);
+    expect(diags[0].code).toBe("bad-model");
+    expect(diags[0].stepId).toBe("<defaults>");
+    expect(diags[0].extra).toMatchObject({
+      stepId: "<defaults>",
+      badName: "ultra",
+      agent: "claude",
+    });
+    expect(Array.isArray((diags[0].extra as Record<string, unknown>).allowedAliases)).toBe(true);
+  });
+
+  it("emits bad-model for a step-level model typo", () => {
+    const wf = goodWorkflow();
+    wf.steps[0].model = { kind: "all", values: ["wrongone"] };
+    const diags = validateWorkflowModels(wf);
+    expect(diags.some((d) => d.code === "bad-model" && d.stepId === "kickoff")).toBe(true);
+  });
+
+  it("emits bad-model per (agent, model) cross-product for kind:all", () => {
+    const wf = goodWorkflow();
+    wf.defaultAgent = ["claude", "gemini"];
+    wf.defaultModel = { kind: "all", values: ["opus"] };
+    // opus is valid for claude but not for gemini.
+    const diags = validateWorkflowModels(wf);
+    const bad = diags.filter((d) => d.code === "bad-model");
+    expect(bad).toHaveLength(1);
+    expect(bad[0].extra).toMatchObject({ agent: "gemini", badName: "opus" });
+  });
+
+  it("validates only explicit pairs for kind:perAgent", () => {
+    const wf = goodWorkflow();
+    wf.defaultAgent = ["claude", "gemini"];
+    wf.defaultModel = {
+      kind: "perAgent",
+      perAgent: { claude: ["opus"], gemini: ["pro"] },
+    };
+    expect(validateWorkflowModels(wf)).toEqual([]);
+  });
+
+  it("warns when perAgent map references an agent not in the agents list", () => {
+    const wf = goodWorkflow();
+    wf.defaultAgent = ["claude"];
+    wf.defaultModel = {
+      kind: "perAgent",
+      perAgent: { claude: ["opus"], gemini: ["pro"] },
+    };
+    const diags = validateWorkflowModels(wf);
+    expect(
+      diags.some(
+        (d) => d.severity === "warning" && d.message.includes('per-agent entry for "gemini"'),
+      ),
+    ).toBe(true);
+  });
+
+  it("skips synthetic legacy steps (no agent/model overrides)", () => {
+    const wf = goodWorkflow();
+    wf.defaultAgent = []; // legacy synth uses empty agents
+    wf.defaultModel = { kind: "all", values: [] };
+    wf.steps = [{ step: "kickoff", modules: [], legacyKickoffBody: "body" }];
+    expect(validateWorkflowModels(wf)).toEqual([]);
+  });
+
+  it("step-level overrides win over defaults", () => {
+    const wf = goodWorkflow();
+    wf.defaultModel = { kind: "all", values: ["sonnet"] };
+    wf.steps[0].model = { kind: "all", values: ["opus"] }; // both valid for claude
+    expect(validateWorkflowModels(wf)).toEqual([]);
+  });
+});

--- a/plugins/op-obsidian/src/workflowFilePure.ts
+++ b/plugins/op-obsidian/src/workflowFilePure.ts
@@ -1,0 +1,821 @@
+import type { WorkflowDiagnostic } from "./workflowDiagnostic";
+import type { BadModelSpec } from "./modelRegistry";
+import { validateModelName } from "./modelRegistry";
+
+// Workflow-file schema, types, and pure parsers. OP-196 (1c) of the OP-184
+// umbrella. No I/O, no Obsidian imports — every input flows in via arguments.
+//
+// A workflow file lives at `Projects/<slug>/WORKFLOW.md` (per-project) or at
+// `Projects/_op-workflow.md` (global default that per-project files reach via
+// `extends:`). Frontmatter declares the schema version, project slug, default
+// agent + model, optional `extends:`, and the list of step records. The
+// markdown body is opaque prose for now — future v2 schema may grow body
+// semantics (a step body that templates inline content, for instance), but
+// today only the synthesised legacy-fallback path attaches body content.
+//
+// Frontmatter contract:
+//
+//   ---
+//   type: workflow                      # required, exact literal
+//   schema: 1                           # required integer; locks the contract
+//   project: obsidian-projects          # required string
+//   default_agent: claude               # list-or-scalar
+//   default_model: opus                 # list-or-scalar-or-keyed-map
+//   extends: Projects/_op-workflow.md   # optional, vault-relative
+//   steps:                              # required (in modern shape)
+//     - step: kickoff
+//       modules: [orient, identify-issue]
+//       agent: claude                   # optional override
+//       model: opus                     # optional override
+//   ---
+//
+// Composition (resolving modules into step bodies, applying user vars,
+// merging with `extends:` parent step lists) is OP-197 (1d). This file ships
+// load-and-validate primitives.
+
+/**
+ * Canonicalized agent specification — always a non-empty string array. A
+ * scalar `default_agent: claude` becomes `["claude"]`; a list passes through.
+ * Order is preserved, duplicates dropped (first wins).
+ */
+export type AgentSpec = string[];
+
+/**
+ * Canonicalized model specification.
+ *
+ * - `kind: "all"` — scalar or list. Applies to every agent in the surrounding
+ *   `AgentSpec`. Composition (1d) iterates the agents and validates each.
+ * - `kind: "perAgent"` — keyed map: `{ claude: "opus", gemini: ["pro", "flash"] }`.
+ *   Each value is itself a list-or-scalar, normalised to a string array.
+ *
+ * The two kinds are kept distinct (rather than collapsed into a single
+ * `Record<string, string[]>` with a magic `*` key) so the renderer can tell
+ * "applies to every agent the user lists" from "explicit per-agent
+ * assignment" without inspecting the agent list at the same time.
+ */
+export type ModelSpec =
+  | { kind: "all"; values: string[] }
+  | { kind: "perAgent"; perAgent: Record<string, string[]> };
+
+/**
+ * One step in a workflow. `agent` and `model` are optional overrides — when
+ * absent, composition uses the workflow's defaults.
+ *
+ * `legacyKickoffBody` is populated only on the synthetic step that the
+ * legacy-fallback ladder (shapes 1, 2, 3, 5) attaches the entire WORKFLOW.md
+ * body to. Modern workflows leave it `undefined`.
+ */
+export interface WorkflowStep {
+  step: string;
+  modules: string[];
+  agent?: AgentSpec;
+  model?: ModelSpec;
+  legacyKickoffBody?: string;
+}
+
+/**
+ * Where a parsed workflow came from. Carried on `WorkflowFile` so diagnostics
+ * and downstream surfaces can name the source path without re-deriving it.
+ */
+export interface WorkflowFileSource {
+  /** Vault-relative path of the WORKFLOW.md the parser saw. */
+  path: string;
+  /** Project slug (the `<slug>` in `Projects/<slug>/WORKFLOW.md`). */
+  project: string;
+  /**
+   * `true` if the file was synthesised via the legacy fallback ladder. The
+   * legacy synthesiser still produces a valid `WorkflowFile`; this flag is a
+   * hint to surfaces that want to display "running in legacy compatibility
+   * mode" warnings.
+   */
+  isLegacy: boolean;
+}
+
+/**
+ * Parsed and validated workflow. Composition (1d) consumes this shape; this
+ * file produces it.
+ */
+export interface WorkflowFile {
+  source: WorkflowFileSource;
+  type: "workflow";
+  schema: 1;
+  project: string;
+  defaultAgent: AgentSpec;
+  defaultModel: ModelSpec;
+  /** Resolved vault-relative path of the parent file, or `null` if no inheritance. */
+  extendsPath: string | null;
+  steps: WorkflowStep[];
+}
+
+/** Re-export for convenience — recovery dialog at 3e (OP-184) consumes this shape. */
+export type { BadModelSpec };
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function describe(v: unknown): string {
+  if (v === null) return "null";
+  if (v === undefined) return "undefined";
+  if (Array.isArray(v)) return "array";
+  if (v instanceof Date) return "Date";
+  return typeof v;
+}
+
+function invalidFieldDiag(
+  path: string,
+  field: string,
+  expected: string,
+  value: unknown,
+): WorkflowDiagnostic {
+  return {
+    code: "malformed-frontmatter",
+    severity: "error",
+    message: `${path}: ${field} must be ${expected}, got ${describe(value)}.`,
+    extra: { path, field, expected, actual: describe(value) },
+  };
+}
+
+function dedupKeepingOrder(values: string[]): string[] {
+  const seen = new Set<string>();
+  const out: string[] = [];
+  for (const v of values) {
+    if (!seen.has(v)) {
+      seen.add(v);
+      out.push(v);
+    }
+  }
+  return out;
+}
+
+// ---------------------------------------------------------------------------
+// list-or-scalar agent parser
+// ---------------------------------------------------------------------------
+
+export interface ParseAgentSpecResult {
+  value: AgentSpec | null;
+  diagnostics: WorkflowDiagnostic[];
+}
+
+/**
+ * Parse a list-or-scalar agent value.
+ *
+ * - String → `[trim(string)]`. Empty/whitespace-only string → diagnostic.
+ * - Array of strings → trimmed, dropped-empty, dedup-preserving order. Empty
+ *   array → diagnostic.
+ * - Anything else → diagnostic.
+ *
+ * `field` and `path` are caller-supplied so diagnostics can name the source
+ * file and the offending frontmatter field. `optional` skips the diagnostic
+ * for `undefined` input (used for per-step `agent:` overrides).
+ */
+export function parseAgentSpec(
+  raw: unknown,
+  ctx: { path: string; field: string; optional?: boolean },
+): ParseAgentSpecResult {
+  if (raw === undefined || raw === null) {
+    if (ctx.optional) return { value: null, diagnostics: [] };
+    return {
+      value: null,
+      diagnostics: [invalidFieldDiag(ctx.path, ctx.field, "a string or list of strings", raw)],
+    };
+  }
+  if (typeof raw === "string") {
+    const trimmed = raw.trim();
+    if (!trimmed) {
+      return {
+        value: null,
+        diagnostics: [invalidFieldDiag(ctx.path, ctx.field, "a non-empty string", raw)],
+      };
+    }
+    return { value: [trimmed], diagnostics: [] };
+  }
+  if (Array.isArray(raw)) {
+    const out: string[] = [];
+    const diagnostics: WorkflowDiagnostic[] = [];
+    for (const entry of raw) {
+      if (typeof entry !== "string") {
+        diagnostics.push(
+          invalidFieldDiag(ctx.path, ctx.field, "every entry to be a string", entry),
+        );
+        continue;
+      }
+      const trimmed = entry.trim();
+      if (!trimmed) continue; // silently drop blank entries — author convenience
+      out.push(trimmed);
+    }
+    if (diagnostics.length > 0) {
+      return { value: null, diagnostics };
+    }
+    if (out.length === 0) {
+      return {
+        value: null,
+        diagnostics: [invalidFieldDiag(ctx.path, ctx.field, "at least one non-empty string", raw)],
+      };
+    }
+    return { value: dedupKeepingOrder(out), diagnostics: [] };
+  }
+  return {
+    value: null,
+    diagnostics: [invalidFieldDiag(ctx.path, ctx.field, "a string or list of strings", raw)],
+  };
+}
+
+// ---------------------------------------------------------------------------
+// list-or-scalar-or-keyed-map model parser
+// ---------------------------------------------------------------------------
+
+export interface ParseModelSpecResult {
+  value: ModelSpec | null;
+  diagnostics: WorkflowDiagnostic[];
+}
+
+/**
+ * Parse a list-or-scalar-or-keyed-map model value.
+ *
+ * - String → `{ kind: "all", values: [trim(string)] }`.
+ * - Array of strings → `{ kind: "all", values: trimmed-dedup }`.
+ * - Plain object (not Date, not Array) → `{ kind: "perAgent", perAgent }`
+ *   where each value is itself parsed list-or-scalar.
+ * - Anything else → diagnostic.
+ *
+ * Empty `kind: "all"` lists and empty `kind: "perAgent"` objects emit
+ * diagnostics — there's no useful semantics for "this step accepts no model."
+ */
+export function parseModelSpec(
+  raw: unknown,
+  ctx: { path: string; field: string; optional?: boolean },
+): ParseModelSpecResult {
+  if (raw === undefined || raw === null) {
+    if (ctx.optional) return { value: null, diagnostics: [] };
+    return {
+      value: null,
+      diagnostics: [
+        invalidFieldDiag(ctx.path, ctx.field, "a string, list of strings, or per-agent map", raw),
+      ],
+    };
+  }
+
+  if (typeof raw === "string") {
+    const trimmed = raw.trim();
+    if (!trimmed) {
+      return {
+        value: null,
+        diagnostics: [invalidFieldDiag(ctx.path, ctx.field, "a non-empty string", raw)],
+      };
+    }
+    return { value: { kind: "all", values: [trimmed] }, diagnostics: [] };
+  }
+
+  if (Array.isArray(raw)) {
+    const out: string[] = [];
+    const diagnostics: WorkflowDiagnostic[] = [];
+    for (const entry of raw) {
+      if (typeof entry !== "string") {
+        diagnostics.push(
+          invalidFieldDiag(ctx.path, ctx.field, "every entry to be a string", entry),
+        );
+        continue;
+      }
+      const trimmed = entry.trim();
+      if (!trimmed) continue;
+      out.push(trimmed);
+    }
+    if (diagnostics.length > 0) {
+      return { value: null, diagnostics };
+    }
+    if (out.length === 0) {
+      return {
+        value: null,
+        diagnostics: [invalidFieldDiag(ctx.path, ctx.field, "at least one non-empty string", raw)],
+      };
+    }
+    return { value: { kind: "all", values: dedupKeepingOrder(out) }, diagnostics: [] };
+  }
+
+  // Plain object: per-agent map. Reject Date and other class instances.
+  if (typeof raw === "object" && !(raw instanceof Date)) {
+    const obj = raw as Record<string, unknown>;
+    const perAgent: Record<string, string[]> = {};
+    const diagnostics: WorkflowDiagnostic[] = [];
+    for (const [agent, value] of Object.entries(obj)) {
+      const trimmedAgent = agent.trim();
+      if (!trimmedAgent) {
+        diagnostics.push(
+          invalidFieldDiag(ctx.path, `${ctx.field}.<key>`, "a non-empty agent id", agent),
+        );
+        continue;
+      }
+      // Re-use the list-or-scalar parser for the value, but in non-optional
+      // mode and with a nested-field name for diagnostic clarity.
+      const sub = parseAgentSpec(value, {
+        path: ctx.path,
+        field: `${ctx.field}.${trimmedAgent}`,
+      });
+      if (sub.value !== null) {
+        perAgent[trimmedAgent] = sub.value;
+      }
+      diagnostics.push(...sub.diagnostics);
+    }
+    if (Object.keys(perAgent).length === 0) {
+      // Either the input was `{}` or every entry was malformed. Emit a
+      // standalone diagnostic so the caller sees "the field has no usable
+      // entries" even when individual entries already produced diagnostics.
+      diagnostics.push(
+        invalidFieldDiag(ctx.path, ctx.field, "at least one agent -> model entry", raw),
+      );
+      return { value: null, diagnostics };
+    }
+    return { value: { kind: "perAgent", perAgent }, diagnostics };
+  }
+
+  return {
+    value: null,
+    diagnostics: [
+      invalidFieldDiag(ctx.path, ctx.field, "a string, list of strings, or per-agent map", raw),
+    ],
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Step parser
+// ---------------------------------------------------------------------------
+
+interface ParseStepArgs {
+  raw: unknown;
+  index: number;
+  path: string;
+}
+
+interface ParseStepResult {
+  step: WorkflowStep | null;
+  diagnostics: WorkflowDiagnostic[];
+}
+
+function parseStep({ raw, index, path }: ParseStepArgs): ParseStepResult {
+  if (!raw || typeof raw !== "object" || Array.isArray(raw) || raw instanceof Date) {
+    return {
+      step: null,
+      diagnostics: [
+        invalidFieldDiag(path, `steps[${index}]`, "a step record (mapping)", raw),
+      ],
+    };
+  }
+  const obj = raw as Record<string, unknown>;
+  const diagnostics: WorkflowDiagnostic[] = [];
+
+  const stepIdRaw = obj.step;
+  if (typeof stepIdRaw !== "string" || !stepIdRaw.trim()) {
+    diagnostics.push(
+      invalidFieldDiag(path, `steps[${index}].step`, "a non-empty string", stepIdRaw),
+    );
+    return { step: null, diagnostics };
+  }
+  const stepId = stepIdRaw.trim();
+
+  const modulesRaw = obj.modules;
+  let modules: string[] = [];
+  if (modulesRaw === undefined || modulesRaw === null) {
+    modules = [];
+  } else if (Array.isArray(modulesRaw)) {
+    const accumulated: string[] = [];
+    for (const m of modulesRaw) {
+      if (typeof m !== "string") {
+        diagnostics.push(
+          invalidFieldDiag(
+            path,
+            `steps[${index}].modules`,
+            "every entry to be a module id string",
+            m,
+          ),
+        );
+        continue;
+      }
+      const trimmed = m.trim();
+      if (trimmed) accumulated.push(trimmed);
+    }
+    modules = dedupKeepingOrder(accumulated);
+  } else {
+    diagnostics.push(
+      invalidFieldDiag(path, `steps[${index}].modules`, "a list of module ids", modulesRaw),
+    );
+    return { step: null, diagnostics };
+  }
+
+  const agentRes = parseAgentSpec(obj.agent, {
+    path,
+    field: `steps[${index}].agent`,
+    optional: true,
+  });
+  diagnostics.push(...agentRes.diagnostics);
+
+  const modelRes = parseModelSpec(obj.model, {
+    path,
+    field: `steps[${index}].model`,
+    optional: true,
+  });
+  diagnostics.push(...modelRes.diagnostics);
+
+  const step: WorkflowStep = {
+    step: stepId,
+    modules,
+  };
+  if (agentRes.value !== null) step.agent = agentRes.value;
+  if (modelRes.value !== null) step.model = modelRes.value;
+
+  return { step, diagnostics };
+}
+
+// ---------------------------------------------------------------------------
+// Top-level parseWorkflowFile
+// ---------------------------------------------------------------------------
+
+export interface ParseWorkflowArgs {
+  /** Vault-relative path of the source file, used in diagnostics. */
+  path: string;
+  /** Project slug — caller derives this from the file path. */
+  project: string;
+  /** Frontmatter object (may be `null` to indicate "no frontmatter at all"). */
+  frontmatter: Record<string, unknown> | null;
+  /** Whether the synthesizer marked this as legacy. */
+  isLegacy?: boolean;
+}
+
+export interface ParseWorkflowResult {
+  workflow: WorkflowFile | null;
+  diagnostics: WorkflowDiagnostic[];
+}
+
+/**
+ * Parse a modern workflow frontmatter into a `WorkflowFile`. Caller is
+ * responsible for handling legacy fallback (see `classifyLegacy` /
+ * `synthesizeLegacyWorkflow`) — this function assumes a modern shape and
+ * emits diagnostics for any required-field violation.
+ *
+ * Pure: no IO, no Obsidian imports. Returns `workflow: null` when the file
+ * cannot be salvaged (missing required fields, wrong type, schema mismatch);
+ * `extends:` resolution is the IO layer's job — this function captures the
+ * raw value into `extendsPath` after string validation.
+ */
+export function parseWorkflowFile(args: ParseWorkflowArgs): ParseWorkflowResult {
+  const { path, project, frontmatter, isLegacy = false } = args;
+  const diagnostics: WorkflowDiagnostic[] = [];
+
+  if (!frontmatter || typeof frontmatter !== "object" || Array.isArray(frontmatter)) {
+    diagnostics.push({
+      code: "malformed-frontmatter",
+      severity: "error",
+      message: `${path}: frontmatter is missing or malformed.`,
+      extra: { path },
+    });
+    return { workflow: null, diagnostics };
+  }
+
+  // type
+  if (frontmatter.type !== "workflow") {
+    diagnostics.push({
+      code: "schema-mismatch",
+      severity: "error",
+      message: `${path}: type must be "workflow", got ${describe(frontmatter.type)}.`,
+      extra: { path, field: "type", expected: "workflow", actual: describe(frontmatter.type) },
+    });
+    return { workflow: null, diagnostics };
+  }
+
+  // schema
+  const schemaRaw = frontmatter.schema;
+  if (schemaRaw !== 1) {
+    diagnostics.push({
+      code: "schema-mismatch",
+      severity: "error",
+      message: `${path}: schema must be 1, got ${describe(schemaRaw)} (${String(schemaRaw)}). This loader supports schema=1 only; future versions will be added with explicit migration.`,
+      extra: { path, field: "schema", expected: "1", actual: String(schemaRaw) },
+    });
+    return { workflow: null, diagnostics };
+  }
+
+  // project (string, must match caller-derived project if both present)
+  const projectField = frontmatter.project;
+  if (typeof projectField !== "string" || !projectField.trim()) {
+    diagnostics.push(invalidFieldDiag(path, "project", "a non-empty string", projectField));
+    return { workflow: null, diagnostics };
+  }
+  if (projectField.trim() !== project) {
+    diagnostics.push({
+      code: "malformed-frontmatter",
+      severity: "warning",
+      message: `${path}: project field "${projectField.trim()}" does not match the file's project slug "${project}". Using the file's slug.`,
+      extra: { path, field: "project", expected: project, actual: projectField.trim() },
+    });
+  }
+
+  // default_agent
+  const agentRes = parseAgentSpec(frontmatter.default_agent, {
+    path,
+    field: "default_agent",
+  });
+  diagnostics.push(...agentRes.diagnostics);
+  if (agentRes.value === null) {
+    return { workflow: null, diagnostics };
+  }
+
+  // default_model
+  const modelRes = parseModelSpec(frontmatter.default_model, {
+    path,
+    field: "default_model",
+  });
+  diagnostics.push(...modelRes.diagnostics);
+  if (modelRes.value === null) {
+    return { workflow: null, diagnostics };
+  }
+
+  // extends (optional)
+  let extendsPath: string | null = null;
+  if (frontmatter.extends !== undefined && frontmatter.extends !== null) {
+    if (typeof frontmatter.extends !== "string" || !frontmatter.extends.trim()) {
+      diagnostics.push(
+        invalidFieldDiag(path, "extends", "a vault-relative path string", frontmatter.extends),
+      );
+      return { workflow: null, diagnostics };
+    }
+    extendsPath = frontmatter.extends.trim();
+  }
+
+  // steps
+  const stepsRaw = frontmatter.steps;
+  if (!Array.isArray(stepsRaw)) {
+    diagnostics.push(invalidFieldDiag(path, "steps", "a list of step records", stepsRaw));
+    return { workflow: null, diagnostics };
+  }
+  const steps: WorkflowStep[] = [];
+  const seenStepIds = new Set<string>();
+  for (let i = 0; i < stepsRaw.length; i++) {
+    const r = parseStep({ raw: stepsRaw[i], index: i, path });
+    diagnostics.push(...r.diagnostics);
+    if (!r.step) continue;
+    if (seenStepIds.has(r.step.step)) {
+      diagnostics.push({
+        code: "malformed-frontmatter",
+        severity: "error",
+        message: `${path}: duplicate step id "${r.step.step}" at steps[${i}]. First occurrence wins.`,
+        extra: { path, field: `steps[${i}].step`, expected: "unique step id", actual: r.step.step },
+        stepId: r.step.step,
+      });
+      continue;
+    }
+    seenStepIds.add(r.step.step);
+    steps.push(r.step);
+  }
+
+  const workflow: WorkflowFile = {
+    source: { path, project, isLegacy },
+    type: "workflow",
+    schema: 1,
+    project,
+    defaultAgent: agentRes.value,
+    defaultModel: modelRes.value,
+    extendsPath,
+    steps,
+  };
+  return { workflow, diagnostics };
+}
+
+// ---------------------------------------------------------------------------
+// Legacy fallback ladder
+// ---------------------------------------------------------------------------
+
+/**
+ * Classification of a raw WORKFLOW.md file's frontmatter shape. Drives the
+ * legacy-fallback ladder. The pure layer reports the shape; the caller
+ * (synthesizer) decides what to do.
+ *
+ * Six shapes (per OP-196 scope):
+ *   1. No frontmatter at all                        -> legacy-1
+ *   2. Frontmatter present, no `type:` field        -> legacy-2
+ *   3. `type: workflow`, no `steps:` field           -> legacy-3
+ *   4. `type: <not workflow>`                        -> legacy-4 (drop file)
+ *   5. Frontmatter parses to `null`                  -> legacy-5
+ *   6. Body starts with `---` after fence            -> "modern" — the fence
+ *      detector already handles this; the test fixture locks the regression.
+ *
+ * Modern files (frontmatter has `type: workflow` and `steps`) classify as
+ * `modern`.
+ */
+export type LegacyShape =
+  | "modern"
+  | "legacy-1"
+  | "legacy-2"
+  | "legacy-3"
+  | "legacy-4"
+  | "legacy-5";
+
+export interface LegacyClassification {
+  shape: LegacyShape;
+  /** The full body content (post-frontmatter) — populated for shapes 1, 2, 3, 5. */
+  body: string;
+}
+
+/**
+ * Strip frontmatter the same way `promptBuild.ts:stripFrontmatter` does:
+ * find the first `\n---` after position 3 (the opening fence's last char).
+ * If no closing fence, the whole file is body. The fence-detection runs
+ * against the FIRST `---` only, so HR-style `---` lines in the body don't
+ * confuse the parser.
+ *
+ * Exported so the legacy synthesizer can re-use it without depending on
+ * `promptBuild.ts`. Behaviour MUST stay byte-for-byte compatible.
+ */
+export function stripWorkflowFrontmatter(raw: string): string {
+  if (!raw.startsWith("---")) return raw;
+  const end = raw.indexOf("\n---", 3);
+  if (end === -1) return raw;
+  const afterFence = raw.indexOf("\n", end + 4);
+  return afterFence === -1 ? "" : raw.slice(afterFence + 1);
+}
+
+/**
+ * Classify a raw WORKFLOW.md file's shape from its file content + the parsed
+ * frontmatter. The frontmatter argument comes from the IO layer (which uses
+ * Obsidian's `metadataCache` or a YAML library).
+ *
+ * Inputs:
+ *   - `raw`: full file content as string. Used to extract the body for
+ *     legacy synthesis and to detect "no frontmatter at all" by looking for
+ *     the opening fence.
+ *   - `frontmatter`: parsed YAML object, or `null` if YAML parsed to null,
+ *     or `undefined` if no frontmatter fence was present.
+ *
+ * Returns the classified shape and (for legacy shapes 1, 2, 3, 5) the body
+ * content the caller can splice into a synthetic kickoff step.
+ */
+export function classifyLegacy(
+  raw: string,
+  frontmatter: Record<string, unknown> | null | undefined,
+): LegacyClassification {
+  const body = stripWorkflowFrontmatter(raw);
+
+  // Shape 1: no frontmatter fence at all.
+  if (!raw.startsWith("---")) {
+    return { shape: "legacy-1", body };
+  }
+
+  // Shape 5: frontmatter fence present but YAML parses to null. Either an
+  // empty fence (`---\n---`) or a fence whose content is `null` / `~` / etc.
+  if (frontmatter === null) {
+    return { shape: "legacy-5", body };
+  }
+
+  // Shape 2: frontmatter present but no `type:` key.
+  if (frontmatter === undefined || !("type" in frontmatter)) {
+    return { shape: "legacy-2", body };
+  }
+
+  // Shape 4: type is set but isn't "workflow".
+  if (frontmatter.type !== "workflow") {
+    return { shape: "legacy-4", body };
+  }
+
+  // Shape 3: type is workflow but no `steps:` field.
+  if (!("steps" in frontmatter)) {
+    return { shape: "legacy-3", body };
+  }
+
+  // Shape 6 / modern: fence detection has already run; the body's HR `---`
+  // lines have no effect on classification.
+  return { shape: "modern", body };
+}
+
+/**
+ * Synthesise a `WorkflowFile` for legacy shapes 1, 2, 3, 5. The synthesised
+ * workflow has one step (`step: "kickoff", modules: []`) carrying the
+ * entire body verbatim in `legacyKickoffBody`. Defaults are empty arrays /
+ * `kind: "all"` with no values — the launch overrides will fill them.
+ *
+ * Caller (IO layer) must guarantee `shape` is one of `legacy-1`, `legacy-2`,
+ * `legacy-3`, `legacy-5` — `legacy-4` (wrong type) should produce a
+ * `schema-mismatch` diagnostic and `null` workflow instead.
+ */
+export function synthesizeLegacyWorkflow(args: {
+  path: string;
+  project: string;
+  body: string;
+  shape: LegacyShape;
+}): WorkflowFile {
+  const { path, project, body, shape } = args;
+  if (shape === "modern" || shape === "legacy-4") {
+    // Defensive: callers should never reach this path with a non-synthesisable
+    // shape. Surface the misuse loudly rather than silently producing a
+    // workflow that hides the underlying schema problem.
+    throw new Error(
+      `synthesizeLegacyWorkflow: shape ${shape} is not synthesisable — ` +
+        `callers must route modern through parseWorkflowFile and legacy-4 through schema-mismatch.`,
+    );
+  }
+  const step: WorkflowStep = {
+    step: "kickoff",
+    modules: [],
+    legacyKickoffBody: body,
+  };
+  return {
+    source: { path, project, isLegacy: true },
+    type: "workflow",
+    schema: 1,
+    project,
+    defaultAgent: [],
+    defaultModel: { kind: "all", values: [] },
+    extendsPath: null,
+    steps: [step],
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Model validation
+// ---------------------------------------------------------------------------
+
+/**
+ * Walk a parsed workflow and validate every model name against the per-agent
+ * registry. Emits one `bad-model` `WorkflowDiagnostic` per failure, carrying
+ * the full `BadModelSpec` payload in `extra`.
+ *
+ * This is a separate pass from `parseWorkflowFile` because:
+ *   1. The workflow's schema is independent of the registry — a workflow can
+ *      be schema-valid yet reference a mistyped model name. Keeping the
+ *      passes separate means a registry update doesn't invalidate cached
+ *      parse results.
+ *   2. The registry import is the only reason this file would otherwise need
+ *      to depend on `modelRegistry.ts`.
+ *
+ * Algorithm:
+ *   - For each step (modern only — legacy synthetic steps have no `agent`/
+ *     `model` overrides), resolve the effective `(agents, model)` pair:
+ *       agents = step.agent ?? workflow.defaultAgent
+ *       model  = step.model ?? workflow.defaultModel
+ *   - For `kind: "all"`, validate every (agent, modelName) cross-product.
+ *   - For `kind: "perAgent"`, validate only the explicit pairings.
+ *   - The same logic runs once for the workflow's defaults (stepId=
+ *     "<defaults>") so a typo in `default_model:` surfaces even when no
+ *     step references it.
+ */
+export function validateWorkflowModels(workflow: WorkflowFile): WorkflowDiagnostic[] {
+  const diagnostics: WorkflowDiagnostic[] = [];
+
+  const validatePair = (
+    agents: AgentSpec,
+    model: ModelSpec,
+    stepId: string,
+  ): void => {
+    if (model.kind === "all") {
+      for (const agent of agents) {
+        for (const name of model.values) {
+          const r = validateModelName(agent, name, stepId);
+          if (!r.ok) diagnostics.push(badModelDiagnostic(r.bad));
+        }
+      }
+      return;
+    }
+    // perAgent — validate the explicit pairings, plus surface any agent in
+    // the perAgent map that isn't in the surrounding agents list (warning).
+    for (const [agent, names] of Object.entries(model.perAgent)) {
+      if (!agents.includes(agent)) {
+        diagnostics.push({
+          code: "malformed-frontmatter",
+          severity: "warning",
+          message: `${workflow.source.path}: model declares a per-agent entry for "${agent}" but the surrounding agents list doesn't include it.`,
+          extra: { path: workflow.source.path, field: "model", agent },
+          stepId,
+        });
+      }
+      for (const name of names) {
+        const r = validateModelName(agent, name, stepId);
+        if (!r.ok) diagnostics.push(badModelDiagnostic(r.bad));
+      }
+    }
+  };
+
+  validatePair(workflow.defaultAgent, workflow.defaultModel, "<defaults>");
+
+  for (const step of workflow.steps) {
+    if (step.legacyKickoffBody !== undefined) continue; // synthetic — skip
+    // If the step inherits both agent and model from the workflow's defaults,
+    // the `<defaults>` pass already validated the pair — don't double-emit.
+    if (step.agent === undefined && step.model === undefined) continue;
+    const agents = step.agent ?? workflow.defaultAgent;
+    const model = step.model ?? workflow.defaultModel;
+    validatePair(agents, model, step.step);
+  }
+
+  return diagnostics;
+}
+
+function badModelDiagnostic(bad: BadModelSpec): WorkflowDiagnostic {
+  return {
+    code: "bad-model",
+    severity: "error",
+    message:
+      `Unknown model "${bad.badName}" for agent "${bad.agent}" at ${bad.stepId}. ` +
+      `Allowed aliases: ${bad.allowedAliases.length ? bad.allowedAliases.join(", ") : "(none — agent unknown)"}. ` +
+      `Allowed versioned ids: ${bad.allowedVersioned.length ? bad.allowedVersioned.join(", ") : "(none — agent unknown)"}.`,
+    stepId: bad.stepId,
+    extra: { ...bad },
+  };
+}

--- a/plugins/op/.claude-plugin/plugin.json
+++ b/plugins/op/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "op",
   "description": "Obsidian Projects workflow — schema, slash commands, and agent skill for running a Jira-lite issue tracker inside an Obsidian vault.",
-  "version": "0.63.1",
+  "version": "0.64.0",
   "author": {
     "name": "Eugene Archibald"
   },


### PR DESCRIPTION
## Summary

Workflow-file schema, IO loader, and per-agent model registry. Third grandchild of OP-184 (Child 1 umbrella) after OP-194 (1a, generic renderer) and OP-195 (1b, module schema); composition (1d / OP-197) is the first consumer.

- `workflowFilePure.ts` — pure types + parsers (`parseAgentSpec`, `parseModelSpec`, `parseWorkflowFile`), legacy classifier + synthesizer, `validateWorkflowModels`. No Obsidian imports.
- `workflowFile.ts` — IO seam: reads `Projects/<slug>/WORKFLOW.md`, applies the legacy fallback ladder, recursively loads the parent at most one level for `extends:`, runs model validation.
- `modelRegistry.ts` — per-agent `{ aliases, versioned }` records for `claude`, `gemini`, `copilot`. Single source of truth for model validation. `BadModelSpec` payload doubles as the `bad-model` `WorkflowDiagnostic.extra` shape.
- Six legacy-workflow fixtures + per-shape unit tests (`__fixtures__/legacy-workflow/`).
- `docs/specs/workflow-file-schema.md` — repo-tracked schema reference.

132 net new tests (105 pure + 18 IO + 9 fixture); full suite 1056/1056; the one failing suite (`iTermPrefs.test.ts`) is the same pre-existing `obsidian` package resolution issue OP-194/195 documented, unrelated.

Bumps op-obsidian `0.63.1 → 0.64.0` (minor — additive infra).

## Test plan

- [x] `npm test` in `plugins/op-obsidian/` — 1056/1056 pass.
- [x] `node scripts/bump-version.mjs minor` — version moves in lockstep across `manifest.json`, `package.json`, `plugin.json`; `main.js` rebuilt and fresher than `manifest.json`.
- [x] `node scripts/dev-sync.mjs` — main.js + manifest.json copied to OP-Test, plugin reloaded.
- [x] OP-Test smoke: `obsidian eval` confirms `op-obsidian@0.64.0` instance with 39 commands registered, no console errors. New types are cold infrastructure (no callsite wires them up yet) so runtime behaviour is unchanged.

## Adversarial review prompts (Copilot)

Please pressure-test:

1. **Parser shape edges**. Can `parseAgentSpec` / `parseModelSpec` produce a `value` that is non-null **and** carries diagnostics? When? Should it? (Look at `kind: "perAgent"` with one valid + one bad entry.) Any input that passes shape validation but is semantically wrong (e.g. `default_agent: ["", "claude"]` — does the silent drop of blank entries hide a typo)?
2. **`schema: 1` lock**. Today this loader hard-rejects any other `schema:` value. Is the diagnostic message specific enough that a future migration tool can be built around it? Does the wording survive being shown to an end-user in a Notice?
3. **Legacy ladder ambiguity**. Shape 5 (null frontmatter) vs. shape 2 (frontmatter without `type:`): for an empty fence `---\n---`, does `metadataCache` reliably return `null`, or does it sometimes return `{}`? Verify the IO disambiguation logic in `workflowFile.ts:loadAtPath` (the `fmCached === undefined ? null : fmCached` branch) — is there a Obsidian frontmatter shape that lands in the wrong shape bucket?
4. **`extends:` cycles**. The recursive call passes `allowExtends: false` to enforce one-level. What if the **child's** `extends:` points at itself (`Projects/foo/WORKFLOW.md` → `Projects/foo/WORKFLOW.md`)? The recursive call would re-read the same file with `allowExtends: false`; the child's `extends:` would then trigger the warning, but is there any way to enter an actual loop?
5. **Step merge by id**. `mergeWorkflows` substitutes a child step at the parent's slot when the id matches. What if a child wants to *remove* a parent step? (Today: can't — v1 limitation. Is the diagnostic / docs clear about this?) What if both the parent and the child have multiple steps with the same id (already a per-file error, but: does the merge still produce sensible output)?
6. **Model validation cross-product blast**. `validateWorkflowModels` for a workflow with `default_agent: [a, b, c]` and `default_model: [m1, m2, m3]` (`kind: "all"`) where `m1` is invalid for all three agents: should this emit 3 diagnostics or 1? Today it emits 3. Is that what an author wants?
7. **Per-agent map referencing absent agent**. We emit a warning when `default_model: { gemini: pro }` is set but `gemini` isn't in `default_agent`. But composition (1d) might *want* this if `default_agent: [claude]` and a step overrides to `agent: gemini` then inherits the `gemini: pro` from defaults. Is the warning-severity right, or should this be silent?
8. **Filename hygiene**. `synthesizeLegacyWorkflow` accepts arbitrary `path` / `project` strings — no validation. If a caller passes `path: "../escape"` does anything bad happen downstream? (Probably not — it's load-and-validate cold infra — but worth confirming.)
9. **`BadModelSpec` privacy**. `allowedAliases` / `allowedVersioned` arrays leak the entire registry to the diagnostic stream. If a future version has private/experimental models, is this surface tenable? (Probably want a "user-visible aliases" subset later.)
10. **Test fixtures vs. real Obsidian behaviour**. The fixture tests hand-build frontmatter objects to simulate `metadataCache` output. Does Obsidian's actual YAML parser produce exactly the shape we hand-build for shapes 2, 3, 5? Specifically: for an empty fence (`---\n---`), what does `metadataCache.getFileCache(file)?.frontmatter` return — `null`, `undefined`, or `{}`? The IO test should ideally lock the answer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)