### PR TITLE
OP-205: bad-model recovery dialog with diff/.bak/revert (3e)

### DIFF
--- a/plugins/op-obsidian/manifest.json
+++ b/plugins/op-obsidian/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "op-obsidian",
   "name": "Obsidian Projects (op)",
-  "version": "0.71.0",
+  "version": "0.72.0",
   "minAppVersion": "1.5.0",
   "description": "Jira-lite issue tracker for Obsidian vaults — deterministic commands backing the op workflow.",
   "author": "Eugene Archibald",

--- a/plugins/op-obsidian/package.json
+++ b/plugins/op-obsidian/package.json
@@ -1,6 +1,6 @@
 {
   "name": "op-obsidian",
-  "version": "0.71.0",
+  "version": "0.72.0",
   "description": "Obsidian plugin that owns the deterministic half of the op workflow.",
   "main": "main.js",
   "scripts": {

--- a/plugins/op-obsidian/src/main.ts
+++ b/plugins/op-obsidian/src/main.ts
@@ -116,6 +116,12 @@ import { openLaunchAgentModal } from "./launchAgentModal";
 import { editWorkflow } from "./editWorkflow";
 import { editModule } from "./editModule";
 import { loadModules } from "./workflowModule";
+import { loadWorkflowFile } from "./workflowFile";
+import {
+  openRecoveryDialog,
+  synthesizeBadModelErrorFromDiagnostic,
+} from "./recoveryDialog";
+import { revertLastWorkflowPatch, type VaultLike, type VaultFileLike } from "./recoveryPatchApply";
 import { VarEditorSuggest } from "./varSuggestObsidian";
 import { readAgentList, readModelScalarOrList } from "./varSuggest";
 import { launchInTerminal, SHARED_TMUX_SESSION, tmuxWindowName } from "./terminalLaunch";
@@ -722,6 +728,25 @@ export default class OpPlugin extends Plugin {
       id: "op-edit-module",
       name: "op: edit workflow module",
       callback: () => this.runEditModuleCommand(),
+    });
+
+    // OP-205 (3e): proactive recovery surface — open the dialog without an
+    // in-flight launch. Resolves a project, reads its WORKFLOW.md, finds the
+    // first bad-model diagnostic, and renders the same modal in advisory
+    // mode so users can fix the file before the next launch.
+    this.addCommand({
+      id: "op-open-recovery-dialog",
+      name: "op: open recovery dialog for project workflow",
+      callback: () => void this.runOpenRecoveryDialogCommand(),
+    });
+
+    // OP-205 (3e): one-step undo of the most recent .bak-* for a workflow
+    // file. Reusable from anywhere; a button in the dialog dispatches the
+    // same command.
+    this.addCommand({
+      id: "op-revert-workflow-patch",
+      name: "op: revert last workflow patch",
+      callback: () => void this.runRevertWorkflowPatchCommand(),
     });
 
     this.addCommand({
@@ -3398,6 +3423,111 @@ export default class OpPlugin extends Plugin {
     }).open();
   }
 
+  /**
+   * OP-205 (3e): proactive recovery surface. Picks a project, loads its
+   * workflow file, scans `validateWorkflowModels`-derived diagnostics for the
+   * first `bad-model` entry, and opens the dialog in advisory mode (no
+   * launch in flight). When no bad-model warnings are present, surfaces a
+   * Notice rather than opening an empty dialog.
+   */
+  private async runOpenRecoveryDialogCommand(): Promise<void> {
+    const projects = applyProjectOrder(listProjects(this.app), this.settings.projectOrder);
+    if (projects.length === 0) {
+      notify("op: no projects found under Projects/");
+      return;
+    }
+    new ProjectSuggestModal(this.app, projects, (project) => {
+      void this.openRecoveryDialogForProject(project.slug);
+    }).open();
+  }
+
+  private async openRecoveryDialogForProject(slug: string): Promise<void> {
+    const { diagnostics } = await loadWorkflowFile(this.app, slug);
+    const bad = diagnostics.find((d) => d.code === "bad-model");
+    if (!bad) {
+      notify(`op: no bad-model warnings in Projects/${slug}/WORKFLOW.md`);
+      return;
+    }
+    const err = synthesizeBadModelErrorFromDiagnostic(bad);
+    if (!err) {
+      notify(
+        `op: bad-model diagnostic for Projects/${slug}/WORKFLOW.md is malformed — open the file directly to fix.`,
+      );
+      return;
+    }
+    openRecoveryDialog({
+      app: this.app,
+      issueId: `Projects/${slug}`,
+      project: slug,
+      error: err,
+      mode: "advisory",
+      onResolved: () => {},
+    });
+  }
+
+  /**
+   * OP-205 (3e): one-step undo. Picks a project, finds the latest `.bak-*`
+   * sibling of its WORKFLOW.md, and restores it (trashing the backup).
+   */
+  private async runRevertWorkflowPatchCommand(): Promise<void> {
+    const projects = applyProjectOrder(listProjects(this.app), this.settings.projectOrder);
+    if (projects.length === 0) {
+      notify("op: no projects found under Projects/");
+      return;
+    }
+    new ProjectSuggestModal(this.app, projects, (project) => {
+      void this.revertWorkflowPatchForProject(project.slug);
+    }).open();
+  }
+
+  private async revertWorkflowPatchForProject(slug: string): Promise<void> {
+    const path = `Projects/${slug}/WORKFLOW.md`;
+    const file = this.app.vault.getAbstractFileByPath(path);
+    if (!(file instanceof TFile)) {
+      notify(`op: ${path} not found`);
+      return;
+    }
+    const vault: VaultLike = {
+      read: (f) => this.app.vault.read(f as TFile),
+      modify: (f, data) => this.app.vault.modify(f as TFile, data),
+      create: async (p, data) => (await this.app.vault.create(p, data)) as VaultFileLike,
+      trash: (f, system) => this.app.vault.trash(f as TFile, system),
+      getFileByPath: (p) => {
+        const x = this.app.vault.getAbstractFileByPath(p);
+        return x instanceof TFile ? (x as VaultFileLike) : null;
+      },
+      listSiblingPaths: (parentFolder) => {
+        const folder = parentFolder
+          ? this.app.vault.getAbstractFileByPath(parentFolder)
+          : this.app.vault.getRoot();
+        const children = (folder as { children?: Array<{ path: string }> } | null)?.children;
+        return Array.isArray(children) ? children.map((c) => c.path) : [];
+      },
+    };
+    try {
+      const r = await revertLastWorkflowPatch({
+        vault,
+        // Pass the live TFile via getFileByPath so vault.modify / vault.trash
+        // get the real Obsidian-resolved file instance (a plain `{path}`
+        // object would be cast through `f as TFile` but isn't actually a
+        // TFile and fails on the trash() seam).
+        workflowFile: vault.getFileByPath(path) ?? { path },
+      });
+      if (r.status === "no-backup") {
+        notify(`op: no backup found for ${path}`);
+        return;
+      }
+      notify(`op: reverted ${path} from ${r.restoredFromPath}`);
+    } catch (err) {
+      const e = err as Error;
+      console.error(
+        "[op-obsidian] op-revert-workflow-patch failed",
+        e?.stack ?? e?.message ?? err,
+      );
+      notify(`op-revert-workflow-patch failed: ${e?.message ?? String(err)}`);
+    }
+  }
+
   private async handleEditModulePick(
     pick:
       | { kind: "existing"; moduleId: string; scopeKind: "global" | "project"; projectSlug?: string }
@@ -3572,6 +3702,10 @@ export default class OpPlugin extends Plugin {
       /** OP-204 (3d): per-launch user-var overrides from the launch modal,
        *  the URI parser, or the auto-advance carry-through. */
       launchVars?: Record<string, string>;
+      /** OP-205 (3e): see {@link OpenAgentArgs.interactive}. */
+      interactive?: boolean;
+      /** OP-205 (3e): see {@link OpenAgentArgs.launchModelOverride}. */
+      launchModelOverride?: string;
     } = {},
   ): Promise<void> {
     try {
@@ -3615,6 +3749,22 @@ export default class OpPlugin extends Plugin {
           agentOverride: effectiveAgentOverride,
           mode: opts.mode,
           launchVars: effectiveLaunchVars,
+          interactive: opts.interactive,
+          launchModelOverride: opts.launchModelOverride,
+          // OP-205 (3e): when the recovery dialog resolves with a usable
+          // outcome, retry the launch automatically — the user already told
+          // us how to proceed (override or patched-and-good).
+          onResolverFailureResolved: (outcome) => {
+            if (outcome.kind === "override") {
+              void this.doOpenAgent(entry, {
+                ...opts,
+                launchModelOverride: outcome.canonicalModel,
+              });
+            } else if (outcome.kind === "patched") {
+              void this.doOpenAgent(entry, opts);
+            }
+            // `cancelled` / `reverted` — no retry; user closes the loop.
+          },
         },
       );
       if (res) {
@@ -3808,8 +3958,12 @@ export default class OpPlugin extends Plugin {
     // off the cached frontmatter via metadataCache (no disk re-read needed —
     // openAgent just wrote the field if there were any overrides).
     const carriedLaunchVars = this.readLaunchVarsFrontmatter(target.path);
+    // OP-205 (3e): auto-advance is headless — surface bad-model failures via
+    // the actionable Notice rather than yanking the user into a modal they
+    // didn't trigger.
     await this.doOpenAgent(target, {
       mode: decision.nextMode,
+      interactive: false,
       launchVars:
         Object.keys(carriedLaunchVars).length > 0 ? carriedLaunchVars : undefined,
     });

--- a/plugins/op-obsidian/src/main.ts
+++ b/plugins/op-obsidian/src/main.ts
@@ -3808,7 +3808,11 @@ export default class OpPlugin extends Plugin {
       this.settings,
       this.detector,
       () => this.saveSettings(),
-      { entry, agentOverride, forcePick, mode, launchVars },
+      // OP-205 (3e): URI launches are automation — do NOT yank the user into
+      // the recovery modal on a bad-model error; surface via actionable Notice
+      // instead. The URI caller expressed intent in the URI shape and cannot
+      // participate in a modal dialog callback loop.
+      { entry, agentOverride, forcePick, mode, launchVars, interactive: false },
     );
     if (!res) throw new Error("op-open-agent was cancelled or no agent available");
     await this.recordRecency(res.issueId);

--- a/plugins/op-obsidian/src/openAgent.ts
+++ b/plugins/op-obsidian/src/openAgent.ts
@@ -29,7 +29,11 @@ import {
   type ResolveStepOutput,
 } from "./stepResolver";
 import { showActionableNotice } from "./actionableNotices";
-import { openRecoveryDialog } from "./recoveryDialog";
+import {
+  openRecoveryDialog,
+  type RecoveryDialogOutcome,
+} from "./recoveryDialog";
+import { validateModelName } from "./modelRegistry";
 
 /** Arguments accepted by {@link openAgent}. */
 export interface OpenAgentArgs {
@@ -50,6 +54,33 @@ export interface OpenAgentArgs {
    * inherits the same overrides; an empty/absent map writes nothing.
    */
   launchVars?: Record<string, string>;
+  /**
+   * OP-205 (3e): launch-only model override. When set, the resolver
+   * short-circuits its own `model:` walk and uses this canonical model id.
+   * The workflow file is left untouched — this is the "Use as launch
+   * override" path from the recovery dialog.
+   *
+   * Validated against `modelRegistry` for the resolver's chosen agent at
+   * launch time; an invalid override throws `BadModelSpecError` (which
+   * re-opens the recovery dialog rather than silently substituting).
+   */
+  launchModelOverride?: string;
+  /**
+   * OP-205 (3e): whether this launch is a user-initiated interactive launch
+   * (default `true`) or a headless auto-advance (set `false`). On resolver
+   * failure, interactive launches open the recovery dialog directly;
+   * headless launches surface the existing actionable Notice with an "Open
+   * recovery dialog now" link. Headless ↔ "user is not at the keyboard."
+   */
+  interactive?: boolean;
+  /**
+   * OP-205 (3e): notified when the recovery dialog resolves after a launch
+   * failure. The caller can use this to retry the launch (with
+   * `launchModelOverride` set) on `override` / `patched` outcomes. `null` /
+   * undefined → the dialog opens with a no-op resolver, matching the OP-200
+   * behavior where the user re-launches by hand.
+   */
+  onResolverFailureResolved?: (outcome: RecoveryDialogOutcome) => void;
 }
 
 /** Result payload returned when a launch succeeds. */
@@ -116,10 +147,23 @@ export async function openAgent(
   try {
     resolved = args.agentOverride || args.forcePick || settings.alwaysPick
       ? null
-      : await loadAndResolveStep(app, args.entry.project, mode, detection, settings.defaultAgent);
+      : await loadAndResolveStep(
+          app,
+          args.entry.project,
+          mode,
+          detection,
+          settings.defaultAgent,
+          args.launchModelOverride,
+        );
   } catch (err) {
     if (err instanceof BadModelSpecError || err instanceof NoInstalledAgentError) {
-      surfaceResolverError(app, args.entry.id, err);
+      surfaceResolverError(
+        app,
+        args.entry,
+        err,
+        args.interactive ?? true,
+        args.onResolverFailureResolved,
+      );
       return undefined;
     }
     throw err;
@@ -431,6 +475,7 @@ async function loadAndResolveStep(
   mode: AgentLaunchMode,
   detection: DetectionMap,
   fallbackAgent: AgentId,
+  launchModelOverride: string | undefined,
 ): Promise<ResolveStepOutput | null> {
   if (!project) return null;
   const { workflow } = await loadWorkflowFile(app, project);
@@ -443,12 +488,40 @@ async function loadAndResolveStep(
   if (!step && (!workflow.defaultAgent || workflow.defaultAgent.length === 0)) {
     return null;
   }
-  return resolveStepAgentAndModel({
+  // Run the agent walk + model walk normally. We need the chosen agent in
+  // hand before we can validate `launchModelOverride` (the override is bound
+  // to the resolver's chosen agent — picking a claude alias when the resolver
+  // walked into gemini would be incoherent).
+  const resolved = resolveStepAgentAndModel({
     step,
     workflow,
     detection,
     fallbackAgent,
   });
+
+  if (launchModelOverride !== undefined) {
+    // OP-205 (3e): honour the launch override. Validate against the chosen
+    // agent's registry; an invalid override throws BadModelSpecError so the
+    // recovery dialog re-opens (we never silently substitute).
+    const v = validateModelName(resolved.agent, launchModelOverride, stepName);
+    if (!v.ok) {
+      throw new BadModelSpecError(
+        stepName,
+        resolved.agent,
+        [{ name: launchModelOverride, classification: { kind: "typo" } }],
+        "typo",
+        v.bad,
+      );
+    }
+    return {
+      agent: resolved.agent,
+      canonicalModel: v.canonicalId,
+      agentSource: resolved.agentSource,
+      modelSource: "step",
+    };
+  }
+
+  return resolved;
 }
 
 /**
@@ -478,23 +551,49 @@ function withModelFlag(
  */
 function surfaceResolverError(
   app: App,
-  issueId: string,
+  entry: IssueEntry,
   err: BadModelSpecError | NoInstalledAgentError,
+  interactive: boolean,
+  onResolved: ((outcome: RecoveryDialogOutcome) => void) | undefined,
 ): void {
   const summary =
     err instanceof BadModelSpecError
-      ? `${issueId}: bad model spec for step "${err.stepId}" (${err.reason}) — "${err.bad.badName}" not usable for "${err.chosenAgent}"`
-      : `${issueId}: no installed agent for step "${err.stepId}" — tried ${err.attemptedAgents.join(", ")}`;
+      ? `${entry.id}: bad model spec for step "${err.stepId}" (${err.reason}) — "${err.bad.badName}" not usable for "${err.chosenAgent}"`
+      : `${entry.id}: no installed agent for step "${err.stepId}" — tried ${err.attemptedAgents.join(", ")}`;
+  console.warn("[op-obsidian] openAgent resolver failure", err);
+  const handler = onResolved ?? ((): void => {});
+  if (interactive) {
+    // OP-205 (3e): the user is at the keyboard — open the modal directly.
+    // The Notice indirection adds a click for nothing on this path.
+    openRecoveryDialog({
+      app,
+      issueId: entry.id,
+      project: entry.project ?? "",
+      error: err,
+      mode: "launch",
+      onResolved: handler,
+    });
+    return;
+  }
+  // Headless auto-advance: the user wasn't watching. Surface the actionable
+  // Notice so they can click into the dialog when they come back.
   showActionableNotice({
     text: summary,
     actions: [
       {
         label: "Open recovery dialog now",
-        onClick: () => openRecoveryDialog({ app, issueId, error: err }),
+        onClick: () =>
+          openRecoveryDialog({
+            app,
+            issueId: entry.id,
+            project: entry.project ?? "",
+            error: err,
+            mode: "launch",
+            onResolved: handler,
+          }),
       },
     ],
   });
-  console.warn("[op-obsidian] openAgent resolver failure", err);
 }
 
 function readParentId(app: App, path: string): string | null {

--- a/plugins/op-obsidian/src/recoveryDialog.test.ts
+++ b/plugins/op-obsidian/src/recoveryDialog.test.ts
@@ -11,29 +11,38 @@ vi.mock("obsidian", () => ({
     }
     hide() {}
   },
+  Modal: class {
+    contentEl: any = { empty() {}, createEl() {}, createDiv() {}, addClass() {} };
+    constructor(_app: any) {}
+    open() {}
+    close() {}
+    onOpen() {}
+    onClose() {}
+  },
+  Setting: class {
+    constructor(_el: any) {}
+    setName() { return this; }
+    setDesc() { return this; }
+    addText() { return this; }
+    addButton() { return this; }
+  },
+  TFile: class {
+    constructor(public path: string) {}
+  },
 }));
 
-import { openRecoveryDialog } from "./recoveryDialog";
+import {
+  describeFailure,
+  openRecoveryDialog,
+  synthesizeBadModelErrorFromDiagnostic,
+} from "./recoveryDialog";
 import { BadModelSpecError, NoInstalledAgentError } from "./stepResolver";
 import type { BadModelSpec } from "./modelRegistry";
+import type { WorkflowDiagnostic } from "./workflowDiagnostic";
 
 beforeEach(() => {
   noticeCalls.length = 0;
 });
-
-const opened: string[] = [];
-const opens: string[] = [];
-
-function fakeApp() {
-  opened.length = 0;
-  opens.length = 0;
-  return {
-    setting: {
-      open: () => opens.push("open"),
-      openTabById: (id: string) => opened.push(id),
-    },
-  } as any;
-}
 
 function badSpec(name: string): BadModelSpec {
   return {
@@ -45,9 +54,8 @@ function badSpec(name: string): BadModelSpec {
   };
 }
 
-describe("openRecoveryDialog", () => {
-  it("opens the op-obsidian Settings tab", () => {
-    const app = fakeApp();
+describe("describeFailure", () => {
+  it("renders cross-agent-overflow phrasing for an all-overflow BadModelSpecError", () => {
     const err = new BadModelSpecError(
       "implement",
       "claude",
@@ -55,32 +63,14 @@ describe("openRecoveryDialog", () => {
       "all-overflow",
       badSpec("pro"),
     );
-    openRecoveryDialog({ app, issueId: "OP-200", error: err });
-    expect(opens).toEqual(["open"]);
-    expect(opened).toEqual(["op-obsidian"]);
-  });
-
-  it("surfaces a sticky Notice describing a cross-agent-overflow failure", () => {
-    const app = fakeApp();
-    const err = new BadModelSpecError(
-      "implement",
-      "claude",
-      [{ name: "pro", classification: { kind: "cross-agent-overflow", otherAgent: "gemini" } }],
-      "all-overflow",
-      badSpec("pro"),
-    );
-    openRecoveryDialog({ app, issueId: "OP-200", error: err });
-    expect(noticeCalls).toHaveLength(1);
-    expect(noticeCalls[0].duration).toBe(0); // sticky
-    const text = String(noticeCalls[0].msg);
+    const text = describeFailure(err);
     expect(text).toContain('Step "implement"');
-    expect(text).toContain("agent \"claude\"");
+    expect(text).toContain('agent "claude"');
     expect(text).toContain('"pro" belongs to a different agent');
     expect(text).toContain("Allowed aliases:");
   });
 
-  it("surfaces a typo failure with the typo-specific phrasing", () => {
-    const app = fakeApp();
+  it("renders typo phrasing for a typo BadModelSpecError", () => {
     const err = new BadModelSpecError(
       "review",
       "claude",
@@ -88,30 +78,82 @@ describe("openRecoveryDialog", () => {
       "typo",
       badSpec("opuss"),
     );
-    openRecoveryDialog({ app, issueId: "OP-200", error: err });
-    const text = String(noticeCalls[0].msg);
+    const text = describeFailure(err);
     expect(text).toContain("typo");
-    expect(text).toContain("\"opuss\" is unknown to every registered agent");
+    expect(text).toContain('"opuss" is unknown to every registered agent');
   });
 
-  it("surfaces NoInstalledAgentError with the attempted-agent list", () => {
-    const app = fakeApp();
+  it("renders attempted-agent list for NoInstalledAgentError", () => {
     const err = new NoInstalledAgentError("plan", ["gemini", "copilot"]);
-    openRecoveryDialog({ app, issueId: "OP-200", error: err });
-    const text = String(noticeCalls[0].msg);
+    const text = describeFailure(err);
     expect(text).toContain('Step "plan" has no installed agent');
     expect(text).toContain("gemini, copilot");
   });
+});
 
-  it("does not throw when app.setting is unavailable (defensive)", () => {
-    expect(() =>
-      openRecoveryDialog({
-        app: {} as any,
-        issueId: "OP-200",
-        error: new NoInstalledAgentError("plan", ["claude"]),
-      }),
-    ).not.toThrow();
-    // Notice still fires.
+describe("openRecoveryDialog", () => {
+  it("falls back to a sticky Notice when app has no workspace (defensive)", () => {
+    openRecoveryDialog({
+      app: {} as any, // no workspace -> Notice fallback path
+      issueId: "OP-200",
+      project: "demo",
+      mode: "launch",
+      error: new NoInstalledAgentError("plan", ["claude"]),
+      onResolved: () => {},
+    });
     expect(noticeCalls).toHaveLength(1);
+    expect(noticeCalls[0].duration).toBe(0);
+    expect(String(noticeCalls[0].msg)).toContain('Step "plan" has no installed agent');
+  });
+});
+
+describe("synthesizeBadModelErrorFromDiagnostic", () => {
+  it("rebuilds a BadModelSpecError from a structured bad-model diagnostic (typo branch)", () => {
+    const d: WorkflowDiagnostic = {
+      code: "bad-model",
+      severity: "error",
+      message: "x",
+      stepId: "implement",
+      extra: badSpec("opuss"),
+    };
+    const err = synthesizeBadModelErrorFromDiagnostic(d);
+    expect(err).not.toBeNull();
+    expect(err!.reason).toBe("typo");
+    expect(err!.bad.badName).toBe("opuss");
+    expect(err!.chosenAgent).toBe("claude");
+    expect(err!.attempts).toHaveLength(1);
+    expect(err!.attempts[0].classification.kind).toBe("typo");
+  });
+
+  it("classifies overflow when the bad name is a known model for another agent", () => {
+    const d: WorkflowDiagnostic = {
+      code: "bad-model",
+      severity: "error",
+      message: "x",
+      stepId: "implement",
+      extra: { ...badSpec("pro") },
+    };
+    const err = synthesizeBadModelErrorFromDiagnostic(d);
+    expect(err).not.toBeNull();
+    expect(err!.reason).toBe("all-overflow");
+    expect(err!.attempts[0].classification.kind).toBe("cross-agent-overflow");
+  });
+
+  it("returns null for diagnostics that aren't bad-model", () => {
+    const d: WorkflowDiagnostic = {
+      code: "schema-mismatch",
+      severity: "error",
+      message: "x",
+    };
+    expect(synthesizeBadModelErrorFromDiagnostic(d)).toBeNull();
+  });
+
+  it("returns null for malformed bad-model diagnostics (missing extra)", () => {
+    const d: WorkflowDiagnostic = {
+      code: "bad-model",
+      severity: "error",
+      message: "x",
+    };
+    expect(synthesizeBadModelErrorFromDiagnostic(d)).toBeNull();
   });
 });

--- a/plugins/op-obsidian/src/recoveryDialog.ts
+++ b/plugins/op-obsidian/src/recoveryDialog.ts
@@ -1,51 +1,98 @@
-import type { App } from "obsidian";
-import { Notice } from "obsidian";
+// OP-205 (3e) recovery dialog. Replaces the OP-200 stub with an interactive
+// modal that lets the user fix a bad-model workflow declaration on the spot.
+//
+// Two entrypoints:
+//
+//   - launch mode: the resolver threw `BadModelSpecError` /
+//     `NoInstalledAgentError` during a launch. The modal opens with a picker
+//     for valid models for the resolved agent. "Use as launch override" wins
+//     for this launch only (workflow file untouched). "Patch workflow with
+//     this model" rewrites the file (after a unified-diff confirm + a
+//     `.bak-<ts>` backup). Cancel aborts the launch — `onResolved` fires with
+//     `{ kind: "cancelled" }` and the launch returns `undefined`.
+//
+//   - advisory mode: the user invoked the palette command for a project
+//     whose `validateWorkflowModels` surfaced `bad-model` warnings. Same UI,
+//     but cancel is just a close (no launch to abort) and the launch-override
+//     button is disabled with a tooltip ("No active launch — Patch the file
+//     instead, or close and launch first.").
+//
+// `describeFailure` is exported separately so the headless actionable Notice
+// in `openAgent.ts` can use the same phrasing without instantiating the
+// modal.
+
+import {
+  Modal,
+  Notice,
+  Setting,
+  TFile,
+  type App,
+} from "obsidian";
 import {
   BadModelSpecError,
   NoInstalledAgentError,
 } from "./stepResolver";
+import {
+  MODEL_REGISTRY,
+  validateModelName,
+  type BadModelSpec,
+} from "./modelRegistry";
+import {
+  applyBadModelPatch,
+  revertLastWorkflowPatch,
+  type VaultLike,
+  type VaultFileLike,
+} from "./recoveryPatchApply";
+import { findLatestBackup, planBadModelPatch } from "./recoveryPatch";
+import type { WorkflowDiagnostic } from "./workflowDiagnostic";
 
-// OP-200 (2c) recovery-dialog seam. Today this is a stub that opens the
-// op-obsidian Settings tab and surfaces a follow-up Notice describing the
-// failing entry. OP-?-3e replaces the body with the interactive picker — the
-// signature stays stable so callers (openAgent's actionable Notice, the
-// auto-advance failure path in main.ts) don't need to be retouched.
-//
-// The signature accepts both error classes so callers can route either
-// resolver failure through the same seam — the picker UI in 3e will branch on
-// `error instanceof BadModelSpecError` vs `NoInstalledAgentError` to render
-// the right options.
+export type RecoveryDialogMode = "launch" | "advisory";
+
+export type RecoveryDialogOutcome =
+  | { kind: "override"; canonicalModel: string }
+  | { kind: "patched"; canonicalModel: string; backupPath: string }
+  | { kind: "reverted"; restoredFromPath: string }
+  | { kind: "cancelled" };
 
 export interface RecoveryDialogArgs {
   app: App;
-  /** Issue id surfaced in the follow-up Notice (e.g. `OP-200`). */
+  /** Issue id (e.g. `OP-200`) — used in headers + Notice text. */
   issueId: string;
   /** Resolver failure that triggered the dialog. */
   error: BadModelSpecError | NoInstalledAgentError;
+  /** Project slug — used to find the workflow file for patching. */
+  project: string;
+  /**
+   * Whether the dialog is opening at launch time (with a launch about to
+   * proceed) or advisory (no in-flight launch).
+   */
+  mode: RecoveryDialogMode;
+  /**
+   * Called once the user resolves the dialog. Caller responds:
+   *   - `override` → re-launch with `launchModelOverride: canonicalModel`.
+   *   - `patched`  → re-launch (workflow file is now valid).
+   *   - `reverted` → reload the workflow file (the user undid a prior patch).
+   *   - `cancelled` → abort the launch (launch mode) or no-op (advisory mode).
+   */
+  onResolved: (outcome: RecoveryDialogOutcome) => void;
 }
 
 export function openRecoveryDialog(args: RecoveryDialogArgs): void {
-  // Open the op-obsidian Settings tab. OP-201 (Child 3a) will deep-link to
-  // the Workflows section once that lands; until then, the user sees the
-  // settings index and can navigate manually.
-  try {
-    // `app.setting` is on the runtime App but isn't typed in the public d.ts.
-    const setting = (args.app as unknown as { setting?: { open(): void; openTabById(id: string): void } }).setting;
-    if (setting) {
-      setting.open();
-      setting.openTabById("op-obsidian");
-    }
-  } catch (err) {
-    console.warn("[op-obsidian] openRecoveryDialog: failed to open Settings tab:", err);
+  // Defensive: when the runtime App we're handed doesn't expose Modal-able
+  // ergonomics (early-boot races, tests that pass a stub), fall back to the
+  // Notice-only path so the user still sees the diagnostic.
+  if (!args.app || typeof (args.app as { workspace?: unknown }).workspace !== "object") {
+    new Notice(describeFailure(args.error), 0);
+    return;
   }
-
-  // Follow-up Notice with the per-entry detail. Sticky (no auto-dismiss) so
-  // the user can read the diagnostic before clicking through to the file.
-  const text = describeFailure(args.error);
-  new Notice(text, 0);
+  new RecoveryDialogModal(args).open();
 }
 
-function describeFailure(
+/**
+ * Build a human-friendly one-line description of the resolver failure.
+ * Shared between the modal header and the headless actionable Notice text.
+ */
+export function describeFailure(
   err: BadModelSpecError | NoInstalledAgentError,
 ): string {
   if (err.name === "NoInstalledAgentError") {
@@ -72,4 +119,479 @@ function describeFailure(
     `Step "${e.stepId}" model spec has no usable entry for agent "${e.chosenAgent}". ` +
     `"${e.bad.badName}" belongs to a different agent. ${aliasHint}${versionedHint}`
   );
+}
+
+/**
+ * Synthesize a `BadModelSpecError` from a stored `bad-model` diagnostic — used
+ * by the advisory entrypoint when the palette command opens the dialog from
+ * an `op-explain-workflow` warnings list. Returns `null` if the diagnostic
+ * doesn't carry a `BadModelSpec` payload (shouldn't happen with the modern
+ * pipeline; defensive against legacy callers).
+ */
+export function synthesizeBadModelErrorFromDiagnostic(
+  d: WorkflowDiagnostic,
+): BadModelSpecError | null {
+  if (d.code !== "bad-model") return null;
+  const extra = d.extra as Partial<BadModelSpec> | undefined;
+  if (
+    !extra ||
+    typeof extra.stepId !== "string" ||
+    typeof extra.badName !== "string" ||
+    typeof extra.agent !== "string" ||
+    !Array.isArray(extra.allowedAliases) ||
+    !Array.isArray(extra.allowedVersioned)
+  ) {
+    return null;
+  }
+  const bad: BadModelSpec = {
+    stepId: extra.stepId,
+    badName: extra.badName,
+    agent: extra.agent,
+    allowedAliases: extra.allowedAliases,
+    allowedVersioned: extra.allowedVersioned,
+  };
+  // Heuristic: if the bad name is unknown to every registered agent → typo;
+  // otherwise → all-overflow. Matches the resolver's classifier semantics.
+  const reason: "typo" | "all-overflow" = isUnknownToEveryAgent(bad.badName)
+    ? "typo"
+    : "all-overflow";
+  // The diagnostic-derived error doesn't carry a meaningful classifier per
+  // attempt — we only have the one bad name. Construct a single-attempt
+  // payload so the modal renders consistently.
+  // Cast through unknown so the AgentId narrow doesn't trip in advisory mode
+  // (the diagnostic may carry an unknown agent string; the modal renders the
+  // string verbatim and falls back to empty registry columns).
+  return new BadModelSpecError(
+    bad.stepId,
+    bad.agent as never,
+    [
+      {
+        name: bad.badName,
+        classification:
+          reason === "typo"
+            ? { kind: "typo" }
+            : { kind: "cross-agent-overflow", otherAgent: detectOverflowAgent(bad.badName) ?? "another agent" },
+      },
+    ],
+    reason,
+    bad,
+  );
+}
+
+function isUnknownToEveryAgent(name: string): boolean {
+  const trimmed = (name ?? "").trim();
+  for (const reg of Object.values(MODEL_REGISTRY)) {
+    if (Object.prototype.hasOwnProperty.call(reg.aliases, trimmed)) return false;
+    if (reg.versioned.has(trimmed)) return false;
+  }
+  return true;
+}
+
+function detectOverflowAgent(name: string): string | null {
+  const trimmed = (name ?? "").trim();
+  for (const [agent, reg] of Object.entries(MODEL_REGISTRY)) {
+    if (Object.prototype.hasOwnProperty.call(reg.aliases, trimmed)) return agent;
+    if (reg.versioned.has(trimmed)) return agent;
+  }
+  return null;
+}
+
+class RecoveryDialogModal extends Modal {
+  private picker = "";
+  private replacement: string | null = null;
+  private vaultLike: VaultLike;
+  private workflowFile: VaultFileLike | null = null;
+  private rawWorkflow: string | null = null;
+  private patchStatusEl: HTMLElement | null = null;
+  private patchBtn: HTMLButtonElement | null = null;
+  private overrideBtn: HTMLButtonElement | null = null;
+  private resolved = false;
+
+  constructor(private readonly args: RecoveryDialogArgs) {
+    super(args.app);
+    this.vaultLike = makeVaultLikeFromApp(args.app);
+  }
+
+  onOpen(): void {
+    const { contentEl } = this;
+    contentEl.empty();
+    contentEl.addClass("op-recovery-modal");
+
+    contentEl.createEl("h2", { text: this.headerText() });
+    contentEl.createEl("p", {
+      text: describeFailure(this.args.error),
+      cls: "op-recovery-modal__lede",
+    });
+
+    if (this.args.error instanceof BadModelSpecError) {
+      this.renderColumns(contentEl, this.args.error.chosenAgent);
+      this.renderPicker(contentEl, this.args.error);
+    } else {
+      // NoInstalledAgentError — the picker offers no replacement; only
+      // "Open WORKFLOW.md" + Cancel make sense. Render an actionable note.
+      contentEl.createEl("p", {
+        cls: "op-recovery-modal__no-agent-hint",
+        text:
+          `Install one of: ${this.args.error.attemptedAgents.join(", ")}. ` +
+          `Then re-run the launch. (Cancel here to abort.)`,
+      });
+    }
+
+    void this.loadWorkflowFile().then(() => this.refreshPatchStatus());
+    this.renderActions(contentEl);
+    this.renderRevertRow(contentEl);
+  }
+
+  onClose(): void {
+    this.contentEl.empty();
+    if (!this.resolved) {
+      this.resolved = true;
+      this.args.onResolved({ kind: "cancelled" });
+    }
+  }
+
+  private headerText(): string {
+    if (this.args.error instanceof BadModelSpecError) {
+      return `Recover: bad model spec — ${this.args.issueId}`;
+    }
+    return `Recover: no installed agent — ${this.args.issueId}`;
+  }
+
+  private renderColumns(contentEl: HTMLElement, agent: string): void {
+    const reg = MODEL_REGISTRY[agent];
+    const wrap = contentEl.createDiv({ cls: "op-recovery-modal__columns" });
+    const aliasCol = wrap.createDiv({ cls: "op-recovery-modal__column" });
+    aliasCol.createEl("h3", { text: "Allowed aliases" });
+    const aliasList = aliasCol.createEl("ul");
+    if (reg) {
+      for (const alias of Object.keys(reg.aliases).sort()) {
+        const li = aliasList.createEl("li");
+        const btn = li.createEl("button", { text: alias, cls: "op-recovery-modal__chip" });
+        btn.title = `→ ${reg.aliases[alias]}`;
+        btn.addEventListener("click", () => this.setPicker(alias));
+      }
+    } else {
+      aliasCol.createEl("p", { text: "(unknown agent — no registry data)" });
+    }
+
+    const verCol = wrap.createDiv({ cls: "op-recovery-modal__column" });
+    verCol.createEl("h3", { text: "Allowed versioned ids" });
+    const verList = verCol.createEl("ul");
+    if (reg) {
+      for (const v of Array.from(reg.versioned).sort()) {
+        const li = verList.createEl("li");
+        const btn = li.createEl("button", { text: v, cls: "op-recovery-modal__chip" });
+        btn.addEventListener("click", () => this.setPicker(v));
+      }
+    } else {
+      verCol.createEl("p", { text: "(unknown agent — no registry data)" });
+    }
+  }
+
+  private renderPicker(contentEl: HTMLElement, err: BadModelSpecError): void {
+    new Setting(contentEl)
+      .setName("Replacement model")
+      .setDesc("Type or click an entry above. Pressing Enter auto-validates.")
+      .addText((t) => {
+        t.setPlaceholder("e.g. opus, claude-sonnet-4-6")
+          .setValue("")
+          .onChange((v) => {
+            this.picker = v;
+            this.refreshPatchStatus();
+          });
+        t.inputEl.addEventListener("keydown", (ev) => {
+          if (ev.key === "Enter") {
+            ev.preventDefault();
+            this.handleOverride(err);
+          }
+        });
+      });
+  }
+
+  private setPicker(value: string): void {
+    this.picker = value;
+    const setting = this.contentEl.querySelector<HTMLInputElement>(".setting-item input[type=text]");
+    if (setting) setting.value = value;
+    this.refreshPatchStatus();
+  }
+
+  private renderActions(contentEl: HTMLElement): void {
+    this.patchStatusEl = contentEl.createEl("p", { cls: "op-recovery-modal__patch-status" });
+
+    const setting = new Setting(contentEl);
+    setting.addButton((b) => {
+      this.overrideBtn = b
+        .setButtonText("Use as launch override")
+        .setCta()
+        .onClick(() => {
+          if (!(this.args.error instanceof BadModelSpecError)) return;
+          this.handleOverride(this.args.error);
+        }).buttonEl;
+      if (this.args.mode === "advisory") {
+        this.overrideBtn.disabled = true;
+        this.overrideBtn.title =
+          "No active launch — use Patch workflow to fix the file, or close this dialog and launch first to override.";
+      }
+      if (!(this.args.error instanceof BadModelSpecError)) {
+        // No model to override with; the only path forward is install + retry.
+        this.overrideBtn.disabled = true;
+      }
+    });
+
+    setting.addButton((b) => {
+      this.patchBtn = b
+        .setButtonText("Patch workflow with this model")
+        .onClick(() => this.handlePatch())
+        .buttonEl;
+      this.patchBtn.disabled = true;
+    });
+
+    setting.addButton((b) =>
+      b.setButtonText("Cancel").onClick(() => this.close()),
+    );
+  }
+
+  private renderRevertRow(contentEl: HTMLElement): void {
+    const row = contentEl.createDiv({ cls: "op-recovery-modal__bak-row" });
+    row.style.display = "none";
+    const label = row.createEl("span", {
+      cls: "op-recovery-modal__bak-label",
+    });
+    const btn = row.createEl("button", {
+      text: "Revert last patch",
+      cls: "op-recovery-modal__revert-btn",
+    });
+    btn.addEventListener("click", () => void this.handleRevert(row, label));
+
+    void this.refreshRevertRow(row, label);
+  }
+
+  private async refreshRevertRow(row: HTMLElement, label: HTMLElement): Promise<void> {
+    const wf = await this.loadWorkflowFile();
+    if (!wf) return;
+    const folder = parentFolder(wf.path);
+    const siblings = this.vaultLike.listSiblingPaths(folder);
+    const latest = findLatestBackup(siblings, wf.path);
+    if (!latest) {
+      row.style.display = "none";
+      return;
+    }
+    row.style.display = "";
+    const ts = latest.match(/\.bak-([\d-]+)$/)?.[1] ?? "<unknown>";
+    label.textContent = `Last backup: ${ts}`;
+  }
+
+  private async loadWorkflowFile(): Promise<VaultFileLike | null> {
+    if (this.workflowFile) return this.workflowFile;
+    const path = `Projects/${this.args.project}/WORKFLOW.md`;
+    const file = this.vaultLike.getFileByPath(path);
+    if (!file) return null;
+    this.workflowFile = file;
+    this.rawWorkflow = await this.vaultLike.read(file);
+    return file;
+  }
+
+  private async refreshPatchStatus(): Promise<void> {
+    if (!this.patchStatusEl || !this.patchBtn) return;
+    if (!(this.args.error instanceof BadModelSpecError)) return;
+    const picker = this.picker.trim();
+    if (!picker) {
+      this.patchStatusEl.textContent = "";
+      this.patchBtn.disabled = true;
+      this.replacement = null;
+      return;
+    }
+    const v = validateModelName(this.args.error.chosenAgent, picker, this.args.error.stepId);
+    if (!v.ok) {
+      this.patchStatusEl.textContent = `"${picker}" is not a valid model for agent "${this.args.error.chosenAgent}".`;
+      this.patchStatusEl.removeClass("op-recovery-modal__patch-status--ok");
+      this.patchStatusEl.addClass("op-recovery-modal__patch-status--error");
+      this.patchBtn.disabled = true;
+      this.replacement = null;
+      return;
+    }
+    this.replacement = v.canonicalId;
+    const wf = await this.loadWorkflowFile();
+    if (!wf || this.rawWorkflow === null) {
+      this.patchStatusEl.textContent = `Resolved → ${v.canonicalId}. Workflow file not found at Projects/${this.args.project}/WORKFLOW.md — Patch unavailable.`;
+      this.patchStatusEl.removeClass("op-recovery-modal__patch-status--ok");
+      this.patchStatusEl.addClass("op-recovery-modal__patch-status--error");
+      this.patchBtn.disabled = true;
+      return;
+    }
+    this.patchStatusEl.textContent = `Resolved → ${v.canonicalId}. Patch will rewrite ${this.args.error.bad.badName} → ${v.canonicalId} in ${wf.path}.`;
+    this.patchStatusEl.addClass("op-recovery-modal__patch-status--ok");
+    this.patchStatusEl.removeClass("op-recovery-modal__patch-status--error");
+    this.patchBtn.disabled = false;
+  }
+
+  private handleOverride(err: BadModelSpecError): void {
+    if (this.args.mode === "advisory") return;
+    if (!this.replacement) return;
+    const v = validateModelName(err.chosenAgent, this.picker.trim(), err.stepId);
+    if (!v.ok) return;
+    this.resolved = true;
+    this.args.onResolved({ kind: "override", canonicalModel: v.canonicalId });
+    this.close();
+  }
+
+  private async handlePatch(): Promise<void> {
+    if (!(this.args.error instanceof BadModelSpecError)) return;
+    if (!this.replacement) return;
+    const wf = await this.loadWorkflowFile();
+    if (!wf || this.rawWorkflow === null) return;
+    const replacement = this.replacement;
+    const badName = this.args.error.bad.badName;
+
+    // Open the diff-confirm sub-modal first; only on confirm do we touch
+    // disk.
+    new DiffConfirmModal(this.app, {
+      diff: this.computeDiffPreview(this.rawWorkflow, badName, replacement, wf.path),
+      onConfirm: () => void this.commitPatch(wf, badName, replacement),
+    }).open();
+  }
+
+  private computeDiffPreview(
+    raw: string,
+    badName: string,
+    replacement: string,
+    path: string,
+  ): string {
+    // Reuse the planner's diff so what the user sees == what gets applied.
+    const r = planBadModelPatch({ raw, path, badName, replacement });
+    if (r.status !== "ok") return "(no change)";
+    return r.diff;
+  }
+
+  private async commitPatch(
+    wf: VaultFileLike,
+    badName: string,
+    replacement: string,
+  ): Promise<void> {
+    const raw = this.rawWorkflow ?? "";
+    try {
+      const r = await applyBadModelPatch({
+        vault: this.vaultLike,
+        workflowFile: wf,
+        raw,
+        badName,
+        replacement,
+      });
+      if (r.status !== "ok") {
+        new Notice(`Patch skipped: ${r.reason.status}`, 6000);
+        return;
+      }
+      new Notice(
+        `Patched ${wf.path}. Backup at ${r.backupPath} — use "op: revert last workflow patch" to undo.`,
+        0,
+      );
+      this.resolved = true;
+      this.args.onResolved({
+        kind: "patched",
+        canonicalModel: replacement,
+        backupPath: r.backupPath,
+      });
+      this.close();
+    } catch (err) {
+      console.error("[op-obsidian] recoveryDialog.commitPatch failed", err);
+      new Notice(`Patch failed: ${(err as Error).message ?? String(err)}`, 8000);
+    }
+  }
+
+  private async handleRevert(row: HTMLElement, label: HTMLElement): Promise<void> {
+    const wf = await this.loadWorkflowFile();
+    if (!wf) return;
+    try {
+      const r = await revertLastWorkflowPatch({ vault: this.vaultLike, workflowFile: wf });
+      if (r.status === "no-backup") {
+        new Notice("No backup found for this workflow file.", 5000);
+        return;
+      }
+      // Refresh the cached raw text so subsequent operations see the restored
+      // contents.
+      this.rawWorkflow = await this.vaultLike.read(wf);
+      new Notice(`Reverted ${wf.path} from ${r.restoredFromPath}.`, 6000);
+      void this.refreshRevertRow(row, label);
+      this.resolved = true;
+      this.args.onResolved({ kind: "reverted", restoredFromPath: r.restoredFromPath });
+      // After a revert, the file may once again be invalid for THIS error —
+      // we close so the user can re-launch and (if still bad) open a fresh
+      // dialog reflecting the now-restored state.
+      this.close();
+    } catch (err) {
+      console.error("[op-obsidian] recoveryDialog.handleRevert failed", err);
+      new Notice(`Revert failed: ${(err as Error).message ?? String(err)}`, 8000);
+    }
+  }
+}
+
+class DiffConfirmModal extends Modal {
+  constructor(app: App, private opts: { diff: string; onConfirm: () => void }) {
+    super(app);
+  }
+  onOpen(): void {
+    const { contentEl } = this;
+    contentEl.empty();
+    contentEl.addClass("op-recovery-modal__diff-confirm");
+    contentEl.createEl("h2", { text: "Confirm workflow patch" });
+    contentEl.createEl("p", {
+      text:
+        "A timestamped backup will be written before the change is applied. " +
+        'You can undo this with "op: revert last workflow patch" (one-step).',
+    });
+    const pre = contentEl.createEl("pre", { cls: "op-recovery-modal__diff" });
+    pre.textContent = this.opts.diff;
+    new Setting(contentEl)
+      .addButton((b) =>
+        b
+          .setButtonText("Apply patch")
+          .setCta()
+          .onClick(() => {
+            this.close();
+            this.opts.onConfirm();
+          }),
+      )
+      .addButton((b) => b.setButtonText("Cancel").onClick(() => this.close()));
+  }
+  onClose(): void {
+    this.contentEl.empty();
+  }
+}
+
+function makeVaultLikeFromApp(app: App): VaultLike {
+  const vault = app.vault;
+  return {
+    async read(file) {
+      return vault.read(file as TFile);
+    },
+    async modify(file, data) {
+      await vault.modify(file as TFile, data);
+    },
+    async create(path, data) {
+      return (await vault.create(path, data)) as VaultFileLike;
+    },
+    async trash(file, system) {
+      await vault.trash(file as TFile, system);
+    },
+    getFileByPath(path) {
+      const f = vault.getAbstractFileByPath(path);
+      return f instanceof TFile ? (f as VaultFileLike) : null;
+    },
+    listSiblingPaths(parentFolderPath) {
+      const out: string[] = [];
+      const folder = parentFolderPath ? vault.getAbstractFileByPath(parentFolderPath) : vault.getRoot();
+      if (!folder || !("children" in (folder as object))) return out;
+      const children = (folder as { children?: Array<{ path: string }> }).children;
+      if (!Array.isArray(children)) return out;
+      for (const child of children) {
+        if (child && typeof child.path === "string") out.push(child.path);
+      }
+      return out;
+    },
+  };
+}
+
+function parentFolder(path: string): string {
+  const i = path.lastIndexOf("/");
+  return i < 0 ? "" : path.slice(0, i);
 }

--- a/plugins/op-obsidian/src/recoveryDialog.ts
+++ b/plugins/op-obsidian/src/recoveryDialog.ts
@@ -43,7 +43,7 @@ import {
   type VaultLike,
   type VaultFileLike,
 } from "./recoveryPatchApply";
-import { findLatestBackup, formatUnifiedDiff, planBadModelPatch } from "./recoveryPatch";
+import { findLatestBackup, formatUnifiedDiff, parseBackupTimestamp, planBadModelPatch } from "./recoveryPatch";
 import type { WorkflowDiagnostic } from "./workflowDiagnostic";
 
 export type RecoveryDialogMode = "launch" | "advisory";
@@ -377,7 +377,7 @@ class RecoveryDialogModal extends Modal {
       return;
     }
     row.style.display = "";
-    const ts = latest.match(/\.bak-([\d-]+)$/)?.[1] ?? "<unknown>";
+    const ts = parseBackupTimestamp(latest) ?? "<unknown>";
     label.textContent = `Last backup: ${ts}`;
   }
 
@@ -525,8 +525,8 @@ class RecoveryDialogModal extends Modal {
       const diff = formatUnifiedDiff(currentContent, backupContent, wf.path);
       new RevertConfirmModal(this.app, {
         diff,
-        backupTimestamp: latestBak.match(/\.bak-([\d-]+(?:-\d{3})?)$/)?.[1] ?? "<unknown>",
-        onConfirm: () => void this.commitRevert(wf, row, label),
+        backupTimestamp: parseBackupTimestamp(latestBak) ?? "<unknown>",
+        onConfirm: () => { this.commitRevert(wf, row, label).catch((e) => console.error("[op-obsidian] recoveryDialog.commitRevert unexpected", e)); },
       }).open();
     } catch (err) {
       console.error("[op-obsidian] recoveryDialog.handleRevert failed", err);

--- a/plugins/op-obsidian/src/recoveryDialog.ts
+++ b/plugins/op-obsidian/src/recoveryDialog.ts
@@ -43,7 +43,7 @@ import {
   type VaultLike,
   type VaultFileLike,
 } from "./recoveryPatchApply";
-import { findLatestBackup, planBadModelPatch } from "./recoveryPatch";
+import { findLatestBackup, formatUnifiedDiff, planBadModelPatch } from "./recoveryPatch";
 import type { WorkflowDiagnostic } from "./workflowDiagnostic";
 
 export type RecoveryDialogMode = "launch" | "advisory";
@@ -502,6 +502,44 @@ class RecoveryDialogModal extends Modal {
     const wf = await this.loadWorkflowFile();
     if (!wf) return;
     try {
+      // Look up the latest backup before committing to anything, so we can
+      // show the user a diff between their current (possibly hand-edited)
+      // content and the backup they're about to restore.
+      const folder = parentFolder(wf.path);
+      const siblings = this.vaultLike.listSiblingPaths(folder);
+      const latestBak = findLatestBackup(siblings, wf.path);
+      if (!latestBak) {
+        new Notice("No backup found for this workflow file.", 5000);
+        return;
+      }
+      const bakFile = this.vaultLike.getFileByPath(latestBak);
+      if (!bakFile) {
+        new Notice("No backup found for this workflow file.", 5000);
+        return;
+      }
+      const currentContent = await this.vaultLike.read(wf);
+      const backupContent = await this.vaultLike.read(bakFile);
+      // Show a diff of what will be LOST (current → backup). The user must
+      // explicitly confirm before we clobber any hand-edits they made after
+      // the last patch.
+      const diff = formatUnifiedDiff(currentContent, backupContent, wf.path);
+      new RevertConfirmModal(this.app, {
+        diff,
+        backupTimestamp: latestBak.match(/\.bak-([\d-]+(?:-\d{3})?)$/)?.[1] ?? "<unknown>",
+        onConfirm: () => void this.commitRevert(wf, row, label),
+      }).open();
+    } catch (err) {
+      console.error("[op-obsidian] recoveryDialog.handleRevert failed", err);
+      new Notice(`Revert failed: ${(err as Error).message ?? String(err)}`, 8000);
+    }
+  }
+
+  private async commitRevert(
+    wf: VaultFileLike,
+    row: HTMLElement,
+    label: HTMLElement,
+  ): Promise<void> {
+    try {
       const r = await revertLastWorkflowPatch({ vault: this.vaultLike, workflowFile: wf });
       if (r.status === "no-backup") {
         new Notice("No backup found for this workflow file.", 5000);
@@ -519,7 +557,7 @@ class RecoveryDialogModal extends Modal {
       // dialog reflecting the now-restored state.
       this.close();
     } catch (err) {
-      console.error("[op-obsidian] recoveryDialog.handleRevert failed", err);
+      console.error("[op-obsidian] recoveryDialog.commitRevert failed", err);
       new Notice(`Revert failed: ${(err as Error).message ?? String(err)}`, 8000);
     }
   }
@@ -545,6 +583,49 @@ class DiffConfirmModal extends Modal {
       .addButton((b) =>
         b
           .setButtonText("Apply patch")
+          .setCta()
+          .onClick(() => {
+            this.close();
+            this.opts.onConfirm();
+          }),
+      )
+      .addButton((b) => b.setButtonText("Cancel").onClick(() => this.close()));
+  }
+  onClose(): void {
+    this.contentEl.empty();
+  }
+}
+
+/**
+ * Confirmation modal shown before a revert overwrites the live workflow file.
+ * Displays a diff of current → backup so the user can see any hand-edits they
+ * are about to lose. Mirrors `DiffConfirmModal` but with revert-specific
+ * labelling and a warning that the current state will be replaced.
+ */
+class RevertConfirmModal extends Modal {
+  constructor(
+    app: App,
+    private opts: { diff: string; backupTimestamp: string; onConfirm: () => void },
+  ) {
+    super(app);
+  }
+  onOpen(): void {
+    const { contentEl } = this;
+    contentEl.empty();
+    contentEl.addClass("op-recovery-modal__diff-confirm");
+    contentEl.createEl("h2", { text: "Confirm revert" });
+    contentEl.createEl("p", {
+      text:
+        `Restoring from backup ${this.opts.backupTimestamp}. ` +
+        "Any edits you made to the workflow file after the last patch will be lost. " +
+        "The diff below shows what will change (− lines disappear, + lines are restored).",
+    });
+    const pre = contentEl.createEl("pre", { cls: "op-recovery-modal__diff" });
+    pre.textContent = this.opts.diff || "(no changes detected between current file and backup)";
+    new Setting(contentEl)
+      .addButton((b) =>
+        b
+          .setButtonText("Restore from backup")
           .setCta()
           .onClick(() => {
             this.close();

--- a/plugins/op-obsidian/src/recoveryPatch.test.ts
+++ b/plugins/op-obsidian/src/recoveryPatch.test.ts
@@ -1,0 +1,277 @@
+import { describe, it, expect } from "vitest";
+import {
+  backupPathFor,
+  findLatestBackup,
+  formatBackupTimestamp,
+  formatUnifiedDiff,
+  planBadModelPatch,
+} from "./recoveryPatch";
+
+const PATH = "Projects/foo/WORKFLOW.md";
+
+function fm(body: string): string {
+  return `---\n${body}\n---\n# WORKFLOW\n\nbody prose here.\n`;
+}
+
+describe("planBadModelPatch", () => {
+  it("rewrites a scalar `model: <bad>` to the canonical id", () => {
+    const raw = fm(
+      [
+        "type: workflow",
+        "schema: 1",
+        "project: foo",
+        "default_agent: claude",
+        "default_model: opuss",
+      ].join("\n"),
+    );
+    const r = planBadModelPatch({
+      raw,
+      path: PATH,
+      badName: "opuss",
+      replacement: "claude-opus-4-7",
+    });
+    expect(r.status).toBe("ok");
+    if (r.status !== "ok") return;
+    expect(r.newText).toContain("default_model: claude-opus-4-7");
+    expect(r.newText).not.toContain("opuss");
+    // body prose untouched
+    expect(r.newText).toContain("# WORKFLOW");
+    expect(r.newText).toContain("body prose here.");
+  });
+
+  it("rewrites a flow-list element without disturbing siblings", () => {
+    const raw = fm(
+      [
+        "type: workflow",
+        "default_model: [opus, opuss, sonnet]",
+      ].join("\n"),
+    );
+    const r = planBadModelPatch({
+      raw,
+      path: PATH,
+      badName: "opuss",
+      replacement: "claude-haiku-4-5-20251001",
+    });
+    expect(r.status).toBe("ok");
+    if (r.status !== "ok") return;
+    expect(r.newText).toContain("[opus, claude-haiku-4-5-20251001, sonnet]");
+  });
+
+  it("rewrites a block-list element", () => {
+    const raw = fm(
+      ["type: workflow", "default_model:", "  - opus", "  - opuss", "  - sonnet"].join("\n"),
+    );
+    const r = planBadModelPatch({
+      raw,
+      path: PATH,
+      badName: "opuss",
+      replacement: "claude-haiku-4-5",
+    });
+    expect(r.status).toBe("ok");
+    if (r.status !== "ok") return;
+    expect(r.newText).toContain("- claude-haiku-4-5");
+    expect(r.newText.match(/- opus\b/g)?.length).toBe(1);
+  });
+
+  it("preserves quoting around a quoted scalar", () => {
+    const raw = fm(['default_model: "opuss"'].join("\n"));
+    const r = planBadModelPatch({
+      raw,
+      path: PATH,
+      badName: "opuss",
+      replacement: "claude-opus-4-7",
+    });
+    expect(r.status).toBe("ok");
+    if (r.status !== "ok") return;
+    expect(r.newText).toContain('default_model: "claude-opus-4-7"');
+  });
+
+  it("does NOT match the bad name as a substring of a longer token", () => {
+    const raw = fm(
+      ["default_model: claude-opus-4-7", 'note: "opus is preferred"'].join("\n"),
+    );
+    const r = planBadModelPatch({
+      raw,
+      path: PATH,
+      badName: "opus",
+      replacement: "sonnet",
+    });
+    // `opus` appears once as a free token (the note), but inside
+    // `claude-opus-4-7` it sits between hyphens which are token chars.
+    // Both should be matchable individually — the registry's word boundary
+    // treats `[A-Za-z0-9._-]` as token chars, so `opus` is NOT inside
+    // `claude-opus-4-7` (the leading char is `-`, which is a token char,
+    // so the run containing `opus` is the whole `claude-opus-4-7`).
+    expect(r.status).toBe("ok");
+    if (r.status !== "ok") return;
+    expect(r.newText).toContain("note: \"sonnet is preferred\"");
+    expect(r.newText).toContain("claude-opus-4-7");
+  });
+
+  it("returns ambiguous when the bad name appears in multiple frontmatter lines", () => {
+    const raw = fm(["default_model: opuss", "steps:", "  - step: kickoff", "    model: opuss"].join("\n"));
+    const r = planBadModelPatch({
+      raw,
+      path: PATH,
+      badName: "opuss",
+      replacement: "claude-opus-4-7",
+    });
+    expect(r.status).toBe("ambiguous");
+    if (r.status !== "ambiguous") return;
+    expect(r.matches).toBe(2);
+  });
+
+  it("returns not-found when the bad name is absent from frontmatter", () => {
+    const raw = fm(["default_model: opus"].join("\n"));
+    const r = planBadModelPatch({
+      raw,
+      path: PATH,
+      badName: "opuss",
+      replacement: "claude-opus-4-7",
+    });
+    expect(r.status).toBe("not-found");
+  });
+
+  it("ignores body occurrences (only frontmatter is patched)", () => {
+    const raw = `---\ndefault_model: opus\n---\n# Note about \`opuss\` typo seen earlier.\n`;
+    const r = planBadModelPatch({
+      raw,
+      path: PATH,
+      badName: "opuss",
+      replacement: "claude-opus-4-7",
+    });
+    expect(r.status).toBe("not-found");
+  });
+
+  it("returns not-found for a file with no frontmatter", () => {
+    const r = planBadModelPatch({
+      raw: "# heading only\n",
+      path: PATH,
+      badName: "opuss",
+      replacement: "claude-opus-4-7",
+    });
+    expect(r.status).toBe("not-found");
+  });
+
+  it("emits a diff that includes the change", () => {
+    const raw = fm(["default_model: opuss"].join("\n"));
+    const r = planBadModelPatch({
+      raw,
+      path: PATH,
+      badName: "opuss",
+      replacement: "claude-opus-4-7",
+    });
+    expect(r.status).toBe("ok");
+    if (r.status !== "ok") return;
+    expect(r.diff).toContain(`--- a/${PATH}`);
+    expect(r.diff).toContain(`+++ b/${PATH}`);
+    expect(r.diff).toContain("-default_model: opuss");
+    expect(r.diff).toContain("+default_model: claude-opus-4-7");
+    expect(r.diff).toMatch(/@@ -\d+,\d+ \+\d+,\d+ @@/);
+  });
+
+  it("escapes regex metacharacters in the bad name", () => {
+    const raw = fm(['default_model: "v1.2+beta"'].join("\n"));
+    const r = planBadModelPatch({
+      raw,
+      path: PATH,
+      badName: "v1.2+beta",
+      replacement: "v1.2",
+    });
+    expect(r.status).toBe("ok");
+    if (r.status !== "ok") return;
+    expect(r.newText).toContain('default_model: "v1.2"');
+  });
+});
+
+describe("formatUnifiedDiff", () => {
+  it("renders a single hunk for a one-line change", () => {
+    const a = "alpha\nbravo\ncharlie\n";
+    const b = "alpha\nBRAVO\ncharlie\n";
+    const d = formatUnifiedDiff(a, b, "x.txt");
+    expect(d.split("\n")).toEqual([
+      "--- a/x.txt",
+      "+++ b/x.txt",
+      "@@ -1,3 +1,3 @@",
+      " alpha",
+      "-bravo",
+      "+BRAVO",
+      " charlie",
+    ]);
+  });
+
+  it("returns headers only when texts are identical", () => {
+    const d = formatUnifiedDiff("foo\nbar\n", "foo\nbar\n", "x.txt");
+    expect(d).toBe("--- a/x.txt\n+++ b/x.txt");
+  });
+
+  it("clamps context at the start of the file", () => {
+    const a = "alpha\nbravo\n";
+    const b = "ALPHA\nbravo\n";
+    const d = formatUnifiedDiff(a, b, "x.txt");
+    expect(d).toContain("@@ -1,2 +1,2 @@");
+    expect(d).toContain("-alpha");
+    expect(d).toContain("+ALPHA");
+    expect(d).toContain(" bravo");
+  });
+});
+
+describe("formatBackupTimestamp", () => {
+  it("formats UTC time with zero-pad", () => {
+    const d = new Date(Date.UTC(2026, 3, 5, 7, 8, 9)); // April 5, 07:08:09 UTC
+    expect(formatBackupTimestamp(d)).toBe("20260405-070809");
+  });
+
+  it("uses UTC, not local time", () => {
+    const d = new Date(Date.UTC(2026, 0, 1, 0, 0, 0));
+    expect(formatBackupTimestamp(d)).toBe("20260101-000000");
+  });
+
+  it("backupPathFor stitches path + timestamp", () => {
+    expect(backupPathFor("Projects/x/WORKFLOW.md", "20260101-000000")).toBe(
+      "Projects/x/WORKFLOW.md.bak-20260101-000000",
+    );
+  });
+});
+
+describe("findLatestBackup", () => {
+  const W = "Projects/x/WORKFLOW.md";
+
+  it("returns the most recent .bak-* by lex sort", () => {
+    const siblings = [
+      "Projects/x/WORKFLOW.md.bak-20260101-000000",
+      "Projects/x/WORKFLOW.md.bak-20260426-122345",
+      "Projects/x/WORKFLOW.md.bak-20260301-090000",
+      "Projects/x/STATUS.md", // unrelated
+    ];
+    expect(findLatestBackup(siblings, W)).toBe(
+      "Projects/x/WORKFLOW.md.bak-20260426-122345",
+    );
+  });
+
+  it("returns null when no backup matches", () => {
+    expect(findLatestBackup(["Projects/x/STATUS.md"], W)).toBeNull();
+    expect(findLatestBackup([], W)).toBeNull();
+  });
+
+  it("ignores files with malformed .bak-* suffix", () => {
+    const siblings = [
+      "Projects/x/WORKFLOW.md.bak-foo",
+      "Projects/x/WORKFLOW.md.bak-2026",
+      "Projects/x/WORKFLOW.md.bak-20260101-000000",
+    ];
+    expect(findLatestBackup(siblings, W)).toBe(
+      "Projects/x/WORKFLOW.md.bak-20260101-000000",
+    );
+  });
+
+  it("does not match a .bak-* belonging to a different file", () => {
+    const siblings = [
+      "Projects/x/OTHER.md.bak-20260426-000000",
+      "Projects/x/WORKFLOW.md.bak-20260101-000000",
+    ];
+    expect(findLatestBackup(siblings, W)).toBe(
+      "Projects/x/WORKFLOW.md.bak-20260101-000000",
+    );
+  });
+});

--- a/plugins/op-obsidian/src/recoveryPatch.test.ts
+++ b/plugins/op-obsidian/src/recoveryPatch.test.ts
@@ -121,6 +121,53 @@ describe("planBadModelPatch", () => {
     expect(r.matches).toBe(2);
   });
 
+  // Issue 1: the bad name in a YAML inline comment on the same line as the
+  // value counts as a second occurrence and triggers "ambiguous". This is
+  // intentionally conservative — patching the wrong token silently is worse
+  // than asking the user to edit manually. The dialog disables the patch
+  // button and shows "multiple occurrences" so the user knows why.
+  it("treats a bad name in an inline YAML comment as a second occurrence (ambiguous, conservative)", () => {
+    const raw = fm([
+      "default_model: opuss  # was opuss in a prior commit",
+    ].join("\n"));
+    const r = planBadModelPatch({
+      raw,
+      path: PATH,
+      badName: "opuss",
+      replacement: "claude-opus-4-7",
+    });
+    // Two token-matches in the frontmatter (value + comment) → ambiguous.
+    expect(r.status).toBe("ambiguous");
+    if (r.status !== "ambiguous") return;
+    expect(r.matches).toBe(2);
+  });
+
+  // Issue 2 (reviewed): the regex \r?\n---(?:\r?\n|$) requires "---" to appear
+  // immediately after a newline with no leading whitespace, so an indented
+  // "---" inside a YAML literal-block scalar body does NOT trip the closing-
+  // fence detector. The extractor finds the real closing "---" correctly.
+  it("correctly ignores indented '---' in a YAML literal-block scalar (extractor is safe)", () => {
+    const raw =
+      "---\n" +
+      "description: |\n" +
+      "  line one\n" +
+      "  ---\n" +     // indented — does NOT match \n---
+      "  line two\n" +
+      "default_model: opuss\n" +
+      "---\n" +
+      "# body\n";
+    const r = planBadModelPatch({
+      raw,
+      path: PATH,
+      badName: "opuss",
+      replacement: "claude-opus-4-7",
+    });
+    // Extractor correctly finds the real closing fence; default_model is visible.
+    expect(r.status).toBe("ok");
+    if (r.status !== "ok") return;
+    expect(r.newText).toContain("default_model: claude-opus-4-7");
+  });
+
   it("returns not-found when the bad name is absent from frontmatter", () => {
     const raw = fm(["default_model: opus"].join("\n"));
     const r = planBadModelPatch({

--- a/plugins/op-obsidian/src/recoveryPatch.test.ts
+++ b/plugins/op-obsidian/src/recoveryPatch.test.ts
@@ -4,6 +4,7 @@ import {
   findLatestBackup,
   formatBackupTimestamp,
   formatUnifiedDiff,
+  parseBackupTimestamp,
   planBadModelPatch,
 } from "./recoveryPatch";
 
@@ -320,5 +321,34 @@ describe("findLatestBackup", () => {
     expect(findLatestBackup(siblings, W)).toBe(
       "Projects/x/WORKFLOW.md.bak-20260101-000000",
     );
+  });
+
+  it("lex-sorts counter-suffixed backups after plain backups of the same second", () => {
+    const siblings = [
+      `${W}.bak-20260426-123456`,
+      `${W}.bak-20260426-123456-001`,
+      `${W}.bak-20260426-123456-002`,
+    ];
+    // -002 is lexicographically last → most recent
+    expect(findLatestBackup(siblings, W)).toBe(`${W}.bak-20260426-123456-002`);
+  });
+});
+
+describe("parseBackupTimestamp", () => {
+  it("extracts the plain timestamp", () => {
+    expect(parseBackupTimestamp("Projects/x/WORKFLOW.md.bak-20260426-123456")).toBe(
+      "20260426-123456",
+    );
+  });
+
+  it("extracts a timestamp with counter suffix", () => {
+    expect(parseBackupTimestamp("Projects/x/WORKFLOW.md.bak-20260426-123456-001")).toBe(
+      "20260426-123456-001",
+    );
+  });
+
+  it("returns null for a non-backup path", () => {
+    expect(parseBackupTimestamp("Projects/x/WORKFLOW.md")).toBeNull();
+    expect(parseBackupTimestamp("Projects/x/WORKFLOW.md.bak-foo")).toBeNull();
   });
 });

--- a/plugins/op-obsidian/src/recoveryPatch.ts
+++ b/plugins/op-obsidian/src/recoveryPatch.ts
@@ -130,7 +130,26 @@ export function backupPathFor(workflowPath: string, timestamp: string): string {
   return `${workflowPath}.bak-${timestamp}`;
 }
 
-const BACKUP_SUFFIX_RE = /\.bak-(\d{8}-\d{6})$/;
+/**
+ * The timestamp portion of a backup path. The base shape is `YYYYMMDD-HHmmss`
+ * (8 digits, hyphen, 6 digits). A collision-avoidance counter suffix `-NNN`
+ * may be appended (see `createBackupUnique` in `recoveryPatchApply.ts`).
+ *
+ * This pattern is also the lex-sort key used by `findLatestBackup`: with the
+ * `YYYYMMDD-HHmmss` prefix, lex order === chronological order; the optional
+ * `-NNN` counter keeps same-second backups in creation order.
+ */
+const BACKUP_TIMESTAMP_RE = /\.bak-(\d{8}-\d{6}(?:-\d{3})?)$/;
+
+/**
+ * Extract the timestamp (plus optional counter suffix) from a backup path
+ * such as `Projects/x/WORKFLOW.md.bak-20260426-123456` or
+ * `Projects/x/WORKFLOW.md.bak-20260426-123456-001`.
+ * Returns `null` when the path doesn't match the backup-path shape.
+ */
+export function parseBackupTimestamp(backupPath: string): string | null {
+  return backupPath.match(BACKUP_TIMESTAMP_RE)?.[1] ?? null;
+}
 
 /**
  * Pick the most recent backup for `workflowPath` from the given list of
@@ -142,7 +161,7 @@ const BACKUP_SUFFIX_RE = /\.bak-(\d{8}-\d{6})$/;
 export function findLatestBackup(siblingPaths: string[], workflowPath: string): string | null {
   const prefix = `${workflowPath}.bak-`;
   const candidates = siblingPaths.filter(
-    (p) => p.startsWith(prefix) && BACKUP_SUFFIX_RE.test(p),
+    (p) => p.startsWith(prefix) && BACKUP_TIMESTAMP_RE.test(p),
   );
   if (candidates.length === 0) return null;
   candidates.sort();

--- a/plugins/op-obsidian/src/recoveryPatch.ts
+++ b/plugins/op-obsidian/src/recoveryPatch.ts
@@ -1,0 +1,291 @@
+// Pure helpers for OP-205 (3e) — the bad-model recovery dialog. No Obsidian
+// imports. The dialog (`recoveryDialog.ts`) is the only consumer; tests live
+// alongside in `recoveryPatch.test.ts`.
+//
+// Three jobs:
+//
+//   1. `planBadModelPatch` — given the raw WORKFLOW.md text and the bad model
+//      name, find the (single) frontmatter occurrence and compute the new
+//      text. v1 contract is strict: replace only when the bad name appears
+//      EXACTLY ONCE in the frontmatter. Multiple matches surface as
+//      `"ambiguous"` so the dialog disables the patch button rather than
+//      silently rewriting the wrong copy.
+//
+//   2. `formatUnifiedDiff` — render a minimal one-or-two-hunk unified diff for
+//      the dialog's confirm step. We never patch more than a handful of lines,
+//      so a hand-rolled implementation beats pulling a diff dependency.
+//
+//   3. `formatBackupTimestamp` + `findLatestBackup` — the `.bak-<YYYYMMDD-HHmmss>`
+//      naming + lex-sortable selection used by the patch + revert flows. UTC
+//      to keep the timestamp reproducible across DST/timezones, matching the
+//      `today()` convention in `promptBuild.ts`.
+
+export type PlanBadModelPatchResult =
+  | { status: "ok"; newText: string; diff: string }
+  | { status: "ambiguous"; matches: number }
+  | { status: "not-found" };
+
+export interface PlanBadModelPatchInput {
+  /** Full file contents of WORKFLOW.md. */
+  raw: string;
+  /** Vault-relative path; only used for the diff headers. */
+  path: string;
+  /** The model name to substitute (`BadModelSpec.badName`). */
+  badName: string;
+  /** The canonical id to replace it with (validated by the caller). */
+  replacement: string;
+}
+
+/**
+ * Compute the patched WORKFLOW.md text + a unified diff describing the change.
+ *
+ * Scope: only the YAML frontmatter (`---` … `---` at the top of the file). A
+ * body mention of the bad name (in prose, a comment, an example) does not
+ * count — the patch is a frontmatter rewrite.
+ *
+ * Word boundaries: a matching token is a contiguous run of [A-Za-z0-9._-]
+ * characters that equals `badName`. Two consequences:
+ *   - `model: opus` matches `opus` cleanly even when the value is unquoted.
+ *   - `model: [opuss, opus]` matches `opus` once (not twice — `opuss` is a
+ *     different token).
+ *   - A quoted form `model: "opus"` matches because the quotes are not part
+ *     of the token; the surrounding quotes are preserved by replacing only
+ *     the inner span.
+ *
+ * Single-occurrence enforcement: when more than one frontmatter occurrence is
+ * found we return `{ status: "ambiguous", matches }`. The dialog disables the
+ * patch button and points the user at manual editing. Patching the wrong copy
+ * silently is the failure mode this rule rules out.
+ */
+export function planBadModelPatch(
+  input: PlanBadModelPatchInput,
+): PlanBadModelPatchResult {
+  const frontmatter = extractFrontmatter(input.raw);
+  if (!frontmatter) return { status: "not-found" };
+
+  const re = new RegExp(`(^|[^A-Za-z0-9._-])(${escapeRegex(input.badName)})(?=$|[^A-Za-z0-9._-])`, "g");
+  const fmText = frontmatter.text;
+  const matches: Array<{ start: number; end: number }> = [];
+  for (const m of fmText.matchAll(re)) {
+    const idx = (m.index ?? 0) + m[1].length;
+    matches.push({ start: idx, end: idx + m[2].length });
+  }
+  if (matches.length === 0) return { status: "not-found" };
+  if (matches.length > 1) return { status: "ambiguous", matches: matches.length };
+
+  const hit = matches[0];
+  const newFm = fmText.slice(0, hit.start) + input.replacement + fmText.slice(hit.end);
+  const newText =
+    input.raw.slice(0, frontmatter.bodyStart) + newFm + input.raw.slice(frontmatter.bodyEnd);
+  const diff = formatUnifiedDiff(input.raw, newText, input.path);
+  return { status: "ok", newText, diff };
+}
+
+interface FrontmatterSpan {
+  /** Index where the frontmatter content (after the opening `---\n`) starts. */
+  bodyStart: number;
+  /** Index where the frontmatter content ends (before the closing `---\n`). */
+  bodyEnd: number;
+  /** Slice between bodyStart and bodyEnd. */
+  text: string;
+}
+
+function extractFrontmatter(raw: string): FrontmatterSpan | null {
+  if (!raw.startsWith("---\n") && !raw.startsWith("---\r\n")) return null;
+  const opener = raw.startsWith("---\r\n") ? 5 : 4;
+  // Closing fence: a line that is exactly "---" (optionally followed by \r).
+  const re = /\r?\n---(?:\r?\n|$)/g;
+  re.lastIndex = opener;
+  const m = re.exec(raw);
+  if (!m) return null;
+  return {
+    bodyStart: opener,
+    // The slice ends *before* the leading newline of the closing fence so the
+    // closing `---` itself is preserved by the surrounding `raw` slice.
+    bodyEnd: m.index + 1,
+    text: raw.slice(opener, m.index + 1),
+  };
+}
+
+function escapeRegex(s: string): string {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+/**
+ * Pad-zero a UTC date to `YYYYMMDD-HHmmss`. UTC is intentional: the timestamp
+ * is durable across DST/timezones, and lex-sort matches chronological order.
+ */
+export function formatBackupTimestamp(date: Date): string {
+  const yyyy = String(date.getUTCFullYear()).padStart(4, "0");
+  const mm = String(date.getUTCMonth() + 1).padStart(2, "0");
+  const dd = String(date.getUTCDate()).padStart(2, "0");
+  const hh = String(date.getUTCHours()).padStart(2, "0");
+  const mi = String(date.getUTCMinutes()).padStart(2, "0");
+  const ss = String(date.getUTCSeconds()).padStart(2, "0");
+  return `${yyyy}${mm}${dd}-${hh}${mi}${ss}`;
+}
+
+/** Build the absolute backup path for a given workflow path + timestamp. */
+export function backupPathFor(workflowPath: string, timestamp: string): string {
+  return `${workflowPath}.bak-${timestamp}`;
+}
+
+const BACKUP_SUFFIX_RE = /\.bak-(\d{8}-\d{6})$/;
+
+/**
+ * Pick the most recent backup for `workflowPath` from the given list of
+ * sibling vault paths. Returns `null` when no `.bak-*` matches.
+ *
+ * Selection is lex-sort over the timestamp suffix — the `YYYYMMDD-HHmmss`
+ * shape is contrived to make string comparison match chronological order.
+ */
+export function findLatestBackup(siblingPaths: string[], workflowPath: string): string | null {
+  const prefix = `${workflowPath}.bak-`;
+  const candidates = siblingPaths.filter(
+    (p) => p.startsWith(prefix) && BACKUP_SUFFIX_RE.test(p),
+  );
+  if (candidates.length === 0) return null;
+  candidates.sort();
+  return candidates[candidates.length - 1];
+}
+
+/**
+ * Minimal unified-diff renderer. Produces standard `---`/`+++`/`@@` headers
+ * plus one hunk per contiguous block of changed lines (3 lines of context on
+ * each side, clamped at file edges).
+ *
+ * We never apply this elsewhere — the result is human-display-only — so we
+ * skip features a real diff library carries (rename detection, byte-mode
+ * patches, function-context lines). For one-or-two-line edits the output
+ * matches `diff -u` byte-for-byte where it matters.
+ */
+export function formatUnifiedDiff(oldText: string, newText: string, path: string): string {
+  const oldLines = splitLines(oldText);
+  const newLines = splitLines(newText);
+  const ops = lcsDiff(oldLines, newLines);
+  const hunks = groupHunks(ops, 3);
+  const out: string[] = [`--- a/${path}`, `+++ b/${path}`];
+  for (const h of hunks) {
+    out.push(`@@ -${h.oldStart},${h.oldLen} +${h.newStart},${h.newLen} @@`);
+    for (const line of h.lines) out.push(line);
+  }
+  return out.join("\n");
+}
+
+function splitLines(s: string): string[] {
+  if (s === "") return [];
+  const parts = s.split(/\r?\n/);
+  // A trailing newline produces a phantom empty trailing element that we drop
+  // — diff hunks treat the trailing newline as a file-level convention, not as
+  // a "blank last line."
+  if (parts.length > 0 && parts[parts.length - 1] === "") parts.pop();
+  return parts;
+}
+
+type DiffOp =
+  | { kind: "ctx"; line: string }
+  | { kind: "del"; line: string }
+  | { kind: "add"; line: string };
+
+/**
+ * Classic LCS-table line diff. Quadratic in the number of lines on each side,
+ * which is fine for WORKFLOW.md (typically <500 lines). Each `del` precedes
+ * its matching `add` to keep the visual order consistent with `diff -u`.
+ */
+function lcsDiff(a: string[], b: string[]): DiffOp[] {
+  const n = a.length;
+  const m = b.length;
+  const dp: number[][] = Array.from({ length: n + 1 }, () => new Array(m + 1).fill(0));
+  for (let i = n - 1; i >= 0; i--) {
+    for (let j = m - 1; j >= 0; j--) {
+      dp[i][j] = a[i] === b[j] ? dp[i + 1][j + 1] + 1 : Math.max(dp[i + 1][j], dp[i][j + 1]);
+    }
+  }
+  const out: DiffOp[] = [];
+  let i = 0;
+  let j = 0;
+  while (i < n && j < m) {
+    if (a[i] === b[j]) {
+      out.push({ kind: "ctx", line: a[i] });
+      i++;
+      j++;
+    } else if (dp[i + 1][j] >= dp[i][j + 1]) {
+      out.push({ kind: "del", line: a[i] });
+      i++;
+    } else {
+      out.push({ kind: "add", line: b[j] });
+      j++;
+    }
+  }
+  while (i < n) out.push({ kind: "del", line: a[i++] });
+  while (j < m) out.push({ kind: "add", line: b[j++] });
+  return out;
+}
+
+interface Hunk {
+  oldStart: number;
+  oldLen: number;
+  newStart: number;
+  newLen: number;
+  lines: string[];
+}
+
+/**
+ * Walk the linear op stream and emit one hunk per cluster of changes plus
+ * `context` lines on either side (collapsed when consecutive clusters fall
+ * within `2 * context + 1` lines of each other — matches `diff -u` defaults).
+ */
+function groupHunks(ops: DiffOp[], context: number): Hunk[] {
+  const hunks: Hunk[] = [];
+  let i = 0;
+  // Cumulative {oldLine, newLine} for each op index.
+  const oldLineAt: number[] = new Array(ops.length + 1);
+  const newLineAt: number[] = new Array(ops.length + 1);
+  oldLineAt[0] = 1;
+  newLineAt[0] = 1;
+  for (let k = 0; k < ops.length; k++) {
+    const o = ops[k];
+    oldLineAt[k + 1] = oldLineAt[k] + (o.kind === "ctx" || o.kind === "del" ? 1 : 0);
+    newLineAt[k + 1] = newLineAt[k] + (o.kind === "ctx" || o.kind === "add" ? 1 : 0);
+  }
+
+  while (i < ops.length) {
+    if (ops[i].kind === "ctx") {
+      i++;
+      continue;
+    }
+    let start = Math.max(0, i - context);
+    while (start > 0 && ops[start - 1].kind === "ctx" && i - start < context) start--;
+    let end = i;
+    while (end < ops.length) {
+      // Extend to include nearby change clusters separated by < 2*context
+      // pure-context ops.
+      if (ops[end].kind !== "ctx") {
+        end++;
+        continue;
+      }
+      let runEnd = end;
+      while (runEnd < ops.length && ops[runEnd].kind === "ctx") runEnd++;
+      if (runEnd >= ops.length) break;
+      if (runEnd - end > 2 * context) break;
+      end = runEnd;
+    }
+    const tail = Math.min(ops.length, end + context);
+    const slice = ops.slice(start, tail);
+
+    const lines: string[] = [];
+    for (const o of slice) {
+      if (o.kind === "ctx") lines.push(` ${o.line}`);
+      else if (o.kind === "del") lines.push(`-${o.line}`);
+      else lines.push(`+${o.line}`);
+    }
+
+    const oldStart = oldLineAt[start];
+    const newStart = newLineAt[start];
+    const oldLen = oldLineAt[tail] - oldLineAt[start];
+    const newLen = newLineAt[tail] - newLineAt[start];
+    hunks.push({ oldStart, oldLen, newStart, newLen, lines });
+    i = tail;
+  }
+  return hunks;
+}

--- a/plugins/op-obsidian/src/recoveryPatchApply.test.ts
+++ b/plugins/op-obsidian/src/recoveryPatchApply.test.ts
@@ -1,0 +1,155 @@
+import { describe, it, expect } from "vitest";
+import {
+  applyBadModelPatch,
+  revertLastWorkflowPatch,
+  type VaultLike,
+  type VaultFileLike,
+} from "./recoveryPatchApply";
+
+class FakeVault implements VaultLike {
+  files = new Map<string, string>();
+  trashed: string[] = [];
+
+  setFile(path: string, data: string): VaultFileLike {
+    this.files.set(path, data);
+    return { path };
+  }
+
+  async read(file: VaultFileLike): Promise<string> {
+    const v = this.files.get(file.path);
+    if (v === undefined) throw new Error(`fake-vault: ENOENT ${file.path}`);
+    return v;
+  }
+
+  async modify(file: VaultFileLike, data: string): Promise<void> {
+    if (!this.files.has(file.path)) throw new Error(`fake-vault: ENOENT ${file.path}`);
+    this.files.set(file.path, data);
+  }
+
+  async create(path: string, data: string): Promise<VaultFileLike> {
+    if (this.files.has(path)) throw new Error(`fake-vault: EEXIST ${path}`);
+    this.files.set(path, data);
+    return { path };
+  }
+
+  async trash(file: VaultFileLike): Promise<void> {
+    this.files.delete(file.path);
+    this.trashed.push(file.path);
+  }
+
+  getFileByPath(path: string): VaultFileLike | null {
+    return this.files.has(path) ? { path } : null;
+  }
+
+  listSiblingPaths(parentFolder: string): string[] {
+    const prefix = parentFolder ? `${parentFolder}/` : "";
+    return [...this.files.keys()].filter((p) => p.startsWith(prefix) && !p.slice(prefix.length).includes("/"));
+  }
+}
+
+const FM = `---\ntype: workflow\nschema: 1\nproject: foo\ndefault_agent: claude\ndefault_model: opuss\n---\n# WORKFLOW\n`;
+const W = "Projects/foo/WORKFLOW.md";
+
+describe("applyBadModelPatch", () => {
+  it("writes a .bak-<ts> then modifies the workflow file (in that order)", async () => {
+    const vault = new FakeVault();
+    vault.setFile(W, FM);
+    const r = await applyBadModelPatch({
+      vault,
+      workflowFile: { path: W },
+      raw: FM,
+      badName: "opuss",
+      replacement: "claude-opus-4-7",
+      now: new Date(Date.UTC(2026, 3, 26, 12, 34, 56)),
+    });
+    expect(r.status).toBe("ok");
+    if (r.status !== "ok") return;
+    expect(r.backupPath).toBe(`${W}.bak-20260426-123456`);
+    expect(vault.files.get(r.backupPath)).toBe(FM); // backup carries the ORIGINAL
+    expect(vault.files.get(W)).toContain("default_model: claude-opus-4-7");
+    expect(vault.files.get(W)).not.toContain("opuss");
+  });
+
+  it("returns skipped when the bad name is ambiguous (no .bak created)", async () => {
+    const fm = `---\ndefault_model: opuss\nsteps:\n  - step: kickoff\n    model: opuss\n---\n`;
+    const vault = new FakeVault();
+    vault.setFile(W, fm);
+    const r = await applyBadModelPatch({
+      vault,
+      workflowFile: { path: W },
+      raw: fm,
+      badName: "opuss",
+      replacement: "claude-opus-4-7",
+    });
+    expect(r.status).toBe("skipped");
+    if (r.status !== "skipped") return;
+    expect(r.reason.status).toBe("ambiguous");
+    // No backup should exist.
+    expect([...vault.files.keys()].some((p) => p.includes(".bak-"))).toBe(false);
+    // Workflow file should be untouched.
+    expect(vault.files.get(W)).toBe(fm);
+  });
+
+  it("returns skipped when the bad name is not found in frontmatter", async () => {
+    const fm = `---\ndefault_model: opus\n---\n`;
+    const vault = new FakeVault();
+    vault.setFile(W, fm);
+    const r = await applyBadModelPatch({
+      vault,
+      workflowFile: { path: W },
+      raw: fm,
+      badName: "opuss",
+      replacement: "claude-opus-4-7",
+    });
+    expect(r.status).toBe("skipped");
+    if (r.status !== "skipped") return;
+    expect(r.reason.status).toBe("not-found");
+  });
+});
+
+describe("revertLastWorkflowPatch", () => {
+  it("restores the file from the latest .bak-* and trashes the backup", async () => {
+    const vault = new FakeVault();
+    const original = "ORIGINAL\n";
+    const patched = "PATCHED\n";
+    const olderBak = `${W}.bak-20260101-000000`;
+    const newerBak = `${W}.bak-20260426-123456`;
+    vault.setFile(W, patched);
+    vault.setFile(olderBak, "older content\n");
+    vault.setFile(newerBak, original);
+
+    const r = await revertLastWorkflowPatch({
+      vault,
+      workflowFile: { path: W },
+    });
+    expect(r.status).toBe("ok");
+    if (r.status !== "ok") return;
+    expect(r.restoredFromPath).toBe(newerBak);
+    expect(vault.files.get(W)).toBe(original);
+    // The newer .bak is gone, the older one stays.
+    expect(vault.files.has(newerBak)).toBe(false);
+    expect(vault.files.has(olderBak)).toBe(true);
+    expect(vault.trashed).toEqual([newerBak]);
+  });
+
+  it("returns no-backup when the workflow has never been patched", async () => {
+    const vault = new FakeVault();
+    vault.setFile(W, "any content\n");
+    const r = await revertLastWorkflowPatch({
+      vault,
+      workflowFile: { path: W },
+    });
+    expect(r.status).toBe("no-backup");
+  });
+
+  it("ignores .bak-* belonging to other workflow files", async () => {
+    const vault = new FakeVault();
+    vault.setFile(W, "current\n");
+    vault.setFile("Projects/foo/OTHER.md.bak-20260426-000000", "decoy\n");
+    const r = await revertLastWorkflowPatch({
+      vault,
+      workflowFile: { path: W },
+    });
+    expect(r.status).toBe("no-backup");
+  });
+});

--- a/plugins/op-obsidian/src/recoveryPatchApply.test.ts
+++ b/plugins/op-obsidian/src/recoveryPatchApply.test.ts
@@ -70,6 +70,54 @@ describe("applyBadModelPatch", () => {
     expect(vault.files.get(W)).not.toContain("opuss");
   });
 
+  it("retries with a counter suffix when the timestamp backup path already exists (EEXIST race)", async () => {
+    const vault = new FakeVault();
+    vault.setFile(W, FM);
+    // Pre-seed the plain timestamp path so the first create attempt hits EEXIST.
+    const ts = "20260426-123456";
+    vault.setFile(`${W}.bak-${ts}`, "earlier backup\n");
+
+    const r = await applyBadModelPatch({
+      vault,
+      workflowFile: { path: W },
+      raw: FM,
+      badName: "opuss",
+      replacement: "claude-opus-4-7",
+      now: new Date(Date.UTC(2026, 3, 26, 12, 34, 56)),
+    });
+    expect(r.status).toBe("ok");
+    if (r.status !== "ok") return;
+    // Should have used the -001 suffix instead of the already-taken plain path.
+    expect(r.backupPath).toBe(`${W}.bak-${ts}-001`);
+    expect(vault.files.get(r.backupPath)).toBe(FM);
+    // The original earlier backup must be untouched.
+    expect(vault.files.get(`${W}.bak-${ts}`)).toBe("earlier backup\n");
+    expect(vault.files.get(W)).toContain("default_model: claude-opus-4-7");
+  });
+
+  it("retries multiple counter steps when several suffixes are already taken", async () => {
+    const vault = new FakeVault();
+    vault.setFile(W, FM);
+    const ts = "20260426-123456";
+    // Pre-seed the plain + -001 + -002 paths.
+    vault.setFile(`${W}.bak-${ts}`, "b0\n");
+    vault.setFile(`${W}.bak-${ts}-001`, "b1\n");
+    vault.setFile(`${W}.bak-${ts}-002`, "b2\n");
+
+    const r = await applyBadModelPatch({
+      vault,
+      workflowFile: { path: W },
+      raw: FM,
+      badName: "opuss",
+      replacement: "claude-opus-4-7",
+      now: new Date(Date.UTC(2026, 3, 26, 12, 34, 56)),
+    });
+    expect(r.status).toBe("ok");
+    if (r.status !== "ok") return;
+    expect(r.backupPath).toBe(`${W}.bak-${ts}-003`);
+    expect(vault.files.get(r.backupPath)).toBe(FM);
+  });
+
   it("returns skipped when the bad name is ambiguous (no .bak created)", async () => {
     const fm = `---\ndefault_model: opuss\nsteps:\n  - step: kickoff\n    model: opuss\n---\n`;
     const vault = new FakeVault();

--- a/plugins/op-obsidian/src/recoveryPatchApply.ts
+++ b/plugins/op-obsidian/src/recoveryPatchApply.ts
@@ -1,0 +1,121 @@
+// Vault-side controllers for OP-205 (3e). One job: take the pure plan from
+// `recoveryPatch.ts` and apply it via the Obsidian vault adapter. Kept
+// separate from `recoveryDialog.ts` so the patch + revert flows are testable
+// against a small `VaultLike` interface — no Modal, no DOM, no Notice.
+
+import {
+  backupPathFor,
+  findLatestBackup,
+  formatBackupTimestamp,
+  planBadModelPatch,
+  type PlanBadModelPatchResult,
+} from "./recoveryPatch";
+
+/** Minimum vault surface we use. Subset of `obsidian.Vault` for testing. */
+export interface VaultLike {
+  read(file: VaultFileLike): Promise<string>;
+  modify(file: VaultFileLike, data: string): Promise<void>;
+  create(path: string, data: string): Promise<VaultFileLike>;
+  trash(file: VaultFileLike, system: boolean): Promise<void>;
+  /**
+   * Resolve a vault-relative path to a TFile-like handle, or null if it
+   * doesn't exist (or isn't a file). Mirrors `app.vault.getAbstractFileByPath`
+   * semantics (we cast to TFile at the seam).
+   */
+  getFileByPath(path: string): VaultFileLike | null;
+  /**
+   * List sibling vault paths in the same parent folder. Used to find the
+   * most recent `.bak-*` for a workflow file.
+   */
+  listSiblingPaths(parentFolder: string): string[];
+}
+
+export interface VaultFileLike {
+  path: string;
+}
+
+export interface ApplyPatchInput {
+  vault: VaultLike;
+  workflowFile: VaultFileLike;
+  /** Pre-read raw contents (we already have them when planning the diff). */
+  raw: string;
+  badName: string;
+  replacement: string;
+  /** Injectable for tests; defaults to `new Date()`. */
+  now?: Date;
+}
+
+export type ApplyPatchResult =
+  | { status: "ok"; backupPath: string; newText: string }
+  | { status: "skipped"; reason: PlanBadModelPatchResult };
+
+/**
+ * Apply the bad-model patch to a workflow file.
+ *
+ * Order of operations:
+ *   1. Run the pure planner — bail early on `ambiguous` / `not-found`.
+ *   2. Write the `.bak-<ts>` backup via `vault.create` BEFORE the modify so
+ *      a partial failure leaves the original on disk + a backup exists.
+ *      Order is critical for the "always have a path back" guarantee.
+ *   3. `vault.modify` the workflow file with the new text.
+ *
+ * Returns the backup path on success so the dialog can display "backup at
+ * <path>." On any plan failure we return `skipped` with the planner result
+ * — the caller (the modal) renders the diagnostic in-place.
+ */
+export async function applyBadModelPatch(input: ApplyPatchInput): Promise<ApplyPatchResult> {
+  const plan = planBadModelPatch({
+    raw: input.raw,
+    path: input.workflowFile.path,
+    badName: input.badName,
+    replacement: input.replacement,
+  });
+  if (plan.status !== "ok") return { status: "skipped", reason: plan };
+
+  const ts = formatBackupTimestamp(input.now ?? new Date());
+  const backupPath = backupPathFor(input.workflowFile.path, ts);
+  await input.vault.create(backupPath, input.raw);
+  await input.vault.modify(input.workflowFile, plan.newText);
+  return { status: "ok", backupPath, newText: plan.newText };
+}
+
+export interface RevertLastPatchInput {
+  vault: VaultLike;
+  workflowFile: VaultFileLike;
+}
+
+export type RevertLastPatchResult =
+  | { status: "ok"; restoredFromPath: string; trashed: boolean }
+  | { status: "no-backup" };
+
+/**
+ * Restore the workflow file from its most recent `.bak-*` and trash that
+ * backup (system trash). One-step undo: older backups are not touched and
+ * survive in-place — to restore them the user moves them manually.
+ *
+ * "Trashed" status is reported separately because `vault.trash` is the only
+ * step that can fail without compromising correctness — the file IS restored
+ * even if the trash step throws (we re-throw so callers learn about it).
+ */
+export async function revertLastWorkflowPatch(
+  input: RevertLastPatchInput,
+): Promise<RevertLastPatchResult> {
+  const folder = parentFolder(input.workflowFile.path);
+  const siblings = input.vault.listSiblingPaths(folder);
+  const latest = findLatestBackup(siblings, input.workflowFile.path);
+  if (!latest) return { status: "no-backup" };
+
+  const bakFile = input.vault.getFileByPath(latest);
+  if (!bakFile) return { status: "no-backup" };
+  const bakContents = await input.vault.read(bakFile);
+  await input.vault.modify(input.workflowFile, bakContents);
+  // Restore is now committed. Trash the .bak — if it throws, surface it but
+  // don't pretend the restore failed.
+  await input.vault.trash(bakFile, true);
+  return { status: "ok", restoredFromPath: latest, trashed: true };
+}
+
+function parentFolder(path: string): string {
+  const i = path.lastIndexOf("/");
+  return i < 0 ? "" : path.slice(0, i);
+}

--- a/plugins/op-obsidian/src/recoveryPatchApply.ts
+++ b/plugins/op-obsidian/src/recoveryPatchApply.ts
@@ -101,8 +101,15 @@ async function createBackupUnique(
       await vault.create(path, raw);
       return path;
     } catch (err) {
+      // Check `err.code` first (Node.js / Obsidian adapter style), then fall
+      // back to message substring matching for vault implementations that wrap
+      // the underlying fs error in a generic Error without preserving `code`.
+      const code = (err as { code?: string }).code;
       const msg = (err as Error)?.message ?? String(err);
-      const isExist = msg.includes("EEXIST") || msg.includes("already exists");
+      const isExist =
+        code === "EEXIST" ||
+        msg.includes("EEXIST") ||
+        msg.includes("already exists");
       if (isExist && i < maxAttempts - 1) continue;
       throw err;
     }

--- a/plugins/op-obsidian/src/recoveryPatchApply.ts
+++ b/plugins/op-obsidian/src/recoveryPatchApply.ts
@@ -57,6 +57,9 @@ export type ApplyPatchResult =
  *   2. Write the `.bak-<ts>` backup via `vault.create` BEFORE the modify so
  *      a partial failure leaves the original on disk + a backup exists.
  *      Order is critical for the "always have a path back" guarantee.
+ *      If the timestamp-named path already exists (two patches within the
+ *      same second), the helper retries with a `-001` / `-002` … counter
+ *      suffix rather than throwing EEXIST at the caller.
  *   3. `vault.modify` the workflow file with the new text.
  *
  * Returns the backup path on success so the dialog can display "backup at
@@ -73,10 +76,39 @@ export async function applyBadModelPatch(input: ApplyPatchInput): Promise<ApplyP
   if (plan.status !== "ok") return { status: "skipped", reason: plan };
 
   const ts = formatBackupTimestamp(input.now ?? new Date());
-  const backupPath = backupPathFor(input.workflowFile.path, ts);
-  await input.vault.create(backupPath, input.raw);
+  const backupPath = await createBackupUnique(input.vault, input.workflowFile.path, input.raw, ts);
   await input.vault.modify(input.workflowFile, plan.newText);
   return { status: "ok", backupPath, newText: plan.newText };
+}
+
+/**
+ * Write the backup file, retrying with a `-001` … `-005` counter suffix when
+ * the plain timestamp path already exists (race: two patches within the same
+ * second, or a leftover from a test).  Throws only on the final attempt or on
+ * errors that aren't EEXIST-flavoured.
+ */
+async function createBackupUnique(
+  vault: VaultLike,
+  workflowPath: string,
+  raw: string,
+  baseTimestamp: string,
+  maxAttempts = 6,
+): Promise<string> {
+  for (let i = 0; i < maxAttempts; i++) {
+    const suffix = i === 0 ? "" : `-${String(i).padStart(3, "0")}`;
+    const path = backupPathFor(workflowPath, `${baseTimestamp}${suffix}`);
+    try {
+      await vault.create(path, raw);
+      return path;
+    } catch (err) {
+      const msg = (err as Error)?.message ?? String(err);
+      const isExist = msg.includes("EEXIST") || msg.includes("already exists");
+      if (isExist && i < maxAttempts - 1) continue;
+      throw err;
+    }
+  }
+  /* istanbul ignore next — unreachable: loop always throws or returns */
+  throw new Error("createBackupUnique: all attempts exhausted");
 }
 
 export interface RevertLastPatchInput {

--- a/plugins/op-obsidian/styles.css
+++ b/plugins/op-obsidian/styles.css
@@ -1145,3 +1145,91 @@ a.op-sidebar__agent:hover {
   font-family: var(--font-monospace, monospace);
   width: 100%;
 }
+
+/* OP-205 (3e) — bad-model recovery dialog. */
+
+.op-recovery-modal__lede {
+  margin-bottom: 0.75rem;
+  color: var(--text-muted);
+}
+
+.op-recovery-modal__columns {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 1rem;
+  margin: 0.75rem 0;
+}
+
+.op-recovery-modal__column h3 {
+  font-size: var(--font-ui-small);
+  margin: 0 0 0.25rem 0;
+  color: var(--text-muted);
+}
+
+.op-recovery-modal__column ul {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.25rem;
+}
+
+.op-recovery-modal__chip {
+  font-family: var(--font-monospace);
+  font-size: var(--font-ui-smaller, 0.75rem);
+  padding: 0.1rem 0.4rem;
+  background: var(--background-secondary);
+  border: 1px solid var(--background-modifier-border);
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+.op-recovery-modal__chip:hover {
+  background: var(--background-modifier-hover);
+}
+
+.op-recovery-modal__patch-status {
+  font-size: var(--font-ui-small);
+  margin: 0.5rem 0;
+  min-height: 1.2em;
+}
+
+.op-recovery-modal__patch-status--ok {
+  color: var(--text-success, var(--color-green));
+}
+
+.op-recovery-modal__patch-status--error {
+  color: var(--text-error, var(--color-red));
+}
+
+.op-recovery-modal__diff-confirm pre.op-recovery-modal__diff,
+.op-recovery-modal pre.op-recovery-modal__diff {
+  font-family: var(--font-monospace);
+  font-size: var(--font-ui-smaller, 0.75rem);
+  background: var(--background-secondary);
+  border: 1px solid var(--background-modifier-border);
+  border-radius: 4px;
+  padding: 0.5rem 0.75rem;
+  max-height: 320px;
+  overflow: auto;
+  white-space: pre;
+}
+
+.op-recovery-modal__bak-row {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  margin-top: 1rem;
+  padding-top: 0.5rem;
+  border-top: 1px solid var(--background-modifier-border);
+  font-size: var(--font-ui-small);
+}
+
+.op-recovery-modal__bak-label {
+  color: var(--text-muted);
+}
+
+.op-recovery-modal__no-agent-hint {
+  margin: 0.5rem 0;
+}

--- a/plugins/op/.claude-plugin/plugin.json
+++ b/plugins/op/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "op",
   "description": "Obsidian Projects workflow — schema, slash commands, and agent skill for running a Jira-lite issue tracker inside an Obsidian vault.",
-  "version": "0.71.0",
+  "version": "0.72.0",
   "author": {
     "name": "Eugene Archibald"
   },


### PR DESCRIPTION
## Summary

Replaces the OP-200 recovery-dialog stub with the real interactive modal called for in OP-186 child 3e (issue [#243](https://github.com/earchibald/obsidian-projects/issues/243)).

- **Interactive launch failure** → `BadModelSpecError` opens the modal directly. The user picks a valid model from the registry (typeahead + side-by-side `aliases` / `versioned` columns rendered live from `MODEL_REGISTRY`). Two actions:
  - `Use as launch override` — the launch retries with `launchModelOverride: <canonical>` set; workflow file is left untouched. The override is validated against the chosen agent's registry and re-throws on mismatch (re-opens the dialog) so we never silently substitute.
  - `Patch workflow with this model` — runs the pure planner, opens a unified-diff confirm sub-modal, and on confirm writes a `.bak-<YYYYMMDD-HHmmss>` backup BEFORE mutating the workflow file. Single-occurrence enforcement: ambiguous matches disable the patch button rather than risk rewriting the wrong copy.
- **Headless auto-advance failure** keeps the OP-200 actionable Notice with `Open recovery dialog now`. New `OpenAgentArgs.interactive` (default `true`) flips to `false` from `advanceFlowAndLaunch` so the user isn't yanked into a modal they didn't trigger.
- **Revert** — palette command `op: revert last workflow patch` + button in the dialog footer. Restores from the most recent `.bak-*` and trashes it; older backups untouched (one-step undo only).
- **Advisory entrypoint** — palette command `op: open recovery dialog for project workflow` opens the same modal proactively for any project whose `validateWorkflowModels` returned `bad-model` warnings, so users can fix the file before the next launch.
- **Cancellation** aborts the in-flight launch (no silent fallback).

## Files

- new: `recoveryPatch.{ts,test.ts}` (pure planner + diff + timestamp + latest-backup picker — 21 vitest cases), `recoveryPatchApply.{ts,test.ts}` (vault-side controllers — 6 cases against a fake `VaultLike`)
- rewritten: `recoveryDialog.{ts,test.ts}` — real `RecoveryDialogModal` + diff confirm sub-modal + revert row; `describeFailure` and `synthesizeBadModelErrorFromDiagnostic` exported for the headless Notice + advisory entrypoints
- edited: `openAgent.ts` (`launchModelOverride` + `interactive` + `onResolverFailureResolved` on `OpenAgentArgs`; resolver short-circuit on override; interactive vs headless surface), `main.ts` (`doOpenAgent` retry plumbing + `advanceFlowAndLaunch interactive=false` + two new palette commands), `styles.css` (`.op-recovery-modal__*` classes)
- bump: `0.71.0 → 0.72.0` (minor — additive: new commands + new optional `OpenAgentArgs` fields)

## Tests

- vitest **1385 / 1385** (35 new: 21 pure-planner + 6 vault-controller + 8 modal phrasing/diagnostic synth)
- live OP-Test DOM smoke (executed pre-PR):
  1. `runOpenRecoveryDialogForProject("demo")` after seeding `default_model: opuss` → modal renders with 3 alias chips + 7 versioned chips, `h2 == "Recover: bad model spec — Projects/demo"`.
  2. Click `opus` chip → picker resolves to `claude-opus-4-7`, patch button enabled, status reads "Resolved → claude-opus-4-7. Patch will rewrite opuss → claude-opus-4-7 in Projects/demo/WORKFLOW.md."
  3. Click Patch → confirm sub-modal renders the unified diff verbatim → Apply → `default_model: claude-opus-4-7` on disk + `Projects/demo/WORKFLOW.md.bak-<ts>` exists.
  4. `runRevertWorkflowPatchForProject("demo")` → file restored to `default_model: opuss`, `.bak-*` trashed.

## Test plan

- [ ] Reviewer pulls the branch, runs `npm test` in `plugins/op-obsidian/` → 1385/1385.
- [ ] Reviewer seeds a bad-model in any project's `WORKFLOW.md` (e.g. `default_model: opuss`), runs `op: open recovery dialog for project workflow`, verifies the modal columns + picker resolve.
- [ ] Reviewer exercises both actions: `Use as launch override` (no file change), `Patch workflow with this model` (file change + `.bak-*` sibling).
- [ ] Reviewer runs `op: revert last workflow patch` → verifies the file is restored from the backup and the backup is gone.
- [ ] Adversarial Copilot review (see follow-up PR comment).

🤖 Generated with [Claude Code](https://claude.com/claude-code)