### PR TITLE
OP-201: Settings — top-level Workflows group + unified WorkflowDiagnostic formatter

### DIFF
--- a/plugins/op-obsidian/manifest.json
+++ b/plugins/op-obsidian/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "op-obsidian",
   "name": "Obsidian Projects (op)",
-  "version": "0.65.0",
+  "version": "0.66.0",
   "minAppVersion": "1.5.0",
   "description": "Jira-lite issue tracker for Obsidian vaults — deterministic commands backing the op workflow.",
   "author": "Eugene Archibald",

--- a/plugins/op-obsidian/package.json
+++ b/plugins/op-obsidian/package.json
@@ -1,6 +1,6 @@
 {
   "name": "op-obsidian",
-  "version": "0.65.0",
+  "version": "0.66.0",
   "description": "Obsidian plugin that owns the deterministic half of the op workflow.",
   "main": "main.js",
   "scripts": {

--- a/plugins/op-obsidian/src/settings.ts
+++ b/plugins/op-obsidian/src/settings.ts
@@ -576,6 +576,13 @@ export class OpSettingsTab extends PluginSettingTab {
               if (r.installed.length) parts.push(`${r.installed.length} installed`);
               if (r.skipped.length) parts.push(`${r.skipped.length} skipped (already present)`);
               notify(`Example library: ${parts.join(", ") || "no changes"}.`, 6000);
+              // metadataCache populates each new file's frontmatter
+              // asynchronously after vault.create resolves — rendering
+              // immediately can miss files whose cache hasn't caught up,
+              // showing only the first installed module. Wait for the
+              // batch-resolve event (or a short timeout fallback) before
+              // re-rendering so loadModules sees every installed file.
+              await waitForCacheSettle(this.app, 500);
               this.rerenderSection("workflows");
             } catch (e) {
               notify(`Could not install example library: ${(e as Error).message}`, 8000);
@@ -1935,6 +1942,32 @@ function appendBadge(
   parentEl.createSpan({
     cls: `op-workflow-badge op-workflow-badge--${severity}`,
     text: `${count} ${severity}${count === 1 ? "" : "s"}`,
+  });
+}
+
+/**
+ * Wait for `metadataCache` to fire its batch-`resolved` event (signalling
+ * the cache has caught up with newly-created files), or for a timeout
+ * fallback — whichever comes first. Without this, a render that follows a
+ * `vault.create` can miss files whose frontmatter hasn't been parsed yet
+ * (the file is in `getMarkdownFiles()` but `getFileCache(file).frontmatter`
+ * is still null). The timeout is the floor: if the cache was already
+ * resolved before we registered the listener, we still rerender promptly.
+ */
+async function waitForCacheSettle(app: App, timeoutMs: number): Promise<void> {
+  await new Promise<void>((resolve) => {
+    let done = false;
+    const settle = (): void => {
+      if (done) return;
+      done = true;
+      app.metadataCache.offref(ref);
+      window.clearTimeout(handle);
+      resolve();
+    };
+    // The 'resolved' event fires after the cache has finished indexing the
+    // current batch of changes — exactly the signal we need.
+    const ref = app.metadataCache.on("resolved", settle);
+    const handle = window.setTimeout(settle, timeoutMs);
   });
 }
 

--- a/plugins/op-obsidian/src/settings.ts
+++ b/plugins/op-obsidian/src/settings.ts
@@ -6,6 +6,15 @@ import {
   prepareFuzzySearch,
 } from "obsidian";
 import { notify } from "./notificationLog";
+import { loadModules, type WorkflowModule } from "./workflowModule";
+import { PLUGIN_VAR_REGISTRY } from "./pluginVarRegistry";
+import {
+  diagnosticToBlock,
+  formatDiagnostic,
+  type FormattedDiagnostic,
+} from "./workflowDiagnosticFormat";
+import type { WorkflowDiagnostic } from "./workflowDiagnostic";
+import { EXAMPLE_MODULES, installExampleLibrary } from "./workflowExamples";
 import {
   applyPreset,
   defaultPreset,
@@ -68,6 +77,8 @@ type SectionId =
   | "sidebarTab"
   | "onboarding"
   | "hotkeyPreset"
+  // Workflows (top-level, between Daily and Advanced — OP-201)
+  | "workflows"
   // Advanced
   | "injection"
   | "workingDirs"
@@ -182,6 +193,23 @@ export class OpSettingsTab extends PluginSettingTab {
     this.mountSection(daily, "onboarding", (el) => this.renderDailyOnboarding(el));
     this.mountSection(daily, "hotkeyPreset", (el) => this.renderDailyHotkey(el));
 
+    // Workflows — top-level group BETWEEN Daily and Advanced (OP-201). It's
+    // its own group (not a 9th Advanced collapsible) because it surfaces the
+    // workflow-modules tree, per-module diagnostics, the Available variables
+    // reference panel, and an empty-state install button — too important and
+    // too referenced to bury.
+    const workflows = containerEl.createDiv({
+      cls: "op-settings__group op-settings__group--workflows",
+    });
+    workflows.dataset.opSection = "workflows";
+    workflows.createEl("h2", { text: "Workflows" });
+    workflows.createEl("p", {
+      cls: "setting-item-description op-settings__group-blurb",
+      text:
+        "Workflow modules compose the prompt the launched agent sees. Loaded modules appear here with their diagnostics; the Available variables panel lists tokens you can reference in module bodies via {{name}}.",
+    });
+    this.mountSection(workflows, "workflows", (el) => this.renderWorkflows(el));
+
     // Advanced — single H2 with each subsection in its own collapsible
     // (collapsed by default). Drag-safe: the collapsibles use JS-controlled
     // display:none/block, NOT native <details>, so getBoundingClientRect()
@@ -262,6 +290,9 @@ export class OpSettingsTab extends PluginSettingTab {
         return this.renderDailyOnboarding(el);
       case "hotkeyPreset":
         return this.renderDailyHotkey(el);
+      // Workflows
+      case "workflows":
+        return this.renderWorkflows(el);
       // Advanced
       case "injection":
       case "workingDirs":
@@ -474,6 +505,250 @@ export class OpSettingsTab extends PluginSettingTab {
             new HotkeyPresetResultsModal(this.app, preset, result).open();
           }),
       );
+  }
+
+  // ─── Workflows section renderer (OP-201) ────────────────────────────────
+
+  private renderWorkflows(containerEl: HTMLElement): void {
+    const result = loadModules(this.app);
+    const { modules, diagnostics } = result;
+
+    if (modules.length === 0) {
+      this.renderWorkflowsEmptyState(containerEl);
+    } else {
+      this.renderWorkflowsModuleList(containerEl, modules, diagnostics);
+    }
+
+    // Available variables panel — always rendered (even when no modules), so
+    // a brand-new user can see what tokens they'll be able to reference once
+    // they install or author a module. Collapsed by default to avoid
+    // dominating the panel.
+    const varsCollapsible = new OpCollapsible(
+      containerEl,
+      "Available variables",
+      { startOpen: false },
+    );
+    varsCollapsible.root.dataset.opSection = "workflowsVars";
+    addHelpExpandable(
+      varsCollapsible.body,
+      "What is this?",
+      "Tokens you can reference in a module body via {{name}}. These are computed per-launch from the issue, the agent profile, and the launch context — they sit at Launch override (the highest precedence). User-declared {{vars.<name>}} are a separate namespace declared in a module's `vars:` block.",
+    );
+    this.renderAvailableVariables(varsCollapsible.body);
+  }
+
+  private renderWorkflowsEmptyState(parentEl: HTMLElement): void {
+    const empty = parentEl.createDiv({
+      cls: "op-workflow-empty-state",
+    });
+    empty.dataset.opEmptyState = "true";
+    empty.createEl("p", {
+      cls: "op-workflow-empty-state__title",
+      text: "No modules yet",
+    });
+    const body = empty.createEl("p", {
+      cls: "op-workflow-empty-state__body setting-item-description",
+    });
+    body.appendText("Open the ");
+    // Quickstart docs link target ships in OP-?-10a; the URL is wired here so
+    // landing the docs file is a one-line follow-up.
+    const quickstart = body.createEl("a", {
+      text: "5-min Quickstart",
+      href: "https://github.com/earchibald/obsidian-projects/blob/main/docs/quickstart.md",
+    });
+    quickstart.setAttribute("target", "_blank");
+    quickstart.setAttribute("rel", "noopener");
+    body.appendText(", or install the example library below to get a working modules tree in one click.");
+
+    new Setting(empty)
+      .setName("Install example library")
+      .setDesc(
+        `Writes ${EXAMPLE_MODULES.length} starter modules into Projects/_op-modules/. Existing files are never overwritten — safe to click again. Open the installed files to see complete, valid module shape.`,
+      )
+      .addButton((b) =>
+        b
+          .setButtonText("Install example library")
+          .setCta()
+          .onClick(async () => {
+            try {
+              const r = await installExampleLibrary(this.app);
+              const parts: string[] = [];
+              if (r.installed.length) parts.push(`${r.installed.length} installed`);
+              if (r.skipped.length) parts.push(`${r.skipped.length} skipped (already present)`);
+              notify(`Example library: ${parts.join(", ") || "no changes"}.`, 6000);
+              this.rerenderSection("workflows");
+            } catch (e) {
+              notify(`Could not install example library: ${(e as Error).message}`, 8000);
+            }
+          }),
+      );
+  }
+
+  private renderWorkflowsModuleList(
+    parentEl: HTMLElement,
+    modules: readonly WorkflowModule[],
+    diagnostics: readonly WorkflowDiagnostic[],
+  ): void {
+    // Bucket diagnostics by moduleId so each row can render its own count
+    // without re-scanning the full list. Diagnostics with no moduleId
+    // (e.g. some intra-scope-collision payloads) bucket under "" and surface
+    // in the unattributed footer below.
+    const byModule = new Map<string, WorkflowDiagnostic[]>();
+    for (const d of diagnostics) {
+      const key = d.moduleId ?? "";
+      const arr = byModule.get(key) ?? [];
+      arr.push(d);
+      byModule.set(key, arr);
+    }
+
+    const list = parentEl.createDiv({ cls: "op-workflow-module-list" });
+    for (const m of modules) {
+      const row = list.createDiv({ cls: "op-workflow-module" });
+      row.dataset.moduleId = m.id;
+
+      const head = row.createDiv({ cls: "op-workflow-module__head" });
+      head.createSpan({ cls: "op-workflow-module__id", text: m.id });
+      head.createSpan({ cls: "op-workflow-module__title", text: m.title });
+      const sourceLabel =
+        m.source.kind === "global"
+          ? "global"
+          : `project: ${m.source.projectSlug}`;
+      head.createSpan({
+        cls: "op-workflow-module__source",
+        text: sourceLabel,
+      });
+
+      const ds = byModule.get(m.id) ?? [];
+      const counts = countsBySeverity(ds);
+      if (counts.error || counts.warning || counts.info) {
+        const badges = head.createSpan({ cls: "op-workflow-module__badges" });
+        if (counts.error) appendBadge(badges, "error", counts.error);
+        if (counts.warning) appendBadge(badges, "warning", counts.warning);
+        if (counts.info) appendBadge(badges, "info", counts.info);
+      } else {
+        head.createSpan({
+          cls: "op-workflow-module__badges op-workflow-module__badges--ok",
+          text: "ok",
+        });
+      }
+
+      // Per-module diagnostic lines through the unified formatter. One line
+      // per diagnostic — modal renders the multi-line block on Explain click.
+      if (ds.length) {
+        const diagList = row.createDiv({ cls: "op-workflow-module__diagnostics" });
+        for (const d of ds) {
+          const f = formatDiagnostic(d);
+          const line = diagList.createDiv({
+            cls: `op-workflow-module__diagnostic op-workflow-module__diagnostic--${f.severity}`,
+          });
+          const badge = line.createSpan({
+            cls: "op-workflow-module__diagnostic-badge",
+            text: f.severityBadge,
+          });
+          // Tooltip shows the full code label, NOT the abbreviation. The
+          // abbreviation is the single-letter glyph in the badge text itself
+          // — primary copy in the tooltip stays canonical.
+          badge.setAttribute("aria-label", f.codeLabel);
+          badge.setAttribute("title", f.codeLabel);
+          line.createSpan({
+            cls: "op-workflow-module__diagnostic-code",
+            text: f.codeLabel,
+          });
+          line.createSpan({
+            cls: "op-workflow-module__diagnostic-message",
+            text: f.message,
+          });
+          if (f.scopeLabel) {
+            // Full canonical scope label in primary copy. The single-letter
+            // form is for the badge tooltip only — never shown here.
+            line.createSpan({
+              cls: "op-workflow-module__diagnostic-scope",
+              text: f.scopeLabel,
+            });
+          }
+        }
+      }
+
+      // Explain action — opens the modal that renders every diagnostic for
+      // this module through the unified formatter's multi-line block. Even
+      // when ds.length === 0 the modal still opens (showing "No diagnostics")
+      // so users can verify they're looking at the right module.
+      const actions = row.createDiv({ cls: "op-workflow-module__actions" });
+      const explain = actions.createEl("button", {
+        cls: "op-workflow-module__explain",
+        text: "Explain workflow",
+      });
+      explain.addEventListener("click", () => {
+        new WorkflowExplainModal(this.app, m, ds).open();
+      });
+    }
+
+    // Surface diagnostics that don't pair with a loaded module: either
+    // diagnostics with no moduleId at all, or diagnostics whose moduleId
+    // points at a module that failed to parse (so the file never made it
+    // into the modules list). Without this footer, parse-failure
+    // diagnostics would silently vanish — exactly the failure mode the
+    // unified formatter is meant to prevent.
+    const loadedIds = new Set(modules.map((m) => m.id));
+    const orphaned: WorkflowDiagnostic[] = [];
+    for (const [moduleId, ds] of byModule) {
+      if (moduleId === "" || !loadedIds.has(moduleId)) orphaned.push(...ds);
+    }
+    if (orphaned.length) {
+      const foot = parentEl.createDiv({ cls: "op-workflow-module-list__orphan" });
+      foot.dataset.opOrphanDiagnostics = "true";
+      foot.createEl("h4", { text: "Unattributed diagnostics" });
+      foot.createEl("p", {
+        cls: "setting-item-description",
+        text: "Diagnostics from modules that failed to parse, or that don't bind to a single module.",
+      });
+      for (const d of orphaned) {
+        const f = formatDiagnostic(d);
+        const line = foot.createDiv({
+          cls: `op-workflow-module__diagnostic op-workflow-module__diagnostic--${f.severity}`,
+        });
+        const badge = line.createSpan({
+          cls: "op-workflow-module__diagnostic-badge",
+          text: f.severityBadge,
+        });
+        badge.setAttribute("aria-label", f.codeLabel);
+        badge.setAttribute("title", f.codeLabel);
+        line.createSpan({
+          cls: "op-workflow-module__diagnostic-code",
+          text: f.codeLabel,
+        });
+        line.createSpan({
+          cls: "op-workflow-module__diagnostic-message",
+          text: d.moduleId ? `${d.moduleId}: ${f.message}` : f.message,
+        });
+        if (f.scopeLabel) {
+          line.createSpan({
+            cls: "op-workflow-module__diagnostic-scope",
+            text: f.scopeLabel,
+          });
+        }
+      }
+    }
+  }
+
+  private renderAvailableVariables(parentEl: HTMLElement): void {
+    const list = parentEl.createDiv({ cls: "op-workflow-vars-panel" });
+    for (const v of Object.values(PLUGIN_VAR_REGISTRY)) {
+      const row = list.createDiv({ cls: "op-workflow-vars-panel__row" });
+      const head = row.createDiv({ cls: "op-workflow-vars-panel__head" });
+      head.createSpan({
+        cls: "op-workflow-vars-panel__name",
+        text: `{{${v.name}}}`,
+      });
+      head.createSpan({
+        cls: "op-workflow-vars-panel__example",
+        text: `e.g. ${v.example}`,
+      });
+      row.createDiv({
+        cls: "op-workflow-vars-panel__desc setting-item-description",
+        text: v.description,
+      });
+    }
   }
 
   // ─── Advanced section renderers ─────────────────────────────────────────
@@ -1637,3 +1912,127 @@ export class HotkeyPresetResultsModal extends Modal {
     this.contentEl.empty();
   }
 }
+
+// ─── Workflow helpers + Explain modal (OP-201) ────────────────────────────
+
+interface SeverityCounts {
+  error: number;
+  warning: number;
+  info: number;
+}
+
+function countsBySeverity(ds: readonly WorkflowDiagnostic[]): SeverityCounts {
+  const out: SeverityCounts = { error: 0, warning: 0, info: 0 };
+  for (const d of ds) out[d.severity] += 1;
+  return out;
+}
+
+function appendBadge(
+  parentEl: HTMLElement,
+  severity: WorkflowDiagnostic["severity"],
+  count: number,
+): void {
+  parentEl.createSpan({
+    cls: `op-workflow-badge op-workflow-badge--${severity}`,
+    text: `${count} ${severity}${count === 1 ? "" : "s"}`,
+  });
+}
+
+/**
+ * Modal that prints every diagnostic for a single workflow module through
+ * the unified `diagnosticToBlock` formatter. Renders the same shape every
+ * other 3* surface will (op-explain-workflow CLI / dry-run banner / launch
+ * pre-flight) — this in-Settings version is the proof the formatter
+ * contract is end-to-end usable before the CLI ships in OP-203.
+ */
+export class WorkflowExplainModal extends Modal {
+  constructor(
+    app: App,
+    private module: WorkflowModule,
+    private diagnostics: readonly WorkflowDiagnostic[],
+  ) {
+    super(app);
+  }
+
+  onOpen(): void {
+    const { contentEl } = this;
+    contentEl.empty();
+    contentEl.addClass("op-workflow-explain");
+
+    contentEl.createEl("h2", { text: this.module.title });
+    const subtitle = contentEl.createEl("p", {
+      cls: "setting-item-description",
+    });
+    subtitle.appendText(`id: ${this.module.id} · scope: ${this.module.scope} · `);
+    subtitle.appendText(
+      this.module.source.kind === "global"
+        ? `global (${this.module.source.path})`
+        : `project ${this.module.source.projectSlug} (${this.module.source.path})`,
+    );
+
+    if (this.diagnostics.length === 0) {
+      contentEl.createEl("p", {
+        text: "No diagnostics. This module loaded clean.",
+      });
+    } else {
+      const list = contentEl.createDiv({ cls: "op-workflow-explain__list" });
+      for (const d of this.diagnostics) {
+        const block = list.createEl("pre", {
+          cls: `op-workflow-explain__block op-workflow-explain__block--${d.severity}`,
+          text: diagnosticToBlock(d),
+        });
+        block.dataset.code = d.code;
+      }
+    }
+
+    if (this.module.vars.length) {
+      contentEl.createEl("h3", { text: "Declared variables" });
+      const vars = contentEl.createDiv({ cls: "op-workflow-explain__vars" });
+      for (const v of this.module.vars) {
+        const row = vars.createDiv({ cls: "op-workflow-explain__var" });
+        row.createSpan({ text: `{{${v.name}}}` });
+        switch (v.kind) {
+          case "bare":
+            row.createSpan({
+              cls: "setting-item-description",
+              text: " — no default; satisfied at a higher precedence scope (Project default or Launch override).",
+            });
+            break;
+          case "default":
+            row.createSpan({
+              cls: "setting-item-description",
+              text: ` — Module default = ${JSON.stringify(v.value)}.`,
+            });
+            break;
+          case "object":
+            if (v.description) {
+              row.createSpan({
+                cls: "setting-item-description",
+                text: ` — ${v.description}`,
+              });
+            }
+            if (v.default !== undefined) {
+              row.createSpan({
+                cls: "setting-item-description",
+                text: ` Module default = ${JSON.stringify(v.default)}.`,
+              });
+            }
+            break;
+        }
+      }
+    }
+
+    new Setting(contentEl).addButton((b) =>
+      b.setButtonText("Close").onClick(() => this.close()),
+    );
+  }
+
+  onClose(): void {
+    this.contentEl.empty();
+  }
+}
+
+// `FormattedDiagnostic` is imported above so callers in this module that
+// need the shape can refer to it directly. Re-export here to keep the
+// module's public surface flat for downstream consumers.
+export type { FormattedDiagnostic };

--- a/plugins/op-obsidian/src/workflowDiagnosticFormat.test.ts
+++ b/plugins/op-obsidian/src/workflowDiagnosticFormat.test.ts
@@ -1,0 +1,284 @@
+import { describe, it, expect } from "vitest";
+import type { WorkflowDiagnostic, WorkflowDiagnosticCode } from "./workflowDiagnostic";
+import {
+  PRECEDENCE_SCOPES,
+  codeLabel,
+  diagnosticToBlock,
+  diagnosticToLine,
+  formatDiagnostic,
+  formatDiagnostics,
+  isPrecedenceScope,
+  precedenceScopeAbbrev,
+  precedenceScopeLabel,
+  severityBadge,
+  type PrecedenceScope,
+} from "./workflowDiagnosticFormat";
+
+const ALL_CODES: WorkflowDiagnosticCode[] = [
+  "bad-model",
+  "missing-var",
+  "unknown-module",
+  "schema-mismatch",
+  "import-collision",
+  "intra-scope-collision",
+  "malformed-frontmatter",
+];
+
+const ALL_SCOPES: PrecedenceScope[] = ["module", "global", "project", "launch"];
+
+function diag(over: Partial<WorkflowDiagnostic> = {}): WorkflowDiagnostic {
+  return {
+    code: "missing-var",
+    severity: "warning",
+    message: "Variable {{foo}} is undefined.",
+    ...over,
+  };
+}
+
+// ─── Precedence scope canonicalization ───────────────────────────────────
+
+describe("precedence scopes", () => {
+  it("maps every scope to a full canonical label", () => {
+    expect(precedenceScopeLabel("module")).toBe("Module default");
+    expect(precedenceScopeLabel("global")).toBe("Global default");
+    expect(precedenceScopeLabel("project")).toBe("Project default");
+    expect(precedenceScopeLabel("launch")).toBe("Launch override");
+  });
+
+  it("maps every scope to a single-letter abbreviation for tooltip text only", () => {
+    expect(precedenceScopeAbbrev("module")).toBe("M");
+    expect(precedenceScopeAbbrev("global")).toBe("G");
+    expect(precedenceScopeAbbrev("project")).toBe("P");
+    expect(precedenceScopeAbbrev("launch")).toBe("L");
+  });
+
+  it("isPrecedenceScope guards correctly", () => {
+    for (const s of ALL_SCOPES) expect(isPrecedenceScope(s)).toBe(true);
+    for (const bad of ["", "Module", "MODULE", "user", undefined, null, 0, {}]) {
+      expect(isPrecedenceScope(bad)).toBe(false);
+    }
+  });
+
+  it("PRECEDENCE_SCOPES is frozen — entries cannot be mutated", () => {
+    expect(Object.isFrozen(PRECEDENCE_SCOPES)).toBe(true);
+    expect(Object.isFrozen(PRECEDENCE_SCOPES.module)).toBe(true);
+  });
+
+  it("abbreviations are unique", () => {
+    const seen = new Set<string>();
+    for (const s of ALL_SCOPES) {
+      const abbrev = precedenceScopeAbbrev(s);
+      expect(seen.has(abbrev)).toBe(false);
+      seen.add(abbrev);
+    }
+  });
+});
+
+// ─── Severity badges ─────────────────────────────────────────────────────
+
+describe("severityBadge", () => {
+  it("maps every severity to a single-letter glyph", () => {
+    expect(severityBadge("error")).toBe("E");
+    expect(severityBadge("warning")).toBe("W");
+    expect(severityBadge("info")).toBe("I");
+  });
+});
+
+// ─── Code labels ─────────────────────────────────────────────────────────
+
+describe("codeLabel", () => {
+  it("returns a sentence-case label for every WorkflowDiagnosticCode", () => {
+    expect(codeLabel("bad-model")).toBe("Bad model spec");
+    expect(codeLabel("missing-var")).toBe("Missing variable");
+    expect(codeLabel("unknown-module")).toBe("Unknown module");
+    expect(codeLabel("schema-mismatch")).toBe("Schema mismatch");
+    expect(codeLabel("import-collision")).toBe("Import collision");
+    expect(codeLabel("intra-scope-collision")).toBe("Intra-scope collision");
+    expect(codeLabel("malformed-frontmatter")).toBe("Malformed frontmatter");
+  });
+
+  it("never returns the raw kebab-case code (verifies humanization happened)", () => {
+    for (const code of ALL_CODES) {
+      const label = codeLabel(code);
+      expect(label).not.toBe(code);
+      expect(label.startsWith(label[0]?.toUpperCase() ?? "")).toBe(true);
+    }
+  });
+});
+
+// ─── formatDiagnostic — exhaustiveness over codes ────────────────────────
+
+describe("formatDiagnostic — every code", () => {
+  for (const code of ALL_CODES) {
+    it(`formats ${code} without throwing and populates the contract fields`, () => {
+      const d = diag({ code, severity: "error", message: `msg for ${code}` });
+      const f = formatDiagnostic(d);
+      expect(f.code).toBe(code);
+      expect(f.codeLabel).toBe(codeLabel(code));
+      expect(f.severity).toBe("error");
+      expect(f.severityBadge).toBe("E");
+      expect(f.message).toBe(`msg for ${code}`);
+      expect(typeof f.hint).toBe("string");
+      expect(f.hint!.length).toBeGreaterThan(0);
+    });
+  }
+});
+
+describe("formatDiagnostic — passthrough fields", () => {
+  it("copies severity verbatim and assigns the matching badge", () => {
+    expect(formatDiagnostic(diag({ severity: "info" })).severityBadge).toBe("I");
+    expect(formatDiagnostic(diag({ severity: "warning" })).severityBadge).toBe("W");
+    expect(formatDiagnostic(diag({ severity: "error" })).severityBadge).toBe("E");
+  });
+
+  it("copies message verbatim — no rewriting", () => {
+    const text = "Specific prose with {{tokens}} and 'punctuation'.";
+    expect(formatDiagnostic(diag({ message: text })).message).toBe(text);
+  });
+});
+
+// ─── Location summary ────────────────────────────────────────────────────
+
+describe("formatDiagnostic — location summary", () => {
+  it("is empty when no location fields are set", () => {
+    expect(formatDiagnostic(diag()).location).toBe("");
+  });
+
+  it("includes moduleId, stepId, varName when present", () => {
+    const f = formatDiagnostic(
+      diag({ moduleId: "review", stepId: "lint", varName: "foo" }),
+    );
+    expect(f.location).toBe("module review · step lint · var foo");
+  });
+
+  it("appends extra.path when present", () => {
+    const f = formatDiagnostic(
+      diag({
+        code: "malformed-frontmatter",
+        moduleId: "broken",
+        extra: { path: "Projects/_op-modules/broken.md", field: "scope" },
+      }),
+    );
+    expect(f.location).toBe("module broken · Projects/_op-modules/broken.md");
+  });
+
+  it("ignores non-string extra.path", () => {
+    const f = formatDiagnostic(
+      diag({ moduleId: "x", extra: { path: 42 } }),
+    );
+    expect(f.location).toBe("module x");
+  });
+});
+
+// ─── Precedence scope rendering ──────────────────────────────────────────
+
+describe("formatDiagnostic — precedence scope", () => {
+  it("omits scopeLabel and scopeAbbrev when extra.precedenceScope is absent", () => {
+    const f = formatDiagnostic(diag());
+    expect(f.scopeLabel).toBeUndefined();
+    expect(f.scopeAbbrev).toBeUndefined();
+  });
+
+  it.each(ALL_SCOPES)("renders %s as full label + abbreviation", (scope) => {
+    const f = formatDiagnostic(diag({ extra: { precedenceScope: scope } }));
+    expect(f.scopeLabel).toBe(precedenceScopeLabel(scope));
+    expect(f.scopeAbbrev).toBe(precedenceScopeAbbrev(scope));
+  });
+
+  it("ignores invalid extra.precedenceScope values silently", () => {
+    const f = formatDiagnostic(diag({ extra: { precedenceScope: "user" } }));
+    expect(f.scopeLabel).toBeUndefined();
+    expect(f.scopeAbbrev).toBeUndefined();
+  });
+
+  it("never lets the abbreviation appear in primary copy fields", () => {
+    const f = formatDiagnostic(diag({ extra: { precedenceScope: "module" } }));
+    expect(f.message).not.toContain("(M)");
+    expect(f.codeLabel).not.toContain("(M)");
+    expect(f.codeLabel).not.toContain(" M ");
+  });
+});
+
+// ─── formatDiagnostics — list passthrough ────────────────────────────────
+
+describe("formatDiagnostics", () => {
+  it("preserves order and length", () => {
+    const xs = ALL_CODES.map((code) => diag({ code, message: code }));
+    const fs = formatDiagnostics(xs);
+    expect(fs).toHaveLength(xs.length);
+    expect(fs.map((f) => f.code)).toEqual(ALL_CODES);
+  });
+});
+
+// ─── diagnosticToLine — primary copy uses full scope name ────────────────
+
+describe("diagnosticToLine", () => {
+  it("renders the canonical shape with severity badge + label + message", () => {
+    const line = diagnosticToLine(
+      diag({ code: "missing-var", severity: "warning", message: "{{foo}} undefined." }),
+    );
+    expect(line).toBe("[W] Missing variable — {{foo}} undefined.");
+  });
+
+  it("appends location in parens when present", () => {
+    const line = diagnosticToLine(
+      diag({ moduleId: "m", stepId: "s", message: "m." }),
+    );
+    expect(line).toContain("(in module m · step s)");
+  });
+
+  it("appends the FULL scope label, not the abbreviation", () => {
+    const line = diagnosticToLine(
+      diag({ extra: { precedenceScope: "launch" } }),
+    );
+    expect(line).toContain("[Launch override]");
+    expect(line).not.toContain("[L]");
+  });
+
+  it("emits a stable shape for every code (snapshot of structure, not text)", () => {
+    for (const code of ALL_CODES) {
+      const line = diagnosticToLine(diag({ code, severity: "error" }));
+      expect(line).toMatch(/^\[E\] .+ — .+$/);
+    }
+  });
+});
+
+// ─── diagnosticToBlock — multi-line modal copy ───────────────────────────
+
+describe("diagnosticToBlock", () => {
+  it("starts with the code label and full severity word", () => {
+    const block = diagnosticToBlock(diag({ severity: "error" }));
+    expect(block.split("\n")[0]).toBe("Missing variable  (error)");
+  });
+
+  it("includes the message line and the hint line", () => {
+    const block = diagnosticToBlock(diag({ severity: "info", message: "the message" }));
+    const lines = block.split("\n");
+    expect(lines).toContain("the message");
+    expect(lines.some((l) => l.startsWith("Hint:"))).toBe(true);
+  });
+
+  it("renders precedence scope as the FULL canonical name in primary copy", () => {
+    const block = diagnosticToBlock(
+      diag({ extra: { precedenceScope: "project" } }),
+    );
+    expect(block).toContain("Project default");
+    // Abbreviation must NOT appear as a standalone word in primary copy.
+    expect(block).not.toMatch(/(^|\s)P(\s|$)/);
+  });
+
+  it("omits the location line when there is no location info", () => {
+    const block = diagnosticToBlock(diag());
+    const lines = block.split("\n");
+    // Expected lines: codeLabel+severity, message, hint. No location.
+    expect(lines).toHaveLength(3);
+  });
+
+  it("omits the scope line when no precedence scope is attached", () => {
+    const block = diagnosticToBlock(diag({ moduleId: "m" }));
+    expect(block).not.toContain("Module default");
+    expect(block).not.toContain("Global default");
+    expect(block).not.toContain("Project default");
+    expect(block).not.toContain("Launch override");
+  });
+});

--- a/plugins/op-obsidian/src/workflowDiagnosticFormat.test.ts
+++ b/plugins/op-obsidian/src/workflowDiagnosticFormat.test.ts
@@ -22,6 +22,7 @@ const ALL_CODES: WorkflowDiagnosticCode[] = [
   "import-collision",
   "intra-scope-collision",
   "malformed-frontmatter",
+  "size-budget",
 ];
 
 const ALL_SCOPES: PrecedenceScope[] = ["module", "global", "project", "launch"];
@@ -95,6 +96,7 @@ describe("codeLabel", () => {
     expect(codeLabel("import-collision")).toBe("Import collision");
     expect(codeLabel("intra-scope-collision")).toBe("Intra-scope collision");
     expect(codeLabel("malformed-frontmatter")).toBe("Malformed frontmatter");
+    expect(codeLabel("size-budget")).toBe("Workflow size notice");
   });
 
   it("never returns the raw kebab-case code (verifies humanization happened)", () => {
@@ -167,6 +169,30 @@ describe("formatDiagnostic — location summary", () => {
       diag({ moduleId: "x", extra: { path: 42 } }),
     );
     expect(f.location).toBe("module x");
+  });
+});
+
+// ─── Direct accessor fields (moduleId / varName) ─────────────────────────
+
+describe("formatDiagnostic — direct accessors", () => {
+  it("populates moduleId and varName when present in source diagnostic", () => {
+    const f = formatDiagnostic(
+      diag({ moduleId: "my-module", varName: "my_var" }),
+    );
+    expect(f.moduleId).toBe("my-module");
+    expect(f.varName).toBe("my_var");
+  });
+
+  it("omits moduleId and varName when absent in source diagnostic", () => {
+    const f = formatDiagnostic(diag());
+    expect(f.moduleId).toBeUndefined();
+    expect(f.varName).toBeUndefined();
+  });
+
+  it("moduleId in FormattedDiagnostic matches moduleId in location string", () => {
+    const f = formatDiagnostic(diag({ moduleId: "review-mod" }));
+    expect(f.moduleId).toBe("review-mod");
+    expect(f.location).toContain("review-mod");
   });
 });
 

--- a/plugins/op-obsidian/src/workflowDiagnosticFormat.ts
+++ b/plugins/op-obsidian/src/workflowDiagnosticFormat.ts
@@ -128,6 +128,13 @@ export interface FormattedDiagnostic {
    */
   scopeAbbrev?: PrecedenceScopeAbbrev;
   /**
+   * Direct stable accessors — avoid parsing the `location` string in
+   * programmatic consumers (OP-203 CLI, OP-207 squiggles, etc.). Populated
+   * from the source diagnostic's own fields when present.
+   */
+  moduleId?: string;
+  varName?: string;
+  /**
    * Optional one-line hint for what the user can do about this diagnostic.
    * Surface it as a secondary line in modals; omit in compact contexts.
    */
@@ -142,6 +149,7 @@ const CODE_LABELS: Readonly<Record<WorkflowDiagnosticCode, string>> = Object.fre
   "import-collision": "Import collision",
   "intra-scope-collision": "Intra-scope collision",
   "malformed-frontmatter": "Malformed frontmatter",
+  "size-budget": "Workflow size notice",
 });
 
 export function codeLabel(code: WorkflowDiagnosticCode): string {
@@ -163,6 +171,8 @@ const HINTS: Readonly<Record<WorkflowDiagnosticCode, string>> = Object.freeze({
     "Multiple modules declare the same scope key. Make the scope strings distinct, or merge the modules.",
   "malformed-frontmatter":
     "Open the module file and fix the highlighted field — the existing value is the wrong type.",
+  "size-budget":
+    "The composed workflow exceeds the recommended character budget. Modern models handle this well — consider splitting the workflow into smaller modules if latency increases.",
 });
 
 /**
@@ -183,6 +193,7 @@ export function formatDiagnostic(d: WorkflowDiagnostic): FormattedDiagnostic {
     case "import-collision":
     case "intra-scope-collision":
     case "malformed-frontmatter":
+    case "size-budget":
       return buildFormatted(d);
     default:
       return assertNeverCode(code);
@@ -203,6 +214,8 @@ function buildFormatted(d: WorkflowDiagnostic): FormattedDiagnostic {
     location: buildLocation(d),
     hint: HINTS[d.code],
   };
+  if (d.moduleId) out.moduleId = d.moduleId;
+  if (d.varName) out.varName = d.varName;
   const scope = readPrecedenceScope(d);
   if (scope) {
     out.scopeLabel = precedenceScopeLabel(scope);

--- a/plugins/op-obsidian/src/workflowDiagnosticFormat.ts
+++ b/plugins/op-obsidian/src/workflowDiagnosticFormat.ts
@@ -1,0 +1,265 @@
+// Unified renderer for `WorkflowDiagnostic` records. Every diagnostic surface
+// in the workflow-modules engine — Settings → Workflows panel (this issue),
+// op-explain-workflow / op-list-vars CLIs (OP-203), editor squiggles (OP-207),
+// dry-run banner (OP-206), launch-modal pre-flight (OP-204) — feeds its
+// `WorkflowDiagnostic[]` through this one formatter. One shape in, one prose
+// shape out. Pure: no Obsidian imports, no I/O.
+//
+// Public contract: `formatDiagnostic(d)` returns a `FormattedDiagnostic`
+// carrying everything any UI surface needs (severity badge, code label,
+// optional precedence-scope rendering, location summary, the diagnostic's own
+// prose message). UI surfaces compose these fields; they do NOT re-derive
+// labels by switching on `code` again. If you find yourself doing that in a
+// caller, extend `FormattedDiagnostic` instead.
+//
+// Canonical scope names: when a diagnostic carries `extra.precedenceScope`
+// (one of `module|global|project|launch`), the formatter exposes the full
+// canonical name (e.g. `Module default`) for primary copy and the
+// abbreviation (e.g. `M`) for compact tooltip text. Per OP-201 spec,
+// abbreviations MUST NOT appear in primary copy.
+
+import {
+  assertNeverCode,
+  type WorkflowDiagnostic,
+  type WorkflowDiagnosticCode,
+  type WorkflowDiagnosticSeverity,
+} from "./workflowDiagnostic";
+
+/**
+ * Variable-resolution precedence stack. Higher level wins. Source of truth
+ * for the four canonical scope names called out in OP-181 plan + OP-201.
+ *
+ * `module`  → a module's own `vars:` declaration default.
+ * `global`  → vault-wide override (`Projects/_op-modules/_overrides.md`).
+ * `project` → per-project override (`Projects/<slug>/MODULES/_overrides.md`).
+ * `launch`  → per-launch context (computed from `pluginVarRegistry` plus the
+ *             optional Workflow-variables panel — OP-204).
+ */
+export type PrecedenceScope = "module" | "global" | "project" | "launch";
+
+export type PrecedenceScopeLabel =
+  | "Module default"
+  | "Global default"
+  | "Project default"
+  | "Launch override";
+
+export type PrecedenceScopeAbbrev = "M" | "G" | "P" | "L";
+
+interface PrecedenceScopeEntry {
+  label: PrecedenceScopeLabel;
+  abbrev: PrecedenceScopeAbbrev;
+}
+
+/**
+ * Canonical lookup table. Use `precedenceScopeLabel(scope)` and
+ * `precedenceScopeAbbrev(scope)` to read it; the table itself is exported
+ * frozen so direct callers can iterate when rendering a reference panel.
+ */
+export const PRECEDENCE_SCOPES: Readonly<Record<PrecedenceScope, PrecedenceScopeEntry>> =
+  Object.freeze({
+    module: Object.freeze({ label: "Module default", abbrev: "M" }),
+    global: Object.freeze({ label: "Global default", abbrev: "G" }),
+    project: Object.freeze({ label: "Project default", abbrev: "P" }),
+    launch: Object.freeze({ label: "Launch override", abbrev: "L" }),
+  });
+
+export function precedenceScopeLabel(scope: PrecedenceScope): PrecedenceScopeLabel {
+  return PRECEDENCE_SCOPES[scope].label;
+}
+
+export function precedenceScopeAbbrev(scope: PrecedenceScope): PrecedenceScopeAbbrev {
+  return PRECEDENCE_SCOPES[scope].abbrev;
+}
+
+/**
+ * Type guard for `extra.precedenceScope`. Diagnostics emitted by 1b/1c/1d
+ * may attach a precedence scope to indicate where a variable resolved (or
+ * failed to resolve) in the stack. The formatter reads this opportunistically
+ * — diagnostics without it render fine, just without the scope chip.
+ */
+export function isPrecedenceScope(x: unknown): x is PrecedenceScope {
+  return x === "module" || x === "global" || x === "project" || x === "launch";
+}
+
+/**
+ * Single-letter severity glyph. Compact UI surfaces (badges, gutters) use
+ * this; primary copy uses the full severity word.
+ */
+export type SeverityBadge = "E" | "W" | "I";
+
+export function severityBadge(s: WorkflowDiagnosticSeverity): SeverityBadge {
+  switch (s) {
+    case "error":
+      return "E";
+    case "warning":
+      return "W";
+    case "info":
+      return "I";
+  }
+}
+
+/**
+ * Output of the formatter — every UI surface composes fields from this rather
+ * than re-switching on `code`. Adding a field here is the migration path when
+ * a new surface needs a different rendering of the same diagnostic.
+ */
+export interface FormattedDiagnostic {
+  code: WorkflowDiagnosticCode;
+  /** Sentence-case human label for the code, e.g. "Missing variable". */
+  codeLabel: string;
+  severity: WorkflowDiagnosticSeverity;
+  severityBadge: SeverityBadge;
+  /** Verbatim prose message from the source diagnostic. */
+  message: string;
+  /**
+   * Compact location summary built from `moduleId` / `stepId` / `varName` /
+   * `extra.path`, comma-separated. Empty string when none of those are set.
+   */
+  location: string;
+  /**
+   * Full canonical scope name for primary copy. Only populated when the
+   * diagnostic carries `extra.precedenceScope`. Per OP-201 contract: this
+   * field — never `scopeAbbrev` — is what user-visible primary text shows.
+   */
+  scopeLabel?: PrecedenceScopeLabel;
+  /**
+   * Compact abbreviation paired with `scopeLabel`. Use ONLY in tooltip text
+   * or compact badge hovers. MUST NOT appear in primary copy.
+   */
+  scopeAbbrev?: PrecedenceScopeAbbrev;
+  /**
+   * Optional one-line hint for what the user can do about this diagnostic.
+   * Surface it as a secondary line in modals; omit in compact contexts.
+   */
+  hint?: string;
+}
+
+const CODE_LABELS: Readonly<Record<WorkflowDiagnosticCode, string>> = Object.freeze({
+  "bad-model": "Bad model spec",
+  "missing-var": "Missing variable",
+  "unknown-module": "Unknown module",
+  "schema-mismatch": "Schema mismatch",
+  "import-collision": "Import collision",
+  "intra-scope-collision": "Intra-scope collision",
+  "malformed-frontmatter": "Malformed frontmatter",
+});
+
+export function codeLabel(code: WorkflowDiagnosticCode): string {
+  return CODE_LABELS[code];
+}
+
+const HINTS: Readonly<Record<WorkflowDiagnosticCode, string>> = Object.freeze({
+  "bad-model":
+    "Pick from the agent's allowed-models list, or open the recovery dialog to patch the workflow.",
+  "missing-var":
+    "Declare a default in the module's `vars:` block, or supply a value at the next-higher precedence scope.",
+  "unknown-module":
+    "Check the spelling, or create the module file at `Projects/_op-modules/<id>.md`.",
+  "schema-mismatch":
+    "Update the module to the current schema version. See docs/schema.md for the migration.",
+  "import-collision":
+    "Two modules contribute the same variable name at the same scope. Rename one, or move it to a higher scope so it shadows the other.",
+  "intra-scope-collision":
+    "Multiple modules declare the same scope key. Make the scope strings distinct, or merge the modules.",
+  "malformed-frontmatter":
+    "Open the module file and fix the highlighted field — the existing value is the wrong type.",
+});
+
+/**
+ * Format one diagnostic. Pure: input → output, no side effects. Exhaustive
+ * over `WorkflowDiagnosticCode` via `assertNeverCode` in the default branch
+ * so adding a new code raises a TypeScript error here until handled.
+ */
+export function formatDiagnostic(d: WorkflowDiagnostic): FormattedDiagnostic {
+  const code = d.code;
+  // Compile-time exhaustiveness fence: keep the switch even though every
+  // current branch returns the same shape — when a new code lands, this
+  // forces a deliberate decision per code rather than a generic fallthrough.
+  switch (code) {
+    case "bad-model":
+    case "missing-var":
+    case "unknown-module":
+    case "schema-mismatch":
+    case "import-collision":
+    case "intra-scope-collision":
+    case "malformed-frontmatter":
+      return buildFormatted(d);
+    default:
+      return assertNeverCode(code);
+  }
+}
+
+export function formatDiagnostics(ds: readonly WorkflowDiagnostic[]): FormattedDiagnostic[] {
+  return ds.map(formatDiagnostic);
+}
+
+function buildFormatted(d: WorkflowDiagnostic): FormattedDiagnostic {
+  const out: FormattedDiagnostic = {
+    code: d.code,
+    codeLabel: codeLabel(d.code),
+    severity: d.severity,
+    severityBadge: severityBadge(d.severity),
+    message: d.message,
+    location: buildLocation(d),
+    hint: HINTS[d.code],
+  };
+  const scope = readPrecedenceScope(d);
+  if (scope) {
+    out.scopeLabel = precedenceScopeLabel(scope);
+    out.scopeAbbrev = precedenceScopeAbbrev(scope);
+  }
+  return out;
+}
+
+function buildLocation(d: WorkflowDiagnostic): string {
+  const parts: string[] = [];
+  if (d.moduleId) parts.push(`module ${d.moduleId}`);
+  if (d.stepId) parts.push(`step ${d.stepId}`);
+  if (d.varName) parts.push(`var ${d.varName}`);
+  const path = d.extra && typeof d.extra.path === "string" ? d.extra.path : undefined;
+  if (path) parts.push(path);
+  return parts.join(" · ");
+}
+
+function readPrecedenceScope(d: WorkflowDiagnostic): PrecedenceScope | undefined {
+  const raw = d.extra?.precedenceScope;
+  return isPrecedenceScope(raw) ? raw : undefined;
+}
+
+/**
+ * One-line plain-text rendering for CLI / log surfaces.
+ *
+ * Shape: `[E] <Code label> — <message>` with optional ` (in <location>)` and
+ * ` [<scope label>]` suffixes. Primary-copy rule: full scope name, never the
+ * abbreviation.
+ */
+export function diagnosticToLine(d: WorkflowDiagnostic): string {
+  const f = formatDiagnostic(d);
+  let line = `[${f.severityBadge}] ${f.codeLabel} — ${f.message}`;
+  if (f.location) line += ` (in ${f.location})`;
+  if (f.scopeLabel) line += ` [${f.scopeLabel}]`;
+  return line;
+}
+
+/**
+ * Multi-line rendering for in-modal / in-panel display. One diagnostic per
+ * call; callers join the array of blocks with a blank line between for
+ * scannability.
+ *
+ * Shape:
+ *   <Code label>  (severity word)
+ *   <location>             ← omitted when empty
+ *   <scope label>          ← omitted when no scope
+ *   <message>
+ *   Hint: <hint>           ← omitted when no hint
+ */
+export function diagnosticToBlock(d: WorkflowDiagnostic): string {
+  const f = formatDiagnostic(d);
+  const lines: string[] = [];
+  lines.push(`${f.codeLabel}  (${f.severity})`);
+  if (f.location) lines.push(f.location);
+  if (f.scopeLabel) lines.push(f.scopeLabel);
+  lines.push(f.message);
+  if (f.hint) lines.push(`Hint: ${f.hint}`);
+  return lines.join("\n");
+}

--- a/plugins/op-obsidian/src/workflowExamples.test.ts
+++ b/plugins/op-obsidian/src/workflowExamples.test.ts
@@ -20,15 +20,18 @@ function makeFakeApp(initial: Partial<FakeAdapterState> = {}) {
   };
   const adapter = {
     exists: async (p: string) => state.files.has(p) || state.dirs.has(p),
-    write: async (p: string, content: string) => {
+  };
+  const vault = {
+    adapter,
+    create: async (p: string, content: string) => {
       state.files.set(p, content);
     },
-    mkdir: async (p: string) => {
+    createFolder: async (p: string) => {
       state.dirs.add(p);
     },
   };
-  const app = { vault: { adapter } } as unknown;
-  return { app: app as any, state, adapter };
+  const app = { vault } as unknown;
+  return { app: app as any, state, adapter, vault };
 }
 
 describe("EXAMPLE_MODULES", () => {
@@ -76,13 +79,13 @@ describe("installExampleLibrary", () => {
     expect(state.dirs.has("Projects/_op-modules/")).toBe(true);
   });
 
-  it("does not call mkdir when the directory already exists", async () => {
-    const { app, state } = makeFakeApp({
+  it("does not call createFolder when the directory already exists", async () => {
+    const { app, state, vault } = makeFakeApp({
       dirs: new Set(["Projects/_op-modules/"]),
     });
-    const mkdirSpy = vi.spyOn(app.vault.adapter, "mkdir");
+    const createFolderSpy = vi.spyOn(vault, "createFolder");
     await installExampleLibrary(app);
-    expect(mkdirSpy).not.toHaveBeenCalled();
+    expect(createFolderSpy).not.toHaveBeenCalled();
     expect(state.dirs.size).toBe(1);
   });
 
@@ -99,12 +102,12 @@ describe("installExampleLibrary", () => {
   });
 
   it("is idempotent — running twice produces no new writes the second time", async () => {
-    const { app } = makeFakeApp();
+    const { app, vault } = makeFakeApp();
     await installExampleLibrary(app);
-    const writeSpy = vi.spyOn(app.vault.adapter, "write");
+    const createSpy = vi.spyOn(vault, "create");
     const second = await installExampleLibrary(app);
     expect(second.installed).toEqual([]);
     expect(second.skipped.length).toBe(EXAMPLE_MODULES.length);
-    expect(writeSpy).not.toHaveBeenCalled();
+    expect(createSpy).not.toHaveBeenCalled();
   });
 });

--- a/plugins/op-obsidian/src/workflowExamples.test.ts
+++ b/plugins/op-obsidian/src/workflowExamples.test.ts
@@ -1,0 +1,110 @@
+import { describe, it, expect, vi } from "vitest";
+
+vi.mock("obsidian", () => ({}));
+
+import {
+  EXAMPLE_MODULES,
+  installExampleLibrary,
+  type InstallExamplesResult,
+} from "./workflowExamples";
+
+interface FakeAdapterState {
+  files: Map<string, string>;
+  dirs: Set<string>;
+}
+
+function makeFakeApp(initial: Partial<FakeAdapterState> = {}) {
+  const state: FakeAdapterState = {
+    files: initial.files ?? new Map(),
+    dirs: initial.dirs ?? new Set(),
+  };
+  const adapter = {
+    exists: async (p: string) => state.files.has(p) || state.dirs.has(p),
+    write: async (p: string, content: string) => {
+      state.files.set(p, content);
+    },
+    mkdir: async (p: string) => {
+      state.dirs.add(p);
+    },
+  };
+  const app = { vault: { adapter } } as unknown;
+  return { app: app as any, state, adapter };
+}
+
+describe("EXAMPLE_MODULES", () => {
+  it("ships at least one example", () => {
+    expect(EXAMPLE_MODULES.length).toBeGreaterThan(0);
+  });
+
+  it("every example carries an id and a frontmatter id matching it", () => {
+    for (const ex of EXAMPLE_MODULES) {
+      expect(ex.id).toMatch(/^[a-z][a-z0-9-]*$/);
+      expect(ex.content).toContain(`id: ${ex.id}`);
+    }
+  });
+
+  it("every example declares the workflow-module type and a scope", () => {
+    for (const ex of EXAMPLE_MODULES) {
+      expect(ex.content).toContain("type: workflow-module");
+      expect(ex.content).toMatch(/\nscope: \S+/);
+    }
+  });
+
+  it("the library and its entries are frozen", () => {
+    expect(Object.isFrozen(EXAMPLE_MODULES)).toBe(true);
+    for (const ex of EXAMPLE_MODULES) {
+      expect(Object.isFrozen(ex)).toBe(true);
+    }
+  });
+});
+
+describe("installExampleLibrary", () => {
+  it("writes every example into Projects/_op-modules/<id>.md on a fresh vault", async () => {
+    const { app, state } = makeFakeApp();
+    const r: InstallExamplesResult = await installExampleLibrary(app);
+    expect(r.installed.length).toBe(EXAMPLE_MODULES.length);
+    expect(r.skipped).toEqual([]);
+    for (const ex of EXAMPLE_MODULES) {
+      const path = `Projects/_op-modules/${ex.id}.md`;
+      expect(state.files.get(path)).toBe(ex.content);
+    }
+  });
+
+  it("creates the parent directory if missing", async () => {
+    const { app, state } = makeFakeApp();
+    await installExampleLibrary(app);
+    expect(state.dirs.has("Projects/_op-modules/")).toBe(true);
+  });
+
+  it("does not call mkdir when the directory already exists", async () => {
+    const { app, state } = makeFakeApp({
+      dirs: new Set(["Projects/_op-modules/"]),
+    });
+    const mkdirSpy = vi.spyOn(app.vault.adapter, "mkdir");
+    await installExampleLibrary(app);
+    expect(mkdirSpy).not.toHaveBeenCalled();
+    expect(state.dirs.size).toBe(1);
+  });
+
+  it("never overwrites an existing file — skips and reports it", async () => {
+    const target = `Projects/_op-modules/${EXAMPLE_MODULES[0].id}.md`;
+    const { app, state } = makeFakeApp({
+      files: new Map([[target, "user-edited content do not destroy"]]),
+    });
+    const r = await installExampleLibrary(app);
+    expect(r.skipped).toContain(target);
+    expect(state.files.get(target)).toBe("user-edited content do not destroy");
+    // Other examples that didn't pre-exist still installed.
+    expect(r.installed.length).toBe(EXAMPLE_MODULES.length - 1);
+  });
+
+  it("is idempotent — running twice produces no new writes the second time", async () => {
+    const { app } = makeFakeApp();
+    await installExampleLibrary(app);
+    const writeSpy = vi.spyOn(app.vault.adapter, "write");
+    const second = await installExampleLibrary(app);
+    expect(second.installed).toEqual([]);
+    expect(second.skipped.length).toBe(EXAMPLE_MODULES.length);
+    expect(writeSpy).not.toHaveBeenCalled();
+  });
+});

--- a/plugins/op-obsidian/src/workflowExamples.ts
+++ b/plugins/op-obsidian/src/workflowExamples.ts
@@ -1,0 +1,123 @@
+import type { App } from "obsidian";
+
+// Inline example workflow-module library for the Settings → Workflows
+// empty-state. The "Install example library" button writes these files into
+// the global modules dir so a brand-new user goes from zero to a working
+// modules tree in one click.
+//
+// Inline (not loaded from a vault folder) so the install path is
+// self-contained — no chicken-and-egg dependency on OP-189 ("migrate this
+// project's WORKFLOW.md content into named modules") or on the user having
+// any pre-existing module files. Examples are deliberately tiny: one minimal,
+// one with a `vars:` block. They serve double duty as documentation — opening
+// either file shows a complete, valid module.
+
+const EXAMPLES_DIR = "Projects/_op-modules/";
+
+export interface ExampleModule {
+  /** Module id — used for the filename, must match the frontmatter `id:`. */
+  id: string;
+  /** Markdown body including frontmatter. Written to disk verbatim. */
+  content: string;
+}
+
+/**
+ * The inlined example library. Order is the install order — first example is
+ * the simplest and the one a new user reads first when the Notice surfaces
+ * "Open `example-minimal.md` to see a complete module". Keep it short.
+ */
+export const EXAMPLE_MODULES: readonly ExampleModule[] = Object.freeze([
+  Object.freeze({
+    id: "example-minimal",
+    content: `---
+id: example-minimal
+title: "Example: minimal module"
+type: workflow-module
+scope: example
+order: 0
+---
+
+This is a minimal workflow module. The frontmatter declares its id, title,
+scope (used to partition the workflow), and order (sort key within the scope).
+
+A module with no \`vars:\` block has no template variables to resolve — it
+simply contributes its body to the composed workflow. Delete this file once
+you have your own modules.
+`,
+  }),
+  Object.freeze({
+    id: "example-with-vars",
+    content: `---
+id: example-with-vars
+title: "Example: module with variables"
+type: workflow-module
+scope: example
+order: 10
+vars:
+  - bare_var
+  - default_var=hello
+  - { name: described_var, default: "world", description: "A var with a description" }
+---
+
+This module declares three variables in its \`vars:\` frontmatter block:
+
+- \`bare_var\` — no default; the launcher must supply a value at a higher
+  precedence scope (Project default or Launch override).
+- \`default_var\` — short form, default is the literal string \`hello\`.
+- \`described_var\` — long form with a description that surfaces in the
+  Settings → Workflows reference panel and \`op-list-vars\`.
+
+Reference these in the body via \`{{bare_var}}\`, \`{{default_var}}\`,
+\`{{described_var}}\`.
+`,
+  }),
+]);
+
+export interface InstallExamplesResult {
+  /** Files newly written. */
+  installed: string[];
+  /** Files skipped because they already existed (no overwrite). */
+  skipped: string[];
+}
+
+/**
+ * Write each example to `Projects/_op-modules/<id>.md`. Idempotent: existing
+ * files are NEVER overwritten — re-running after a partial install completes
+ * the rest, and re-running after a full install is a no-op.
+ *
+ * Why no overwrite: the user may have edited an example file in place to
+ * learn from it, and clicking the button again should not silently throw
+ * that work away. The skipped list lets the caller surface a Notice
+ * distinguishing "installed N" from "skipped N already-present".
+ */
+export async function installExampleLibrary(app: App): Promise<InstallExamplesResult> {
+  const adapter = app.vault.adapter;
+  const installed: string[] = [];
+  const skipped: string[] = [];
+  await ensureDir(app, EXAMPLES_DIR);
+  for (const ex of EXAMPLE_MODULES) {
+    const path = `${EXAMPLES_DIR}${ex.id}.md`;
+    if (await adapter.exists(path)) {
+      skipped.push(path);
+      continue;
+    }
+    await adapter.write(path, ex.content);
+    installed.push(path);
+  }
+  return { installed, skipped };
+}
+
+async function ensureDir(app: App, dir: string): Promise<void> {
+  const adapter = app.vault.adapter;
+  // `mkdir` is idempotent on Obsidian's adapter — it's a no-op if the dir
+  // already exists. Wrap in try/catch defensively in case future adapter
+  // implementations diverge.
+  if (await adapter.exists(dir)) return;
+  try {
+    await adapter.mkdir(dir);
+  } catch {
+    // Another concurrent caller (or pre-existing folder we somehow missed)
+    // — re-check and only re-throw if it's still missing.
+    if (!(await adapter.exists(dir))) throw new Error(`Could not create ${dir}`);
+  }
+}

--- a/plugins/op-obsidian/src/workflowExamples.ts
+++ b/plugins/op-obsidian/src/workflowExamples.ts
@@ -89,35 +89,36 @@ export interface InstallExamplesResult {
  * learn from it, and clicking the button again should not silently throw
  * that work away. The skipped list lets the caller surface a Notice
  * distinguishing "installed N" from "skipped N already-present".
+ *
+ * Uses `vault.create` (not `adapter.write`) so newly-written files are
+ * immediately registered with `metadataCache` — `loadModules` will see them
+ * on the re-render that follows without waiting for the file-watcher cycle.
  */
 export async function installExampleLibrary(app: App): Promise<InstallExamplesResult> {
-  const adapter = app.vault.adapter;
   const installed: string[] = [];
   const skipped: string[] = [];
   await ensureDir(app, EXAMPLES_DIR);
   for (const ex of EXAMPLE_MODULES) {
-    const path = `${EXAMPLES_DIR}${ex.id}.md`;
-    if (await adapter.exists(path)) {
-      skipped.push(path);
+    const filePath = `${EXAMPLES_DIR}${ex.id}.md`;
+    if (await app.vault.adapter.exists(filePath)) {
+      skipped.push(filePath);
       continue;
     }
-    await adapter.write(path, ex.content);
-    installed.push(path);
+    await app.vault.create(filePath, ex.content);
+    installed.push(filePath);
   }
   return { installed, skipped };
 }
 
 async function ensureDir(app: App, dir: string): Promise<void> {
-  const adapter = app.vault.adapter;
-  // `mkdir` is idempotent on Obsidian's adapter — it's a no-op if the dir
-  // already exists. Wrap in try/catch defensively in case future adapter
-  // implementations diverge.
-  if (await adapter.exists(dir)) return;
+  // Use the adapter for the existence check (filesystem truth) but the
+  // vault-layer createFolder so the folder is indexed immediately.
+  if (await app.vault.adapter.exists(dir)) return;
   try {
-    await adapter.mkdir(dir);
+    await app.vault.createFolder(dir);
   } catch {
     // Another concurrent caller (or pre-existing folder we somehow missed)
     // — re-check and only re-throw if it's still missing.
-    if (!(await adapter.exists(dir))) throw new Error(`Could not create ${dir}`);
+    if (!(await app.vault.adapter.exists(dir))) throw new Error(`Could not create ${dir}`);
   }
 }

--- a/plugins/op-obsidian/styles.css
+++ b/plugins/op-obsidian/styles.css
@@ -780,3 +780,223 @@ a.op-sidebar__agent:hover {
   font-weight: 600;
   padding: 0.25rem 0;
 }
+
+/* ─── Workflows section (OP-201) ────────────────────────────────────────── */
+
+.op-settings__group--workflows {
+  margin-bottom: 1rem;
+}
+
+.op-settings__group-blurb {
+  margin-top: -0.25rem;
+  margin-bottom: 0.5rem;
+}
+
+.op-workflow-empty-state {
+  border: 1px dashed var(--background-modifier-border);
+  border-radius: 4px;
+  padding: 0.75rem;
+  background: var(--background-secondary);
+}
+
+.op-workflow-empty-state__title {
+  margin: 0 0 0.25rem;
+  font-weight: 600;
+}
+
+.op-workflow-empty-state__body {
+  margin: 0 0 0.5rem;
+}
+
+.op-workflow-module-list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+  margin-bottom: 0.5rem;
+}
+
+.op-workflow-module {
+  border: 1px solid var(--background-modifier-border);
+  border-radius: 4px;
+  background: var(--background-secondary);
+  padding: 0.5rem 0.75rem;
+}
+
+.op-workflow-module__head {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+}
+
+.op-workflow-module__id {
+  font-family: var(--font-monospace, monospace);
+  font-weight: 600;
+}
+
+.op-workflow-module__title {
+  flex: 1;
+  min-width: 0;
+  color: var(--text-normal);
+}
+
+.op-workflow-module__source {
+  font-size: var(--font-ui-smaller, 0.75rem);
+  color: var(--text-muted);
+}
+
+.op-workflow-module__badges {
+  display: inline-flex;
+  gap: 0.25rem;
+}
+
+.op-workflow-module__badges--ok {
+  color: var(--color-green, #2e7d32);
+  font-size: var(--font-ui-smaller, 0.75rem);
+}
+
+.op-workflow-badge {
+  font-size: var(--font-ui-smaller, 0.75rem);
+  padding: 0.1rem 0.4rem;
+  border-radius: 3px;
+  border: 1px solid var(--background-modifier-border);
+}
+
+.op-workflow-badge--error {
+  color: var(--color-red, #c62828);
+  border-color: var(--color-red, #c62828);
+}
+
+.op-workflow-badge--warning {
+  color: var(--color-yellow, #b58900);
+  border-color: var(--color-yellow, #b58900);
+}
+
+.op-workflow-badge--info {
+  color: var(--text-muted);
+}
+
+.op-workflow-module__diagnostics {
+  margin-top: 0.4rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.op-workflow-module__diagnostic {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+  align-items: baseline;
+  font-size: var(--font-ui-smaller, 0.75rem);
+}
+
+.op-workflow-module__diagnostic-badge {
+  font-family: var(--font-monospace, monospace);
+  font-weight: 600;
+  padding: 0 0.25rem;
+  border-radius: 2px;
+  background: var(--background-modifier-border);
+}
+
+.op-workflow-module__diagnostic--error .op-workflow-module__diagnostic-badge {
+  color: var(--color-red, #c62828);
+}
+
+.op-workflow-module__diagnostic--warning .op-workflow-module__diagnostic-badge {
+  color: var(--color-yellow, #b58900);
+}
+
+.op-workflow-module__diagnostic-code {
+  font-weight: 600;
+}
+
+.op-workflow-module__diagnostic-message {
+  flex: 1;
+  min-width: 0;
+}
+
+.op-workflow-module__diagnostic-scope {
+  font-style: italic;
+  color: var(--text-muted);
+}
+
+.op-workflow-module__actions {
+  margin-top: 0.4rem;
+}
+
+.op-workflow-module__explain {
+  font-size: var(--font-ui-smaller, 0.75rem);
+}
+
+.op-workflow-module-list__orphan {
+  margin-top: 0.5rem;
+  padding: 0.5rem;
+  border: 1px solid var(--background-modifier-border);
+  border-radius: 4px;
+  background: var(--background-secondary);
+}
+
+.op-workflow-vars-panel {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+}
+
+.op-workflow-vars-panel__row {
+  padding: 0.3rem 0.4rem;
+  border-bottom: 1px solid var(--background-modifier-border);
+}
+
+.op-workflow-vars-panel__row:last-child {
+  border-bottom: none;
+}
+
+.op-workflow-vars-panel__head {
+  display: flex;
+  gap: 0.5rem;
+  align-items: baseline;
+}
+
+.op-workflow-vars-panel__name {
+  font-family: var(--font-monospace, monospace);
+  font-weight: 600;
+}
+
+.op-workflow-vars-panel__example {
+  font-size: var(--font-ui-smaller, 0.75rem);
+  color: var(--text-muted);
+}
+
+.op-workflow-vars-panel__desc {
+  margin-top: 0.1rem;
+}
+
+.op-workflow-explain__list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.op-workflow-explain__block {
+  padding: 0.5rem 0.75rem;
+  border-left: 3px solid var(--background-modifier-border);
+  background: var(--background-secondary);
+  white-space: pre-wrap;
+  font-family: var(--font-text);
+  font-size: var(--font-ui-small);
+}
+
+.op-workflow-explain__block--error {
+  border-left-color: var(--color-red, #c62828);
+}
+
+.op-workflow-explain__block--warning {
+  border-left-color: var(--color-yellow, #b58900);
+}
+
+.op-workflow-explain__vars {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}

--- a/plugins/op/.claude-plugin/plugin.json
+++ b/plugins/op/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "op",
   "description": "Obsidian Projects workflow — schema, slash commands, and agent skill for running a Jira-lite issue tracker inside an Obsidian vault.",
-  "version": "0.65.0",
+  "version": "0.66.0",
   "author": {
     "name": "Eugene Archibald"
   },


### PR DESCRIPTION
## Summary

- Adds a NEW top-level `Workflows` group in op-obsidian Settings (between Daily and Advanced — too important and too referenced to bury under Advanced) showing the workflow modules tree, per-module severity badges, formatter-rendered inline diagnostics, an `Explain workflow` action, and an `Available variables` panel sourced from `pluginVarRegistry`.
- Empty-state with a one-click `Install example library` button that writes 2 starter modules into `Projects/_op-modules/` (idempotent; never overwrites). Closes the zero-to-working gap a brand-new user faces.
- Ships the unified **`WorkflowDiagnostic` formatter** (`workflowDiagnosticFormat.ts`) that every other 3* surface (op-explain-workflow, op-list-vars, editor squiggles, dry-run banner, launch-modal pre-flight) will consume. Renders canonical precedence-scope names (`Module default` / `Global default` / `Project default` / `Launch override`) in primary copy; abbreviations (M/G/P/L) only in compact tooltip text per the OP-201 spec. Exhaustive `switch` over `WorkflowDiagnosticCode` so a new code at the type level forces a deliberate decision here.

Implements OP-201 (3a of OP-186 umbrella). Closes earchibald/obsidian-projects#239.

## Test plan

- [x] `npx vitest run` — 1105 / 1105 pass (47 new)
- [x] `npx tsc --noEmit` — 8 errors, all pre-existing in `main` (verified by `git stash && tsc`); zero new errors introduced
- [x] OP-Test smoke probes (CLAUDE.md §5 recipe, `vault=OP-Test` on every call):
  - `.op-settings__group--workflows` + `[data-op-section="workflows"]` render
  - `[data-op-empty-state="true"]` shows when no modules exist
  - After clicking `Install example library`: 2 modules render with `ok` badges + Explain buttons; empty-state gone
  - Synthetic malformed module surfaces in the orphan-diagnostic footer with formatter prose, severity badge `E`, and canonical `Malformed frontmatter` tooltip (NOT abbreviation in primary copy)
  - `Available variables` panel renders all 16 `PLUGIN_VAR_REGISTRY` entries
  - Existing Daily group (5 rows) and Advanced group (8 collapsibles) intact, no regressions
  - `dev:console` clean, no errors

## Out of scope

Own issues under OP-186: `op-explain-workflow` / `op-list-vars` CLIs (OP-203), launch-modal pre-flight (OP-204), bad-model recovery dialog (OP-205), dry-run banner (OP-206), editor squiggles (OP-207), retiring legacy injection cap (OP-208).

🤖 Generated with [Claude Code](https://claude.com/claude-code)