### PR TITLE
OP-212: 10b — authoring tutorials with checked-in examples

### DIFF
--- a/docs/examples/README.md
+++ b/docs/examples/README.md
@@ -1,0 +1,57 @@
+# Workflow Modules — Example Library
+
+Each subdirectory under this folder mirrors the layout of a real Obsidian
+vault. Copy any subtree into your own vault (under the same paths) and the
+files work verbatim — they're the canonical examples the tutorials in
+[`docs/workflow-modules/`](../workflow-modules/) walk through, and they
+ship to CI to keep the docs from drifting away from the engine.
+
+## What's here
+
+| Subtree | Tutorial it backs | What it shows |
+| :--- | :--- | :--- |
+| [`author-first-module/`](./author-first-module/) | [03 — Author your first module](../workflow-modules/03-author-your-first-module.md) | A single global module, no vars, no workflow file. The minimum viable file. |
+| [`compose-first-workflow/`](./compose-first-workflow/) | [04 — Compose your first workflow](../workflow-modules/04-compose-your-first-workflow.md) | Global default workflow + a per-project workflow that `extends:` it, with two modules and a per-step agent override. |
+| [`variables-and-templating/`](./variables-and-templating/) | [05 — Use variables and templating](../workflow-modules/05-variables-and-templating.md) | Plugin vars (`{{branch}}`, `{{today}}`, `{{repo_path}}`), user vars (`{{vars.package_name}}`), `name=VALUE` inline defaults, and the precedence chain in action. |
+
+## How the layouts map onto your vault
+
+Every example's top folder *is* a vault root — paths inside it line up 1:1
+with where the loader expects to find files in your own vault.
+
+| Path inside an example | Path inside your real vault | Purpose |
+| :--- | :--- | :--- |
+| `Projects/_op-modules/<id>.md` | `<vault>/Projects/_op-modules/<id>.md` | Global module — applies to every project. |
+| `Projects/<slug>/MODULES/<id>.md` | `<vault>/Projects/<slug>/MODULES/<id>.md` | Per-project module — applies to one project; shadows a same-id global. |
+| `Projects/<slug>/WORKFLOW.md` | `<vault>/Projects/<slug>/WORKFLOW.md` | Per-project workflow — picks the step list, can `extends:` a global default. |
+| `Projects/_op-workflow.md` | `<vault>/Projects/_op-workflow.md` | Global default workflow — referenced from per-project files via `extends:`. |
+
+The slug `tutorial-project` is a placeholder — replace it with your own
+project's slug when you copy the files in. The two paths to update inside
+the file contents are `project: tutorial-project` (workflow file
+frontmatter) and any in-prose project references.
+
+## Verifying an example
+
+Once the files are in your vault, run **op: explain workflow** from the
+command palette (or `obsidian op-explain-workflow id=<your-issue-id>
+mode=kickoff`) and read the diagnostics block. Zero diagnostics means the
+example loaded and composed cleanly; any diagnostic surfaces here as a
+short row with the offending file and a one-line `code: …` description.
+
+CI runs the same check against every file in this folder via
+`plugins/op-obsidian/src/docsExamples.test.ts`. If you edit an example and
+break it, that test goes red — and so does the merge gate.
+
+## Reading the schema reference alongside
+
+The tutorials are the prose; the spec docs are the contract:
+
+- [`docs/specs/workflow-module-schema.md`](../specs/workflow-module-schema.md)
+  — every frontmatter field on a module file, every diagnostic code, every
+  edge case in the `vars:` parser.
+- [`docs/specs/workflow-file-schema.md`](../specs/workflow-file-schema.md)
+  — workflow file format, `extends:` rules, model registry, the legacy
+  `WORKFLOW.md` fallback ladder.
+
+When in doubt, the spec wins.

--- a/docs/examples/author-first-module/Projects/_op-modules/branching.md
+++ b/docs/examples/author-first-module/Projects/_op-modules/branching.md
@@ -1,0 +1,17 @@
+---
+id: branching
+title: Branching discipline
+type: workflow-module
+scope: kickoff
+order: 10
+---
+
+Always create a feature branch off `main` before making changes — no
+exceptions, including one-line tweaks. Branch names use
+`<issue-id>-<slug>` (e.g. `OP-212-author-tutorials`). Push commits to that
+branch only; never directly to `main`.
+
+If you're working on a delegated issue and the main checkout is held by
+another agent, isolate further by creating a git worktree first. The
+delegating agent's checkout and yours can coexist as long as you don't
+share the same working tree.

--- a/docs/examples/compose-first-workflow/Projects/_op-modules/orient.md
+++ b/docs/examples/compose-first-workflow/Projects/_op-modules/orient.md
@@ -1,0 +1,13 @@
+---
+id: orient
+title: Orient yourself before touching code
+type: workflow-module
+scope: kickoff
+order: 10
+---
+
+Read the issue note before doing anything else. Confirm the scope, look
+for prior commits or open PRs on the same branch, and surface any
+ambiguity in the requirements before writing code. If the scope is empty
+or one line, treat it as ambiguous — state your interpretation and ask
+for confirmation, even in auto mode.

--- a/docs/examples/compose-first-workflow/Projects/_op-workflow.md
+++ b/docs/examples/compose-first-workflow/Projects/_op-workflow.md
@@ -1,0 +1,15 @@
+---
+type: workflow
+schema: 1
+project: _global
+default_agent: claude
+default_model: opus
+steps:
+  - step: kickoff
+    modules: [orient]
+---
+
+Global default workflow. Every per-project workflow that declares
+`extends: Projects/_op-workflow.md` inherits this kickoff step. Per-project
+files can replace the inherited step (by repeating the same `step: kickoff`
+id) or append new steps with new ids.

--- a/docs/examples/compose-first-workflow/Projects/tutorial-project/MODULES/review-and-merge.md
+++ b/docs/examples/compose-first-workflow/Projects/tutorial-project/MODULES/review-and-merge.md
@@ -1,0 +1,19 @@
+---
+id: review-and-merge
+title: Review and merge
+type: workflow-module
+scope: review
+order: 10
+---
+
+Before merging:
+
+- Tests are green and the CI status check is passing.
+- The PR description matches what the diff actually does (don't ship a
+  diff whose summary lies about its scope).
+- No untracked files belong with the change.
+
+Merge with `gh pr merge --squash --delete-branch`. If the squash fails
+locally because another worktree holds `main`, that's expected — verify
+the merge landed on GitHub via `gh pr view <#> --json state,mergedAt` and
+then delete the remote branch and tear down the worktree manually.

--- a/docs/examples/compose-first-workflow/Projects/tutorial-project/WORKFLOW.md
+++ b/docs/examples/compose-first-workflow/Projects/tutorial-project/WORKFLOW.md
@@ -1,0 +1,19 @@
+---
+type: workflow
+schema: 1
+project: tutorial-project
+default_agent: claude
+default_model: opus
+extends: Projects/_op-workflow.md
+steps:
+  - step: review
+    agent: copilot
+    model: gpt-5
+    modules: [review-and-merge]
+---
+
+Per-project workflow. Inherits `kickoff` from the global default at
+`Projects/_op-workflow.md` and adds a `review` step that runs under
+copilot/gpt-5 instead of the workflow defaults. The merged step list the
+loader hands the composer is `[kickoff, review]` — parent first, then
+child.

--- a/docs/examples/variables-and-templating/Projects/_op-modules/repo-paths.md
+++ b/docs/examples/variables-and-templating/Projects/_op-modules/repo-paths.md
@@ -1,0 +1,21 @@
+---
+id: repo-paths
+title: Where to find code in this repo
+type: workflow-module
+scope: kickoff
+order: 30
+vars:
+  - { name: docs_dir, default: "docs", description: "Top-level documentation directory" }
+  - reviewer_handle
+---
+
+You're working on **{{id}}** ({{title}}) on branch `{{branch}}`. Code
+lives under `{{repo_path}}`. Documentation lives under
+`{{repo_path}}/{{vars.docs_dir}}` — long-form prose goes there, not in
+README.
+
+When the PR is ready for adversarial review, tag
+`{{vars.reviewer_handle}}` and ask for concrete pressure-test prompts.
+The handle isn't supplied with a default in this module — every project
+sets its own (typically via `STATUS.md` `vars:` so the value lives next
+to the project's other config).

--- a/docs/examples/variables-and-templating/Projects/_op-modules/version-cadence.md
+++ b/docs/examples/variables-and-templating/Projects/_op-modules/version-cadence.md
@@ -1,0 +1,20 @@
+---
+id: version-cadence
+title: Version bump cadence
+type: workflow-module
+scope: kickoff
+order: 20
+vars:
+  - "package_name=op-obsidian"
+---
+
+After every change to `plugins/{{vars.package_name}}/`, run
+`node scripts/bump-version.mjs <patch|minor|major>` so the manifest,
+package, and plugin JSON files move in lockstep. Pick the bump level by
+judgment: patch = fix, minor = additive, major = breaking. Today is
+{{today}}.
+
+`{{vars.package_name}}` defaults to `op-obsidian` via the
+`name=VALUE` shorthand in this module's `vars:` block — set
+`vars.package_name` at the global, project, or launch scope to point the
+rule at a different package without forking the module.

--- a/docs/examples/variables-and-templating/Projects/tutorial-project/WORKFLOW.md
+++ b/docs/examples/variables-and-templating/Projects/tutorial-project/WORKFLOW.md
@@ -1,0 +1,15 @@
+---
+type: workflow
+schema: 1
+project: tutorial-project
+default_agent: claude
+default_model: opus
+steps:
+  - step: kickoff
+    modules: [version-cadence, repo-paths]
+---
+
+Per-project workflow that composes both example modules at kickoff. No
+`extends:` — the workflow stands alone for didactic clarity. In a real
+vault you'd typically `extends: Projects/_op-workflow.md` instead so the
+project picks up vault-wide defaults for free.

--- a/docs/workflow-modules/03-author-your-first-module.md
+++ b/docs/workflow-modules/03-author-your-first-module.md
@@ -1,0 +1,246 @@
+# Author Your First Module
+
+This walkthrough takes you from "I want to teach my agent a rule" to a
+loadable workflow module file the launch preview shows verbatim. By the
+end you'll have authored
+[`docs/examples/author-first-module/Projects/_op-modules/branching.md`](../examples/author-first-module/Projects/_op-modules/branching.md)
+in your own vault and seen it appear in the composed-prompt preview.
+
+You should already be in `workflowMode: modules` and have a project
+scaffolded. If you don't, run through the [5-minute
+quickstart](./02-quickstart.md) first — it sets up the prerequisites for
+this tutorial.
+
+## What's in a module
+
+Open
+[`docs/examples/author-first-module/Projects/_op-modules/branching.md`](../examples/author-first-module/Projects/_op-modules/branching.md)
+in another tab. The whole file is about ten lines:
+
+```yaml
+---
+id: branching
+title: Branching discipline
+type: workflow-module
+scope: kickoff
+order: 10
+---
+
+Always create a feature branch off `main` before making changes — no
+exceptions, including one-line tweaks. Branch names use
+`<issue-id>-<slug>` (e.g. `OP-212-author-tutorials`). Push commits to
+that branch only; never directly to `main`.
+```
+
+Five frontmatter fields and a body. That's the entire authoring surface;
+once you internalise these five fields you can write any module.
+
+The frontmatter fields decide *whether* and *when* the module participates
+in a workflow. The body is plain markdown that gets injected into the
+agent's prompt at the matching step. There's no DSL; everything past the
+closing `---` is opaque prose to the loader.
+
+## The five required-or-near-required fields
+
+### `id` — must match the filename basename
+
+`id: branching` lives in a file named `branching.md`. **Mismatches are a
+hard error.** A file named `branching-rules.md` declaring `id: branching`
+gets dropped at load time with a `malformed-frontmatter` diagnostic and
+never reaches the agent.
+
+The id is the handle other surfaces use to refer to the module: a
+workflow file's `steps[].modules: [branching]` list, a per-project file
+shadowing a global with the same id, the diagnostics surface citing
+"module `branching`". Keep it short, lowercase, and meaningful — kebab-
+case is conventional.
+
+### `title` — what the settings UI calls it
+
+A non-empty human-readable string. Surfaces in the Settings →
+Workflows reference panel, the launch preview's per-chunk breakdown, and
+any future op-list-modules CLI. Title once, refine later — agents read
+the body, not the title.
+
+### `type: workflow-module` — exact literal
+
+The loader is suspicious: any markdown file with frontmatter walks past
+the same scanner, and `type: workflow-module` is the discriminator that
+says "yes, treat me as a module". A wrong value (`type: skill`,
+`type: notes`) emits `malformed-frontmatter` and the file is dropped.
+Leaving it off entirely also drops the file.
+
+### `scope` — where the module plugs into a workflow
+
+The string in `scope:` is the partition key the workflow file's
+`steps[].step` matches against. The kickoff module above uses
+`scope: kickoff`; a review-stage module would use `scope: review`; a
+plan-stage module would use `scope: plan`.
+
+**Scope names are open-ended.** The composer doesn't care whether you
+call your steps `kickoff`, `triage`, `qa-handoff`, or `cleanup` — it
+just buckets modules by scope and stitches each step's bucket into the
+prompt at launch time. The convention emerging in the shipped fixtures
+is `kickoff` / `plan` / `review` / `finalize`, but a project that wants
+its own taxonomy is free to invent one.
+
+#### When to use `scope: kickoff` vs a step-scoped value
+
+- **`kickoff`** — orientation rules the agent needs at the **top of the
+  very first prompt**: branching discipline, where the issue note lives,
+  the test command, mandatory pause-before-push behaviors. Kickoff fires
+  exactly once per launch chain and stays in the agent's prompt for the
+  rest of the session.
+- **`plan` / `review` / `finalize` / etc.** — instructions specific to
+  one stage of the work: "before merging, request an adversarial
+  Copilot review", "when the plan is ready, post it for sign-off",
+  "before resolving, write the Summary section". The composer only
+  injects step-scoped modules **at the moment that step launches** —
+  before that, they don't burn the agent's context.
+
+A common mistake is to overload `kickoff` with everything. The system
+gives you free per-step injection — use it. Move the "before merging"
+prose into a `review`-scoped module so the implementer doesn't carry
+review-stage rules through implementation.
+
+There's no "always" scope shipped today; **if you want a module to fire
+at every step, list it in every step's `modules:` list in the workflow
+file**. Forcing the choice into the workflow file rather than a magic
+scope keeps the composer's behavior easy to reason about — every step's
+prompt is exactly the modules its step record names, no more.
+
+### `order` — sort key within a scope
+
+Optional, default `0`, integer. When two modules share the same scope,
+the composer sorts them ascending by `order` to decide which prose comes
+first in the composed prompt. Negative numbers work; ties fall back to
+module-id alphabetical.
+
+`order: 10` instead of `order: 1` is conventional. Leaving room between
+numbers means you can insert a new module between two existing ones
+without renumbering. Pick `10`, `20`, `30` for the first three modules
+in a scope and you'll thank yourself when the fourth shows up.
+
+## Optional frontmatter fields
+
+These don't show up in the example, but they're worth knowing about:
+
+### `project` — restrict a global module to one project
+
+A global module file at `Projects/_op-modules/<id>.md` applies to every
+project by default. Add `project: <slug>` to its frontmatter to restrict
+it to one project — useful when you've outgrown a per-project module
+file and moved the contents global, but only one project should still
+see it. (The more common pattern is the inverse: keep the module global,
+let other projects pick it up via their workflow file's `steps:` list.)
+
+### `agent` — restrict the module to one agent id
+
+`agent: claude` filters the module out of every launch where the
+resolved agent isn't `claude`. The loader doesn't enforce this today —
+consumers (the launcher, the composer) apply it — but having it on the
+module file is the cleanest way to declare intent. Use it for
+agent-specific instructions that wouldn't make sense to the others
+(e.g., a Claude-specific tool-use note, a Gemini-specific safety
+disclaimer).
+
+### `vars:` — declared variables consumed by the body
+
+The body can reference user-supplied template variables via
+`{{vars.<name>}}` syntax. Declaring those names in `vars:` does three
+things:
+
+1. The composer knows where to look for the value (and which scope
+   should win — see [05 — Use variables and templating](./05-variables-and-templating.md)).
+2. Authoring surfaces (autocomplete, the Settings → Workflows panel)
+   know the var exists and can show it to other authors.
+3. The loader can flag intra-scope-collision (two modules at the same
+   scope declaring the same var name) before the value is ever
+   resolved.
+
+For a module that doesn't reference any user vars in its body, leave
+`vars:` off entirely. Variables and templating are the subject of
+[tutorial 05](./05-variables-and-templating.md); this tutorial keeps the
+example module variable-free so you can focus on the frontmatter
+contract first.
+
+## Where the file lives
+
+| Goal | Path |
+| :--- | :--- |
+| **Apply this rule to every project in your vault** | `Projects/_op-modules/<id>.md` |
+| **Apply only to one project** | `Projects/<slug>/MODULES/<id>.md` |
+| **Override a global rule for one project** | `Projects/<slug>/MODULES/<id>.md` *with the same id as the global* |
+
+Per-project modules **silently shadow** same-id globals — only the
+per-project copy is loaded and the global is dropped. There's no
+diagnostic; the design is that a project should always be able to
+override a vault-wide rule without ceremony. Comment your shadow modules
+("this overrides the global X because…") so a future you can find the
+shadowing relationship from `git blame` rather than from comparing files.
+
+## Try it: drop the module in and see it compose
+
+The example file is ready to copy. From this repo's root:
+
+```bash
+mkdir -p <your-vault>/Projects/_op-modules/
+cp docs/examples/author-first-module/Projects/_op-modules/branching.md \
+   <your-vault>/Projects/_op-modules/
+```
+
+Then add a workflow file to a project that uses the module:
+
+```bash
+cat > <your-vault>/Projects/<your-slug>/WORKFLOW.md <<'EOF'
+---
+type: workflow
+schema: 1
+project: <your-slug>
+default_agent: claude
+default_model: opus
+steps:
+  - step: kickoff
+    modules: [branching]
+---
+EOF
+```
+
+(Replace `<your-vault>` and `<your-slug>` with real paths.) Open any
+issue in that project, run **op: open agent** from the command palette,
+and expand the **▶ Composed prompt preview** disclosure. You should see
+the body of `branching.md` rendered as the kickoff prompt, with a header
+line reading something like `1 module · 0 diagnostics`.
+
+The 0-diagnostics part is the goal: zero diagnostics means the loader
+accepted your module exactly as you wrote it. Anything else is the
+system telling you something's off — read the diagnostic message, fix
+the file, and the count goes back to zero.
+
+## Common mistakes the loader catches
+
+| Symptom | Likely cause | Diagnostic code |
+| :--- | :--- | :--- |
+| Module silently missing from the preview | Filename basename ≠ `id:` field | `malformed-frontmatter` |
+| Module silently missing from the preview | `type:` field absent or wrong | `malformed-frontmatter` |
+| Module loads but body shows `{{vars.foo}}` literally | Body references `vars.foo` but `vars:` doesn't declare it (or no scope supplies a value) | `missing-var` (warning) |
+| Two modules' bodies collide on a var name | Both at the same scope declaring the same var | `intra-scope-collision` |
+| Workflow file says "modules: [foo]" but no body | Module id doesn't match any loaded module | `unknown-module` (info) |
+
+Every diagnostic carries a `moduleId` (and often a file path in `extra`)
+so you can jump straight to the offending file. The composed-prompt
+preview surface and `op-explain-workflow` both render diagnostics
+verbatim — they're how you debug.
+
+## Where to next
+
+- [04 — Compose your first workflow](./04-compose-your-first-workflow.md)
+  takes the module you just authored and shows how a workflow file
+  decides which steps it participates in (and which agent runs each
+  step).
+- [05 — Use variables and templating](./05-variables-and-templating.md)
+  unlocks `{{vars.foo}}` in your module bodies — and explains the
+  precedence chain that decides whose value wins.
+- [`docs/specs/workflow-module-schema.md`](../specs/workflow-module-schema.md)
+  is the contract — every field, every diagnostic, every edge case in
+  the `vars:` parser. Keep it next to your editor when authoring.

--- a/docs/workflow-modules/04-compose-your-first-workflow.md
+++ b/docs/workflow-modules/04-compose-your-first-workflow.md
@@ -1,0 +1,304 @@
+# Compose Your First Workflow
+
+A module is just prose with frontmatter. A **workflow file** decides
+which modules a project's agent actually sees, in what order, at which
+step, and under which agent and model. This walkthrough builds a
+realistic two-step workflow on top of the modules you saw in
+[03 — Author your first module](./03-author-your-first-module.md), with
+a global default that every project inherits and a per-project override
+that adds an adversarial review step.
+
+The working files for this tutorial live under
+[`docs/examples/compose-first-workflow/`](../examples/compose-first-workflow/).
+
+## What a workflow file does
+
+A workflow file lives at `Projects/<slug>/WORKFLOW.md` (per-project) or
+`Projects/_op-workflow.md` (global default — referenced via `extends:`).
+It declares:
+
+- **Which steps exist** for this project (named with arbitrary string
+  ids like `kickoff`, `plan`, `review`).
+- **Which modules each step composes from**, by id.
+- **Which agent runs each step** (and which model that agent uses) —
+  step-level overrides on top of workflow defaults.
+- **Optionally, a parent workflow file to inherit from** via `extends:`.
+
+The composer, given an issue and a step name, reads the matching step
+record, pulls the named modules from the loaded module set, sorts them
+by `order`, renders templates, and concatenates the bodies into one
+prompt. That's the whole job; the workflow file is the routing table
+that decides what gets composed.
+
+## A two-file setup
+
+For most vaults, the lowest-effort way to give every project a coherent
+default workflow — without copy-pasting per-project files — is **one
+global `Projects/_op-workflow.md` plus per-project `WORKFLOW.md` files
+that `extends:` it**.
+
+Here's the global default from
+[`docs/examples/compose-first-workflow/Projects/_op-workflow.md`](../examples/compose-first-workflow/Projects/_op-workflow.md):
+
+```yaml
+---
+type: workflow
+schema: 1
+project: _global
+default_agent: claude
+default_model: opus
+steps:
+  - step: kickoff
+    modules: [orient]
+---
+```
+
+And here's the per-project file from
+[`docs/examples/compose-first-workflow/Projects/tutorial-project/WORKFLOW.md`](../examples/compose-first-workflow/Projects/tutorial-project/WORKFLOW.md):
+
+```yaml
+---
+type: workflow
+schema: 1
+project: tutorial-project
+default_agent: claude
+default_model: opus
+extends: Projects/_op-workflow.md
+steps:
+  - step: review
+    agent: copilot
+    model: gpt-5
+    modules: [review-and-merge]
+---
+```
+
+The merged effect: `tutorial-project` runs the `kickoff` step (inherited
+from the global) under claude/opus, then a `review` step under
+copilot/gpt-5. The merge happens at load time; the composer sees a
+single resolved workflow.
+
+## Anatomy of the frontmatter
+
+### Required fields
+
+#### `type: workflow` — exact literal
+
+Same role as `type: workflow-module` on a module file: discriminator.
+Anything else and the loader either drops the file (`schema-mismatch`)
+or treats it as a legacy `WORKFLOW.md` and synthesizes a single-step
+fallback.
+
+#### `schema: 1` — version lock
+
+The integer `1` is the only value the loader currently accepts. Future
+schema versions will add explicit migration paths; until then,
+`schema: 2` (or any non-1) emits `schema-mismatch` and the file is
+dropped. **This is on purpose** — locking the format version means a
+future engine can detect "this file is from the old shape" and run a
+migration instead of silently ingesting it wrong.
+
+#### `project: <slug>` — non-empty string
+
+Must equal the enclosing folder slug. If you write
+`project: foo` in `Projects/bar/WORKFLOW.md`, the loader emits a
+warning and uses the folder name (`bar`); the warning is intentional, so
+you spot the mismatch when copy-pasting between projects. The global
+default uses `project: _global` by convention — there's no folder
+constraint on `Projects/_op-workflow.md`.
+
+#### `default_agent` — list-or-scalar
+
+The agent that runs steps that don't override. Two shapes accepted:
+
+- **Scalar** — `default_agent: claude`. Sugar for a one-element list.
+- **List** — `default_agent: [claude, gemini]`. The launcher walks the
+  list and picks the first agent whose binary is installed, falling
+  back to subsequent entries.
+
+Single-agent setups are the common case; the list form is for vaults
+with multiple agents and a preference order.
+
+#### `default_model` — list-or-scalar-or-keyed-map
+
+Three shapes accepted:
+
+- **Scalar** — `default_model: opus`. Applies to every agent in
+  `default_agent`. Internally normalized to "all" + `[opus]`.
+- **List** — `default_model: [opus, sonnet]`. Walks with safe failure:
+  for the chosen agent, picks the first model that validates against
+  that agent's registry, **silently skipping cross-agent mismatches**
+  (so `opus` in a list resolved to `gemini` is skipped, not an error).
+- **Keyed map** — `default_model: { claude: opus, gemini: pro }`.
+  Each value can be a scalar or list. Used when you genuinely run
+  multiple agents with disjoint model namespaces and want to declare
+  each agent's preference explicitly.
+
+When in doubt, start with a scalar and only reach for the keyed map
+when a single-agent default doesn't fit.
+
+#### `steps` — required (in modern shape)
+
+A list of step records. Each record:
+
+- **`step:`** — required, unique step id within the workflow. The
+  partition key matched against module `scope:` fields. Repeating an id
+  emits `malformed-frontmatter` and the second entry is dropped.
+- **`modules:`** — required, list of module ids. May be empty. Module
+  ids the loader doesn't recognize emit `unknown-module` warnings (the
+  step still composes from whatever ids do load).
+- **`agent:`** (optional) — list-or-scalar override of `default_agent`.
+- **`model:`** (optional) — list-or-scalar-or-keyed-map override of
+  `default_model`. Step-level model overrides skip validation when the
+  step doesn't declare an `agent:` (it'd be redundant — the defaults
+  pass already validated that pair).
+
+A step record that supplies neither `agent:` nor `model:` inherits
+both from the workflow's defaults.
+
+### Optional fields
+
+#### `extends: <vault-relative-path>` — one level only
+
+Points at a parent workflow file, vault-relative. The loader reads the
+parent, parses it the same way, and merges:
+
+- **Defaults** are shallow-merged. Child wins on per-key collisions.
+  Empty child defaults (`default_agent: []`) fall through to the parent.
+- **Step lists** are merged by step id: child step records with the
+  same `step:` as a parent step *replace* the parent's record at the
+  parent's slot; child step records with new ids append in their
+  original order.
+
+In the example: the parent declares a `kickoff` step; the child declares
+a `review` step. After merge, the workflow has both, in that order.
+Had the child declared its own `kickoff` (with the same id), the
+child's `kickoff` would have replaced the parent's at the same slot —
+no doubling, no ambiguity.
+
+**The chain is one level only.** A parent file declaring its *own*
+`extends:` emits a warning-severity `schema-mismatch` and the
+grandparent is ignored. Author intent is rarely "deep chain"; the v1
+lock is conservative on purpose.
+
+## Per-step agent and model overrides
+
+The `review` step in the example uses the verbose form:
+
+```yaml
+- step: review
+  agent: copilot
+  model: gpt-5
+  modules: [review-and-merge]
+```
+
+The intent: *implementation* runs under the workflow default
+(claude/opus), but *review* runs under a different agent — copilot at
+gpt-5 — for an adversarial second opinion. This is the shipped pattern
+for adversarial Copilot review: same workflow file, different agent and
+model at the review step.
+
+Other useful per-step combinations:
+
+```yaml
+# Plan mode under a stronger reasoning model:
+- step: plan
+  model: claude-opus-4-7   # versioned id; pinned, never auto-upgraded
+  modules: [plan-rules]
+
+# Cross-agent fallback list:
+- step: implement
+  agent: [claude, gemini]
+  model: [opus, pro]       # walked with safe failure per chosen agent
+  modules: [implement-rules]
+
+# Keyed map for genuinely multi-agent workflows:
+- step: review
+  agent: [copilot, claude]
+  model:
+    copilot: gpt-5
+    claude: [opus, sonnet]
+  modules: [review-and-merge]
+```
+
+The "list vs scalar vs keyed map" choice is ergonomics:
+
+- **Scalar** is shortest when you have one agent and one model.
+- **List** is shortest when models share names across agents *and*
+  you're happy with safe-failure walking.
+- **Keyed map** is clearest when agents have disjoint model namespaces
+  (Claude's `opus` is meaningless to Gemini); each agent gets its own
+  preference list under its own key.
+
+The validator catches typos: a model name not in the chosen agent's
+registry surfaces a `bad-model` diagnostic with `BadModelSpec` payload
+(allowed aliases + allowed versioned ids). The recovery dialog renders
+that payload as a "did you mean?" picker so users don't have to spelunk
+the registry.
+
+## Try it
+
+The example tree is loadable as-is. From this repo's root:
+
+```bash
+cp -R docs/examples/compose-first-workflow/Projects/* \
+      <your-vault>/Projects/
+```
+
+(`-R` because the tree includes both files and folders.) Then open any
+issue under `<your-vault>/Projects/tutorial-project/` and run
+**op: open agent**:
+
+- The kickoff step (inherited from `Projects/_op-workflow.md`) injects
+  the `orient` module body under `claude / opus`.
+- Click **▶ Composed prompt preview** to verify the body of
+  `orient.md` shows up. The header line should read
+  `1 module · 0 diagnostics`.
+- To see the review step, you'd launch the agent at `mode=review` (via
+  CLI: `obsidian op-open-agent id=<issue-id> mode=review`). The
+  composer then composes `review-and-merge.md` instead, and the launch
+  modal switches the resolved agent/model to `copilot / gpt-5`.
+
+You don't actually have to launch the agent — the preview disclosure
+shows you the composed string before it's sent. The whole tutorial
+verifies via preview, not via an actual agent run.
+
+## When to add `extends:` vs duplicate
+
+The two-file setup pays off as soon as you have **two or more
+projects** sharing the same baseline workflow. Adding a third project
+is then a one-line file (`extends:` + an empty `steps: []`).
+
+For a single-project vault, skip `extends:` and put everything in the
+project's `WORKFLOW.md`. The redundancy of an `_op-workflow.md` you
+extend exactly once isn't worth the file. You can add it later when a
+second project shows up — the migration is additive.
+
+## Common mistakes the loader catches
+
+| Symptom | Likely cause | Diagnostic code |
+| :--- | :--- | :--- |
+| Workflow file silently dropped | `type:` not `workflow`, or `schema:` not `1` | `schema-mismatch` |
+| Workflow file silently dropped | `extends:` points at a file the loader can't find | `schema-mismatch` |
+| `extends:` warning-only — grandparent ignored | The parent file itself declares `extends:` | `schema-mismatch` (warning) |
+| Workflow file warning — parsing falls back to "kickoff body" mode | Frontmatter present but `steps:` missing (legacy shape 3) | `schema-mismatch` (warning) |
+| Step record dropped from the merged step list | Two step records share the same `step:` id | `malformed-frontmatter` |
+| Step references a module id that doesn't exist | The named module isn't loaded for this project | `unknown-module` |
+| Model name highlighted with "did you mean…" picker | Model name doesn't validate against the agent's registry | `bad-model` |
+
+Run `obsidian op-explain-workflow id=<issue-id> mode=<step>` to surface
+all of these in one place — the diagnostics block is rendered through
+the same unified formatter the editor squiggles use.
+
+## Where to next
+
+- [05 — Use variables and templating](./05-variables-and-templating.md)
+  goes one layer deeper: how `{{vars.foo}}` references resolve when
+  the same name is set in a module default, in global settings, in
+  the project's `STATUS.md`, and at launch time — i.e., the precedence
+  chain in action.
+- [`docs/specs/workflow-file-schema.md`](../specs/workflow-file-schema.md)
+  is the workflow-file contract: every field, every diagnostic, the
+  full legacy fallback ladder, and the model registry per agent.
+- [`docs/specs/workflow-module-schema.md`](../specs/workflow-module-schema.md)
+  is the matching module-file contract — keep it open when authoring
+  the modules a workflow file composes from.

--- a/docs/workflow-modules/05-variables-and-templating.md
+++ b/docs/workflow-modules/05-variables-and-templating.md
@@ -1,0 +1,296 @@
+# Use Variables and Templating
+
+Modules with hard-coded prose only get you so far. **Variables** —
+single-pass `{{name}}` substitutions — let one module file work across
+many projects, agents, and launches without forking. This walkthrough
+covers the two namespaces (always-on plugin vars and user vars), the
+four-layer precedence chain, and the inline-defaults shorthand the
+import flow uses to bootstrap missing values.
+
+The working modules and workflow file for this tutorial live under
+[`docs/examples/variables-and-templating/`](../examples/variables-and-templating/).
+
+## Two namespaces, disjoint by token shape
+
+The composer recognises two kinds of `{{…}}` tokens:
+
+| Shape | Namespace | Where it resolves |
+| :--- | :--- | :--- |
+| `{{<name>}}` (no dot) | **Plugin vars** — always-on, computed per launch | Launch context only — see registry below. |
+| `{{vars.<name>}}` | **User vars** — author-declared, optional | Module → Global → Project → Launch precedence. |
+
+The shapes are intentionally disjoint. Writing `{{vars.id}}` does *not*
+shadow the plugin's `{{id}}`; they're different tokens. This is by
+design — it means a module author can declare a user var named
+`id`, `branch`, or `today` without colliding with the always-on
+registry.
+
+## The plugin-var registry
+
+Every always-on var ships in
+[`plugins/op-obsidian/src/pluginVarRegistry.ts`](../../plugins/op-obsidian/src/pluginVarRegistry.ts);
+the table below mirrors it. **This list is the single source of truth.**
+Adding a new always-on var means one entry in the registry — every
+surface (renderer, autocomplete, settings panel, `op-list-vars` CLI,
+generated reference docs) reads from there.
+
+| Group | Var | What it resolves to | Example |
+| :--- | :--- | :--- | :--- |
+| **Issue identity** | `{{id}}` | The issue's canonical id from frontmatter. | `OP-212` |
+|  | `{{title}}` | The issue's title. | `10b: Authoring tutorials with checked-in examples` |
+|  | `{{project}}` | The project slug the issue belongs to. | `obsidian-projects` |
+|  | `{{status}}` | Lifecycle status. | `in-progress` |
+|  | `{{priority}}` | Priority — undefined when not set. | `med` |
+| **Issue links** | `{{parent}}` | Parent issue id, or the prose sentinel `(none — this is a top-level issue)` when there's no parent. | `OP-193` |
+|  | `{{pr_url}}` | PR URL once one exists; undefined before. | `https://github.com/.../pull/272` |
+|  | `{{github_issue}}` | Mirrored GH issue URL when GH-linked. | `https://github.com/.../issues/250` |
+| **Repo / vault** | `{{repo_path}}` | Absolute path to the project's code repo; undefined for meta-only projects. | `/Users/you/Projects/obsidian-projects` |
+|  | `{{vault_path}}` | Absolute path to the active vault. | `/Users/you/work/Agent-Vault` |
+|  | `{{vault_name}}` | Display name of the active vault. | `Agent-Vault` |
+|  | `{{branch}}` | Git branch the agent is on; undefined before the worktree exists. | `worktree-OP-212` |
+| **Run context** | `{{today}}` | ISO `YYYY-MM-DD`, computed by the launching surface. | `2026-04-26` |
+|  | `{{agent}}` | Agent id launching this session. | `claude` |
+|  | `{{model}}` | Resolved model id; undefined when the agent doesn't pick one per launch. | `claude-opus-4-7` |
+|  | `{{mode}}` | Launch mode (the step name). | `kickoff`, `review`, `finalize` |
+
+A token whose `compute` returns `undefined` (e.g. `{{branch}}` before
+the worktree exists, `{{pr_url}}` before the PR opens) **is left
+verbatim** in the rendered prompt and a `missing-var` diagnostic
+fires. Soft failure — never silent corruption. If your module is
+reading vars that may be undefined at the launch you care about, write
+the prose so the surrounding sentence still parses (e.g. "PR:
+{{pr_url}}" reads fine when the URL is missing because the user can
+see what's missing).
+
+The full registry — including descriptions and examples surfaced in the
+Settings → Workflows reference panel — is in
+[`pluginVarRegistry.ts`](../../plugins/op-obsidian/src/pluginVarRegistry.ts).
+The auto-generated reference docs (10c) will pull from the same source.
+
+## User vars and the precedence chain
+
+A user var is anything you declare in a module's `vars:` block:
+
+```yaml
+vars:
+  - "package_name=op-obsidian"
+  - { name: docs_dir, default: "docs", description: "..." }
+  - reviewer_handle
+```
+
+References to `{{vars.package_name}}` in any module body — at any scope
+in any module — go through the **four-layer precedence chain**, lowest
+to highest, latest wins:
+
+```
+   Module default     ────►   The `vars: [name=value]` shorthand on
+                              the module that *declares* the variable.
+                              The lowest precedence; functions as a
+                              "if nothing else supplies a value, fall
+                              back to this".
+
+   Global default     ────►   `settings.workflowVars` — vault-wide,
+                              edited in Settings → Workflows. Shadows
+                              every module default.
+
+   Project default    ────►   `Projects/<slug>/STATUS.md` `vars:` map.
+                              Per-project, shadows globals.
+
+   Launch override    ────►   The "Workflow variables" launch panel
+                              (also: URI `var.<name>=<value>` query
+                              params, headless launch context). Wins
+                              over everything below.
+```
+
+A useful way to think about it: layers 1–3 describe **what the project
+agrees on**; layer 4 is **what's true for this one run**. Layers 1–3
+should change rarely; layer 4 is ephemeral.
+
+The launch preview's per-var "from M / G / P / L" badge tells you
+*which* layer supplied each rendered value — so authors can verify the
+chain resolved the way they expected before launch.
+
+### Inline defaults — `name=VALUE` shorthand
+
+The shorthand form
+
+```yaml
+vars:
+  - "package_name=op-obsidian"
+```
+
+is equivalent to:
+
+```yaml
+vars:
+  - { name: package_name, default: "op-obsidian" }
+```
+
+The first `=` splits name from value. `name=` (no value) is *not* the
+same as bare `name` — it explicitly defaults to the empty string,
+which is distinct from "the caller must supply a value". Subsequent
+`=` characters in the value are part of the value verbatim
+(`expr=a=b=c` parses to `name=expr`, `value=a=b=c`).
+
+**Watch out for the YAML auto-coercion gotcha.** A bare
+`- 2026-04-25` becomes a `Date`, not a string, and the loader rejects
+it with `malformed-frontmatter`. Quote the value (`'2026-04-25'`) or
+use the shorthand (`due=2026-04-25`) to keep it as a string.
+
+### Why declare vars at all?
+
+Declaring vars in `vars:` does three things the composer relies on:
+
+1. **The composer knows where the value's module-default came from.**
+   Without a declaration, a `{{vars.foo}}` token whose value isn't set
+   anywhere fires `malformed-frontmatter` ("undeclared but
+   referenced") rather than `missing-var` ("declared somewhere but no
+   layer supplied a value").
+2. **The intra-scope-collision validator can run.** Two modules at the
+   same scope declaring the same var name (with module defaults) is an
+   authoring bug — different module defaults mean unpredictable
+   composition. The loader catches this at load time.
+3. **The import flow knows which vars to prompt for.** `op-import-module`
+   reads `vars:` and, for each declared var that has no value at any
+   higher-precedence scope in the target vault, prompts the user for a
+   value before landing the module. The shorthand default pre-fills
+   the prompt; bare declarations get an empty prompt.
+
+## Walking through the example
+
+The two modules in
+[`docs/examples/variables-and-templating/`](../examples/variables-and-templating/)
+demonstrate every form together.
+
+### `version-cadence.md` — shorthand default + plugin vars
+
+```yaml
+---
+id: version-cadence
+title: Version bump cadence
+type: workflow-module
+scope: kickoff
+order: 20
+vars:
+  - "package_name=op-obsidian"
+---
+
+After every change to `plugins/{{vars.package_name}}/`, run
+`node scripts/bump-version.mjs <patch|minor|major>` so the manifest,
+package, and plugin JSON files move in lockstep. Pick the bump level by
+judgment: patch = fix, minor = additive, major = breaking. Today is
+{{today}}.
+```
+
+`{{vars.package_name}}` resolves to `op-obsidian` from the module
+default. `{{today}}` is a plugin var supplied by the launch context —
+the launching surface stamps it as ISO `YYYY-MM-DD`.
+
+A second project that ships a different package (say, `op-cli`) doesn't
+fork this module. Instead, the project's `STATUS.md` sets
+`vars: { package_name: op-cli }` and the project-default layer wins
+over the module default — same module, different rendered prompt.
+
+### `repo-paths.md` — object-form default + bare var + multiple plugin vars
+
+```yaml
+---
+id: repo-paths
+title: Where to find code in this repo
+type: workflow-module
+scope: kickoff
+order: 30
+vars:
+  - { name: docs_dir, default: "docs", description: "..." }
+  - reviewer_handle
+---
+
+You're working on **{{id}}** ({{title}}) on branch `{{branch}}`. Code
+lives under `{{repo_path}}`. Documentation lives under
+`{{repo_path}}/{{vars.docs_dir}}` ...
+
+When the PR is ready for adversarial review, tag
+`{{vars.reviewer_handle}}` ...
+```
+
+Two user vars and four plugin vars. The interesting one is
+`reviewer_handle`: bare, no module default. If neither global, project,
+nor launch supplies a value, the composer fires `missing-var`
+(warning) and the body renders `{{vars.reviewer_handle}}` literally.
+
+That's the design point of bare vars: **they make the requirement
+explicit**. Anyone reading the module knows the project hosting it must
+supply a `reviewer_handle` — and the diagnostic surface tells the
+operator before launch.
+
+### Composing both modules together
+
+The example workflow file at
+[`docs/examples/variables-and-templating/Projects/tutorial-project/WORKFLOW.md`](../examples/variables-and-templating/Projects/tutorial-project/WORKFLOW.md)
+puts both modules at `kickoff`:
+
+```yaml
+steps:
+  - step: kickoff
+    modules: [version-cadence, repo-paths]
+```
+
+Run **op: explain workflow** with `mode=kickoff` (or expand the launch
+preview) and you see the two bodies concatenated in `order:` order
+(20, then 30) with all the substitutions applied. The dry-run preview
+header line tallies the chunk count and diagnostic count — the goal is
+0 diagnostics.
+
+## When the value should live where
+
+Quick decision flow for "where do I set this var":
+
+- **Just for one launch** — Workflow-variables panel in the launch
+  modal, or the URI `var.<name>=<value>` param. The override applies
+  to this run only and disappears.
+- **Just for one project, persistently** — `Projects/<slug>/STATUS.md`
+  `vars:` map. Lives next to the project's other config; survives
+  across launches; doesn't leak to other projects.
+- **For every project in the vault** — Settings → Workflows →
+  *Workflow vars* (writes `settings.workflowVars`). One value, every
+  project picks it up unless overridden.
+- **For every vault that imports the module** — module default
+  (`name=VALUE` shorthand or `{ default: VALUE }` object form). The
+  fallback when nothing else supplies a value, and the seed for the
+  import-time prompt.
+
+A useful heuristic: **the more places a var should "just work", the
+lower-precedence the layer you set it at.** Module default = "applies
+anywhere this module lands"; launch override = "applies only here, only
+now".
+
+## Common mistakes the loader catches
+
+| Symptom | Likely cause | Diagnostic code |
+| :--- | :--- | :--- |
+| Token renders literally as `{{vars.foo}}` | No layer supplied a value, or the var wasn't declared in any module | `missing-var` (warning) or `malformed-frontmatter` (warning, "undeclared but referenced") |
+| Module dropped at load | `vars:` declared the same name twice in one module | `malformed-frontmatter` |
+| Module dropped at load | Bare entry in `vars:` is a `Date` (e.g., `- 2026-04-25` parsed by YAML as a date) | `malformed-frontmatter` |
+| Two modules collide on a var | Both at the same `scope:` declaring the same name with defaults | `intra-scope-collision` |
+| Token renders literally as `{{branch}}` | The launch context didn't supply a branch (e.g., worktree not yet created) | `missing-var` (warning) |
+| Var declaration with `defualt:` typo doesn't take effect | Object-form key misspelled (the loader silently accepts unknown keys for forward-compat) | None — review the spelling manually |
+
+Run `obsidian op-list-vars project=<slug> issue=<id>` to dump the full
+resolved chain for a given issue/launch — every plugin var and every
+declared user var, with their resolved values and the supplying scope.
+That CLI is the fastest way to confirm a var resolves the way you
+expected before you launch the agent.
+
+## Where to next
+
+- [01 — Workflow modules overview](./01-overview.md) revisits the
+  precedence chain alongside the storage layout — useful as a refresher
+  once you've authored a few modules with vars.
+- [`docs/specs/workflow-module-schema.md`](../specs/workflow-module-schema.md)
+  is the full `vars:` parser contract: every form (`bare`, `default`,
+  `object`), every edge case (YAML auto-coercion, empty defaults, the
+  first-`=` split rule), every diagnostic.
+- [`pluginVarRegistry.ts`](../../plugins/op-obsidian/src/pluginVarRegistry.ts)
+  is the canonical list of always-on plugin vars. When 10c lands, the
+  auto-generated reference docs will inline the registry verbatim;
+  until then this file is the source of truth.

--- a/plugins/op-obsidian/manifest.json
+++ b/plugins/op-obsidian/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "op-obsidian",
   "name": "Obsidian Projects (op)",
-  "version": "0.74.0",
+  "version": "0.74.1",
   "minAppVersion": "1.5.0",
   "description": "Jira-lite issue tracker for Obsidian vaults — deterministic commands backing the op workflow.",
   "author": "Eugene Archibald",

--- a/plugins/op-obsidian/package-lock.json
+++ b/plugins/op-obsidian/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "op-obsidian",
-  "version": "0.74.0",
+  "version": "0.74.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "op-obsidian",
-      "version": "0.74.0",
+      "version": "0.74.1",
       "license": "MIT",
       "dependencies": {
         "protobufjs": "^8.0.1"
@@ -370,6 +370,24 @@
         "node": ">=12"
       }
     },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.0.tgz",
+      "integrity": "sha512-CR/RYotgtCKwtftMwJlUU7xCVNg3lMYZ0RzTmAHSfLCXw3NtZtNpswLEj/Kkf6kEL3Gw+BpOekRX0BYCtklhUw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@esbuild/netbsd-x64": {
       "version": "0.20.2",
       "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.20.2.tgz",
@@ -387,6 +405,24 @@
         "node": ">=12"
       }
     },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.0.tgz",
+      "integrity": "sha512-cXb5vApOsRsxsEl4mcZ1XY3D4DzcoMxR/nnc4IyqYs0rTI8ZKmW6kyyg+11Z8yvgMfAEldKzP7AdP64HnSC/6g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@esbuild/openbsd-x64": {
       "version": "0.20.2",
       "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.20.2.tgz",
@@ -402,6 +438,24 @@
       ],
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.0.tgz",
+      "integrity": "sha512-FLGfyizszcef5C3YtoyQDACyg95+dndv79i2EekILBofh5wpCa1KuBqOWKrEHZg3zrL3t5ouE5jgr94vA+Wb2w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/sunos-x64": {
@@ -1805,6 +1859,420 @@
         }
       }
     },
+    "node_modules/vitest/node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.0.tgz",
+      "integrity": "sha512-lhRUCeuOyJQURhTxl4WkpFTjIsbDayJHih5kZC1giwE+MhIzAb7mEsQMqMf18rHLsrb5qI1tafG20mLxEWcWlA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/android-arm": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.0.tgz",
+      "integrity": "sha512-wqh0ByljabXLKHeWXYLqoJ5jKC4XBaw6Hk08OfMrCRd2nP2ZQ5eleDZC41XHyCNgktBGYMbqnrJKq/K/lzPMSQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/android-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.0.tgz",
+      "integrity": "sha512-+WzIXQOSaGs33tLEgYPYe/yQHf0WTU0X42Jca3y8NWMbUVhp7rUnw+vAsRC/QiDrdD31IszMrZy+qwPOPjd+rw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/android-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.0.tgz",
+      "integrity": "sha512-+VJggoaKhk2VNNqVL7f6S189UzShHC/mR9EE8rDdSkdpN0KflSwWY/gWjDrNxxisg8Fp1ZCD9jLMo4m0OUfeUA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.0.tgz",
+      "integrity": "sha512-0T+A9WZm+bZ84nZBtk1ckYsOvyA3x7e2Acj1KdVfV4/2tdG4fzUp91YHx+GArWLtwqp77pBXVCPn2We7Letr0Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.0.tgz",
+      "integrity": "sha512-fyzLm/DLDl/84OCfp2f/XQ4flmORsjU7VKt8HLjvIXChJoFFOIL6pLJPH4Yhd1n1gGFF9mPwtlN5Wf82DZs+LQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.0.tgz",
+      "integrity": "sha512-l9GeW5UZBT9k9brBYI+0WDffcRxgHQD8ShN2Ur4xWq/NFzUKm3k5lsH4PdaRgb2w7mI9u61nr2gI2mLI27Nh3Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.0.tgz",
+      "integrity": "sha512-BXoQai/A0wPO6Es3yFJ7APCiKGc1tdAEOgeTNy3SsB491S3aHn4S4r3e976eUnPdU+NbdtmBuLncYir2tMU9Nw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-arm": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.0.tgz",
+      "integrity": "sha512-CjaaREJagqJp7iTaNQjjidaNbCKYcd4IDkzbwwxtSvjI7NZm79qiHc8HqciMddQ6CKvJT6aBd8lO9kN/ZudLlw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.0.tgz",
+      "integrity": "sha512-RVyzfb3FWsGA55n6WY0MEIEPURL1FcbhFE6BffZEMEekfCzCIMtB5yyDcFnVbTnwk+CLAgTujmV/Lgvih56W+A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.0.tgz",
+      "integrity": "sha512-KBnSTt1kxl9x70q+ydterVdl+Cn0H18ngRMRCEQfrbqdUuntQQ0LoMZv47uB97NljZFzY6HcfqEZ2SAyIUTQBQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.0.tgz",
+      "integrity": "sha512-zpSlUce1mnxzgBADvxKXX5sl8aYQHo2ezvMNI8I0lbblJtp8V4odlm3Yzlj7gPyt3T8ReksE6bK+pT3WD+aJRg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.0.tgz",
+      "integrity": "sha512-2jIfP6mmjkdmeTlsX/9vmdmhBmKADrWqN7zcdtHIeNSCH1SqIoNI63cYsjQR8J+wGa4Y5izRcSHSm8K3QWmk3w==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.0.tgz",
+      "integrity": "sha512-bc0FE9wWeC0WBm49IQMPSPILRocGTQt3j5KPCA8os6VprfuJ7KD+5PzESSrJ6GmPIPJK965ZJHTUlSA6GNYEhg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.0.tgz",
+      "integrity": "sha512-SQPZOwoTTT/HXFXQJG/vBX8sOFagGqvZyXcgLA3NhIqcBv1BJU1d46c0rGcrij2B56Z2rNiSLaZOYW5cUk7yLQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.0.tgz",
+      "integrity": "sha512-SCfR0HN8CEEjnYnySJTd2cw0k9OHB/YFzt5zgJEwa+wL/T/raGWYMBqwDNAC6dqFKmJYZoQBRfHjgwLHGSrn3Q==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.0.tgz",
+      "integrity": "sha512-us0dSb9iFxIi8srnpl931Nvs65it/Jd2a2K3qs7fz2WfGPHqzfzZTfec7oxZJRNPXPnNYZtanmRc4AL/JwVzHQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.0.tgz",
+      "integrity": "sha512-nU1yhmYutL+fQ71Kxnhg8uEOdC0pwEW9entHykTgEbna2pw2dkbFSMeqjjyHZoCmt8SBkOSvV+yNmm94aUrrqw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.0.tgz",
+      "integrity": "sha512-8wZM2qqtv9UP3mzy7HiGYNH/zjTA355mpeuA+859TyR+e+Tc08IHYpLJuMsfpDJwoLo1ikIJI8jC3GFjnRClzA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.0.tgz",
+      "integrity": "sha512-1ZgjUoEdHZZl/YlV76TSCz9Hqj9h9YmMGAgAPYd+q4SicWNX3G5GCyx9uhQWSLcbvPW8Ni7lj4gDa1T40akdlw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.0.tgz",
+      "integrity": "sha512-Q9StnDmQ/enxnpxCCLSg0oo4+34B9TdXpuyPeTedN/6+iXBJ4J+zwfQI28u/Jl40nOYAxGoNi7mFP40RUtkmUA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.0.tgz",
+      "integrity": "sha512-zF3ag/gfiCe6U2iczcRzSYJKH1DCI+ByzSENHlM2FcDbEeo5Zd2C86Aq0tKUYAJJ1obRP84ymxIAksZUcdztHA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/win32-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.0.tgz",
+      "integrity": "sha512-pEl1bO9mfAmIC+tW5btTmrKaujg3zGtUmWNdCw/xs70FBjwAL3o9OEKNHvNmnyylD6ubxUERiEhdsL0xBQ9efw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/vitest/node_modules/@vitest/mocker": {
       "version": "4.1.4",
       "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.4.tgz",
@@ -1830,6 +2298,50 @@
         "vite": {
           "optional": true
         }
+      }
+    },
+    "node_modules/vitest/node_modules/esbuild": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.0.tgz",
+      "integrity": "sha512-sNR9MHpXSUV/XB4zmsFKN+QgVG82Cc7+/aaxJ8Adi8hyOac+EXptIp45QBPaVyX3N70664wRbTcLTOemCAnyqw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.0",
+        "@esbuild/android-arm": "0.28.0",
+        "@esbuild/android-arm64": "0.28.0",
+        "@esbuild/android-x64": "0.28.0",
+        "@esbuild/darwin-arm64": "0.28.0",
+        "@esbuild/darwin-x64": "0.28.0",
+        "@esbuild/freebsd-arm64": "0.28.0",
+        "@esbuild/freebsd-x64": "0.28.0",
+        "@esbuild/linux-arm": "0.28.0",
+        "@esbuild/linux-arm64": "0.28.0",
+        "@esbuild/linux-ia32": "0.28.0",
+        "@esbuild/linux-loong64": "0.28.0",
+        "@esbuild/linux-mips64el": "0.28.0",
+        "@esbuild/linux-ppc64": "0.28.0",
+        "@esbuild/linux-riscv64": "0.28.0",
+        "@esbuild/linux-s390x": "0.28.0",
+        "@esbuild/linux-x64": "0.28.0",
+        "@esbuild/netbsd-arm64": "0.28.0",
+        "@esbuild/netbsd-x64": "0.28.0",
+        "@esbuild/openbsd-arm64": "0.28.0",
+        "@esbuild/openbsd-x64": "0.28.0",
+        "@esbuild/openharmony-arm64": "0.28.0",
+        "@esbuild/sunos-x64": "0.28.0",
+        "@esbuild/win32-arm64": "0.28.0",
+        "@esbuild/win32-ia32": "0.28.0",
+        "@esbuild/win32-x64": "0.28.0"
       }
     },
     "node_modules/vitest/node_modules/vite": {

--- a/plugins/op-obsidian/package-lock.json
+++ b/plugins/op-obsidian/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "op-obsidian",
-  "version": "0.67.0",
+  "version": "0.74.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "op-obsidian",
-      "version": "0.67.0",
+      "version": "0.74.0",
       "license": "MIT",
       "dependencies": {
         "protobufjs": "^8.0.1"
@@ -18,7 +18,8 @@
         "obsidian": "latest",
         "tslib": "^2.6.2",
         "typescript": "^5.3.0",
-        "vitest": "^4.1.4"
+        "vitest": "^4.1.4",
+        "yaml": "^2.4.2"
       }
     },
     "node_modules/@codemirror/state": {
@@ -369,24 +370,6 @@
         "node": ">=12"
       }
     },
-    "node_modules/@esbuild/netbsd-arm64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.0.tgz",
-      "integrity": "sha512-CR/RYotgtCKwtftMwJlUU7xCVNg3lMYZ0RzTmAHSfLCXw3NtZtNpswLEj/Kkf6kEL3Gw+BpOekRX0BYCtklhUw==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "netbsd"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
     "node_modules/@esbuild/netbsd-x64": {
       "version": "0.20.2",
       "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.20.2.tgz",
@@ -404,24 +387,6 @@
         "node": ">=12"
       }
     },
-    "node_modules/@esbuild/openbsd-arm64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.0.tgz",
-      "integrity": "sha512-cXb5vApOsRsxsEl4mcZ1XY3D4DzcoMxR/nnc4IyqYs0rTI8ZKmW6kyyg+11Z8yvgMfAEldKzP7AdP64HnSC/6g==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openbsd"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
     "node_modules/@esbuild/openbsd-x64": {
       "version": "0.20.2",
       "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.20.2.tgz",
@@ -437,24 +402,6 @@
       ],
       "engines": {
         "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/openharmony-arm64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.0.tgz",
-      "integrity": "sha512-FLGfyizszcef5C3YtoyQDACyg95+dndv79i2EekILBofh5wpCa1KuBqOWKrEHZg3zrL3t5ouE5jgr94vA+Wb2w==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openharmony"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
       }
     },
     "node_modules/@esbuild/sunos-x64": {
@@ -1858,420 +1805,6 @@
         }
       }
     },
-    "node_modules/vitest/node_modules/@esbuild/aix-ppc64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.0.tgz",
-      "integrity": "sha512-lhRUCeuOyJQURhTxl4WkpFTjIsbDayJHih5kZC1giwE+MhIzAb7mEsQMqMf18rHLsrb5qI1tafG20mLxEWcWlA==",
-      "cpu": [
-        "ppc64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "aix"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vitest/node_modules/@esbuild/android-arm": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.0.tgz",
-      "integrity": "sha512-wqh0ByljabXLKHeWXYLqoJ5jKC4XBaw6Hk08OfMrCRd2nP2ZQ5eleDZC41XHyCNgktBGYMbqnrJKq/K/lzPMSQ==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vitest/node_modules/@esbuild/android-arm64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.0.tgz",
-      "integrity": "sha512-+WzIXQOSaGs33tLEgYPYe/yQHf0WTU0X42Jca3y8NWMbUVhp7rUnw+vAsRC/QiDrdD31IszMrZy+qwPOPjd+rw==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vitest/node_modules/@esbuild/android-x64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.0.tgz",
-      "integrity": "sha512-+VJggoaKhk2VNNqVL7f6S189UzShHC/mR9EE8rDdSkdpN0KflSwWY/gWjDrNxxisg8Fp1ZCD9jLMo4m0OUfeUA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vitest/node_modules/@esbuild/darwin-arm64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.0.tgz",
-      "integrity": "sha512-0T+A9WZm+bZ84nZBtk1ckYsOvyA3x7e2Acj1KdVfV4/2tdG4fzUp91YHx+GArWLtwqp77pBXVCPn2We7Letr0Q==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vitest/node_modules/@esbuild/darwin-x64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.0.tgz",
-      "integrity": "sha512-fyzLm/DLDl/84OCfp2f/XQ4flmORsjU7VKt8HLjvIXChJoFFOIL6pLJPH4Yhd1n1gGFF9mPwtlN5Wf82DZs+LQ==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vitest/node_modules/@esbuild/freebsd-arm64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.0.tgz",
-      "integrity": "sha512-l9GeW5UZBT9k9brBYI+0WDffcRxgHQD8ShN2Ur4xWq/NFzUKm3k5lsH4PdaRgb2w7mI9u61nr2gI2mLI27Nh3Q==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vitest/node_modules/@esbuild/freebsd-x64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.0.tgz",
-      "integrity": "sha512-BXoQai/A0wPO6Es3yFJ7APCiKGc1tdAEOgeTNy3SsB491S3aHn4S4r3e976eUnPdU+NbdtmBuLncYir2tMU9Nw==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vitest/node_modules/@esbuild/linux-arm": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.0.tgz",
-      "integrity": "sha512-CjaaREJagqJp7iTaNQjjidaNbCKYcd4IDkzbwwxtSvjI7NZm79qiHc8HqciMddQ6CKvJT6aBd8lO9kN/ZudLlw==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vitest/node_modules/@esbuild/linux-arm64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.0.tgz",
-      "integrity": "sha512-RVyzfb3FWsGA55n6WY0MEIEPURL1FcbhFE6BffZEMEekfCzCIMtB5yyDcFnVbTnwk+CLAgTujmV/Lgvih56W+A==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vitest/node_modules/@esbuild/linux-ia32": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.0.tgz",
-      "integrity": "sha512-KBnSTt1kxl9x70q+ydterVdl+Cn0H18ngRMRCEQfrbqdUuntQQ0LoMZv47uB97NljZFzY6HcfqEZ2SAyIUTQBQ==",
-      "cpu": [
-        "ia32"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vitest/node_modules/@esbuild/linux-loong64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.0.tgz",
-      "integrity": "sha512-zpSlUce1mnxzgBADvxKXX5sl8aYQHo2ezvMNI8I0lbblJtp8V4odlm3Yzlj7gPyt3T8ReksE6bK+pT3WD+aJRg==",
-      "cpu": [
-        "loong64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vitest/node_modules/@esbuild/linux-mips64el": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.0.tgz",
-      "integrity": "sha512-2jIfP6mmjkdmeTlsX/9vmdmhBmKADrWqN7zcdtHIeNSCH1SqIoNI63cYsjQR8J+wGa4Y5izRcSHSm8K3QWmk3w==",
-      "cpu": [
-        "mips64el"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vitest/node_modules/@esbuild/linux-ppc64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.0.tgz",
-      "integrity": "sha512-bc0FE9wWeC0WBm49IQMPSPILRocGTQt3j5KPCA8os6VprfuJ7KD+5PzESSrJ6GmPIPJK965ZJHTUlSA6GNYEhg==",
-      "cpu": [
-        "ppc64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vitest/node_modules/@esbuild/linux-riscv64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.0.tgz",
-      "integrity": "sha512-SQPZOwoTTT/HXFXQJG/vBX8sOFagGqvZyXcgLA3NhIqcBv1BJU1d46c0rGcrij2B56Z2rNiSLaZOYW5cUk7yLQ==",
-      "cpu": [
-        "riscv64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vitest/node_modules/@esbuild/linux-s390x": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.0.tgz",
-      "integrity": "sha512-SCfR0HN8CEEjnYnySJTd2cw0k9OHB/YFzt5zgJEwa+wL/T/raGWYMBqwDNAC6dqFKmJYZoQBRfHjgwLHGSrn3Q==",
-      "cpu": [
-        "s390x"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vitest/node_modules/@esbuild/linux-x64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.0.tgz",
-      "integrity": "sha512-us0dSb9iFxIi8srnpl931Nvs65it/Jd2a2K3qs7fz2WfGPHqzfzZTfec7oxZJRNPXPnNYZtanmRc4AL/JwVzHQ==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vitest/node_modules/@esbuild/netbsd-x64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.0.tgz",
-      "integrity": "sha512-nU1yhmYutL+fQ71Kxnhg8uEOdC0pwEW9entHykTgEbna2pw2dkbFSMeqjjyHZoCmt8SBkOSvV+yNmm94aUrrqw==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "netbsd"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vitest/node_modules/@esbuild/openbsd-x64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.0.tgz",
-      "integrity": "sha512-8wZM2qqtv9UP3mzy7HiGYNH/zjTA355mpeuA+859TyR+e+Tc08IHYpLJuMsfpDJwoLo1ikIJI8jC3GFjnRClzA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openbsd"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vitest/node_modules/@esbuild/sunos-x64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.0.tgz",
-      "integrity": "sha512-1ZgjUoEdHZZl/YlV76TSCz9Hqj9h9YmMGAgAPYd+q4SicWNX3G5GCyx9uhQWSLcbvPW8Ni7lj4gDa1T40akdlw==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "sunos"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vitest/node_modules/@esbuild/win32-arm64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.0.tgz",
-      "integrity": "sha512-Q9StnDmQ/enxnpxCCLSg0oo4+34B9TdXpuyPeTedN/6+iXBJ4J+zwfQI28u/Jl40nOYAxGoNi7mFP40RUtkmUA==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vitest/node_modules/@esbuild/win32-ia32": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.0.tgz",
-      "integrity": "sha512-zF3ag/gfiCe6U2iczcRzSYJKH1DCI+ByzSENHlM2FcDbEeo5Zd2C86Aq0tKUYAJJ1obRP84ymxIAksZUcdztHA==",
-      "cpu": [
-        "ia32"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vitest/node_modules/@esbuild/win32-x64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.0.tgz",
-      "integrity": "sha512-pEl1bO9mfAmIC+tW5btTmrKaujg3zGtUmWNdCw/xs70FBjwAL3o9OEKNHvNmnyylD6ubxUERiEhdsL0xBQ9efw==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
     "node_modules/vitest/node_modules/@vitest/mocker": {
       "version": "4.1.4",
       "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.4.tgz",
@@ -2297,50 +1830,6 @@
         "vite": {
           "optional": true
         }
-      }
-    },
-    "node_modules/vitest/node_modules/esbuild": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.0.tgz",
-      "integrity": "sha512-sNR9MHpXSUV/XB4zmsFKN+QgVG82Cc7+/aaxJ8Adi8hyOac+EXptIp45QBPaVyX3N70664wRbTcLTOemCAnyqw==",
-      "dev": true,
-      "hasInstallScript": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "bin": {
-        "esbuild": "bin/esbuild"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "optionalDependencies": {
-        "@esbuild/aix-ppc64": "0.28.0",
-        "@esbuild/android-arm": "0.28.0",
-        "@esbuild/android-arm64": "0.28.0",
-        "@esbuild/android-x64": "0.28.0",
-        "@esbuild/darwin-arm64": "0.28.0",
-        "@esbuild/darwin-x64": "0.28.0",
-        "@esbuild/freebsd-arm64": "0.28.0",
-        "@esbuild/freebsd-x64": "0.28.0",
-        "@esbuild/linux-arm": "0.28.0",
-        "@esbuild/linux-arm64": "0.28.0",
-        "@esbuild/linux-ia32": "0.28.0",
-        "@esbuild/linux-loong64": "0.28.0",
-        "@esbuild/linux-mips64el": "0.28.0",
-        "@esbuild/linux-ppc64": "0.28.0",
-        "@esbuild/linux-riscv64": "0.28.0",
-        "@esbuild/linux-s390x": "0.28.0",
-        "@esbuild/linux-x64": "0.28.0",
-        "@esbuild/netbsd-arm64": "0.28.0",
-        "@esbuild/netbsd-x64": "0.28.0",
-        "@esbuild/openbsd-arm64": "0.28.0",
-        "@esbuild/openbsd-x64": "0.28.0",
-        "@esbuild/openharmony-arm64": "0.28.0",
-        "@esbuild/sunos-x64": "0.28.0",
-        "@esbuild/win32-arm64": "0.28.0",
-        "@esbuild/win32-ia32": "0.28.0",
-        "@esbuild/win32-x64": "0.28.0"
       }
     },
     "node_modules/vitest/node_modules/vite": {
@@ -2444,6 +1933,22 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/yaml": {
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
+      "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
       }
     }
   }

--- a/plugins/op-obsidian/package.json
+++ b/plugins/op-obsidian/package.json
@@ -1,6 +1,6 @@
 {
   "name": "op-obsidian",
-  "version": "0.74.0",
+  "version": "0.74.1",
   "description": "Obsidian plugin that owns the deterministic half of the op workflow.",
   "main": "main.js",
   "scripts": {
@@ -24,7 +24,8 @@
     "obsidian": "latest",
     "tslib": "^2.6.2",
     "typescript": "^5.3.0",
-    "vitest": "^4.1.4"
+    "vitest": "^4.1.4",
+    "yaml": "^2.4.2"
   },
   "dependencies": {
     "protobufjs": "^8.0.1"

--- a/plugins/op-obsidian/src/docsExamples.test.ts
+++ b/plugins/op-obsidian/src/docsExamples.test.ts
@@ -1,0 +1,342 @@
+import { describe, it, expect, vi } from "vitest";
+import { readFileSync, readdirSync, statSync } from "node:fs";
+import { join, relative, resolve, sep } from "node:path";
+import { parse as parseYaml } from "yaml";
+
+vi.mock("obsidian", () => {
+  // Minimal Obsidian shims used by the IO seams under test:
+  //   - `TFile` is consumed via `instanceof` checks and field access
+  //     (`path`, `basename`, `name`).
+  //   - `App` and `normalizePath` are imported by `workflowFile.ts`; only
+  //     `normalizePath` has runtime behavior — we mirror Obsidian's
+  //     "collapse multiple slashes, drop leading `./`" pass.
+  class TFile {
+    path = "";
+    basename = "";
+    name = "";
+  }
+  class App {}
+  return {
+    TFile,
+    App,
+    normalizePath: (p: string) => p.replace(/\/+/g, "/").replace(/^\.\//, ""),
+  };
+});
+
+import { TFile } from "obsidian";
+import {
+  loadModuleSources,
+  type ModuleSourceBundle,
+} from "./composeWorkflow";
+import {
+  composeWorkflow,
+  type ComposeContext,
+  DEFAULT_MAX_WORKFLOW_CHARS,
+} from "./composeWorkflowPure";
+import type { WorkflowDiagnostic } from "./workflowDiagnostic";
+
+// --------------------------------------------------------------------------
+// Examples manifest
+//
+// Every entry here corresponds to one subtree under `docs/examples/`. Each
+// subtree is a self-contained "vault root" — paths inside it line up with
+// where the loader expects to find files in a real vault.
+//
+// Spec (OP-212): each example file in docs/examples/ parses cleanly via the
+// loader (1b/1c) and composes cleanly via composeWorkflow (1d) — zero
+// diagnostics. We assert against ERROR-severity diagnostics specifically;
+// warning + info severities are tolerated when they reflect intentional
+// choices (e.g., a bare var with a project-supplied value would emit no
+// `missing-var` because the value resolves — but a future tutorial example
+// might surface an info-level "declared-but-unused" that's pedagogically
+// useful to keep).
+//
+// To add a new example:
+//   1. Drop the vault-shaped tree under `docs/examples/<example-name>/`.
+//   2. Add an entry below describing the project slug (or `null` for
+//      module-only examples), the steps to compose at, and any user-var
+//      values the modules require for clean rendering.
+// --------------------------------------------------------------------------
+
+interface ExampleSpec {
+  /** Subtree name under `docs/examples/`. */
+  name: string;
+  /**
+   * Project slug to compose for. `null` for module-only examples that don't
+   * ship a workflow file — only the module loader runs in that case.
+   */
+  project: string | null;
+  /** Step ids to compose at. Empty for module-only examples. */
+  composeAtSteps: string[];
+  /**
+   * User-var values supplied at the global scope. Useful when an example
+   * deliberately ships a bare var (no module default) and expects the
+   * project hosting it to supply the value.
+   */
+  globalVars?: Record<string, string>;
+  /** User-var values supplied at the project scope (winning over global). */
+  projectVars?: Record<string, string>;
+  /** User-var values supplied at the launch scope (winning over project). */
+  launchVars?: Record<string, string>;
+}
+
+const EXAMPLES: ExampleSpec[] = [
+  {
+    name: "author-first-module",
+    project: null,
+    composeAtSteps: [],
+  },
+  {
+    name: "compose-first-workflow",
+    project: "tutorial-project",
+    composeAtSteps: ["kickoff", "review"],
+  },
+  {
+    name: "variables-and-templating",
+    project: "tutorial-project",
+    composeAtSteps: ["kickoff"],
+    // The `repo-paths` module declares `reviewer_handle` as a bare var
+    // (no module default). A real project would set it via STATUS.md
+    // `vars:` map (project scope). Mirror that here so composition
+    // resolves cleanly.
+    projectVars: {
+      reviewer_handle: "@earchibald",
+    },
+  },
+];
+
+const EXAMPLES_ROOT = resolve(__dirname, "..", "..", "..", "docs", "examples");
+
+// --------------------------------------------------------------------------
+// Filesystem-backed fake App
+// --------------------------------------------------------------------------
+
+interface RawFile {
+  vaultPath: string;
+  fsPath: string;
+  raw: string;
+  frontmatter: Record<string, unknown> | null;
+}
+
+function walk(dir: string): string[] {
+  const out: string[] = [];
+  for (const entry of readdirSync(dir)) {
+    const full = join(dir, entry);
+    if (statSync(full).isDirectory()) {
+      out.push(...walk(full));
+    } else if (entry.endsWith(".md")) {
+      out.push(full);
+    }
+  }
+  return out;
+}
+
+/**
+ * Read every `.md` under `exampleRoot`, parse frontmatter via the `yaml`
+ * package, and return the records keyed by vault-relative path. The
+ * vault-relative path is the suffix after the example root, with OS-native
+ * separators normalized to `/`.
+ *
+ * Files outside `Projects/` are skipped — the loader ignores them anyway,
+ * and the example trees only ship files we want loaded (plus this folder's
+ * top-level README.md, which would falsely match `*.md` without the
+ * `Projects/` filter).
+ */
+function readExample(exampleRoot: string): RawFile[] {
+  const files: RawFile[] = [];
+  for (const fsPath of walk(exampleRoot)) {
+    const rel = relative(exampleRoot, fsPath).split(sep).join("/");
+    if (!rel.startsWith("Projects/")) continue;
+    const raw = readFileSync(fsPath, "utf8");
+    let frontmatter: Record<string, unknown> | null = null;
+    if (raw.startsWith("---")) {
+      const end = raw.indexOf("\n---", 3);
+      if (end > 0) {
+        const yamlText = raw.slice(3, end + 1).replace(/^\n/, "");
+        try {
+          const parsed = parseYaml(yamlText);
+          frontmatter = parsed && typeof parsed === "object" ? (parsed as Record<string, unknown>) : null;
+        } catch (e) {
+          throw new Error(`YAML parse failed for ${fsPath}: ${(e as Error).message}`);
+        }
+      }
+    }
+    files.push({ vaultPath: rel, fsPath, raw, frontmatter });
+  }
+  return files;
+}
+
+interface FakeApp {
+  vault: {
+    getMarkdownFiles: () => unknown[];
+    read: (file: unknown) => Promise<string>;
+    getAbstractFileByPath: (path: string) => unknown;
+  };
+  metadataCache: {
+    getFileCache: (file: unknown) => { frontmatter?: Record<string, unknown> } | null;
+  };
+}
+
+function makeFakeApp(files: RawFile[]): FakeApp {
+  const tfileByPath = new Map<string, TFile>();
+  for (const f of files) {
+    const tf = new TFile();
+    const basename = f.vaultPath.split("/").pop()!.replace(/\.md$/, "");
+    Object.assign(tf, {
+      path: f.vaultPath,
+      basename,
+      name: `${basename}.md`,
+    });
+    tfileByPath.set(f.vaultPath, tf);
+  }
+  const fileToRaw = new Map<TFile, RawFile>();
+  for (const f of files) {
+    const tf = tfileByPath.get(f.vaultPath)!;
+    fileToRaw.set(tf, f);
+  }
+
+  return {
+    vault: {
+      getMarkdownFiles: () => Array.from(tfileByPath.values()),
+      read: async (file: unknown) => {
+        const r = fileToRaw.get(file as TFile);
+        if (!r) throw new Error(`fake-app: unknown TFile`);
+        return r.raw;
+      },
+      getAbstractFileByPath: (path: string) => tfileByPath.get(path) ?? null,
+    },
+    metadataCache: {
+      getFileCache: (file: unknown) => {
+        const r = fileToRaw.get(file as TFile);
+        if (!r || r.frontmatter === null) return null;
+        return { frontmatter: r.frontmatter };
+      },
+    },
+  };
+}
+
+// --------------------------------------------------------------------------
+// Diagnostic filter — error severity is the bar
+// --------------------------------------------------------------------------
+
+function errors(diags: WorkflowDiagnostic[]): WorkflowDiagnostic[] {
+  return diags.filter((d) => d.severity === "error");
+}
+
+function format(diags: WorkflowDiagnostic[]): string {
+  return diags
+    .map((d) => `[${d.code}/${d.severity}] ${d.message}`)
+    .join("\n");
+}
+
+// --------------------------------------------------------------------------
+// Render context — a plausible launch context for compose
+// --------------------------------------------------------------------------
+
+function renderCtx(args: { project: string; mode: string }) {
+  return {
+    id: "TUT-1",
+    title: "Tutorial issue",
+    project: args.project,
+    status: "in-progress",
+    priority: "med",
+    parent: null, // PARENT_NONE_SENTINEL fires
+    pr_url: "https://github.com/example/repo/pull/42",
+    github_issue: "https://github.com/example/repo/issues/41",
+    repo_path: `/Users/example/Projects/${args.project}`,
+    vault_path: "/Users/example/work/Agent-Vault",
+    vault_name: "Agent-Vault",
+    branch: "worktree-TUT-1",
+    today: "2026-04-26",
+    agent: "claude",
+    model: "claude-opus-4-7",
+    mode: args.mode,
+  };
+}
+
+// --------------------------------------------------------------------------
+// Per-example assertion driver
+// --------------------------------------------------------------------------
+
+async function assertExampleClean(spec: ExampleSpec) {
+  const root = resolve(EXAMPLES_ROOT, spec.name);
+  const files = readExample(root);
+  expect(files.length).toBeGreaterThan(0); // sanity: example isn't empty
+  const app = makeFakeApp(files);
+
+  let bundle: ModuleSourceBundle;
+  if (spec.project === null) {
+    // Module-only example — no workflow file. Run the module loader against
+    // the example's set of files via a sentinel project string that filters
+    // nothing. We can't call `loadModuleSources` directly (it requires a
+    // project slug for `loadWorkflowFile`), so reach in via `loadModules`
+    // through a re-exported handle — but `loadModules` only loads modules,
+    // which is what we want here.
+    const { loadModules } = await import("./workflowModule");
+    const r = loadModules(app as never);
+    const errs = errors(r.diagnostics);
+    if (errs.length > 0) {
+      throw new Error(
+        `Example "${spec.name}" produced loader errors:\n${format(errs)}`,
+      );
+    }
+    expect(r.modules.length).toBeGreaterThan(0);
+    return;
+  }
+
+  bundle = await loadModuleSources(app as never, { project: spec.project });
+  const loaderErrs = errors(bundle.diagnostics);
+  if (loaderErrs.length > 0) {
+    throw new Error(
+      `Example "${spec.name}" loader errors:\n${format(loaderErrs)}`,
+    );
+  }
+  expect(bundle.workflow, `Example "${spec.name}" must produce a workflow`).not.toBeNull();
+
+  for (const step of spec.composeAtSteps) {
+    const ctx: ComposeContext = {
+      render: renderCtx({ project: spec.project, mode: step }),
+      globalVars: spec.globalVars ?? {},
+      projectVars: spec.projectVars ?? {},
+      launchVars: spec.launchVars ?? {},
+      maxWorkflowChars: DEFAULT_MAX_WORKFLOW_CHARS,
+    };
+    const composed = composeWorkflow({
+      loadedModules: bundle.loadedModules,
+      workflow: bundle.workflow!,
+      step,
+      ctx,
+    });
+    const composeErrs = errors(composed.diagnostics);
+    if (composeErrs.length > 0) {
+      throw new Error(
+        `Example "${spec.name}" step "${step}" composer errors:\n${format(composeErrs)}`,
+      );
+    }
+    // Sanity: the composed prompt is non-empty for steps we declared.
+    expect(composed.text.length, `Example "${spec.name}" step "${step}" should not be empty`).toBeGreaterThan(0);
+  }
+}
+
+// --------------------------------------------------------------------------
+// Tests
+// --------------------------------------------------------------------------
+
+describe("docs/examples — every shipped tutorial example loads + composes cleanly", () => {
+  for (const spec of EXAMPLES) {
+    it(`example "${spec.name}" produces zero error-severity diagnostics`, async () => {
+      await assertExampleClean(spec);
+    });
+  }
+});
+
+describe("docs/examples — manifest is in sync with the filesystem", () => {
+  it("every subdirectory under docs/examples/ is named in the manifest", () => {
+    const onDisk = readdirSync(EXAMPLES_ROOT, { withFileTypes: true })
+      .filter((d) => d.isDirectory())
+      .map((d) => d.name)
+      .sort();
+    const inManifest = EXAMPLES.map((e) => e.name).sort();
+    expect(onDisk).toEqual(inManifest);
+  });
+});

--- a/plugins/op-obsidian/src/docsExamples.test.ts
+++ b/plugins/op-obsidian/src/docsExamples.test.ts
@@ -266,12 +266,10 @@ async function assertExampleClean(spec: ExampleSpec) {
 
   let bundle: ModuleSourceBundle;
   if (spec.project === null) {
-    // Module-only example — no workflow file. Run the module loader against
-    // the example's set of files via a sentinel project string that filters
-    // nothing. We can't call `loadModuleSources` directly (it requires a
-    // project slug for `loadWorkflowFile`), so reach in via `loadModules`
-    // through a re-exported handle — but `loadModules` only loads modules,
-    // which is what we want here.
+    // Module-only example — no workflow file ships in this subtree, so
+    // `loadModuleSources` (which requires a project slug to fetch the
+    // workflow file) doesn't apply. Call `loadModules` directly with no
+    // project filter; we only need to verify the module file loads cleanly.
     const { loadModules } = await import("./workflowModule");
     const r = loadModules(app as never);
     const errs = errors(r.diagnostics);

--- a/plugins/op/.claude-plugin/plugin.json
+++ b/plugins/op/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "op",
   "description": "Obsidian Projects workflow — schema, slash commands, and agent skill for running a Jira-lite issue tracker inside an Obsidian vault.",
-  "version": "0.74.0",
+  "version": "0.74.1",
   "author": {
     "name": "Eugene Archibald"
   },


### PR DESCRIPTION
## Summary

- Adds three guided walkthroughs under `docs/workflow-modules/` (03 — author a module, 04 — compose a workflow, 05 — variables and templating) on top of OP-211's overview + quickstart.
- Adds full working source under `docs/examples/` — three vault-shaped subtrees the user can copy verbatim, each backing one tutorial.
- Adds a CI guard (`plugins/op-obsidian/src/docsExamples.test.ts`) that walks every `.md` under `docs/examples/`, runs it through `loadModuleSources` (1b/1c) + `composeWorkflow` (1d), and asserts zero error-severity diagnostics — so docs and engine can't silently drift.

Refs OP-181 plan §"Child 10 — Comprehensive user documentation" 10b. Closes #250.

## Test plan

- [x] `npx vitest run` in `plugins/op-obsidian/` → 1436 pass, 0 fail.
- [x] `npx vitest run src/docsExamples.test.ts` → 4 pass (one per example tree, plus the manifest-on-disk parity check).
- [x] `npm ci --dry-run` in `plugins/op-obsidian/` → clean (lockfile sound).
- [x] `node scripts/bump-version.mjs patch` → 0.74.0 → 0.74.1, manifest/package/plugin JSON moved in lockstep, build passed the freshness assertion.
- [x] `node scripts/dev-sync.mjs` → main.js + manifest copied to OP-Test, plugin reloaded.
- [x] OP-Test smoke probe: `eval app.plugins.plugins["op-obsidian"]?.manifest?.version` returns `0.74.1`; `dev:console` shows no errors after exercising the reload.
- [ ] Adversarial Copilot review on this PR (per WORKFLOW.md).
- [ ] Manual eyeball: open each tutorial in a markdown previewer, verify cross-links resolve and code fences render.

🤖 Generated with [Claude Code](https://claude.com/claude-code)