### PR TITLE
OP-197: composeWorkflow split (IO + pure) + RelaySession + launchHeadlessSubtask + integration test

### DIFF
--- a/plugins/op-obsidian/manifest.json
+++ b/plugins/op-obsidian/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "op-obsidian",
   "name": "Obsidian Projects (op)",
-  "version": "0.64.0",
+  "version": "0.65.0",
   "minAppVersion": "1.5.0",
   "description": "Jira-lite issue tracker for Obsidian vaults — deterministic commands backing the op workflow.",
   "author": "Eugene Archibald",

--- a/plugins/op-obsidian/package.json
+++ b/plugins/op-obsidian/package.json
@@ -1,6 +1,6 @@
 {
   "name": "op-obsidian",
-  "version": "0.64.0",
+  "version": "0.65.0",
   "description": "Obsidian plugin that owns the deterministic half of the op workflow.",
   "main": "main.js",
   "scripts": {

--- a/plugins/op-obsidian/src/__fixtures__/integration/_op-workflow.md
+++ b/plugins/op-obsidian/src/__fixtures__/integration/_op-workflow.md
@@ -1,0 +1,12 @@
+---
+type: workflow
+schema: 1
+project: fixture-project
+default_agent: claude
+default_model: opus
+steps:
+  - step: kickoff
+    modules: [branching, version-cadence]
+---
+
+Global default workflow inherited by per-project files via `extends:`.

--- a/plugins/op-obsidian/src/__fixtures__/integration/composed.snapshot.md
+++ b/plugins/op-obsidian/src/__fixtures__/integration/composed.snapshot.md
@@ -1,0 +1,21 @@
+## STEP: kickoff
+
+
+You are working on **OP-FIX-1** (Integration fixture issue) in project `fixture-project` on branch `worktree-OP-FIX-1`. Always create an isolated worktree before making changes — no exceptions, including one-line tweaks. The main checkout may be held by the agent that delegated to you.
+
+
+
+After every change to `plugins/op-obsidian/`, run `node scripts/bump-version.mjs <patch|minor|major>` so the manifest, package, and plugin JSON files move in lockstep. Pick the bump level by judgment: patch = fix, minor = additive, major = breaking. Today is 2026-04-26.
+
+
+## STEP: plan
+
+
+Before implementing, read related code (no more than 10 files), then propose a plan covering: approach, files to touch, tests, risks, and what's deliberately out of scope. Send the plan to @earchibald for sign-off before any commit.
+
+
+## STEP: review
+
+
+Once tests pass and CI is green, request an adversarial Copilot review with concrete pressure-test prompts. After review is addressed, merge with `gh pr merge --squash --delete-branch`. PR: https://github.com/example/repo/pull/42. Issue: OP-FIX-1 (parent: OP-FIX-PARENT).
+

--- a/plugins/op-obsidian/src/__fixtures__/integration/global-modules/branching.md
+++ b/plugins/op-obsidian/src/__fixtures__/integration/global-modules/branching.md
@@ -1,0 +1,9 @@
+---
+id: branching
+title: Always work in a git worktree
+type: workflow-module
+scope: kickoff
+order: 10
+---
+
+You are working on **{{id}}** ({{title}}) in project `{{project}}` on branch `{{branch}}`. Always create an isolated worktree before making changes — no exceptions, including one-line tweaks. The main checkout may be held by the agent that delegated to you.

--- a/plugins/op-obsidian/src/__fixtures__/integration/global-modules/version-cadence.md
+++ b/plugins/op-obsidian/src/__fixtures__/integration/global-modules/version-cadence.md
@@ -1,0 +1,11 @@
+---
+id: version-cadence
+title: Version bump cadence
+type: workflow-module
+scope: kickoff
+order: 20
+vars:
+  - "package_name=op-obsidian"
+---
+
+After every change to `plugins/{{vars.package_name}}/`, run `node scripts/bump-version.mjs <patch|minor|major>` so the manifest, package, and plugin JSON files move in lockstep. Pick the bump level by judgment: patch = fix, minor = additive, major = breaking. Today is {{today}}.

--- a/plugins/op-obsidian/src/__fixtures__/integration/per-project/MODULES/plan-rules.md
+++ b/plugins/op-obsidian/src/__fixtures__/integration/per-project/MODULES/plan-rules.md
@@ -1,0 +1,12 @@
+---
+id: plan-rules
+title: Plan-mode rules for fixture project
+type: workflow-module
+scope: plan
+order: 10
+vars:
+  - "max_files=10"
+  - reviewer_handle
+---
+
+Before implementing, read related code (no more than {{vars.max_files}} files), then propose a plan covering: approach, files to touch, tests, risks, and what's deliberately out of scope. Send the plan to {{vars.reviewer_handle}} for sign-off before any commit.

--- a/plugins/op-obsidian/src/__fixtures__/integration/per-project/MODULES/review-and-merge.md
+++ b/plugins/op-obsidian/src/__fixtures__/integration/per-project/MODULES/review-and-merge.md
@@ -1,0 +1,9 @@
+---
+id: review-and-merge
+title: Adversarial review then merge
+type: workflow-module
+scope: review
+order: 10
+---
+
+Once tests pass and CI is green, request an adversarial Copilot review with concrete pressure-test prompts. After review is addressed, merge with `gh pr merge --squash --delete-branch`. PR: {{pr_url}}. Issue: {{id}} (parent: {{parent}}).

--- a/plugins/op-obsidian/src/__fixtures__/integration/per-project/WORKFLOW.md
+++ b/plugins/op-obsidian/src/__fixtures__/integration/per-project/WORKFLOW.md
@@ -1,0 +1,15 @@
+---
+type: workflow
+schema: 1
+project: fixture-project
+default_agent: claude
+default_model: opus
+extends: Projects/_op-workflow.md
+steps:
+  - step: plan
+    modules: [plan-rules]
+  - step: review
+    modules: [review-and-merge]
+---
+
+Per-project workflow extending the global default. Inherits the `kickoff` step from the parent and adds `plan` + `review` here.

--- a/plugins/op-obsidian/src/composeWorkflow.test.ts
+++ b/plugins/op-obsidian/src/composeWorkflow.test.ts
@@ -1,0 +1,254 @@
+import { describe, it, expect, vi } from "vitest";
+
+vi.mock("obsidian", () => {
+  class TFile {
+    path = "";
+    basename = "";
+    name = "";
+  }
+  return {
+    TFile,
+    normalizePath: (p: string) => p.replace(/\/+/g, "/").replace(/\/$/g, ""),
+  };
+});
+
+import { TFile } from "obsidian";
+import { loadModuleSources, loadAndComposeWorkflow } from "./composeWorkflow";
+
+interface FakeFile {
+  path: string;
+  raw: string;
+  frontmatter?: Record<string, unknown> | null;
+}
+
+function makeFile(path: string): TFile {
+  const basename = path.split("/").pop()!.replace(/\.md$/, "");
+  const f = new TFile();
+  Object.assign(f, { path, basename, name: `${basename}.md` });
+  return f;
+}
+
+function fakeApp(files: FakeFile[]) {
+  const tfiles = files.map((f) => ({
+    tfile: makeFile(f.path),
+    raw: f.raw,
+    fm: f.frontmatter,
+  }));
+  return {
+    vault: {
+      getMarkdownFiles: () => tfiles.map((x) => x.tfile),
+      getAbstractFileByPath: (path: string) => {
+        const hit = tfiles.find((x) => x.tfile.path === path);
+        return hit ? hit.tfile : null;
+      },
+      read: async (file: TFile) => {
+        const hit = tfiles.find((x) => x.tfile === file);
+        if (!hit) throw new Error(`fakeApp: missing raw for ${file.path}`);
+        return hit.raw;
+      },
+    },
+    metadataCache: {
+      getFileCache: (file: TFile) => {
+        const hit = tfiles.find((x) => x.tfile === file);
+        if (!hit) return null;
+        if (hit.fm === undefined) return null;
+        return { frontmatter: hit.fm };
+      },
+    },
+  } as any;
+}
+
+const RENDER_CTX = {
+  id: "OP-FIX-1",
+  title: "Fixture issue",
+  project: "demo",
+  status: "open",
+  priority: "med",
+  parent: null,
+  pr_url: undefined,
+  github_issue: undefined,
+  repo_path: "/repo",
+  vault_path: "/vault",
+  vault_name: "vault",
+  branch: "main",
+  today: "2026-04-26",
+  agent: "claude",
+  model: "opus",
+  mode: "kickoff",
+};
+
+function moduleFile(args: {
+  path: string;
+  id: string;
+  scope: string;
+  body: string;
+  vars?: unknown[];
+}): FakeFile {
+  return {
+    path: args.path,
+    frontmatter: {
+      id: args.id,
+      title: args.id,
+      type: "workflow-module",
+      scope: args.scope,
+      vars: args.vars ?? [],
+    },
+    raw: `---\n# yaml omitted (parsed via metadataCache)\n---\n${args.body}\n`,
+  };
+}
+
+function workflowFile(args: { path: string; project: string; steps: unknown[] }): FakeFile {
+  return {
+    path: args.path,
+    frontmatter: {
+      type: "workflow",
+      schema: 1,
+      project: args.project,
+      default_agent: "claude",
+      default_model: "opus",
+      steps: args.steps,
+    },
+    raw: "---\n# yaml omitted (parsed via metadataCache)\n---\nbody\n",
+  };
+}
+
+describe("loadModuleSources", () => {
+  it("rejects an empty project slug with a schema-mismatch diagnostic", async () => {
+    const app = fakeApp([]);
+    const r = await loadModuleSources(app, { project: "" });
+    expect(r.workflow).toBeNull();
+    expect(r.loadedModules).toEqual([]);
+    expect(r.diagnostics[0]).toMatchObject({
+      code: "schema-mismatch",
+      severity: "error",
+    });
+  });
+
+  it("loads modules and reads their bodies, paired with the parsed module record", async () => {
+    const app = fakeApp([
+      moduleFile({
+        path: "Projects/_op-modules/branching.md",
+        id: "branching",
+        scope: "kickoff",
+        body: "Always work in a worktree.",
+      }),
+      workflowFile({
+        path: "Projects/demo/WORKFLOW.md",
+        project: "demo",
+        steps: [{ step: "kickoff", modules: ["branching"] }],
+      }),
+    ]);
+    const r = await loadModuleSources(app, { project: "demo" });
+    expect(r.loadedModules).toHaveLength(1);
+    expect(r.loadedModules[0].module.id).toBe("branching");
+    expect(r.loadedModules[0].body).toBe("Always work in a worktree.\n");
+    expect(r.workflow?.steps).toHaveLength(1);
+    expect(r.diagnostics.find((d) => d.severity === "error")).toBeUndefined();
+  });
+
+  it("strips frontmatter the same way promptBuild.stripFrontmatter does", async () => {
+    const app = fakeApp([
+      {
+        path: "Projects/_op-modules/raw.md",
+        frontmatter: {
+          id: "raw",
+          title: "Raw",
+          type: "workflow-module",
+          scope: "kickoff",
+        },
+        raw: "---\nid: raw\n---\nfirst line\n\nsecond line with --- in body\n",
+      },
+      workflowFile({
+        path: "Projects/demo/WORKFLOW.md",
+        project: "demo",
+        steps: [{ step: "kickoff", modules: ["raw"] }],
+      }),
+    ]);
+    const r = await loadModuleSources(app, { project: "demo" });
+    expect(r.loadedModules[0].body).toBe("first line\n\nsecond line with --- in body\n");
+  });
+
+  it("propagates loader diagnostics from the workflow file alongside module diagnostics", async () => {
+    const app = fakeApp([
+      // Workflow file references a module that doesn't exist on disk.
+      workflowFile({
+        path: "Projects/demo/WORKFLOW.md",
+        project: "demo",
+        steps: [{ step: "kickoff", modules: ["missing"] }],
+      }),
+    ]);
+    const r = await loadModuleSources(app, { project: "demo" });
+    // Loader doesn't validate step.modules against discovered ids — that's
+    // the composer's job. So here we just assert the bundle came back clean
+    // structurally and the diagnostics stream is empty (no error).
+    expect(r.workflow).not.toBeNull();
+    expect(r.loadedModules).toEqual([]);
+  });
+});
+
+describe("loadAndComposeWorkflow", () => {
+  it("end-to-end happy path: load + compose for a single step", async () => {
+    const app = fakeApp([
+      moduleFile({
+        path: "Projects/_op-modules/branching.md",
+        id: "branching",
+        scope: "kickoff",
+        body: "Working on {{id}} on {{branch}}.",
+      }),
+      workflowFile({
+        path: "Projects/demo/WORKFLOW.md",
+        project: "demo",
+        steps: [{ step: "kickoff", modules: ["branching"] }],
+      }),
+    ]);
+    const r = await loadAndComposeWorkflow(app, {
+      project: "demo",
+      step: "kickoff",
+      ctx: { render: RENDER_CTX as any },
+    });
+    expect(r.composed?.text).toBe("Working on OP-FIX-1 on main.\n");
+    expect(r.bundle.workflow).not.toBeNull();
+  });
+
+  it("returns composed=null when the workflow file is unsalvageable", async () => {
+    const app = fakeApp([]); // no WORKFLOW.md at all
+    const r = await loadAndComposeWorkflow(app, {
+      project: "demo",
+      step: "kickoff",
+      ctx: { render: RENDER_CTX as any },
+    });
+    expect(r.composed).toBeNull();
+    expect(r.bundle.workflow).toBeNull();
+    expect(r.bundle.diagnostics.find((d) => d.severity === "error")).toBeTruthy();
+  });
+
+  it("merges loader diagnostics into composed.diagnostics for unified surface", async () => {
+    const app = fakeApp([
+      // Module body references a never-declared user var → composer diagnostic.
+      moduleFile({
+        path: "Projects/_op-modules/intro.md",
+        id: "intro",
+        scope: "kickoff",
+        body: "stage: {{vars.never_declared}}",
+      }),
+      workflowFile({
+        path: "Projects/demo/WORKFLOW.md",
+        project: "demo",
+        steps: [{ step: "kickoff", modules: ["intro"] }],
+      }),
+    ]);
+    const r = await loadAndComposeWorkflow(app, {
+      project: "demo",
+      step: "kickoff",
+      ctx: { render: RENDER_CTX as any },
+    });
+    expect(r.composed?.diagnostics).toContainEqual(
+      expect.objectContaining({
+        code: "malformed-frontmatter",
+        severity: "warning",
+        moduleId: "intro",
+        varName: "never_declared",
+      }),
+    );
+  });
+});

--- a/plugins/op-obsidian/src/composeWorkflow.ts
+++ b/plugins/op-obsidian/src/composeWorkflow.ts
@@ -1,0 +1,171 @@
+import { App, TFile } from "obsidian";
+import { loadModules, type LoadModulesOptions } from "./workflowModule";
+import { loadWorkflowFile } from "./workflowFile";
+import {
+  composeWorkflow as composePure,
+  type ComposeArgs,
+  type ComposeContext,
+  type ComposedPrompt,
+  type LoadedModule,
+} from "./composeWorkflowPure";
+import type { WorkflowFile } from "./workflowFilePure";
+import type { WorkflowModule } from "./workflowModulePure";
+import type { WorkflowDiagnostic } from "./workflowDiagnostic";
+
+// IO seam for OP-197 composition. Wraps OP-195's `loadModules` and OP-196's
+// `loadWorkflowFile`, then reads each module's body content from disk so the
+// pure composer (`composeWorkflowPure.ts`) has everything it needs as plain
+// data. No composition logic lives here — every shape decision flows through
+// the pure layer.
+
+export type {
+  ComposeArgs,
+  ComposeContext,
+  ComposedChunk,
+  ComposedPrompt,
+  LoadedModule,
+  UserVarScope,
+  UserVarSource,
+} from "./composeWorkflowPure";
+export { composeWorkflow as composeWorkflowPure, DEFAULT_MAX_WORKFLOW_CHARS } from "./composeWorkflowPure";
+
+/**
+ * Bundle returned by `loadModuleSources`. Bundles together the loaded
+ * (frontmatter-parsed) modules with their body content, plus the merged
+ * workflow file and the diagnostic stream from both loaders.
+ *
+ * Callers (OP-198 kickoff injection, OP-186 dry-run preview) feed
+ * `loadedModules` + `workflow` into `composeWorkflow` along with their
+ * `RenderContext`.
+ */
+export interface ModuleSourceBundle {
+  loadedModules: LoadedModule[];
+  workflow: WorkflowFile | null;
+  diagnostics: WorkflowDiagnostic[];
+}
+
+/**
+ * Discover and load every workflow module + the project's workflow file.
+ * IO function — caller MUST invoke after `workspace.onLayoutReady` so
+ * `metadataCache` has resolved frontmatter for the vault.
+ *
+ * Steps:
+ *   1. `loadModules(app, opts)` — discovers every module file at
+ *      `Projects/_op-modules/<id>.md` and `Projects/<slug>/MODULES/<id>.md`,
+ *      applies per-project shadowing, runs intra-scope collision validation.
+ *   2. For every loaded module's `source.path`, read the body via
+ *      `app.vault.read(file)` and strip the frontmatter (everything between
+ *      the leading `---` fence and the matching closing `---`).
+ *   3. `loadWorkflowFile(app, project)` — reads `Projects/<project>/WORKFLOW.md`,
+ *      classifies legacy shape, follows `extends:` one level, validates models.
+ *   4. Returns the bundle. The caller passes it into `composeWorkflow`.
+ *
+ * `opts.project` filters discovered modules — only the project's own
+ * per-project modules + globals targeting that project (or no project) are
+ * returned. The workflow file is always read from `Projects/<project>/`.
+ */
+export async function loadModuleSources(
+  app: App,
+  opts: { project: string } & LoadModulesOptions = { project: "" },
+): Promise<ModuleSourceBundle> {
+  const slug = opts.project.trim();
+  const diagnostics: WorkflowDiagnostic[] = [];
+
+  if (!slug) {
+    diagnostics.push({
+      code: "schema-mismatch",
+      severity: "error",
+      message: "loadModuleSources: project slug is required.",
+      extra: { field: "project" },
+    });
+    return { loadedModules: [], workflow: null, diagnostics };
+  }
+
+  // Module discovery (frontmatter only — body is read below).
+  const moduleResult = loadModules(app, { project: slug });
+  diagnostics.push(...moduleResult.diagnostics);
+
+  // Body load. Each module's `source.path` is vault-relative — re-resolve it
+  // through `getAbstractFileByPath` so we have a `TFile` to read.
+  const loadedModules: LoadedModule[] = [];
+  for (const m of moduleResult.modules) {
+    const file = app.vault.getAbstractFileByPath(m.source.path);
+    if (!(file instanceof TFile)) {
+      diagnostics.push({
+        code: "schema-mismatch",
+        severity: "error",
+        message: `loadModuleSources: module "${m.id}" path ${m.source.path} no longer resolves to a TFile (file moved or deleted between metadataCache walk and body read).`,
+        moduleId: m.id,
+        extra: { path: m.source.path, expected: "TFile", actual: file === null ? "null" : file.constructor.name },
+      });
+      continue;
+    }
+    const raw = await app.vault.read(file);
+    const body = stripFrontmatter(raw);
+    loadedModules.push({ module: m, body });
+  }
+
+  // Workflow file (per-project, follows `extends:` to global default).
+  const workflowResult = await loadWorkflowFile(app, slug);
+  diagnostics.push(...workflowResult.diagnostics);
+
+  return {
+    loadedModules,
+    workflow: workflowResult.workflow,
+    diagnostics,
+  };
+}
+
+/**
+ * Strip a markdown file's frontmatter fence. Byte-for-byte compatible with
+ * `workflowFilePure.ts:stripWorkflowFrontmatter` (which is itself byte-for-
+ * byte compatible with `promptBuild.ts:stripFrontmatter`). Re-implemented
+ * here so the composer pipeline doesn't drag a runtime dependency on the
+ * workflow-file or prompt-build modules.
+ */
+function stripFrontmatter(raw: string): string {
+  if (!raw.startsWith("---")) return raw;
+  const end = raw.indexOf("\n---", 3);
+  if (end === -1) return raw;
+  const afterFence = raw.indexOf("\n", end + 4);
+  return afterFence === -1 ? "" : raw.slice(afterFence + 1);
+}
+
+/**
+ * One-stop composer: load + compose. Convenience wrapper around
+ * `loadModuleSources` + `composeWorkflowPure` for callers that want a single
+ * entry point.
+ *
+ * Returns `null` workflow when the project's `WORKFLOW.md` couldn't be
+ * salvaged at all — caller surfaces the diagnostics and aborts the launch
+ * (or falls back to a no-modules launch, depending on the surface).
+ */
+export async function loadAndComposeWorkflow(
+  app: App,
+  args: { project: string; step: string; ctx: ComposeContext },
+): Promise<{ composed: ComposedPrompt | null; bundle: ModuleSourceBundle }> {
+  const bundle = await loadModuleSources(app, { project: args.project });
+  if (!bundle.workflow) {
+    return { composed: null, bundle };
+  }
+  const composed = composePure({
+    loadedModules: bundle.loadedModules,
+    workflow: bundle.workflow,
+    step: args.step,
+    ctx: args.ctx,
+  });
+  // Concat the loader's diagnostics with the composer's so callers see one
+  // unified stream. The composer's already include any size-budget /
+  // missing-var entries.
+  return {
+    composed: {
+      ...composed,
+      diagnostics: [...bundle.diagnostics, ...composed.diagnostics],
+    },
+    bundle,
+  };
+}
+
+// Re-export the typed module shapes for callers that want them at the same
+// import path as the composer.
+export type { WorkflowFile, WorkflowModule };

--- a/plugins/op-obsidian/src/composeWorkflowPure.test.ts
+++ b/plugins/op-obsidian/src/composeWorkflowPure.test.ts
@@ -1,0 +1,513 @@
+import { describe, it, expect } from "vitest";
+import {
+  composeWorkflow,
+  DEFAULT_MAX_WORKFLOW_CHARS,
+  type ComposeContext,
+  type LoadedModule,
+} from "./composeWorkflowPure";
+import type { RenderContext } from "./pluginVarRegistry";
+import type { WorkflowFile, WorkflowStep } from "./workflowFilePure";
+import type { WorkflowModule, VarDecl } from "./workflowModulePure";
+
+// Pure composer tests. No fake `App`, no metadataCache — every input is built
+// inline as plain data. The IO seam (`composeWorkflow.ts`) has its own tests.
+
+const RENDER_CTX: RenderContext = {
+  id: "OP-197",
+  title: "1d composeWorkflow split",
+  project: "obsidian-projects",
+  status: "in-progress",
+  priority: "high",
+  parent: "OP-184",
+  pr_url: undefined,
+  github_issue: undefined,
+  repo_path: "/Users/me/Projects/obsidian-projects",
+  vault_path: "/Users/me/work/Agent-Vault",
+  vault_name: "Agent-Vault",
+  branch: "worktree-op-197",
+  today: "2026-04-26",
+  agent: "claude",
+  model: "claude-opus-4-7",
+  mode: "implement",
+};
+
+function makeModule(args: {
+  id: string;
+  scope: string;
+  vars?: VarDecl[];
+  project?: string;
+  agent?: string;
+  order?: number;
+  pathPrefix?: "global" | "project";
+}): WorkflowModule {
+  const path =
+    args.pathPrefix === "project"
+      ? `Projects/obsidian-projects/MODULES/${args.id}.md`
+      : `Projects/_op-modules/${args.id}.md`;
+  const source =
+    args.pathPrefix === "project"
+      ? { kind: "project" as const, path, projectSlug: "obsidian-projects" }
+      : { kind: "global" as const, path };
+  return {
+    id: args.id,
+    title: args.id,
+    scope: args.scope,
+    project: args.project,
+    agent: args.agent,
+    order: args.order ?? 0,
+    vars: args.vars ?? [],
+    source,
+  };
+}
+
+function makeWorkflow(steps: WorkflowStep[]): WorkflowFile {
+  return {
+    source: { path: "Projects/obsidian-projects/WORKFLOW.md", project: "obsidian-projects", isLegacy: false },
+    type: "workflow",
+    schema: 1,
+    project: "obsidian-projects",
+    defaultAgent: ["claude"],
+    defaultModel: { kind: "all", values: ["sonnet"] },
+    extendsPath: null,
+    steps,
+  };
+}
+
+const baseCtx: ComposeContext = { render: RENDER_CTX };
+
+// ---------------------------------------------------------------------------
+// Step lookup + module ordering
+// ---------------------------------------------------------------------------
+
+describe("step lookup", () => {
+  it("returns a schema-mismatch error when the step doesn't exist in the workflow", () => {
+    const workflow = makeWorkflow([{ step: "kickoff", modules: [] }]);
+    const r = composeWorkflow({ loadedModules: [], workflow, step: "nonexistent", ctx: baseCtx });
+    expect(r.text).toBe("");
+    expect(r.diagnostics).toHaveLength(1);
+    expect(r.diagnostics[0]).toMatchObject({
+      code: "schema-mismatch",
+      severity: "error",
+      stepId: "nonexistent",
+    });
+    expect(r.diagnostics[0].message).toContain("no step");
+  });
+
+  it("composes modules in the order the step lists them, ignoring file discovery order", () => {
+    const m1 = makeModule({ id: "branching", scope: "kickoff" });
+    const m2 = makeModule({ id: "tmux-safety", scope: "kickoff" });
+    const m3 = makeModule({ id: "version-cadence", scope: "kickoff" });
+    const workflow = makeWorkflow([
+      { step: "kickoff", modules: ["branching", "tmux-safety", "version-cadence"] },
+    ]);
+    // Loader returns modules in arbitrary order — composer must respect the step's order.
+    const loaded: LoadedModule[] = [
+      { module: m3, body: "version-body" },
+      { module: m1, body: "branching-body" },
+      { module: m2, body: "tmux-body" },
+    ];
+    const r = composeWorkflow({ loadedModules: loaded, workflow, step: "kickoff", ctx: baseCtx });
+    expect(r.orderedChunks.map((c) => c.moduleId)).toEqual([
+      "branching",
+      "tmux-safety",
+      "version-cadence",
+    ]);
+    expect(r.text).toBe("branching-body\n\ntmux-body\n\nversion-body");
+  });
+
+  it("emits unknown-module for a step.modules entry with no matching loaded module", () => {
+    const m = makeModule({ id: "branching", scope: "kickoff" });
+    const workflow = makeWorkflow([
+      { step: "kickoff", modules: ["branching", "missing-module"] },
+    ]);
+    const r = composeWorkflow({
+      loadedModules: [{ module: m, body: "branching" }],
+      workflow,
+      step: "kickoff",
+      ctx: baseCtx,
+    });
+    expect(r.diagnostics).toContainEqual(
+      expect.objectContaining({
+        code: "unknown-module",
+        severity: "error",
+        moduleId: "missing-module",
+        stepId: "kickoff",
+      }),
+    );
+    expect(r.orderedChunks.map((c) => c.moduleId)).toEqual(["branching"]);
+  });
+
+  it("returns an empty composed prompt for a step with no modules", () => {
+    const workflow = makeWorkflow([{ step: "kickoff", modules: [] }]);
+    const r = composeWorkflow({ loadedModules: [], workflow, step: "kickoff", ctx: baseCtx });
+    expect(r.text).toBe("");
+    expect(r.orderedChunks).toEqual([]);
+    expect(r.diagnostics).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// User-var precedence
+// ---------------------------------------------------------------------------
+
+describe("user-var precedence (Module → Global → Project → Launch)", () => {
+  function variantWith(overrides: Partial<ComposeContext>): ComposeContext {
+    return { ...baseCtx, ...overrides };
+  }
+
+  const m = makeModule({
+    id: "review-and-merge",
+    scope: "review",
+    vars: [{ kind: "default", name: "reviewer_handle", value: "@module-default" }],
+  });
+  const workflow = makeWorkflow([
+    { step: "review", modules: ["review-and-merge"] },
+  ]);
+  const loaded: LoadedModule[] = [
+    { module: m, body: "Reviewer: {{vars.reviewer_handle}}" },
+  ];
+
+  it("Module-default wins when no other layer supplies a value", () => {
+    const r = composeWorkflow({ loadedModules: loaded, workflow, step: "review", ctx: baseCtx });
+    expect(r.text).toBe("Reviewer: @module-default");
+    expect(r.perVarSourceMap.reviewer_handle).toMatchObject({
+      value: "@module-default",
+      scope: "module",
+      source: "review-and-merge",
+    });
+  });
+
+  it("Global default overrides Module default", () => {
+    const r = composeWorkflow({
+      loadedModules: loaded,
+      workflow,
+      step: "review",
+      ctx: variantWith({ globalVars: { reviewer_handle: "@global" } }),
+    });
+    expect(r.text).toBe("Reviewer: @global");
+    expect(r.perVarSourceMap.reviewer_handle.scope).toBe("global");
+  });
+
+  it("Project default overrides Global", () => {
+    const r = composeWorkflow({
+      loadedModules: loaded,
+      workflow,
+      step: "review",
+      ctx: variantWith({
+        globalVars: { reviewer_handle: "@global" },
+        projectVars: { reviewer_handle: "@project" },
+      }),
+    });
+    expect(r.text).toBe("Reviewer: @project");
+    expect(r.perVarSourceMap.reviewer_handle.scope).toBe("project");
+  });
+
+  it("Launch override wins over everything", () => {
+    const r = composeWorkflow({
+      loadedModules: loaded,
+      workflow,
+      step: "review",
+      ctx: variantWith({
+        globalVars: { reviewer_handle: "@global" },
+        projectVars: { reviewer_handle: "@project" },
+        launchVars: { reviewer_handle: "@launch" },
+      }),
+    });
+    expect(r.text).toBe("Reviewer: @launch");
+    expect(r.perVarSourceMap.reviewer_handle).toMatchObject({
+      value: "@launch",
+      scope: "launch",
+      source: "launch",
+    });
+  });
+
+  it("an empty-string Launch override wins (distinct from absent)", () => {
+    const r = composeWorkflow({
+      loadedModules: loaded,
+      workflow,
+      step: "review",
+      ctx: variantWith({ launchVars: { reviewer_handle: "" } }),
+    });
+    expect(r.text).toBe("Reviewer: ");
+    expect(r.perVarSourceMap.reviewer_handle).toMatchObject({ value: "", scope: "launch" });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Plugin-var fallthrough (OP-194 renderTemplate)
+// ---------------------------------------------------------------------------
+
+describe("plugin-var fallthrough", () => {
+  it("renders {{id}} via PLUGIN_VAR_REGISTRY without a vars: declaration", () => {
+    const m = makeModule({ id: "intro", scope: "kickoff" });
+    const workflow = makeWorkflow([{ step: "kickoff", modules: ["intro"] }]);
+    const loaded: LoadedModule[] = [
+      { module: m, body: "Working on {{id}} for {{project}} on {{branch}}." },
+    ];
+    const r = composeWorkflow({ loadedModules: loaded, workflow, step: "kickoff", ctx: baseCtx });
+    expect(r.text).toBe(
+      "Working on OP-197 for obsidian-projects on worktree-op-197.",
+    );
+  });
+
+  it("user-var and plugin-var namespaces are disjoint by token shape", () => {
+    const m = makeModule({
+      id: "intro",
+      scope: "kickoff",
+      vars: [{ kind: "default", name: "id", value: "user-id" }],
+    });
+    const workflow = makeWorkflow([{ step: "kickoff", modules: ["intro"] }]);
+    const loaded: LoadedModule[] = [
+      { module: m, body: "plugin: {{id}} | user: {{vars.id}}" },
+    ];
+    const r = composeWorkflow({ loadedModules: loaded, workflow, step: "kickoff", ctx: baseCtx });
+    // {{id}} → plugin var; {{vars.id}} → user var with the module's default.
+    expect(r.text).toBe("plugin: OP-197 | user: user-id");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Diagnostics
+// ---------------------------------------------------------------------------
+
+describe("diagnostics", () => {
+  it("missing-var (warning) when a declared user var resolves to no value at any layer", () => {
+    const m = makeModule({
+      id: "intro",
+      scope: "kickoff",
+      vars: [{ kind: "bare", name: "reviewer" }], // declared, no default
+    });
+    const workflow = makeWorkflow([{ step: "kickoff", modules: ["intro"] }]);
+    const loaded: LoadedModule[] = [{ module: m, body: "Reviewer: {{vars.reviewer}}" }];
+    const r = composeWorkflow({ loadedModules: loaded, workflow, step: "kickoff", ctx: baseCtx });
+    expect(r.text).toBe("Reviewer: {{vars.reviewer}}");
+    expect(r.diagnostics).toContainEqual(
+      expect.objectContaining({
+        code: "missing-var",
+        severity: "warning",
+        moduleId: "intro",
+        varName: "reviewer",
+      }),
+    );
+  });
+
+  it("malformed-frontmatter (warning, undeclared-but-referenced) when a body references {{vars.x}} but no module declares x", () => {
+    const m = makeModule({ id: "intro", scope: "kickoff" });
+    const workflow = makeWorkflow([{ step: "kickoff", modules: ["intro"] }]);
+    const loaded: LoadedModule[] = [
+      { module: m, body: "Stage: {{vars.never_declared}}" },
+    ];
+    const r = composeWorkflow({ loadedModules: loaded, workflow, step: "kickoff", ctx: baseCtx });
+    expect(r.text).toBe("Stage: {{vars.never_declared}}");
+    expect(r.diagnostics).toContainEqual(
+      expect.objectContaining({
+        code: "malformed-frontmatter",
+        severity: "warning",
+        moduleId: "intro",
+        varName: "never_declared",
+      }),
+    );
+    expect(r.diagnostics[0].message).toMatch(/never declared/);
+  });
+
+  it("malformed-frontmatter (info, declared-but-unused) when vars: declares x but body never references it", () => {
+    const m = makeModule({
+      id: "intro",
+      scope: "kickoff",
+      vars: [{ kind: "default", name: "unused_var", value: "ignored" }],
+    });
+    const workflow = makeWorkflow([{ step: "kickoff", modules: ["intro"] }]);
+    const loaded: LoadedModule[] = [
+      { module: m, body: "no vars referenced here" },
+    ];
+    const r = composeWorkflow({ loadedModules: loaded, workflow, step: "kickoff", ctx: baseCtx });
+    expect(r.diagnostics).toContainEqual(
+      expect.objectContaining({
+        code: "malformed-frontmatter",
+        severity: "info",
+        moduleId: "intro",
+        varName: "unused_var",
+      }),
+    );
+  });
+
+  it("missing-var (warning) for unknown plugin-var tokens (re-emitted from renderTemplate)", () => {
+    const m = makeModule({ id: "intro", scope: "kickoff" });
+    const workflow = makeWorkflow([{ step: "kickoff", modules: ["intro"] }]);
+    const loaded: LoadedModule[] = [
+      { module: m, body: "Hello {{notavar}}" },
+    ];
+    const r = composeWorkflow({ loadedModules: loaded, workflow, step: "kickoff", ctx: baseCtx });
+    expect(r.text).toBe("Hello {{notavar}}");
+    expect(r.diagnostics).toContainEqual(
+      expect.objectContaining({
+        code: "missing-var",
+        severity: "warning",
+        moduleId: "intro",
+        varName: "notavar",
+      }),
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Size-budget overrun
+// ---------------------------------------------------------------------------
+
+describe("size-budget", () => {
+  it("emits a size-budget info diagnostic when composed text exceeds maxWorkflowChars", () => {
+    const big = "x".repeat(100);
+    const m = makeModule({ id: "fat", scope: "kickoff" });
+    const workflow = makeWorkflow([{ step: "kickoff", modules: ["fat"] }]);
+    const loaded: LoadedModule[] = [{ module: m, body: big }];
+    const r = composeWorkflow({
+      loadedModules: loaded,
+      workflow,
+      step: "kickoff",
+      ctx: { ...baseCtx, maxWorkflowChars: 50 },
+    });
+    expect(r.sizeChars).toBe(100);
+    const d = r.diagnostics.find((x) => x.code === "size-budget");
+    expect(d).toMatchObject({ code: "size-budget", severity: "info" });
+    expect(d?.extra).toMatchObject({ sizeChars: 100, maxWorkflowChars: 50 });
+  });
+
+  it("emits no size-budget diagnostic when below the cap", () => {
+    const m = makeModule({ id: "small", scope: "kickoff" });
+    const workflow = makeWorkflow([{ step: "kickoff", modules: ["small"] }]);
+    const loaded: LoadedModule[] = [{ module: m, body: "tiny body" }];
+    const r = composeWorkflow({
+      loadedModules: loaded,
+      workflow,
+      step: "kickoff",
+      ctx: { ...baseCtx, maxWorkflowChars: 50000 },
+    });
+    expect(r.diagnostics.find((x) => x.code === "size-budget")).toBeUndefined();
+  });
+
+  it("default cap is 50000 when ctx.maxWorkflowChars is unset", () => {
+    expect(DEFAULT_MAX_WORKFLOW_CHARS).toBe(50000);
+    // Compose a small body; no diagnostic at default cap.
+    const m = makeModule({ id: "small", scope: "kickoff" });
+    const workflow = makeWorkflow([{ step: "kickoff", modules: ["small"] }]);
+    const loaded: LoadedModule[] = [{ module: m, body: "tiny" }];
+    const r = composeWorkflow({ loadedModules: loaded, workflow, step: "kickoff", ctx: baseCtx });
+    expect(r.diagnostics.find((x) => x.code === "size-budget")).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// extends: inheritance merge
+// ---------------------------------------------------------------------------
+
+describe("extends inheritance (composer reads merged workflow as opaque)", () => {
+  it("composes modules from steps that came from both parent and child workflows", () => {
+    // Simulate the post-merge workflow OP-196's mergeWorkflows would produce:
+    // parent had [kickoff], child added [review]; the merged step list is
+    // [kickoff, review] in that order.
+    const mergedWorkflow = makeWorkflow([
+      { step: "kickoff", modules: ["from-parent"] },
+      { step: "review", modules: ["from-child"] },
+    ]);
+    const parentMod = makeModule({ id: "from-parent", scope: "kickoff" });
+    const childMod = makeModule({ id: "from-child", scope: "review" });
+    const loaded: LoadedModule[] = [
+      { module: parentMod, body: "parent step body" },
+      { module: childMod, body: "child step body" },
+    ];
+
+    const r1 = composeWorkflow({
+      loadedModules: loaded,
+      workflow: mergedWorkflow,
+      step: "kickoff",
+      ctx: baseCtx,
+    });
+    expect(r1.text).toBe("parent step body");
+
+    const r2 = composeWorkflow({
+      loadedModules: loaded,
+      workflow: mergedWorkflow,
+      step: "review",
+      ctx: baseCtx,
+    });
+    expect(r2.text).toBe("child step body");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Intra-scope collision (OP-195 detector reuse)
+// ---------------------------------------------------------------------------
+
+describe("intra-scope collision visibility", () => {
+  it("does NOT re-detect collisions — the composer trusts the loader's output", () => {
+    // Two modules at the same scope declaring the same var. OP-195's
+    // validateIntraScopeCollisions would have flagged it at load time. The
+    // composer takes the alphabetically-first module's default deterministically;
+    // it does not re-emit the collision diagnostic (that's the loader's job).
+    const m1 = makeModule({
+      id: "alpha",
+      scope: "kickoff",
+      vars: [{ kind: "default", name: "shared", value: "alpha-default" }],
+    });
+    const m2 = makeModule({
+      id: "beta",
+      scope: "kickoff",
+      vars: [{ kind: "default", name: "shared", value: "beta-default" }],
+    });
+    const workflow = makeWorkflow([
+      { step: "kickoff", modules: ["alpha", "beta"] },
+    ]);
+    const loaded: LoadedModule[] = [
+      { module: m1, body: "{{vars.shared}}" },
+      { module: m2, body: "{{vars.shared}}" },
+    ];
+    const r = composeWorkflow({ loadedModules: loaded, workflow, step: "kickoff", ctx: baseCtx });
+    // Both chunks resolve via alpha's default (alphabetically first).
+    expect(r.orderedChunks.map((c) => c.text)).toEqual(["alpha-default", "alpha-default"]);
+    expect(r.perVarSourceMap.shared).toMatchObject({ value: "alpha-default", source: "alpha" });
+    // No intra-scope-collision diagnostic from the composer itself.
+    expect(r.diagnostics.find((x) => x.code === "intra-scope-collision")).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Legacy kickoff splice
+// ---------------------------------------------------------------------------
+
+describe("legacy kickoff body splice", () => {
+  it("splices legacyKickoffBody verbatim with no template substitution", () => {
+    const workflow = makeWorkflow([
+      {
+        step: "kickoff",
+        modules: [],
+        legacyKickoffBody: "legacy body with {{id}} that should NOT substitute",
+      },
+    ]);
+    const r = composeWorkflow({ loadedModules: [], workflow, step: "kickoff", ctx: baseCtx });
+    expect(r.text).toBe("legacy body with {{id}} that should NOT substitute");
+    expect(r.orderedChunks).toEqual([
+      expect.objectContaining({ moduleId: "<legacy-kickoff>", scope: "kickoff" }),
+    ]);
+    expect(r.diagnostics).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Whitespace tolerance in tokens
+// ---------------------------------------------------------------------------
+
+describe("token whitespace", () => {
+  it("tolerates whitespace inside {{vars.name}} braces", () => {
+    const m = makeModule({
+      id: "ws",
+      scope: "kickoff",
+      vars: [{ kind: "default", name: "foo", value: "FOO" }],
+    });
+    const workflow = makeWorkflow([{ step: "kickoff", modules: ["ws"] }]);
+    const loaded: LoadedModule[] = [
+      { module: m, body: "a {{ vars.foo }} b {{vars.foo}} c" },
+    ];
+    const r = composeWorkflow({ loadedModules: loaded, workflow, step: "kickoff", ctx: baseCtx });
+    expect(r.text).toBe("a FOO b FOO c");
+  });
+});

--- a/plugins/op-obsidian/src/composeWorkflowPure.ts
+++ b/plugins/op-obsidian/src/composeWorkflowPure.ts
@@ -1,0 +1,533 @@
+import {
+  PLUGIN_VAR_REGISTRY,
+  type RenderContext,
+} from "./pluginVarRegistry";
+import { renderTemplate } from "./renderTemplate";
+import type { WorkflowDiagnostic } from "./workflowDiagnostic";
+import type { VarDecl, WorkflowModule } from "./workflowModulePure";
+import type { WorkflowFile, WorkflowStep } from "./workflowFilePure";
+
+// Pure composition: turn the (loaded modules, parsed workflow file, mode,
+// render context) tuple into a single composed prompt with per-var source
+// tracking and a unified diagnostic stream. OP-197 (1d) — final grandchild of
+// OP-184. No I/O, no clock, no Obsidian imports — every input flows in via
+// arguments. The IO seam (`loadModuleSources` in `composeWorkflow.ts`) reads
+// vault TFiles + bodies and hands the result to `composeWorkflow` defined here.
+//
+// Precedence (lowest → highest, later wins): Module → Global → Project → Launch.
+//   - Module: a module's `vars: [name=value]` declaration (OP-195 schema).
+//   - Global: vault-wide user vars (OP-181 plan §"Variable precedence" — lives
+//             in `settings.workflowVars`; the wiring lands in OP-198).
+//   - Project: per-project user vars (`STATUS.md` `vars:` map).
+//   - Launch: per-launch overrides threaded through the launch UI / URI / CLI.
+//
+// Always-on plugin vars (OP-194's `PLUGIN_VAR_REGISTRY`) live exclusively at
+// the Launch-override scope — they're computed per-launch from `RenderContext`
+// and shadow any same-named lower-precedence value. The composer resolves user
+// vars first (substituting `{{vars.<name>}}` tokens), then runs the OP-194
+// renderer for `{{<name>}}` plugin-var tokens. This ordering means a user var
+// can never accidentally shadow `{{id}}` or `{{branch}}`; the namespaces are
+// disjoint by token shape.
+//
+// Diagnostics this composer emits (in addition to whatever the loader passed
+// through):
+//   - `missing-var` (warning): a `{{vars.<name>}}` token resolved to nothing
+//     at every precedence layer.
+//   - `missing-var` (warning): an `{{<name>}}` plugin-var token had no entry
+//     in `PLUGIN_VAR_REGISTRY` or its compute returned `undefined`. (Re-emitted
+//     by the OP-194 renderer; surfaced through here.)
+//   - `malformed-frontmatter` (info): a module declared a var (`vars: [foo]`)
+//     that its body never references — surfaces as info because the unused
+//     declaration is harmless but worth flagging.
+//   - `malformed-frontmatter` (warning): a module body references `{{vars.foo}}`
+//     but no module at any scope declared `foo` — distinct from `missing-var`
+//     ("declared somewhere but no value resolved" vs "never declared anywhere"
+//     — OP-197 scope explicitly calls this out as undeclared-but-referenced).
+//   - One info-severity `WorkflowDiagnostic` when the composed prompt's total
+//     character count exceeds `ctx.maxWorkflowChars` (OP-181 Risk 1 mitigation).
+//
+// Returns a `ComposedPrompt` carrying the joined text, the per-chunk
+// breakdown (for surfaces that want to show "module X contributed Y chars"),
+// the per-user-var source map (for the dry-run / preview surface in OP-186),
+// the total size, and the diagnostic stream.
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/** Precedence layer a user-var value resolved from. Lowest → highest. */
+export type UserVarScope = "module" | "global" | "project" | "launch";
+
+/**
+ * Where a single resolved user-var value came from. Surfaced on
+ * `ComposedPrompt.perVarSourceMap` so dry-run / preview surfaces can show
+ * "this value came from the global default, not the module's default".
+ */
+export interface UserVarSource {
+  /** Resolved value (may be `null` if every layer was empty). */
+  value: string | null;
+  /** Layer that supplied the resolved value, or `null` when no layer did. */
+  scope: UserVarScope | null;
+  /** Identifier of the layer source — module id for `module`, "global" / project slug / "launch" otherwise. */
+  source: string;
+}
+
+/**
+ * One module's contribution to the composed prompt.
+ */
+export interface ComposedChunk {
+  moduleId: string;
+  scope: string;
+  text: string;
+  sizeChars: number;
+}
+
+/**
+ * Result of `composeWorkflow`. Pure data — no methods, no live references.
+ */
+export interface ComposedPrompt {
+  /** Joined text of every ordered chunk, separated by `\n\n`. */
+  text: string;
+  orderedChunks: ComposedChunk[];
+  /**
+   * For every user var that was *referenced* anywhere in any composed chunk,
+   * the resolved value + the precedence layer that supplied it. Vars never
+   * referenced are absent from the map (callers asking for a complete dump
+   * should iterate the module declarations instead).
+   */
+  perVarSourceMap: Record<string, UserVarSource>;
+  /** Character count of `text`. */
+  sizeChars: number;
+  diagnostics: WorkflowDiagnostic[];
+}
+
+/**
+ * One pre-loaded module — the IO layer attaches its body content; the pure
+ * composer reads `module.vars` for declarations and `body` for substitution.
+ */
+export interface LoadedModule {
+  module: WorkflowModule;
+  body: string;
+}
+
+/**
+ * Composition input. The plugin-var context lives at `render`; user-var
+ * scopes (Global, Project, Launch) come in as keyed maps so the composer
+ * can flatten them into the precedence chain. `maxWorkflowChars` is the
+ * size-budget cap (info-only).
+ */
+export interface ComposeContext {
+  /** Plugin-var context — drives OP-194's `renderTemplate`. */
+  render: RenderContext;
+  /** Vault-wide user vars (OP-198 wires this from `settings.workflowVars`). */
+  globalVars?: Record<string, string>;
+  /** Per-project user vars (OP-198 wires this from `STATUS.md`). */
+  projectVars?: Record<string, string>;
+  /** Per-launch user vars (OP-186 / OP-198 wires this from launch UI / URI). */
+  launchVars?: Record<string, string>;
+  /** Soft cap — exceeding it surfaces an info-severity diagnostic. Default: 50000. */
+  maxWorkflowChars?: number;
+}
+
+/**
+ * Step selector. The composer reads the step record's `modules:` list and
+ * filters the loaded module set by id; legacy synthetic steps with a
+ * `legacyKickoffBody` are spliced in verbatim.
+ */
+export interface ComposeArgs {
+  /** All modules the loader discovered, paired with their body content. */
+  loadedModules: LoadedModule[];
+  /** Parsed (post-merge) workflow file. */
+  workflow: WorkflowFile;
+  /** Step id to compose. Must exist in `workflow.steps`. */
+  step: string;
+  /** Render context + user-var scopes + budget. */
+  ctx: ComposeContext;
+}
+
+// ---------------------------------------------------------------------------
+// Defaults + helpers
+// ---------------------------------------------------------------------------
+
+export const DEFAULT_MAX_WORKFLOW_CHARS = 50000;
+
+/**
+ * Token shape for `{{vars.<name>}}`. Conservative `[a-zA-Z_][a-zA-Z0-9_-]*`
+ * name pattern — allows `-` so module authors can write `{{vars.repo-path}}`
+ * if they prefer hyphenated names. Whitespace inside the braces is tolerated.
+ */
+const USER_VAR_TOKEN_RE = /\{\{\s*vars\.([a-zA-Z_][a-zA-Z0-9_-]*)\s*\}\}/g;
+
+/**
+ * Extract every `vars.<name>` referenced in `text`. Returns a `Set<string>`
+ * of unique names (order not preserved — the renderer walks left-to-right).
+ */
+function extractUserVarRefs(text: string): Set<string> {
+  const names = new Set<string>();
+  USER_VAR_TOKEN_RE.lastIndex = 0;
+  let m: RegExpExecArray | null;
+  while ((m = USER_VAR_TOKEN_RE.exec(text)) !== null) {
+    names.add(m[1]);
+  }
+  return names;
+}
+
+/**
+ * Pull the inline default off a `VarDecl`. `bare` declarations have none.
+ */
+function moduleVarDefault(v: VarDecl): string | null {
+  if (v.kind === "bare") return null;
+  if (v.kind === "default") return v.value;
+  if (v.kind === "object") return v.default ?? null;
+  return null;
+}
+
+// ---------------------------------------------------------------------------
+// Precedence resolver
+// ---------------------------------------------------------------------------
+
+interface ResolveUserVarArgs {
+  name: string;
+  modulesDeclaringIt: WorkflowModule[];
+  globalVars: Record<string, string>;
+  projectVars: Record<string, string>;
+  launchVars: Record<string, string>;
+}
+
+/**
+ * Resolve one user var through the precedence chain. Later wins. Returns the
+ * value + the supplying scope (or `null, null` if every layer was empty).
+ */
+function resolveUserVar(args: ResolveUserVarArgs): UserVarSource {
+  const { name, modulesDeclaringIt, globalVars, projectVars, launchVars } = args;
+
+  // Start with the lowest precedence; walk up. The latest non-undefined wins.
+  let value: string | null = null;
+  let scope: UserVarScope | null = null;
+  let source = "(unset)";
+
+  // Module default(s). If multiple modules declare the same var with a
+  // default, OP-195's intra-scope-collision validator already flagged the
+  // problem; the composer takes the first declaration deterministically (by
+  // module id sort) so a stale collision doesn't change rendering.
+  if (modulesDeclaringIt.length > 0) {
+    const sorted = [...modulesDeclaringIt].sort((a, b) => a.id.localeCompare(b.id));
+    for (const m of sorted) {
+      const decl = m.vars.find((v) => v.name === name);
+      if (!decl) continue;
+      const def = moduleVarDefault(decl);
+      if (def !== null) {
+        value = def;
+        scope = "module";
+        source = m.id;
+        break;
+      }
+    }
+  }
+
+  if (Object.prototype.hasOwnProperty.call(globalVars, name)) {
+    value = globalVars[name];
+    scope = "global";
+    source = "global";
+  }
+
+  if (Object.prototype.hasOwnProperty.call(projectVars, name)) {
+    value = projectVars[name];
+    scope = "project";
+    source = "project";
+  }
+
+  if (Object.prototype.hasOwnProperty.call(launchVars, name)) {
+    value = launchVars[name];
+    scope = "launch";
+    source = "launch";
+  }
+
+  return { value, scope, source };
+}
+
+// ---------------------------------------------------------------------------
+// Module body renderer
+// ---------------------------------------------------------------------------
+
+interface RenderModuleArgs {
+  module: WorkflowModule;
+  body: string;
+  /** All loaded modules — used to detect "declared somewhere but never referenced" cases. */
+  allModulesByVarName: Map<string, WorkflowModule[]>;
+  /** Pre-resolved user-var values (the same map ends up on `ComposedPrompt`). */
+  perVarSourceMap: Record<string, UserVarSource>;
+  ctx: ComposeContext;
+}
+
+interface RenderedModule {
+  text: string;
+  diagnostics: WorkflowDiagnostic[];
+}
+
+/**
+ * Render a single module body. Two passes:
+ *   1. Replace `{{vars.<name>}}` tokens via the resolved user-var map. Tokens
+ *      that resolve to a value substitute. Tokens whose user var resolved to
+ *      no value at any scope leave the token verbatim and emit either
+ *      `missing-var` (warning) — declared somewhere but no value resolved —
+ *      or `malformed-frontmatter` (warning, message: "undeclared but
+ *      referenced") — never declared anywhere.
+ *   2. Run OP-194's `renderTemplate` for plugin-var tokens (`{{id}}`, etc.).
+ *      Diagnostics from renderTemplate are concatenated into the chunk's
+ *      diagnostics.
+ *
+ * Always-on plugin vars (OP-194 registry) take precedence over user vars
+ * sharing the same name only by *namespace* — `{{id}}` is plugin, `{{vars.id}}`
+ * is user. The token shapes are disjoint, so there's no actual conflict; the
+ * disjointness is the design.
+ */
+function renderModule(args: RenderModuleArgs): RenderedModule {
+  const { module, body, allModulesByVarName, perVarSourceMap, ctx } = args;
+  const diagnostics: WorkflowDiagnostic[] = [];
+
+  // Pass 1: user-var substitution.
+  const passOne = body.replace(USER_VAR_TOKEN_RE, (match, rawName: string) => {
+    const name = rawName.trim();
+    const source = perVarSourceMap[name];
+    if (source && source.value !== null) {
+      return source.value;
+    }
+    // No value resolved. Distinguish "declared but unset" from "undeclared".
+    const declarers = allModulesByVarName.get(name) ?? [];
+    if (declarers.length > 0) {
+      diagnostics.push({
+        code: "missing-var",
+        severity: "warning",
+        message: `Variable {{vars.${name}}} resolved to no value at any precedence layer in module ${module.id} — left verbatim. Set a default in a module's \`vars:\` declaration, in global settings, in the project's STATUS.md, or as a launch override.`,
+        moduleId: module.id,
+        varName: name,
+      });
+    } else {
+      diagnostics.push({
+        code: "malformed-frontmatter",
+        severity: "warning",
+        message: `Variable {{vars.${name}}} referenced in module ${module.id} but never declared in any module's \`vars:\` block — left verbatim. Add a declaration to a module so the value can be supplied at one of the four precedence layers.`,
+        moduleId: module.id,
+        varName: name,
+      });
+    }
+    return match;
+  });
+
+  // Pass 2: plugin-var substitution via OP-194's renderTemplate.
+  const rendered = renderTemplate(passOne, ctx.render);
+  for (const d of rendered.diagnostics) {
+    diagnostics.push({ ...d, moduleId: d.moduleId ?? module.id });
+  }
+
+  // Declared-but-unused check: walk the module's vars: declarations; any name
+  // not referenced in the *original* body emits an info-severity diagnostic.
+  const refs = extractUserVarRefs(body);
+  for (const decl of module.vars) {
+    if (!refs.has(decl.name)) {
+      diagnostics.push({
+        code: "malformed-frontmatter",
+        severity: "info",
+        message: `Module ${module.id} declares \`vars: [${decl.name}]\` but the body never references {{vars.${decl.name}}} — declaration is unused.`,
+        moduleId: module.id,
+        varName: decl.name,
+      });
+    }
+  }
+
+  return { text: rendered.text, diagnostics };
+}
+
+// ---------------------------------------------------------------------------
+// Top-level composer
+// ---------------------------------------------------------------------------
+
+/**
+ * Compose the prompt for one (workflow, step, ctx) tuple. Pure, sync.
+ *
+ * Algorithm:
+ *   1. Find the named step in `workflow.steps`. Missing → returns a
+ *      `schema-mismatch` diagnostic and an empty `ComposedPrompt`.
+ *   2. If the step is the synthesised legacy kickoff (`legacyKickoffBody`),
+ *      splice it inline — no module composition.
+ *   3. Otherwise: walk `step.modules`, look up each id in `loadedModules`,
+ *      compose in declared order. Missing module ids emit `unknown-module`.
+ *   4. Resolve every referenced user var through the precedence chain once,
+ *      then render every module's body with the resolved map.
+ *   5. Join chunk texts with `\n\n`. Emit the size-budget info diagnostic if
+ *      the total exceeds `ctx.maxWorkflowChars`.
+ */
+export function composeWorkflow(args: ComposeArgs): ComposedPrompt {
+  const { loadedModules, workflow, step, ctx } = args;
+  const diagnostics: WorkflowDiagnostic[] = [];
+
+  const stepRecord = workflow.steps.find((s) => s.step === step);
+  if (!stepRecord) {
+    diagnostics.push({
+      code: "schema-mismatch",
+      severity: "error",
+      message: `composeWorkflow: workflow ${workflow.source.path} has no step "${step}".`,
+      stepId: step,
+      extra: { path: workflow.source.path, step },
+    });
+    return emptyComposed(diagnostics);
+  }
+
+  // Legacy kickoff: synthesised step that wraps the entire WORKFLOW.md body.
+  // OP-196 produces this when the file matches one of legacy shapes 1/2/3/5.
+  // The composer splices the body verbatim — no template substitution because
+  // legacy bodies predate the {{var}} contract.
+  if (stepRecord.legacyKickoffBody !== undefined) {
+    const text = stepRecord.legacyKickoffBody;
+    const chunk: ComposedChunk = {
+      moduleId: "<legacy-kickoff>",
+      scope: stepRecord.step,
+      text,
+      sizeChars: text.length,
+    };
+    return finaliseComposed({
+      orderedChunks: [chunk],
+      perVarSourceMap: {},
+      diagnostics,
+      maxChars: ctx.maxWorkflowChars ?? DEFAULT_MAX_WORKFLOW_CHARS,
+    });
+  }
+
+  // Modern step: look up each module by id, in the order the step lists them.
+  const moduleById = new Map<string, LoadedModule>();
+  for (const lm of loadedModules) moduleById.set(lm.module.id, lm);
+
+  const orderedModules: LoadedModule[] = [];
+  for (const id of stepRecord.modules) {
+    const lm = moduleById.get(id);
+    if (!lm) {
+      diagnostics.push({
+        code: "unknown-module",
+        severity: "error",
+        message: `composeWorkflow: step "${step}" references module "${id}" but no loaded module has that id. Check the module file exists at Projects/_op-modules/${id}.md or Projects/<slug>/MODULES/${id}.md.`,
+        stepId: step,
+        moduleId: id,
+        extra: { step, moduleId: id },
+      });
+      continue;
+    }
+    orderedModules.push(lm);
+  }
+
+  if (orderedModules.length === 0) {
+    return finaliseComposed({
+      orderedChunks: [],
+      perVarSourceMap: {},
+      diagnostics,
+      maxChars: ctx.maxWorkflowChars ?? DEFAULT_MAX_WORKFLOW_CHARS,
+    });
+  }
+
+  // Build the "which modules declare which user var" index from ALL loaded
+  // modules — declarations from non-composed modules still count for the
+  // undeclared-vs-declared distinction so the Module-default precedence layer
+  // surfaces values authored elsewhere in the project.
+  const allModulesByVarName = new Map<string, WorkflowModule[]>();
+  for (const lm of loadedModules) {
+    for (const decl of lm.module.vars) {
+      const list = allModulesByVarName.get(decl.name) ?? [];
+      list.push(lm.module);
+      allModulesByVarName.set(decl.name, list);
+    }
+  }
+
+  // Collect every user-var name referenced in any composed module body so we
+  // resolve each exactly once (avoids re-walking precedence per occurrence).
+  const referencedNames = new Set<string>();
+  for (const lm of orderedModules) {
+    for (const name of extractUserVarRefs(lm.body)) {
+      referencedNames.add(name);
+    }
+  }
+
+  const perVarSourceMap: Record<string, UserVarSource> = {};
+  for (const name of referencedNames) {
+    perVarSourceMap[name] = resolveUserVar({
+      name,
+      modulesDeclaringIt: allModulesByVarName.get(name) ?? [],
+      globalVars: ctx.globalVars ?? {},
+      projectVars: ctx.projectVars ?? {},
+      launchVars: ctx.launchVars ?? {},
+    });
+  }
+
+  const orderedChunks: ComposedChunk[] = [];
+  for (const lm of orderedModules) {
+    const r = renderModule({
+      module: lm.module,
+      body: lm.body,
+      allModulesByVarName,
+      perVarSourceMap,
+      ctx,
+    });
+    diagnostics.push(...r.diagnostics);
+    orderedChunks.push({
+      moduleId: lm.module.id,
+      scope: lm.module.scope,
+      text: r.text,
+      sizeChars: r.text.length,
+    });
+  }
+
+  return finaliseComposed({
+    orderedChunks,
+    perVarSourceMap,
+    diagnostics,
+    maxChars: ctx.maxWorkflowChars ?? DEFAULT_MAX_WORKFLOW_CHARS,
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Tail
+// ---------------------------------------------------------------------------
+
+interface FinaliseArgs {
+  orderedChunks: ComposedChunk[];
+  perVarSourceMap: Record<string, UserVarSource>;
+  diagnostics: WorkflowDiagnostic[];
+  maxChars: number;
+}
+
+function finaliseComposed(args: FinaliseArgs): ComposedPrompt {
+  const text = args.orderedChunks.map((c) => c.text).join("\n\n");
+  const sizeChars = text.length;
+  const diagnostics = [...args.diagnostics];
+  if (sizeChars > args.maxChars) {
+    diagnostics.push({
+      code: "size-budget",
+      severity: "info",
+      message:
+        `Composed workflow is ${sizeChars} chars (cap ${args.maxChars}). ` +
+        `Modern models tolerate this comfortably; the cap is a guardrail, not a constraint. ` +
+        `Consider splitting a module if this surprises you.`,
+      extra: { sizeChars, maxWorkflowChars: args.maxChars },
+    });
+  }
+  return {
+    text,
+    orderedChunks: args.orderedChunks,
+    perVarSourceMap: args.perVarSourceMap,
+    sizeChars,
+    diagnostics,
+  };
+}
+
+function emptyComposed(diagnostics: WorkflowDiagnostic[]): ComposedPrompt {
+  return {
+    text: "",
+    orderedChunks: [],
+    perVarSourceMap: {},
+    sizeChars: 0,
+    diagnostics,
+  };
+}
+
+// Re-export the registry for callers that want to introspect plugin vars
+// alongside the user-var resolution above. Keeps a single import boundary.
+export { PLUGIN_VAR_REGISTRY };

--- a/plugins/op-obsidian/src/composeWorkflowPure.ts
+++ b/plugins/op-obsidian/src/composeWorkflowPure.ts
@@ -96,7 +96,13 @@ export interface ComposedPrompt {
    * should iterate the module declarations instead).
    */
   perVarSourceMap: Record<string, UserVarSource>;
-  /** Character count of `text`. */
+  /**
+   * UTF-16 code-unit count of `text` (i.e., `text.length`). This matches
+   * JavaScript's `String.prototype.length` semantics — characters outside the
+   * Basic Multilingual Plane (e.g. emoji) count as 2. Sufficient for the
+   * informational size-budget guardrail; do not use for token-accurate
+   * billing estimates.
+   */
   sizeChars: number;
   diagnostics: WorkflowDiagnostic[];
 }
@@ -155,8 +161,17 @@ export const DEFAULT_MAX_WORKFLOW_CHARS = 50000;
  * Token shape for `{{vars.<name>}}`. Conservative `[a-zA-Z_][a-zA-Z0-9_-]*`
  * name pattern — allows `-` so module authors can write `{{vars.repo-path}}`
  * if they prefer hyphenated names. Whitespace inside the braces is tolerated.
+ *
+ * Factory function — returns a *fresh* `RegExp` instance each time. The `g`
+ * flag makes the object stateful (`lastIndex` advances with every `exec`), so
+ * a module-level shared regex is a footgun: any new call-site that starts
+ * iterating before the previous one finishes would reset `lastIndex` beneath
+ * the first caller. Returning a new instance per call eliminates the shared
+ * state entirely.
  */
-const USER_VAR_TOKEN_RE = /\{\{\s*vars\.([a-zA-Z_][a-zA-Z0-9_-]*)\s*\}\}/g;
+function newUserVarTokenRe(): RegExp {
+  return /\{\{\s*vars\.([a-zA-Z_][a-zA-Z0-9_-]*)\s*\}\}/g;
+}
 
 /**
  * Extract every `vars.<name>` referenced in `text`. Returns a `Set<string>`
@@ -164,9 +179,9 @@ const USER_VAR_TOKEN_RE = /\{\{\s*vars\.([a-zA-Z_][a-zA-Z0-9_-]*)\s*\}\}/g;
  */
 function extractUserVarRefs(text: string): Set<string> {
   const names = new Set<string>();
-  USER_VAR_TOKEN_RE.lastIndex = 0;
+  const re = newUserVarTokenRe();
   let m: RegExpExecArray | null;
-  while ((m = USER_VAR_TOKEN_RE.exec(text)) !== null) {
+  while ((m = re.exec(text)) !== null) {
     names.add(m[1]);
   }
   return names;
@@ -287,7 +302,7 @@ function renderModule(args: RenderModuleArgs): RenderedModule {
   const diagnostics: WorkflowDiagnostic[] = [];
 
   // Pass 1: user-var substitution.
-  const passOne = body.replace(USER_VAR_TOKEN_RE, (match, rawName: string) => {
+  const passOne = body.replace(newUserVarTokenRe(), (match, rawName: string) => {
     const name = rawName.trim();
     const source = perVarSourceMap[name];
     if (source && source.value !== null) {

--- a/plugins/op-obsidian/src/evaluator.test.ts
+++ b/plugins/op-obsidian/src/evaluator.test.ts
@@ -5,6 +5,7 @@ import {
   runEvaluatorFlow,
 } from "./evaluator";
 import type { IssueEntry } from "./types";
+import { makeTestRelay } from "./relaySession";
 
 const entry: IssueEntry = {
   id: "OP-99",
@@ -93,7 +94,7 @@ describe("runEvaluatorFlow", () => {
       complexity: "simple",
     });
     const res = await runEvaluatorFlow(
-      { launch, setEvaluation, setFlow },
+      { launch, setEvaluation, setFlow, relaySession: makeTestRelay() },
       entry,
       "scope",
     );
@@ -116,7 +117,7 @@ describe("runEvaluatorFlow", () => {
     const setEvaluation = vi.fn();
     const setFlow = vi.fn();
     await expect(
-      runEvaluatorFlow({ launch, setEvaluation, setFlow }, entry, ""),
+      runEvaluatorFlow({ launch, setEvaluation, setFlow, relaySession: makeTestRelay() }, entry, ""),
     ).rejects.toThrow(/boom/);
     expect(setEvaluation).not.toHaveBeenCalled();
     expect(setFlow).not.toHaveBeenCalled();
@@ -134,7 +135,7 @@ describe("runEvaluatorFlow", () => {
     const setEvaluation = vi.fn();
     const setFlow = vi.fn();
     await expect(
-      runEvaluatorFlow({ launch, setEvaluation, setFlow }, entry, ""),
+      runEvaluatorFlow({ launch, setEvaluation, setFlow, relaySession: makeTestRelay() }, entry, ""),
     ).rejects.toThrow(/COMPLEXITY/);
     expect(setEvaluation).not.toHaveBeenCalled();
     expect(setFlow).not.toHaveBeenCalled();
@@ -152,7 +153,7 @@ describe("runEvaluatorFlow", () => {
     const setEvaluation = vi.fn().mockRejectedValue(new Error("vault locked"));
     const setFlow = vi.fn();
     await expect(
-      runEvaluatorFlow({ launch, setEvaluation, setFlow }, entry, ""),
+      runEvaluatorFlow({ launch, setEvaluation, setFlow, relaySession: makeTestRelay() }, entry, ""),
     ).rejects.toThrow(/vault locked/);
     expect(setFlow).not.toHaveBeenCalled();
   });

--- a/plugins/op-obsidian/src/evaluator.ts
+++ b/plugins/op-obsidian/src/evaluator.ts
@@ -2,7 +2,11 @@ import type { IssueEntry } from "./types";
 import type { Complexity } from "./setFlow";
 import type { SetEvaluationResult } from "./setEvaluation";
 import type { SetFlowResult } from "./setFlow";
-import type { LaunchHeadlessInput, LaunchHeadlessResult } from "./launchHeadless";
+import type {
+  LaunchHeadlessSubtaskInput,
+  LaunchHeadlessSubtaskResult,
+} from "./launchHeadlessSubtask";
+import type { RelaySession } from "./relaySession";
 
 const EVALUATOR_AGENT_NAME = "op-evaluate";
 
@@ -75,12 +79,20 @@ export function buildEvaluatorPrompt(entry: IssueEntry, body: string): string {
 }
 
 export interface EvaluatorFlowDeps {
-  launch: (input: LaunchHeadlessInput) => Promise<LaunchHeadlessResult>;
+  launch: (input: LaunchHeadlessSubtaskInput) => Promise<LaunchHeadlessSubtaskResult>;
   setEvaluation: (entry: IssueEntry, evaluation: string) => Promise<SetEvaluationResult>;
   setFlow: (
     entry: IssueEntry,
     input: { flow?: "evaluate"; complexity?: Complexity },
   ) => Promise<SetFlowResult>;
+  /**
+   * Visibility-tenet relay that the headless evaluator subtask streams into.
+   * Production callers construct a tmux-shaped relay backed by `Notice` +
+   * `console.log` (see `main.ts:runEvaluatorForIssue`); tests construct
+   * `makeTestRelay()` and assert on the captured event stream. Required —
+   * the typechecker rejects deps that omit it.
+   */
+  relaySession: RelaySession;
 }
 
 export interface EvaluatorFlowResult {
@@ -90,7 +102,7 @@ export interface EvaluatorFlowResult {
   setFlowResult: SetFlowResult;
 }
 
-// Orchestrates launchHeadless → setEvaluation → setFlow. On any failure the
+// Orchestrates launchHeadlessSubtask → setEvaluation → setFlow. On any failure the
 // error is rethrown so the caller can surface it via Notice and skip the
 // frontmatter writes (flow/complexity stay unset).
 export async function runEvaluatorFlow(
@@ -105,6 +117,7 @@ export async function runEvaluatorFlow(
     agent: EVALUATOR_AGENT_NAME,
     permissionMode: "dontAsk",
     allowedTools: EVALUATOR_AGENT_DEFINITION.tools,
+    relaySession: deps.relaySession,
   });
   const parsed = parseEvaluatorClassification(launchResult.text);
   const setEvaluationResult = await deps.setEvaluation(entry, parsed.evaluation);

--- a/plugins/op-obsidian/src/integration.test.ts
+++ b/plugins/op-obsidian/src/integration.test.ts
@@ -1,0 +1,253 @@
+import { describe, it, expect, vi } from "vitest";
+import { readFileSync } from "fs";
+import { join } from "path";
+
+vi.mock("obsidian", () => {
+  class TFile {
+    path = "";
+    basename = "";
+    name = "";
+  }
+  return {
+    TFile,
+    normalizePath: (p: string) => p.replace(/\/+/g, "/").replace(/\/$/g, ""),
+  };
+});
+
+import { TFile } from "obsidian";
+import { loadModuleSources } from "./composeWorkflow";
+import { composeWorkflow } from "./composeWorkflowPure";
+import type { RenderContext } from "./pluginVarRegistry";
+
+// End-to-end integration test for OP-197. Drives the FM-parser → loader →
+// composer → renderer chain against a realistic 3-step workflow fixture and
+// asserts the composed output is byte-equivalent to a golden snapshot. Drift
+// in the snapshot fails CI — this is the canonical guardrail for the whole
+// pipeline.
+//
+// To intentionally re-bake the snapshot after a behavioural change:
+//   npm test -- -u plugins/op-obsidian/src/integration.test.ts
+//
+// Fixture layout (under `__fixtures__/integration/`):
+//   global-modules/branching.md           → vault: Projects/_op-modules/branching.md
+//   global-modules/version-cadence.md     → vault: Projects/_op-modules/version-cadence.md
+//   per-project/MODULES/plan-rules.md     → vault: Projects/fixture-project/MODULES/plan-rules.md
+//   per-project/MODULES/review-and-merge.md → vault: Projects/fixture-project/MODULES/review-and-merge.md
+//   _op-workflow.md                        → vault: Projects/_op-workflow.md (global default workflow)
+//   per-project/WORKFLOW.md                → vault: Projects/fixture-project/WORKFLOW.md (extends global)
+//   composed.snapshot.md                   → byte-equivalent expected composed output
+//
+// The fixture's frontmatter is hand-mirrored into `FIXTURE_FILES` below
+// because vitest's mocked `obsidian` module doesn't ship a YAML parser; the
+// loaders read frontmatter from `metadataCache.getFileCache(file)?.frontmatter`,
+// which the fakeApp returns directly without parsing the raw file's fence.
+// Bodies are read from disk so any tweak to the fixture body files
+// re-shapes the snapshot automatically — the rendering logic is what we're
+// guarding here, not YAML parsing.
+
+const FIXTURE_ROOT = join(__dirname, "__fixtures__", "integration");
+
+interface FixtureFile {
+  vaultPath: string;
+  diskPath: string;
+  frontmatter: Record<string, unknown>;
+}
+
+const FIXTURE_FILES: FixtureFile[] = [
+  {
+    vaultPath: "Projects/_op-modules/branching.md",
+    diskPath: join(FIXTURE_ROOT, "global-modules", "branching.md"),
+    frontmatter: {
+      id: "branching",
+      title: "Always work in a git worktree",
+      type: "workflow-module",
+      scope: "kickoff",
+      order: 10,
+    },
+  },
+  {
+    vaultPath: "Projects/_op-modules/version-cadence.md",
+    diskPath: join(FIXTURE_ROOT, "global-modules", "version-cadence.md"),
+    frontmatter: {
+      id: "version-cadence",
+      title: "Version bump cadence",
+      type: "workflow-module",
+      scope: "kickoff",
+      order: 20,
+      vars: ["package_name=op-obsidian"],
+    },
+  },
+  {
+    vaultPath: "Projects/fixture-project/MODULES/plan-rules.md",
+    diskPath: join(FIXTURE_ROOT, "per-project", "MODULES", "plan-rules.md"),
+    frontmatter: {
+      id: "plan-rules",
+      title: "Plan-mode rules for fixture project",
+      type: "workflow-module",
+      scope: "plan",
+      order: 10,
+      vars: ["max_files=10", "reviewer_handle"],
+    },
+  },
+  {
+    vaultPath: "Projects/fixture-project/MODULES/review-and-merge.md",
+    diskPath: join(FIXTURE_ROOT, "per-project", "MODULES", "review-and-merge.md"),
+    frontmatter: {
+      id: "review-and-merge",
+      title: "Adversarial review then merge",
+      type: "workflow-module",
+      scope: "review",
+      order: 10,
+    },
+  },
+  {
+    vaultPath: "Projects/_op-workflow.md",
+    diskPath: join(FIXTURE_ROOT, "_op-workflow.md"),
+    frontmatter: {
+      type: "workflow",
+      schema: 1,
+      project: "fixture-project",
+      default_agent: "claude",
+      default_model: "opus",
+      steps: [{ step: "kickoff", modules: ["branching", "version-cadence"] }],
+    },
+  },
+  {
+    vaultPath: "Projects/fixture-project/WORKFLOW.md",
+    diskPath: join(FIXTURE_ROOT, "per-project", "WORKFLOW.md"),
+    frontmatter: {
+      type: "workflow",
+      schema: 1,
+      project: "fixture-project",
+      default_agent: "claude",
+      default_model: "opus",
+      extends: "Projects/_op-workflow.md",
+      steps: [
+        { step: "plan", modules: ["plan-rules"] },
+        { step: "review", modules: ["review-and-merge"] },
+      ],
+    },
+  },
+];
+
+function makeFile(path: string): TFile {
+  const basename = path.split("/").pop()!.replace(/\.md$/, "");
+  const f = new TFile();
+  Object.assign(f, { path, basename, name: `${basename}.md` });
+  return f;
+}
+
+function buildFakeApp() {
+  const tfiles = FIXTURE_FILES.map((ff) => ({
+    tfile: makeFile(ff.vaultPath),
+    raw: readFileSync(ff.diskPath, "utf8"),
+    fm: ff.frontmatter,
+  }));
+
+  return {
+    vault: {
+      getMarkdownFiles: () => tfiles.map((x) => x.tfile),
+      getAbstractFileByPath: (p: string) => tfiles.find((x) => x.tfile.path === p)?.tfile ?? null,
+      read: async (file: TFile) => tfiles.find((x) => x.tfile === file)!.raw,
+    },
+    metadataCache: {
+      getFileCache: (file: TFile) => {
+        const hit = tfiles.find((x) => x.tfile === file);
+        if (!hit || !hit.fm) return null;
+        return { frontmatter: hit.fm };
+      },
+    },
+  } as any;
+}
+
+const RENDER_CTX: RenderContext = {
+  id: "OP-FIX-1",
+  title: "Integration fixture issue",
+  project: "fixture-project",
+  status: "in-progress",
+  priority: "high",
+  parent: "OP-FIX-PARENT",
+  pr_url: "https://github.com/example/repo/pull/42",
+  github_issue: undefined,
+  repo_path: "/repo",
+  vault_path: "/vault",
+  vault_name: "Agent-Vault",
+  branch: "worktree-OP-FIX-1",
+  today: "2026-04-26",
+  agent: "claude",
+  model: "claude-opus-4-7",
+  mode: "kickoff",
+};
+
+describe("end-to-end integration: load + compose 3-step workflow against golden snapshot", () => {
+  it("loads modules + workflow (with extends:), composes each step, snapshots match", async () => {
+    const app = buildFakeApp();
+
+    const bundle = await loadModuleSources(app, { project: "fixture-project" });
+    expect(bundle.workflow).not.toBeNull();
+    // Loader-level diagnostics: no errors. Warnings are acceptable (the
+    // workflow merge surfaces a diagnostic when the parent file's project
+    // doesn't exactly match the child's expected slug — fine here).
+    expect(bundle.diagnostics.find((d) => d.severity === "error")).toBeUndefined();
+
+    // Workflow extends the global default → merged step list is
+    // [kickoff (parent), plan (child), review (child)].
+    expect(bundle.workflow!.steps.map((s) => s.step)).toEqual(["kickoff", "plan", "review"]);
+
+    const ctxBase = {
+      render: RENDER_CTX,
+      launchVars: {
+        reviewer_handle: "@earchibald",
+      },
+    };
+
+    const composedKickoff = composeWorkflow({
+      loadedModules: bundle.loadedModules,
+      workflow: bundle.workflow!,
+      step: "kickoff",
+      ctx: { ...ctxBase, render: { ...RENDER_CTX, mode: "kickoff" } },
+    });
+    const composedPlan = composeWorkflow({
+      loadedModules: bundle.loadedModules,
+      workflow: bundle.workflow!,
+      step: "plan",
+      ctx: { ...ctxBase, render: { ...RENDER_CTX, mode: "plan" } },
+    });
+    const composedReview = composeWorkflow({
+      loadedModules: bundle.loadedModules,
+      workflow: bundle.workflow!,
+      step: "review",
+      ctx: { ...ctxBase, render: { ...RENDER_CTX, mode: "review" } },
+    });
+
+    // Sanity: every step produced text and no error-severity diagnostics.
+    expect(composedKickoff.text.length).toBeGreaterThan(0);
+    expect(composedPlan.text.length).toBeGreaterThan(0);
+    expect(composedReview.text.length).toBeGreaterThan(0);
+    for (const c of [composedKickoff, composedPlan, composedReview]) {
+      const errs = c.diagnostics.filter((d) => d.severity === "error");
+      expect(errs).toEqual([]);
+    }
+
+    // Build the snapshot text — combines all three composed steps with
+    // delimiters so a diff-on-failure is human-readable.
+    const snapshot = [
+      "## STEP: kickoff",
+      "",
+      composedKickoff.text,
+      "",
+      "## STEP: plan",
+      "",
+      composedPlan.text,
+      "",
+      "## STEP: review",
+      "",
+      composedReview.text,
+      "",
+    ].join("\n");
+
+    await expect(snapshot).toMatchFileSnapshot(
+      join(FIXTURE_ROOT, "composed.snapshot.md"),
+    );
+  });
+});

--- a/plugins/op-obsidian/src/launchHeadlessSubtask.test.ts
+++ b/plugins/op-obsidian/src/launchHeadlessSubtask.test.ts
@@ -2,11 +2,12 @@ import { describe, it, expect, vi } from "vitest";
 import { EventEmitter } from "events";
 import {
   buildArgs,
-  launchHeadless,
+  launchHeadlessSubtask,
   HeadlessExitError,
   HeadlessParseError,
   HeadlessTimeoutError,
-} from "./launchHeadless";
+} from "./launchHeadlessSubtask";
+import { makeTestRelay, type RelaySession } from "./relaySession";
 
 interface FakeChild extends EventEmitter {
   stdout: EventEmitter;
@@ -36,9 +37,15 @@ function end(_stream: EventEmitter) {
   /* no-op: close event on the child handles completion */
 }
 
+function testRelay(): { relay: RelaySession; capture: ReturnType<typeof vi.fn> } {
+  const capture = vi.fn();
+  const relay = makeTestRelay(capture);
+  return { relay, capture };
+}
+
 describe("buildArgs", () => {
   it("defaults to -p --output-format json + prompt", () => {
-    const args = buildArgs({ prompt: "hi" });
+    const args = buildArgs({ prompt: "hi", relaySession: makeTestRelay() });
     expect(args).toEqual(["-p", "--output-format", "json", "hi"]);
   });
 
@@ -47,6 +54,7 @@ describe("buildArgs", () => {
       prompt: "evaluate",
       agents: { foo: { prompt: "you are foo", tools: ["Read"] } },
       agent: "foo",
+      relaySession: makeTestRelay(),
     });
     const agentsIdx = args.indexOf("--agents");
     expect(agentsIdx).toBeGreaterThan(-1);
@@ -64,6 +72,7 @@ describe("buildArgs", () => {
       allowedTools: ["Read", "Grep"],
       disallowedTools: ["Bash", "Edit"],
       permissionMode: "dontAsk",
+      relaySession: makeTestRelay(),
     });
     expect(args).toContain("--model");
     expect(args[args.indexOf("--model") + 1]).toBe("haiku");
@@ -73,17 +82,18 @@ describe("buildArgs", () => {
   });
 
   it("places prompt last", () => {
-    const args = buildArgs({ prompt: "final", model: "haiku" });
+    const args = buildArgs({ prompt: "final", model: "haiku", relaySession: makeTestRelay() });
     expect(args[args.length - 1]).toBe("final");
   });
 });
 
-describe("launchHeadless", () => {
+describe("launchHeadlessSubtask", () => {
   it("parses a successful JSON response into { text, jsonResult }", async () => {
     const child = makeChild();
     const spawnFn = vi.fn(() => child as any);
+    const { relay } = testRelay();
 
-    const promise = launchHeadless({ prompt: "hello", spawnFn });
+    const promise = launchHeadlessSubtask({ prompt: "hello", relaySession: relay, spawnFn });
 
     queueMicrotask(() => {
       push(child.stdout, JSON.stringify({
@@ -111,7 +121,11 @@ describe("launchHeadless", () => {
 
   it("throws HeadlessExitError on non-zero exit, surfacing stderr", async () => {
     const child = makeChild();
-    const promise = launchHeadless({ prompt: "x", spawnFn: () => child as any });
+    const promise = launchHeadlessSubtask({
+      prompt: "x",
+      relaySession: makeTestRelay(),
+      spawnFn: () => child as any,
+    });
 
     queueMicrotask(() => {
       push(child.stderr, "boom");
@@ -132,7 +146,11 @@ describe("launchHeadless", () => {
 
   it("throws HeadlessParseError on malformed stdout", async () => {
     const child = makeChild();
-    const promise = launchHeadless({ prompt: "x", spawnFn: () => child as any });
+    const promise = launchHeadlessSubtask({
+      prompt: "x",
+      relaySession: makeTestRelay(),
+      spawnFn: () => child as any,
+    });
 
     queueMicrotask(() => {
       push(child.stdout, "not json");
@@ -148,9 +166,10 @@ describe("launchHeadless", () => {
     vi.useFakeTimers();
     try {
       const child = makeChild();
-      const promise = launchHeadless({
+      const promise = launchHeadlessSubtask({
         prompt: "x",
         timeoutMs: 100,
+        relaySession: makeTestRelay(),
         spawnFn: () => child as any,
       });
       // Attach rejection handler immediately so the rejection isn't reported
@@ -168,20 +187,36 @@ describe("launchHeadless", () => {
 
   it("rejects an invalid timeoutMs", async () => {
     await expect(
-      launchHeadless({ prompt: "x", timeoutMs: 0, spawnFn: () => makeChild() as any }),
+      launchHeadlessSubtask({
+        prompt: "x",
+        timeoutMs: 0,
+        relaySession: makeTestRelay(),
+        spawnFn: () => makeChild() as any,
+      }),
     ).rejects.toThrow(/invalid timeoutMs/);
     await expect(
-      launchHeadless({ prompt: "x", timeoutMs: -1, spawnFn: () => makeChild() as any }),
+      launchHeadlessSubtask({
+        prompt: "x",
+        timeoutMs: -1,
+        relaySession: makeTestRelay(),
+        spawnFn: () => makeChild() as any,
+      }),
     ).rejects.toThrow(/invalid timeoutMs/);
   });
 
   it("requires a non-empty prompt", async () => {
-    await expect(launchHeadless({ prompt: "" } as any)).rejects.toThrow(/prompt is required/);
+    await expect(
+      launchHeadlessSubtask({ prompt: "", relaySession: makeTestRelay() } as any),
+    ).rejects.toThrow(/prompt is required/);
   });
 
   it("propagates child spawn 'error' events", async () => {
     const child = makeChild();
-    const promise = launchHeadless({ prompt: "x", spawnFn: () => child as any });
+    const promise = launchHeadlessSubtask({
+      prompt: "x",
+      relaySession: makeTestRelay(),
+      spawnFn: () => child as any,
+    });
     queueMicrotask(() => child.emit("error", new Error("ENOENT")));
     await expect(promise).rejects.toThrow(/ENOENT/);
   });
@@ -189,9 +224,10 @@ describe("launchHeadless", () => {
   it("uses claudeBinary override when provided", async () => {
     const child = makeChild();
     const spawnFn = vi.fn(() => child as any);
-    const promise = launchHeadless({
+    const promise = launchHeadlessSubtask({
       prompt: "x",
       claudeBinary: "/custom/claude",
+      relaySession: makeTestRelay(),
       spawnFn,
     });
     queueMicrotask(() => {
@@ -202,5 +238,79 @@ describe("launchHeadless", () => {
     });
     await promise;
     expect(spawnFn.mock.calls[0][0]).toBe("/custom/claude");
+  });
+
+  it("emits status-line at start, streams stdout/stderr through capture, and emits status-line at completion", async () => {
+    const { relay, capture } = testRelay();
+    const child = makeChild();
+    const promise = launchHeadlessSubtask({
+      prompt: "go",
+      agent: "op-evaluate",
+      relaySession: relay,
+      spawnFn: () => child as any,
+    });
+
+    queueMicrotask(() => {
+      // Stream the JSON payload as one chunk so JSON.parse succeeds; emit a
+      // separate stderr chunk so the relay sees both stream sources.
+      push(child.stderr, "warning: configured nicely\n");
+      push(child.stdout, JSON.stringify({ result: "done" }));
+      child.emit("close", 0, null);
+    });
+
+    await promise;
+
+    const calls = capture.mock.calls.map((c) => c[0] as string);
+    // First call: start status-line.
+    expect(calls[0]).toMatch(/^\[status\] launching headless subtask: op-evaluate/);
+    // Stream chunks land between start + completion (one stdout, one stderr).
+    expect(calls).toContainEqual(expect.stringMatching(/^\[stream\] warning: configured nicely/));
+    expect(calls).toContainEqual(expect.stringMatching(/^\[stream\] \{"result":"done"\}/));
+    // Last call: completion status-line.
+    expect(calls[calls.length - 1]).toMatch(/^\[status\] headless subtask completed in /);
+  });
+
+  it("emits a status-line on non-zero exit so the relay always closes the loop", async () => {
+    const { relay, capture } = testRelay();
+    const child = makeChild();
+    const promise = launchHeadlessSubtask({
+      prompt: "x",
+      relaySession: relay,
+      spawnFn: () => child as any,
+    });
+    queueMicrotask(() => {
+      push(child.stderr, "boom");
+      child.emit("close", 7, null);
+    });
+    await expect(promise).rejects.toBeInstanceOf(HeadlessExitError);
+    const calls = capture.mock.calls.map((c) => c[0] as string);
+    expect(calls.find((s) => /^\[status\] headless subtask exited 7/.test(s))).toBeTruthy();
+  });
+
+  it("emits a status-line on timeout so the relay always closes the loop", async () => {
+    vi.useFakeTimers();
+    try {
+      const { relay, capture } = testRelay();
+      const child = makeChild();
+      const promise = launchHeadlessSubtask({
+        prompt: "x",
+        timeoutMs: 50,
+        relaySession: relay,
+        spawnFn: () => child as any,
+      });
+      const settled = promise.catch((e) => e);
+      await vi.advanceTimersByTimeAsync(75);
+      await settled;
+      const calls = capture.mock.calls.map((c) => c[0] as string);
+      expect(calls.find((s) => /^\[status\] headless subtask timed out/.test(s))).toBeTruthy();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("type-checker rejects callers that omit relaySession", () => {
+    // @ts-expect-error — relaySession is required; missing it must fail compile.
+    const _missingRelay = () => launchHeadlessSubtask({ prompt: "x" });
+    expect(typeof _missingRelay).toBe("function");
   });
 });

--- a/plugins/op-obsidian/src/launchHeadlessSubtask.ts
+++ b/plugins/op-obsidian/src/launchHeadlessSubtask.ts
@@ -1,4 +1,16 @@
 import { spawn as realSpawn, type ChildProcess, type SpawnOptions } from "child_process";
+import { emitStatus, emitStream, type RelaySession } from "./relaySession";
+
+// Spawn `claude -p --output-format json …` with a prompt and agent config,
+// streaming stdout/stderr through a `RelaySession` so the user has a visible
+// surface to watch the headless subtask in. OP-181 §"Visibility tenet" — every
+// step is observable. The discriminated-union `relaySession` arg is required
+// so the typechecker rejects callers that try to skip the relay.
+//
+// Renamed from `launchHeadless` (OP-194/195/196) to `launchHeadlessSubtask`
+// (OP-197) — the new name reflects the role: this isn't a top-level launch,
+// it's a sub-task of an enclosing visible step. The signature change is the
+// type-level enforcement of the visibility tenet.
 
 export const HEADLESS_DEFAULT_TIMEOUT_MS = 10 * 60 * 1000;
 
@@ -14,8 +26,15 @@ export interface AgentsSpec {
 
 export type PermissionMode = "default" | "acceptEdits" | "bypassPermissions" | "dontAsk";
 
-export interface LaunchHeadlessInput {
+export interface LaunchHeadlessSubtaskInput {
   prompt: string;
+  /**
+   * Visibility-tenet relay surface. Every caller must construct one — the
+   * typechecker rejects calls that omit this field. Production paths
+   * construct `{ kind: "tmux", ... }` (see `makeTmuxRelay`), test paths
+   * construct `{ kind: "test", capture: vi.fn() }` (see `makeTestRelay`).
+   */
+  relaySession: RelaySession;
   // Optional inline agent definitions forwarded as `--agents '<json>'`. OP-95
   // confirmed `--agents` composes with `-p`, but the inline agent's `tools:`
   // allowlist is NOT enforced in `--agent <name>` mode; enforce tool scope at
@@ -35,7 +54,7 @@ export interface LaunchHeadlessInput {
   spawnFn?: (cmd: string, args: string[], options: SpawnOptions) => ChildProcess;
 }
 
-export interface LaunchHeadlessResult<TJson = unknown> {
+export interface LaunchHeadlessSubtaskResult<TJson = unknown> {
   text: string;
   jsonResult: TJson;
   stdout: string;
@@ -80,7 +99,7 @@ export class HeadlessParseError extends Error {
   }
 }
 
-export function buildArgs(input: LaunchHeadlessInput): string[] {
+export function buildArgs(input: LaunchHeadlessSubtaskInput): string[] {
   const args: string[] = ["-p", "--output-format", "json"];
   if (input.agents) {
     args.push("--agents", JSON.stringify(input.agents));
@@ -108,25 +127,31 @@ export function buildArgs(input: LaunchHeadlessInput): string[] {
 }
 
 // Spawn `claude -p --output-format json …` with the given prompt and agent
-// config, collect stdout/stderr, JSON-parse stdout, and return the parsed
-// object's `result` text plus the raw JSON. Default timeout: 10 minutes.
+// config, collect stdout/stderr (mirrored to the relay so the user can watch
+// progress live), JSON-parse stdout, and return the parsed object's `result`
+// text plus the raw JSON. Default timeout: 10 minutes.
+//
 // On timeout: kills with SIGTERM (then SIGKILL after 1s grace) and throws
 // HeadlessTimeoutError. On non-zero exit: HeadlessExitError. On malformed
-// stdout: HeadlessParseError.
-export async function launchHeadless<TJson = unknown>(
-  input: LaunchHeadlessInput,
-): Promise<LaunchHeadlessResult<TJson>> {
+// stdout: HeadlessParseError. The relay always sees a status-line at start
+// + at end (success or error) so the visible surface always closes the loop.
+export async function launchHeadlessSubtask<TJson = unknown>(
+  input: LaunchHeadlessSubtaskInput,
+): Promise<LaunchHeadlessSubtaskResult<TJson>> {
   if (!input.prompt || typeof input.prompt !== "string") {
-    throw new Error("launchHeadless: prompt is required");
+    throw new Error("launchHeadlessSubtask: prompt is required");
   }
   const timeoutMs = input.timeoutMs ?? HEADLESS_DEFAULT_TIMEOUT_MS;
   if (!Number.isFinite(timeoutMs) || timeoutMs <= 0) {
-    throw new Error(`launchHeadless: invalid timeoutMs ${timeoutMs}`);
+    throw new Error(`launchHeadlessSubtask: invalid timeoutMs ${timeoutMs}`);
   }
 
   const args = buildArgs(input);
   const cmd = input.claudeBinary ?? "claude";
   const spawnFn = input.spawnFn ?? realSpawn;
+  const relay = input.relaySession;
+  const agentLabel = input.agent ? `${input.agent} ` : "";
+  emitStatus(relay, `launching headless subtask: ${agentLabel}(timeout ${timeoutMs}ms)`);
   const started = Date.now();
 
   const child = spawnFn(cmd, args, {
@@ -138,13 +163,17 @@ export async function launchHeadless<TJson = unknown>(
   let stdout = "";
   let stderr = "";
   child.stdout?.on("data", (chunk: Buffer | string) => {
-    stdout += chunk.toString();
+    const s = chunk.toString();
+    stdout += s;
+    emitStream(relay, s);
   });
   child.stderr?.on("data", (chunk: Buffer | string) => {
-    stderr += chunk.toString();
+    const s = chunk.toString();
+    stderr += s;
+    emitStream(relay, s);
   });
 
-  return new Promise<LaunchHeadlessResult<TJson>>((resolve, reject) => {
+  return new Promise<LaunchHeadlessSubtaskResult<TJson>>((resolve, reject) => {
     let settled = false;
     let killTimer: ReturnType<typeof setTimeout> | undefined;
 
@@ -164,6 +193,7 @@ export async function launchHeadless<TJson = unknown>(
         }
       }, 1000);
       settled = true;
+      emitStatus(relay, `headless subtask timed out after ${timeoutMs}ms`);
       reject(
         new HeadlessTimeoutError(
           `claude -p timed out after ${timeoutMs}ms`,
@@ -178,6 +208,7 @@ export async function launchHeadless<TJson = unknown>(
       if (settled) return;
       settled = true;
       clearTimeout(timer);
+      emitStatus(relay, `headless subtask spawn error: ${err.message}`);
       reject(err);
     });
 
@@ -188,6 +219,10 @@ export async function launchHeadless<TJson = unknown>(
       settled = true;
       const exitCode = typeof code === "number" ? code : -1;
       if (exitCode !== 0) {
+        emitStatus(
+          relay,
+          `headless subtask exited ${exitCode}${signal ? ` (signal ${signal})` : ""}`,
+        );
         reject(
           new HeadlessExitError(
             `claude -p exited ${exitCode}${signal ? ` (signal ${signal})` : ""}: ${stderr.trim()}`,
@@ -203,6 +238,7 @@ export async function launchHeadless<TJson = unknown>(
       try {
         parsed = JSON.parse(stdout);
       } catch (err) {
+        emitStatus(relay, `headless subtask returned malformed JSON`);
         reject(
           new HeadlessParseError(
             `claude -p stdout was not valid JSON: ${(err as Error).message}`,
@@ -213,13 +249,15 @@ export async function launchHeadless<TJson = unknown>(
         return;
       }
       const text = typeof parsed?.result === "string" ? parsed.result : "";
+      const durationMs = Date.now() - started;
+      emitStatus(relay, `headless subtask completed in ${durationMs}ms`);
       resolve({
         text,
         jsonResult: parsed as TJson,
         stdout,
         stderr,
         exitCode,
-        durationMs: Date.now() - started,
+        durationMs,
       });
     });
   });

--- a/plugins/op-obsidian/src/main.ts
+++ b/plugins/op-obsidian/src/main.ts
@@ -39,7 +39,8 @@ import {
 } from "./links";
 import { RELATION_NAMES, type RelationName } from "./relations";
 import { runEvaluatorFlow } from "./evaluator";
-import { launchHeadless } from "./launchHeadless";
+import { launchHeadlessSubtask } from "./launchHeadlessSubtask";
+import { makeTmuxRelay } from "./relaySession";
 import {
   flowAdvanceDecision,
   type FlowAdvanceOutput,
@@ -1642,11 +1643,23 @@ export default class OpPlugin extends Plugin {
     notify(`op: evaluating ${entry.id} — running op-evaluate…`, 6000);
     const body = (input.scope ?? []).map((s) => `- ${s}`).join("\n");
     try {
+      // OP-197: visibility-tenet relay for the headless evaluator subtask.
+      // The evaluator runs in the Obsidian plugin process (no tmux pane), so
+      // statusLine flows to a `Notice` and paneStream to `console.log` — both
+      // surfaces the user can watch live. `target` carries the issue id so log
+      // lines correlate back to a launch. OP-185 will wire a richer streaming
+      // pane; this is the type-level enforcement of the contract today.
+      const relaySession = makeTmuxRelay({
+        target: `obsidian-plugin:${entry.id}`,
+        statusLine: (line) => notify(`op-evaluate ${entry.id}: ${line}`),
+        paneStream: (chunk) => console.log(`[op-evaluate ${entry.id}] ${chunk}`),
+      });
       const result = await runEvaluatorFlow(
         {
-          launch: launchHeadless,
+          launch: launchHeadlessSubtask,
           setEvaluation: (e, evaluation) => setEvaluation(this.app, e, evaluation),
           setFlow: (e, i) => setFlow(this.app, e, i),
+          relaySession,
         },
         entry,
         body,

--- a/plugins/op-obsidian/src/relaySession.test.ts
+++ b/plugins/op-obsidian/src/relaySession.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect, vi } from "vitest";
+import {
+  emitStatus,
+  emitStream,
+  makeTestRelay,
+  makeTmuxRelay,
+  type RelaySession,
+} from "./relaySession";
+
+describe("makeTestRelay", () => {
+  it("returns the test variant with the supplied capture", () => {
+    const capture = vi.fn();
+    const relay = makeTestRelay(capture);
+    expect(relay.kind).toBe("test");
+    if (relay.kind === "test") {
+      relay.capture("hi");
+      expect(capture).toHaveBeenCalledWith("hi");
+    }
+  });
+
+  it("defaults capture to a no-op when called without args", () => {
+    const relay = makeTestRelay();
+    expect(relay.kind).toBe("test");
+    if (relay.kind === "test") {
+      // does not throw
+      relay.capture("ignored");
+    }
+  });
+});
+
+describe("makeTmuxRelay", () => {
+  it("returns the tmux variant with target + callbacks", () => {
+    const statusLine = vi.fn();
+    const paneStream = vi.fn();
+    const relay = makeTmuxRelay({ target: "obsidian-plugin:OP-197", statusLine, paneStream });
+    expect(relay.kind).toBe("tmux");
+    if (relay.kind === "tmux") {
+      expect(relay.target).toBe("obsidian-plugin:OP-197");
+      relay.statusLine("hello");
+      relay.paneStream("chunk");
+      expect(statusLine).toHaveBeenCalledWith("hello");
+      expect(paneStream).toHaveBeenCalledWith("chunk");
+    }
+  });
+});
+
+describe("emitStatus / emitStream", () => {
+  it("routes through tmux callbacks when relay.kind === 'tmux'", () => {
+    const statusLine = vi.fn();
+    const paneStream = vi.fn();
+    const relay: RelaySession = {
+      kind: "tmux",
+      target: "t",
+      statusLine,
+      paneStream,
+    };
+    emitStatus(relay, "running op-evaluate");
+    emitStream(relay, "first chunk");
+    expect(statusLine).toHaveBeenCalledWith("running op-evaluate");
+    expect(paneStream).toHaveBeenCalledWith("first chunk");
+  });
+
+  it("routes status + stream through capture with prefixes when relay.kind === 'test'", () => {
+    const capture = vi.fn();
+    const relay: RelaySession = { kind: "test", capture };
+    emitStatus(relay, "running op-evaluate");
+    emitStream(relay, "first chunk");
+    expect(capture).toHaveBeenNthCalledWith(1, "[status] running op-evaluate");
+    expect(capture).toHaveBeenNthCalledWith(2, "[stream] first chunk");
+  });
+});
+
+describe("type-level enforcement", () => {
+  it("rejects callers that omit relaySession (compile-time assertion)", () => {
+    // The body is intentionally empty — this test exists so the compile-time
+    // `// @ts-expect-error` below is exercised by the typecheck step. The
+    // assertion itself fires at compile time via the launchHeadlessSubtask
+    // signature; vitest runs it as a no-op runtime test for parity.
+    //
+    // The deliberate-error sample lives in launchHeadlessSubtask.test.ts so
+    // the rejection is asserted right next to the real signature.
+    expect(true).toBe(true);
+  });
+});

--- a/plugins/op-obsidian/src/relaySession.ts
+++ b/plugins/op-obsidian/src/relaySession.ts
@@ -1,0 +1,149 @@
+// Visibility-tenet contract for headless subtasks. OP-181 §"Visibility tenet —
+// every step is observable" requires that whenever a workflow step internally
+// invokes a headless sub-process (today's only example: `claude -p` driven by
+// the evaluator) the parent surface MUST also be wired to surface progress to
+// the user — a status line announcing the subtask, a streaming tail of the
+// child's stdout, and an acknowledgement boundary before any vault mutation.
+//
+// `RelaySession` is the discriminated union that codifies this at the type
+// level. `launchHeadlessSubtask` (the rename of OP-195/196's `launchHeadless`)
+// requires a `relaySession: RelaySession` argument; the typechecker rejects
+// callers that try to skip it. There is no `undefined` escape hatch — the
+// discriminated union shape forces every caller to choose a relay variant.
+//
+// Two variants:
+//
+//   - `kind: "tmux"` — production. Status line goes to a tmux pane status row
+//     (or any visible UI surface — the term is historical; today's evaluator
+//     callsite uses `Notice` for the status line and `console.log` for the
+//     pane stream because the evaluator runs in the Obsidian plugin process,
+//     not inside a tmux pane). `target` is a freeform identifier so log lines
+//     can be correlated back to a launch.
+//
+//   - `kind: "test"` — vitest paths. A single `capture(line)` callback
+//     swallows every status-line and pane-stream event so the test can assert
+//     on what the subtask emitted without spinning up a real terminal.
+//
+// Adding a third variant later (e.g., a no-op recorder for dry-runs) costs
+// one entry in the union plus one `assertNeverRelay` exhaustiveness check.
+
+/**
+ * Discriminated union of relay surfaces a `launchHeadlessSubtask` caller can
+ * supply. There is no "no relay" variant — every caller must pick one.
+ */
+export type RelaySession =
+  | {
+      kind: "tmux";
+      /**
+       * Freeform identifier for the relay target — typically a tmux pane id
+       * (`%12`), a session/window pair (`op-agents-1:OP-197`), or a logical
+       * label when no real tmux pane exists (e.g., `obsidian-plugin:OP-197`
+       * for callsites that run inside the Obsidian process and surface via
+       * `Notice` + `console.log`). Used in log lines and diagnostics — never
+       * acted on by the relay itself.
+       */
+      target: string;
+      /**
+       * One-line status update — surfaced near the top of the relay so the
+       * user sees what's happening at a glance ("running op-evaluate for
+       * OP-197"). Called once at start, once at end, and once per logical
+       * milestone in between.
+       */
+      statusLine: (line: string) => void;
+      /**
+       * Streaming tail of the subtask's stdout — chunks may be partial lines.
+       * Production callers route this through whatever streaming surface is
+       * available (a tmux pane in OP-185+, `console.log` for the evaluator
+       * today). Tests don't need this — the `kind: "test"` variant collapses
+       * status + stream into a single `capture` callback.
+       */
+      paneStream: (chunk: string) => void;
+    }
+  | {
+      kind: "test";
+      /**
+       * Single capture callback that receives every status-line and pane-
+       * stream event the subtask would have emitted. Tests typically pass
+       * `vi.fn()` and assert via `capture.mock.calls`.
+       *
+       * Lines are tagged with a `[status]` or `[stream]` prefix so tests can
+       * distinguish without needing two separate sinks.
+       */
+      capture: (line: string) => void;
+    };
+
+/**
+ * Convenience factory for tests. Equivalent to constructing the literal:
+ *
+ *   const relay = makeTestRelay();
+ *   // launchHeadlessSubtask({ ..., relaySession: relay });
+ *   expect(relay.capture).toHaveBeenCalledWith("[status] running op-evaluate");
+ *
+ * The returned `capture` is plain — vitest tests usually wrap it (`vi.fn()`)
+ * and pass that wrapper instead. The factory exists for non-vitest callers
+ * (a future jest harness, a node runtime probe) that still want the right
+ * shape.
+ */
+export function makeTestRelay(capture: (line: string) => void = () => {}): RelaySession {
+  return { kind: "test", capture };
+}
+
+/**
+ * Convenience factory for production callsites that don't have a real tmux
+ * pane to relay through (the evaluator path today). The factory is a thin
+ * literal constructor — useful only for keeping the construction co-located
+ * with the docs for the variant.
+ */
+export function makeTmuxRelay(args: {
+  target: string;
+  statusLine: (line: string) => void;
+  paneStream: (chunk: string) => void;
+}): RelaySession {
+  return {
+    kind: "tmux",
+    target: args.target,
+    statusLine: args.statusLine,
+    paneStream: args.paneStream,
+  };
+}
+
+/**
+ * Emit a status-line event through whichever variant the relay is. Keeps
+ * the call sites concise and centralizes the test-variant capture format
+ * ("[status] <line>"). Returns `void`.
+ */
+export function emitStatus(relay: RelaySession, line: string): void {
+  if (relay.kind === "tmux") {
+    relay.statusLine(line);
+    return;
+  }
+  if (relay.kind === "test") {
+    relay.capture(`[status] ${line}`);
+    return;
+  }
+  return assertNeverRelay(relay);
+}
+
+/**
+ * Emit a stream chunk through whichever variant the relay is.
+ */
+export function emitStream(relay: RelaySession, chunk: string): void {
+  if (relay.kind === "tmux") {
+    relay.paneStream(chunk);
+    return;
+  }
+  if (relay.kind === "test") {
+    relay.capture(`[stream] ${chunk}`);
+    return;
+  }
+  return assertNeverRelay(relay);
+}
+
+/**
+ * Exhaustiveness helper. Adding a new `RelaySession` variant without handling
+ * it in a `switch` becomes a TypeScript compile error pointing at the unhandled
+ * branch.
+ */
+function assertNeverRelay(relay: never): never {
+  throw new Error(`unhandled RelaySession variant: ${JSON.stringify(relay)}`);
+}

--- a/plugins/op-obsidian/src/settings.test.ts
+++ b/plugins/op-obsidian/src/settings.test.ts
@@ -35,9 +35,22 @@ describe("mergeSettings", () => {
     expect(out.injection.maxBodyChars).toBe(1234);
     expect(out.injection.injectBody).toBe(DEFAULT_SETTINGS.injection.injectBody);
     expect(out.injection.extraPreamble).toBe(DEFAULT_SETTINGS.injection.extraPreamble);
+    // OP-197: maxWorkflowChars default raised to 50000 — caller didn't supply
+    // an override, so the merged value matches the (new) default.
+    expect(out.injection.maxWorkflowChars).toBe(50000);
     expect(out.github.autoCreateGithubIssue).toBe(true);
     expect(out.github.closeGithubIssueOnResolve).toBe(DEFAULT_SETTINGS.github.closeGithubIssueOnResolve);
     expect(out.agents.enforceWorktree).toBe(true);
+  });
+
+  it("OP-197: maxWorkflowChars default is 50000 but explicit user values pass through unchanged", () => {
+    // Fresh install: no value saved, sees the new default.
+    expect(mergeSettings({}).injection.maxWorkflowChars).toBe(50000);
+    // Existing install: user explicitly saved the old default; mergeSettings
+    // preserves their value (no surprise upgrade).
+    expect(mergeSettings({ injection: { maxWorkflowChars: 2000 } }).injection.maxWorkflowChars).toBe(2000);
+    // User saved a custom value: also preserved.
+    expect(mergeSettings({ injection: { maxWorkflowChars: 12345 } }).injection.maxWorkflowChars).toBe(12345);
   });
 
   it("flow settings default to off / 10min, accept partial overrides", () => {

--- a/plugins/op-obsidian/src/settingsPure.ts
+++ b/plugins/op-obsidian/src/settingsPure.ts
@@ -139,7 +139,14 @@ export const DEFAULT_SETTINGS: OpSettings = {
     includeRecentCommits: 5,
     extraPreamble: "",
     includeWorkflow: true,
-    maxWorkflowChars: 2000,
+    // OP-197 (1d) raised this default from 2000 to 50000 (≈ 12.5k tokens).
+    // OP-181 plan §"Risks" 1: modern models we target run 200k–1M context
+    // windows so the budget is generous; the cap remains a guardrail (info-
+    // severity diagnostic on overrun via `composeWorkflow`'s `size-budget`
+    // code) rather than a constraint that blocks the launch. Existing user
+    // `data.json` blobs preserve their explicitly-saved value through
+    // `mergeSettings` below — only fresh installs see the new default.
+    maxWorkflowChars: 50000,
   },
   workingDirs: {},
   terminal: "Terminal",

--- a/plugins/op-obsidian/src/workflowDiagnostic.ts
+++ b/plugins/op-obsidian/src/workflowDiagnostic.ts
@@ -14,7 +14,12 @@ export type WorkflowDiagnosticCode =
   | "schema-mismatch"
   | "import-collision"
   | "intra-scope-collision"
-  | "malformed-frontmatter";
+  | "malformed-frontmatter"
+  // OP-197 (1d): info-severity notice when a composed prompt exceeds
+  // `maxWorkflowChars`. Modern models tolerate the size comfortably; the cap
+  // is a guardrail that surfaces "this got bigger than you might have
+  // expected" rather than a constraint that blocks the launch.
+  | "size-budget";
 
 export type WorkflowDiagnosticSeverity = "error" | "warning" | "info";
 

--- a/plugins/op/.claude-plugin/plugin.json
+++ b/plugins/op/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "op",
   "description": "Obsidian Projects workflow — schema, slash commands, and agent skill for running a Jira-lite issue tracker inside an Obsidian vault.",
-  "version": "0.64.0",
+  "version": "0.65.0",
   "author": {
     "name": "Eugene Archibald"
   },


### PR DESCRIPTION
Final grandchild of [OP-184](https://github.com/earchibald/obsidian-projects/issues/222) — the integration glue that turns OP-194 (renderer + `pluginVarRegistry`), OP-195 (module schema + loader), and OP-196 (workflow file schema + `extends:` + `modelRegistry`) into a single load-and-compose pipeline ready for OP-185 to wire into kickoff.

Closes #235.

## Summary

- **`composeWorkflowPure.ts`** — pure composer. Resolves user-var precedence (Module → Global → Project → Launch), runs OP-194's `renderTemplate` for plugin vars, returns `ComposedPrompt { text, orderedChunks, perVarSourceMap, sizeChars, diagnostics }`. No I/O.
- **`composeWorkflow.ts`** — IO seam: `loadModuleSources(app, opts)` wraps OP-195 `loadModules` + OP-196 `loadWorkflowFile`, reads each module's body via `app.vault.read`, returns `ModuleSourceBundle`. `loadAndComposeWorkflow` is a one-stop convenience.
- **`relaySession.ts`** — visibility-tenet discriminated union `{ kind: "tmux", target, statusLine, paneStream } | { kind: "test", capture }`. Factory helpers `makeTmuxRelay()` / `makeTestRelay()`. Type-level enforcement of OP-181 §"Visibility tenet — every step is observable".
- **`launchHeadless` → `launchHeadlessSubtask` rename** with required `relaySession` arg. Streams stdout/stderr through the relay; emits status-line events at every terminal state. Typechecker rejects callers that omit relaySession.
- **`evaluator.ts` + `main.ts`** updated: evaluator's only production caller now constructs `makeTmuxRelay({ target: "obsidian-plugin:<id>", statusLine: Notice, paneStream: console.log })` — visible surfaces inside Obsidian today; OP-185 will wire a richer streaming pane.
- **`settingsPure.ts`** — `injection.maxWorkflowChars` default raised 2000 → 50000 (OP-181 plan §Risks 1: ~5% of smallest 200k context window). `mergeSettings` preserves user-saved overrides; only fresh installs see the new default.
- **`workflowDiagnostic.ts`** — added `size-budget` to `WorkflowDiagnosticCode` for the info-severity overrun notice.
- **End-to-end integration test** under `__fixtures__/integration/` with a realistic 3-step workflow (kickoff/plan/review) extending a global default workflow. Composed output is asserted against `composed.snapshot.md` — drift fails CI. Re-bake with `npm test -- -u`.

## Diagnostics emitted by the composer

- `unknown-module` (error) — step references a module id with no loaded match.
- `missing-var` (warning) — user var declared somewhere but resolved to no value; or unknown plugin var (re-emitted from `renderTemplate`).
- `malformed-frontmatter` (warning) — undeclared-but-referenced user var.
- `malformed-frontmatter` (info) — declared-but-unused user var.
- `size-budget` (info) — composed prompt exceeds `maxWorkflowChars`.
- `schema-mismatch` (error) — step name not found in workflow.

## Tests

1099 / 1099 passing (was 1058). 41 net-new tests covering precedence, intra-scope-collision visibility, missing/undeclared/unused vars, plugin-var fallthrough, size-budget overrun, legacy kickoff splice, `extends:` inheritance, RelaySession routing, `launchHeadlessSubtask` relay events, loader IO behaviour, and the integration golden snapshot. Pre-existing `iTermPrefs.test.ts` infra-failure reproduces identically on unmodified main.

## Smoke (OP-Test)

- Version bump 0.64.0 → 0.65.0 (minor — additive infrastructure; no user-visible behaviour change yet).
- `dev-sync` clean; plugin reloaded; 39 commands registered; `dev:console` clear of errors.

## Test plan

- [x] `npm test` in `plugins/op-obsidian/` — 1099/1099 (excluding pre-existing iTermPrefs infra failure)
- [x] `node scripts/bump-version.mjs minor` (build asserts main.js > manifest.json)
- [x] `node scripts/dev-sync.mjs` into OP-Test
- [x] `obsidian vault=OP-Test eval` smoke probe — 39 commands registered, no console errors
- [x] Integration test golden snapshot generated and committed
- [ ] Adversarial Copilot review

🤖 Generated with [Claude Code](https://claude.com/claude-code)