### PR TITLE
OP-190: OP-Test seed/workflow-modules + smoke harness for workflow modules

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -69,10 +69,20 @@ The OP-Test vault is a git repo with named seed tags capturing known states. Bef
 
 ```bash
 node scripts/reset-test-vault.mjs <seed>
-# valid seeds: empty | scaffolded | mid-flow | github-linked | multi-project
+# valid seeds: empty | scaffolded | mid-flow | github-linked | multi-project | workflow-modules
 ```
 
 The script asserts the OP-Test vault is open in Obsidian (focus not required since OP-175), runs `git reset --hard seed/<name> && git clean -fd` inside OP-Test, then reloads op-obsidian so Obsidian re-reads the vault state. The seed ladder itself is built (and rebuilt) by `node scripts/build-seeds.mjs` — re-runnable so seeds stay in sync as the plugin's scaffolding behavior evolves.
+
+### `seed/workflow-modules` + smoke harness
+
+`seed/workflow-modules` is the launchable checkpoint for the OP-181 workflow-module pipeline (one global module, one per-project module, a per-project workflow file referencing them, project-level `vars:`, plus issue `TST-5`). After resetting to it, run:
+
+```bash
+node scripts/smoke-workflow-modules.mjs
+```
+
+The harness invokes `op-explain-workflow id=TST-5 mode=kickoff` and `mode=plan`, plus `op-list-vars project=testing issue=TST-5`, then asserts the composed prompt contains the expected module bodies, that variables resolve through the precedence chain (project-default overrides the module's `name=VALUE` default), and that no `error`-severity diagnostics are emitted. Other workers landing changes in the OP-181 child series should run this against `seed/workflow-modules` after their dev-sync as part of the per-PR smoke step.
 
 ## Agent-Vault is BRAT-only
 

--- a/scripts/build-seeds.mjs
+++ b/scripts/build-seeds.mjs
@@ -229,10 +229,21 @@ build("seed/workflow-modules", () => {
     fail(
       `seed/workflow-modules: expected op-new to return TST-5 (cumulative ladder includes TST-1..4 from seed/mid-flow), got ${tst5.issueId}. ` +
         "If a new seed has been inserted between seed/mid-flow and seed/workflow-modules that adds testing-project issues, " +
-        "the smoke harness's hardcoded ISSUE = 'TST-5' must move in lockstep.",
+        "update the smoke-config.json write below and re-run.",
     );
   }
   setIssueAgent(tst5.path, "claude");
+
+  // Write a machine-readable config so the smoke harness doesn't hardcode the
+  // issue ID. The file is committed into the seed, so `reset-test-vault
+  // workflow-modules` always lands this exact JSON on disk before the harness
+  // reads it. If a future seed reshuffles issue numbering the build guard above
+  // catches it at seed-build time, and only this single JSON value needs
+  // updating — the harness itself stays free of hardcoded IDs.
+  writeVaultFile(
+    "Projects/_scratch/smoke-config.json",
+    JSON.stringify({ issue: tst5.issueId, project: "testing" }, null, 2) + "\n",
+  );
 });
 
 console.log("\nseed ladder built and tagged. Verify with `git -C <op-test> tag -l seed/*`.");

--- a/scripts/build-seeds.mjs
+++ b/scripts/build-seeds.mjs
@@ -16,12 +16,19 @@
 //   - `gh` CLI is authenticated for the github-linked seed.
 //
 // The seed ladder:
-//   seed/empty          — vault config + op-obsidian enabled, no projects
-//   seed/scaffolded     — one project (TST / testing)
-//   seed/mid-flow       — TST-1 resolved, TST-2 in-progress (with TASKS),
-//                         TST-3 open + related to TST-1, TST-4 open
-//   seed/github-linked  — adds GHB / github-bound, repo: op-test-fixture
-//   seed/multi-project  — adds TWO / second-project, TWO-1 related to TST-3
+//   seed/empty             — vault config + op-obsidian enabled, no projects
+//   seed/scaffolded        — one project (TST / testing)
+//   seed/mid-flow          — TST-1 resolved, TST-2 in-progress (with TASKS),
+//                            TST-3 open + related to TST-1, TST-4 open
+//   seed/github-linked     — adds GHB / github-bound, repo: op-test-fixture
+//   seed/multi-project     — adds TWO / second-project, TWO-1 related to TST-3
+//   seed/workflow-modules  — OP-181 workflow-module artifacts (global module,
+//                            per-project module, per-project workflow file
+//                            referencing them, project-level user vars, plus
+//                            launchable issue TST-5). Smoke probe target for
+//                            `op-explain-workflow` / `op-list-vars`. Run
+//                            `node scripts/smoke-workflow-modules.mjs` after
+//                            resetting to this seed.
 
 import { existsSync } from "node:fs";
 import { spawnSync } from "node:child_process";
@@ -119,6 +126,100 @@ build("seed/multi-project", () => {
   }
 });
 
+build("seed/workflow-modules", () => {
+  // OP-190 (Child 7 of OP-181): introduce one global module, one per-project
+  // module, a per-project workflow file referencing them, a project-level
+  // `vars:` map (project-default precedence layer), and a launchable issue
+  // (TST-5) the smoke probe targets. The artifacts exercise the full
+  // OP-184/185/186 module-injection pipeline end-to-end. The downstream smoke
+  // harness lives at `scripts/smoke-workflow-modules.mjs`.
+
+  // Global module — kickoff scope, exercises always-on plugin vars + a user
+  // var with `name=VALUE` default at the Module-default precedence layer.
+  writeVaultFile(
+    "Projects/_op-modules/branching.md",
+    [
+      "---",
+      "id: branching",
+      "title: Always work in a git worktree",
+      "type: workflow-module",
+      "scope: kickoff",
+      "order: 10",
+      "vars:",
+      '  - "reviewer_handle=@module-default"',
+      "---",
+      "",
+      "You are working on **{{id}}** ({{title}}) in project `{{project}}` on branch `{{branch}}`.",
+      "Always create an isolated worktree before making changes — no exceptions, including",
+      "one-line tweaks. Today is {{today}}; ping {{vars.reviewer_handle}} when the PR is up.",
+      "",
+    ].join("\n"),
+  );
+
+  // Per-project module — plan-mode scope, references the global user var so
+  // both Module-default → Project-default precedence layers participate.
+  writeVaultFile(
+    "Projects/testing/MODULES/plan-rules.md",
+    [
+      "---",
+      "id: plan-rules",
+      "title: Plan-mode rules for the testing project",
+      "type: workflow-module",
+      "scope: plan",
+      "project: testing",
+      "order: 10",
+      "vars:",
+      '  - "max_files=10"',
+      "  - reviewer_handle",
+      "---",
+      "",
+      "Before implementing on **{{id}}**, read no more than {{vars.max_files}} files and",
+      "send the plan to {{vars.reviewer_handle}} for sign-off.",
+      "",
+    ].join("\n"),
+  );
+
+  // Per-project workflow file — references both modules across kickoff + plan
+  // steps. Uses the canonical schema=1 frontmatter shape (OP-196).
+  writeVaultFile(
+    "Projects/testing/WORKFLOW.md",
+    [
+      "---",
+      "type: workflow",
+      "schema: 1",
+      "project: testing",
+      "default_agent: claude",
+      "default_model: sonnet",
+      "steps:",
+      "  - step: kickoff",
+      "    modules: [branching]",
+      "  - step: plan",
+      "    modules: [plan-rules]",
+      "---",
+      "",
+      "Workflow file for the testing project. Composes the global `branching` module at",
+      "kickoff and the per-project `plan-rules` module during plan mode.",
+      "",
+    ].join("\n"),
+  );
+
+  // Project-level vars on STATUS.md so the Project-default precedence layer
+  // overrides the global module's `name=VALUE` default for `reviewer_handle`.
+  setProjectVars("testing", { reviewer_handle: "@op-test-project" });
+
+  // Launchable test issue. The plugin numbers issues by walking the
+  // ISSUES/RESOLVED ISSUES folders, so this lands as TST-5 deterministically
+  // (TST-1..4 came from seed/mid-flow). agent: claude makes the smoke probe's
+  // `op-explain-workflow` call use the claude profile by default.
+  dispatch("op-new", {
+    project: "testing",
+    title: "Workflow modules smoke target",
+    priority: "med",
+    scope: "Smoke probe target for op-explain-workflow + op-list-vars.",
+  });
+  setIssueAgent("Projects/testing/ISSUES/TST-5 Workflow modules smoke target.md", "claude");
+});
+
 console.log("\nseed ladder built and tagged. Verify with `git -C <op-test> tag -l seed/*`.");
 
 // ---------------------------------------------------------------------------
@@ -200,6 +301,59 @@ function setRelated(vaultRelativePath, ids) {
     `if(!f){return {error:"not found:"+${JSON.stringify(vaultRelativePath)}}}` +
     `await app.fileManager.processFrontMatter(f, fm=>{fm.related=${JSON.stringify(ids)}});` +
     `return {ok:true,path:f.path,related:${JSON.stringify(ids)}}})()`;
+  runObsidian(["eval", `code=${code}`]);
+}
+
+// Create a vault file (or overwrite if it already exists). Goes through
+// `app.vault.create` / `app.vault.modify` so the metadataCache picks up new
+// frontmatter immediately — important for workflow-module files the loader
+// reads via `app.vault.getMarkdownFiles()` + `metadataCache.getFileCache()`.
+// Parent folders are created on demand via `adapter.mkdir`.
+function writeVaultFile(vaultRelativePath, content) {
+  const code =
+    `(async()=>{` +
+    `const path=${JSON.stringify(vaultRelativePath)};` +
+    `const content=${JSON.stringify(content)};` +
+    `const adapter=app.vault.adapter;` +
+    `const lastSlash=path.lastIndexOf("/");` +
+    `if(lastSlash>0){` +
+    `const dir=path.slice(0,lastSlash);` +
+    `if(!(await adapter.exists(dir))){await adapter.mkdir(dir);}` +
+    `}` +
+    `const existing=app.vault.getAbstractFileByPath(path);` +
+    `if(existing){await app.vault.modify(existing,content);return {ok:true,path,mode:"modify"};}` +
+    `const f=await app.vault.create(path,content);` +
+    `return {ok:true,path:f.path,mode:"create"};` +
+    `})()`;
+  runObsidian(["eval", `code=${code}`]);
+}
+
+// Merge a `vars:` map into a project's STATUS.md frontmatter via
+// processFrontMatter. Stored as a YAML map (object), matching what
+// `readProjectVars` in `explainWorkflow.ts` expects.
+function setProjectVars(slug, vars) {
+  const statusPath = `Projects/${slug}/STATUS.md`;
+  const code =
+    `(async()=>{` +
+    `const f=app.vault.getAbstractFileByPath(${JSON.stringify(statusPath)});` +
+    `if(!f){return {error:"not found:"+${JSON.stringify(statusPath)}}}` +
+    `await app.fileManager.processFrontMatter(f,fm=>{fm.vars=${JSON.stringify(vars)};});` +
+    `return {ok:true,path:f.path,vars:${JSON.stringify(vars)}};` +
+    `})()`;
+  runObsidian(["eval", `code=${code}`]);
+}
+
+// Set the `agent:` frontmatter field on an issue note. Used to make TST-5's
+// agent deterministic so the smoke probe's `op-explain-workflow` call resolves
+// the same agent profile every run regardless of the vault's defaultAgent.
+function setIssueAgent(vaultRelativePath, agent) {
+  const code =
+    `(async()=>{` +
+    `const f=app.vault.getAbstractFileByPath(${JSON.stringify(vaultRelativePath)});` +
+    `if(!f){return {error:"not found:"+${JSON.stringify(vaultRelativePath)}}}` +
+    `await app.fileManager.processFrontMatter(f,fm=>{fm.agent=${JSON.stringify(agent)};});` +
+    `return {ok:true,path:f.path,agent:${JSON.stringify(agent)}};` +
+    `})()`;
   runObsidian(["eval", `code=${code}`]);
 }
 

--- a/scripts/build-seeds.mjs
+++ b/scripts/build-seeds.mjs
@@ -213,6 +213,12 @@ build("seed/workflow-modules", () => {
   // `op-explain-workflow` call use the claude profile by default. The created
   // path is read back from `op-new`'s JSON response so a future title tweak
   // doesn't desync this script from the on-disk filename.
+  //
+  // EXPECTED_SMOKE_ISSUE is the single place to update if a new seed inserted
+  // between seed/mid-flow and seed/workflow-modules changes the issue counter.
+  // The guard below and the smoke-config.json write both reference this constant,
+  // so a numbering change requires only one edit here.
+  const EXPECTED_SMOKE_ISSUE = "TST-5";
   const tst5 = dispatch("op-new", {
     project: "testing",
     title: "Workflow modules smoke target",
@@ -225,11 +231,11 @@ build("seed/workflow-modules", () => {
         "cannot stamp agent: claude on the issue.",
     );
   }
-  if (tst5.issueId !== "TST-5") {
+  if (tst5.issueId !== EXPECTED_SMOKE_ISSUE) {
     fail(
-      `seed/workflow-modules: expected op-new to return TST-5 (cumulative ladder includes TST-1..4 from seed/mid-flow), got ${tst5.issueId}. ` +
+      `seed/workflow-modules: expected op-new to return ${EXPECTED_SMOKE_ISSUE} (cumulative ladder includes TST-1..4 from seed/mid-flow), got ${tst5.issueId}. ` +
         "If a new seed has been inserted between seed/mid-flow and seed/workflow-modules that adds testing-project issues, " +
-        "update the smoke-config.json write below and re-run.",
+        `update EXPECTED_SMOKE_ISSUE (currently "${EXPECTED_SMOKE_ISSUE}") to match and re-run.`,
     );
   }
   setIssueAgent(tst5.path, "claude");
@@ -238,8 +244,8 @@ build("seed/workflow-modules", () => {
   // issue ID. The file is committed into the seed, so `reset-test-vault
   // workflow-modules` always lands this exact JSON on disk before the harness
   // reads it. If a future seed reshuffles issue numbering the build guard above
-  // catches it at seed-build time, and only this single JSON value needs
-  // updating — the harness itself stays free of hardcoded IDs.
+  // catches it at seed-build time, and only EXPECTED_SMOKE_ISSUE needs updating
+  // — the harness itself stays free of hardcoded IDs.
   writeVaultFile(
     "Projects/_scratch/smoke-config.json",
     JSON.stringify({ issue: tst5.issueId, project: "testing" }, null, 2) + "\n",

--- a/scripts/build-seeds.mjs
+++ b/scripts/build-seeds.mjs
@@ -210,14 +210,29 @@ build("seed/workflow-modules", () => {
   // Launchable test issue. The plugin numbers issues by walking the
   // ISSUES/RESOLVED ISSUES folders, so this lands as TST-5 deterministically
   // (TST-1..4 came from seed/mid-flow). agent: claude makes the smoke probe's
-  // `op-explain-workflow` call use the claude profile by default.
-  dispatch("op-new", {
+  // `op-explain-workflow` call use the claude profile by default. The created
+  // path is read back from `op-new`'s JSON response so a future title tweak
+  // doesn't desync this script from the on-disk filename.
+  const tst5 = dispatch("op-new", {
     project: "testing",
     title: "Workflow modules smoke target",
     priority: "med",
     scope: "Smoke probe target for op-explain-workflow + op-list-vars.",
   });
-  setIssueAgent("Projects/testing/ISSUES/TST-5 Workflow modules smoke target.md", "claude");
+  if (!tst5?.path || !tst5?.issueId) {
+    fail(
+      "seed/workflow-modules: op-new for the testing-project smoke target did not return path+issueId; " +
+        "cannot stamp agent: claude on the issue.",
+    );
+  }
+  if (tst5.issueId !== "TST-5") {
+    fail(
+      `seed/workflow-modules: expected op-new to return TST-5 (cumulative ladder includes TST-1..4 from seed/mid-flow), got ${tst5.issueId}. ` +
+        "If a new seed has been inserted between seed/mid-flow and seed/workflow-modules that adds testing-project issues, " +
+        "the smoke harness's hardcoded ISSUE = 'TST-5' must move in lockstep.",
+    );
+  }
+  setIssueAgent(tst5.path, "claude");
 });
 
 console.log("\nseed ladder built and tagged. Verify with `git -C <op-test> tag -l seed/*`.");

--- a/scripts/reset-test-vault.mjs
+++ b/scripts/reset-test-vault.mjs
@@ -6,7 +6,7 @@
 //   node scripts/reset-test-vault.mjs <seed>
 //
 //   <seed> is the bare seed name; the tag prefix is added automatically:
-//     empty | scaffolded | mid-flow | github-linked | multi-project
+//     empty | scaffolded | mid-flow | github-linked | multi-project | workflow-modules
 //   Or pass the full tag form: seed/<name>.
 
 import {
@@ -23,6 +23,7 @@ const VALID_SEEDS = new Set([
   "mid-flow",
   "github-linked",
   "multi-project",
+  "workflow-modules",
 ]);
 
 const arg = process.argv[2];

--- a/scripts/smoke-workflow-modules.mjs
+++ b/scripts/smoke-workflow-modules.mjs
@@ -95,12 +95,12 @@ expect(
 expect(
   "kickoff: project-default reviewer_handle (@op-test-project) present in composed body",
   kickoff.composed?.text?.includes("@op-test-project"),
-  kickoff.composed?.text,
+  kickoff,
 );
 expect(
   "kickoff: module-default reviewer_handle (@module-default) absent from composed body",
   !kickoff.composed?.text?.includes("@module-default"),
-  kickoff.composed?.text,
+  kickoff,
 );
 expect(
   "kickoff: composed.chunks lists the branching module at kickoff scope",

--- a/scripts/smoke-workflow-modules.mjs
+++ b/scripts/smoke-workflow-modules.mjs
@@ -1,0 +1,176 @@
+#!/usr/bin/env node
+// Re-runnable smoke harness for the OP-181 workflow-module pipeline.
+// (OP-190 / Child 7 of OP-181)
+//
+// Usage:
+//   node scripts/smoke-workflow-modules.mjs
+//
+// Preconditions:
+//   - OP-Test is open in Obsidian (any window — focus is not required since
+//     OP-175; calls route via `vault=OP-Test` explicitly).
+//   - OP-Test is reset to `seed/workflow-modules` (or a tag built on top of
+//     it). Run `node scripts/reset-test-vault.mjs workflow-modules` first.
+//
+// What it asserts:
+//   1. `op-explain-workflow id=TST-5 mode=kickoff agent=claude` —
+//        - `composed.text` contains the rendered global `branching` module
+//          (literal id substituted in, project-default override applied).
+//        - `composed.chunks` lists a `branching` chunk with kickoff scope.
+//        - No error-severity diagnostics.
+//   2. `op-explain-workflow id=TST-5 mode=plan agent=claude` —
+//        - `composed.text` contains the rendered per-project `plan-rules`
+//          module body (project-default override applied for `reviewer_handle`).
+//        - `composed.chunks` lists a `plan-rules` chunk with plan scope.
+//        - No error-severity diagnostics.
+//   3. `op-list-vars project=testing issue=TST-5` —
+//        - `context.hasContext === true`.
+//        - `vars[]` non-empty and includes an `id` row resolving to "TST-5".
+//
+// On any assertion failure, prints a concise FAIL summary with the offending
+// payload excerpt and exits non-zero so callers can chain this from CI / a
+// PR-check shell script.
+
+import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+
+import { OP_TEST_VAULT, assertOpTestVaultOpen, fail, runObsidian } from "./lib/op-test.mjs";
+
+const SCRATCH = join(OP_TEST_VAULT, "Projects/_scratch/op-last-response.md");
+
+const ISSUE = "TST-5";
+const PROJECT = "testing";
+const AGENT = "claude";
+
+assertOpTestVaultOpen();
+
+let failed = 0;
+
+console.log("smoke-workflow-modules: probing op-explain-workflow + op-list-vars\n");
+
+// ---- 1. op-explain-workflow id=TST-5 mode=kickoff -------------------------
+const kickoff = explainWorkflow(ISSUE, "kickoff", AGENT);
+expect("kickoff: payload.issueId === TST-5", kickoff.issueId === ISSUE, kickoff);
+expect("kickoff: payload.project === testing", kickoff.project === PROJECT, kickoff);
+expect("kickoff: payload.mode === kickoff", kickoff.mode === "kickoff", kickoff);
+expect(
+  "kickoff: composed.text mentions the issue id",
+  kickoff.composed?.text?.includes(`**${ISSUE}**`),
+  kickoff,
+);
+expect(
+  "kickoff: composed.text contains the global branching module's body",
+  kickoff.composed?.text?.includes("Always create an isolated worktree"),
+  kickoff,
+);
+expect(
+  "kickoff: project-default reviewer_handle override is rendered (not the module default)",
+  kickoff.composed?.text?.includes("@op-test-project") &&
+    !kickoff.composed?.text?.includes("@module-default"),
+  kickoff,
+);
+expect(
+  "kickoff: composed.chunks lists the branching module at kickoff scope",
+  Array.isArray(kickoff.composed?.chunks) &&
+    kickoff.composed.chunks.some((c) => c.moduleId === "branching" && c.scope === "kickoff"),
+  kickoff,
+);
+expect(
+  "kickoff: zero error-severity diagnostics",
+  countSeverity(kickoff.diagnostics, "error") === 0,
+  kickoff.diagnostics,
+);
+
+// ---- 2. op-explain-workflow id=TST-5 mode=plan ----------------------------
+const plan = explainWorkflow(ISSUE, "plan", AGENT);
+expect("plan: payload.mode === plan", plan.mode === "plan", plan);
+expect(
+  "plan: composed.text contains the per-project plan-rules module body",
+  plan.composed?.text?.includes("Before implementing on") &&
+    plan.composed?.text?.includes(`**${ISSUE}**`),
+  plan,
+);
+expect(
+  "plan: project-default reviewer_handle override is rendered",
+  plan.composed?.text?.includes("@op-test-project"),
+  plan,
+);
+expect(
+  "plan: composed.chunks lists the plan-rules module at plan scope",
+  Array.isArray(plan.composed?.chunks) &&
+    plan.composed.chunks.some((c) => c.moduleId === "plan-rules" && c.scope === "plan"),
+  plan,
+);
+expect(
+  "plan: zero error-severity diagnostics",
+  countSeverity(plan.diagnostics, "error") === 0,
+  plan.diagnostics,
+);
+
+// ---- 3. op-list-vars project=testing issue=TST-5 --------------------------
+const listVars = listVarsForIssue(PROJECT, ISSUE);
+expect("list-vars: context.hasContext === true", listVars.context?.hasContext === true, listVars);
+expect("list-vars: context.issueId === TST-5", listVars.context?.issueId === ISSUE, listVars);
+expect(
+  "list-vars: registry has at least one entry",
+  Array.isArray(listVars.vars) && listVars.vars.length > 0,
+  listVars,
+);
+const idRow = listVars.vars?.find((v) => v.name === "id");
+expect("list-vars: id row resolves to TST-5", idRow?.currentValue === ISSUE, idRow);
+
+// ---- summary --------------------------------------------------------------
+if (failed > 0) {
+  console.error(`\n${failed} assertion${failed === 1 ? "" : "s"} FAILED`);
+  process.exit(1);
+}
+console.log(`\nALL PASS — workflow-module pipeline composes cleanly for ${ISSUE}`);
+
+// ---------------------------------------------------------------------------
+
+function explainWorkflow(issue, mode, agent) {
+  runObsidian([
+    "op-explain-workflow",
+    `issue=${issue}`,
+    `mode=${mode}`,
+    `agent=${agent}`,
+  ]);
+  return readScratchPayload();
+}
+
+function listVarsForIssue(project, issue) {
+  runObsidian(["op-list-vars", `project=${project}`, `issue=${issue}`]);
+  return readScratchPayload();
+}
+
+function readScratchPayload() {
+  if (!existsSync(SCRATCH)) {
+    fail(`expected scratch payload at ${SCRATCH} but it does not exist`);
+  }
+  const raw = readFileSync(SCRATCH, "utf8");
+  const match = raw.match(/\{[\s\S]*\}/);
+  if (!match) fail(`could not extract JSON object from ${SCRATCH}`);
+  try {
+    return JSON.parse(match[0]);
+  } catch (e) {
+    fail(`failed to parse scratch payload as JSON: ${e.message}\n${raw}`);
+  }
+}
+
+function countSeverity(diagnostics, severity) {
+  if (!Array.isArray(diagnostics)) return 0;
+  return diagnostics.filter((d) => d?.severity === severity).length;
+}
+
+function expect(label, ok, evidence) {
+  if (ok) {
+    console.log(`  PASS  ${label}`);
+    return;
+  }
+  failed += 1;
+  console.error(`  FAIL  ${label}`);
+  if (evidence !== undefined) {
+    const summary = JSON.stringify(evidence, null, 2);
+    const trimmed = summary.length > 800 ? `${summary.slice(0, 800)}\n...[truncated]` : summary;
+    console.error(`        evidence: ${trimmed}`);
+  }
+}

--- a/scripts/smoke-workflow-modules.mjs
+++ b/scripts/smoke-workflow-modules.mjs
@@ -73,10 +73,10 @@ let failed = 0;
 
 console.log("smoke-workflow-modules: probing op-explain-workflow + op-list-vars\n");
 
-// ---- 1. op-explain-workflow id=TST-5 mode=kickoff -------------------------
+// ---- 1. op-explain-workflow id=<ISSUE> mode=kickoff -----------------------
 const kickoff = explainWorkflow(ISSUE, "kickoff", AGENT);
-expect("kickoff: payload.issueId === TST-5", kickoff.issueId === ISSUE, kickoff);
-expect("kickoff: payload.project === testing", kickoff.project === PROJECT, kickoff);
+expect(`kickoff: payload.issueId === ${ISSUE}`, kickoff.issueId === ISSUE, kickoff);
+expect(`kickoff: payload.project === ${PROJECT}`, kickoff.project === PROJECT, kickoff);
 expect("kickoff: payload.mode === kickoff", kickoff.mode === "kickoff", kickoff);
 expect(
   "kickoff: composed.text mentions the issue id",
@@ -114,7 +114,7 @@ expect(
   kickoff.diagnostics,
 );
 
-// ---- 2. op-explain-workflow id=TST-5 mode=plan ----------------------------
+// ---- 2. op-explain-workflow id=<ISSUE> mode=plan --------------------------
 const plan = explainWorkflow(ISSUE, "plan", AGENT);
 expect("plan: payload.mode === plan", plan.mode === "plan", plan);
 expect(
@@ -140,7 +140,7 @@ expect(
   plan.diagnostics,
 );
 
-// ---- 3. op-list-vars project=testing issue=TST-5 --------------------------
+// ---- 3. op-list-vars project=<PROJECT> issue=<ISSUE> ---------------------
 const listVars = listVarsForIssue(PROJECT, ISSUE);
 // Fail loudly if op-list-vars returned a top-level error (e.g. project slug
 // mismatch, handler throw) rather than silently passing the structural checks
@@ -152,14 +152,14 @@ if (listVars.error) {
   );
 }
 expect("list-vars: context.hasContext === true", listVars.context?.hasContext === true, listVars);
-expect("list-vars: context.issueId === TST-5", listVars.context?.issueId === ISSUE, listVars);
+expect(`list-vars: context.issueId === ${ISSUE}`, listVars.context?.issueId === ISSUE, listVars);
 expect(
   "list-vars: registry has at least one entry",
   Array.isArray(listVars.vars) && listVars.vars.length > 0,
   listVars,
 );
 const idRow = listVars.vars?.find((v) => v.name === "id");
-expect("list-vars: id row resolves to TST-5", idRow?.currentValue === ISSUE, idRow);
+expect(`list-vars: id row resolves to ${ISSUE}`, idRow?.currentValue === ISSUE, idRow);
 
 // ---- summary --------------------------------------------------------------
 if (failed > 0) {

--- a/scripts/smoke-workflow-modules.mjs
+++ b/scripts/smoke-workflow-modules.mjs
@@ -12,19 +12,23 @@
 //     it). Run `node scripts/reset-test-vault.mjs workflow-modules` first.
 //
 // What it asserts:
-//   1. `op-explain-workflow id=TST-5 mode=kickoff agent=claude` —
+//   1. `op-explain-workflow id=<issue> mode=kickoff agent=claude` —
 //        - `composed.text` contains the rendered global `branching` module
 //          (literal id substituted in, project-default override applied).
 //        - `composed.chunks` lists a `branching` chunk with kickoff scope.
 //        - No error-severity diagnostics.
-//   2. `op-explain-workflow id=TST-5 mode=plan agent=claude` —
+//   2. `op-explain-workflow id=<issue> mode=plan agent=claude` —
 //        - `composed.text` contains the rendered per-project `plan-rules`
 //          module body (project-default override applied for `reviewer_handle`).
 //        - `composed.chunks` lists a `plan-rules` chunk with plan scope.
 //        - No error-severity diagnostics.
-//   3. `op-list-vars project=testing issue=TST-5` —
+//   3. `op-list-vars project=<project> issue=<issue>` —
 //        - `context.hasContext === true`.
-//        - `vars[]` non-empty and includes an `id` row resolving to "TST-5".
+//        - `vars[]` non-empty and includes an `id` row resolving to the issue.
+//
+// Issue ID and project are read from Projects/_scratch/smoke-config.json (written
+// by build-seeds.mjs during the seed/workflow-modules build) so this file never
+// hardcodes the issue number. On the current ladder: issue=TST-5, project=testing.
 //
 // On any assertion failure, prints a concise FAIL summary with the offending
 // payload excerpt and exits non-zero so callers can chain this from CI / a
@@ -37,8 +41,30 @@ import { OP_TEST_VAULT, assertOpTestVaultOpen, fail, runObsidian } from "./lib/o
 
 const SCRATCH = join(OP_TEST_VAULT, "Projects/_scratch/op-last-response.md");
 
-const ISSUE = "TST-5";
-const PROJECT = "testing";
+// Read the issue ID and project from the smoke-config written by build-seeds
+// during the seed/workflow-modules seed build. This keeps the harness free of
+// hardcoded issue IDs — if future seeds reshuffle the issue counter, only
+// build-seeds.mjs (and its guard) needs updating, not this file.
+const SMOKE_CONFIG_PATH = join(OP_TEST_VAULT, "Projects/_scratch/smoke-config.json");
+if (!existsSync(SMOKE_CONFIG_PATH)) {
+  fail(
+    `smoke-config.json not found at ${SMOKE_CONFIG_PATH}.\n` +
+      "Run `node scripts/reset-test-vault.mjs workflow-modules` to restore the seed " +
+      "(or `node scripts/build-seeds.mjs` if the seed ladder hasn't been built yet).",
+  );
+}
+let smokeConfig;
+try {
+  smokeConfig = JSON.parse(readFileSync(SMOKE_CONFIG_PATH, "utf8"));
+} catch (e) {
+  fail(`Failed to parse smoke-config.json: ${e.message}`);
+}
+if (!smokeConfig.issue || !smokeConfig.project) {
+  fail(`smoke-config.json is missing required fields (issue, project): ${JSON.stringify(smokeConfig)}`);
+}
+
+const ISSUE = smokeConfig.issue;
+const PROJECT = smokeConfig.project;
 const AGENT = "claude";
 
 assertOpTestVaultOpen();
@@ -62,11 +88,19 @@ expect(
   kickoff.composed?.text?.includes("Always create an isolated worktree"),
   kickoff,
 );
+// composed.text is the final rendered prompt body — not a diagnostic block.
+// @op-test-project must appear (Project-default layer wins over Module-default)
+// and @module-default must be absent (the name=VALUE default was superseded).
+// These are split into two assertions so a failure identifies which half broke.
 expect(
-  "kickoff: project-default reviewer_handle override is rendered (not the module default)",
-  kickoff.composed?.text?.includes("@op-test-project") &&
-    !kickoff.composed?.text?.includes("@module-default"),
-  kickoff,
+  "kickoff: project-default reviewer_handle (@op-test-project) present in composed body",
+  kickoff.composed?.text?.includes("@op-test-project"),
+  kickoff.composed?.text,
+);
+expect(
+  "kickoff: module-default reviewer_handle (@module-default) absent from composed body",
+  !kickoff.composed?.text?.includes("@module-default"),
+  kickoff.composed?.text,
 );
 expect(
   "kickoff: composed.chunks lists the branching module at kickoff scope",
@@ -108,6 +142,15 @@ expect(
 
 // ---- 3. op-list-vars project=testing issue=TST-5 --------------------------
 const listVars = listVarsForIssue(PROJECT, ISSUE);
+// Fail loudly if op-list-vars returned a top-level error (e.g. project slug
+// mismatch, handler throw) rather than silently passing the structural checks
+// below with undefined context fields.
+if (listVars.error) {
+  fail(
+    `op-list-vars project=${PROJECT} issue=${ISSUE} returned an error: ${listVars.error}\n` +
+      "Check that the issue's project slug matches the project argument passed to op-list-vars.",
+  );
+}
 expect("list-vars: context.hasContext === true", listVars.context?.hasContext === true, listVars);
 expect("list-vars: context.issueId === TST-5", listVars.context?.issueId === ISSUE, listVars);
 expect(


### PR DESCRIPTION
## Summary

Adds `seed/workflow-modules` to the OP-Test seed ladder and ships a re-runnable smoke harness for the OP-181 workflow-module pipeline. Other OP-181 children (OP-189 / OP-191 / OP-208 etc.) can chain `node scripts/smoke-workflow-modules.mjs` after their dev-sync.

- `scripts/build-seeds.mjs` — fifth seed cell. Lays down a global module (`Projects/_op-modules/branching.md`, kickoff scope, `reviewer_handle=@module-default` Module-default), a per-project module (`Projects/testing/MODULES/plan-rules.md`, plan scope), a per-project workflow file (`Projects/testing/WORKFLOW.md`, kickoff→[branching], plan→[plan-rules]), Project-default `vars:` on STATUS.md (`reviewer_handle: "@op-test-project"`), and launchable test issue `TST-5`. New helpers: `writeVaultFile`, `setProjectVars`, `setIssueAgent`.
- `scripts/reset-test-vault.mjs` — accepts `workflow-modules`.
- `scripts/smoke-workflow-modules.mjs` — invokes `op-explain-workflow` for kickoff + plan modes plus `op-list-vars`, then asserts composed-prompt content, Project-default precedence override, chunk shape per step, registry-context resolution, and zero error-severity diagnostics.
- `CLAUDE.md` — documents seed + harness under "Resetting between scenarios".

Plugin code untouched — meta-only repo change.

## Test plan

- [x] `node --check` on all three scripts (`build-seeds.mjs`, `reset-test-vault.mjs`, `smoke-workflow-modules.mjs`)
- [x] eval-body JS strings emitted by `writeVaultFile` / `setProjectVars` / `setIssueAgent` parse cleanly via `new Function(…)`
- [x] schema cross-check against `workflowFilePure.ts` / `workflowModulePure.ts` / `composeWorkflowPure.ts` for required frontmatter shape (`type`, `id`, `title`, `scope`, `schema: 1`, `default_agent`, `default_model`, `steps[].step`, `steps[].modules`)
- [x] smoke-harness assertion logic dry-run against a synthetic `ExplainWorkflowPayload` (OP-203 schema)
- [ ] **End-to-end deferred**: OP-Test on the test machine is currently mutated by the live OP-207 worker (uncommitted `Projects/demo/` from its editor-save-validator smoke test). The OP-Test git repo also has zero commits / no seed tags on this machine — needs a one-time initial commit before `build-seeds.mjs` can run end-to-end. Verification recipe captured in the issue note's Notes section: run `build-seeds → reset-test-vault workflow-modules → smoke-workflow-modules → build-seeds again` and assert `ALL PASS` + identical state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)