### PR TITLE
OP-213: Reference docs auto-generated from registries + CI guard (10c)

### DIFF
--- a/.github/workflows/op-obsidian-pr-checks.yml
+++ b/.github/workflows/op-obsidian-pr-checks.yml
@@ -46,3 +46,41 @@ jobs:
         if: steps.op_changes.outputs.relevant == 'true'
         working-directory: plugins/op-obsidian
         run: npm ci --dry-run
+
+  workflow-docs-drift:
+    name: Workflow docs drift (auto-generated reference tables)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      # Always-run job with step-level if: gating, same shape as the
+      # lockfile-sync job above so the check shows up cleanly in
+      # required-status UX without blocking unrelated PRs.
+      - name: Detect workflow-docs-relevant changes
+        id: docs_changes
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          if git diff --name-only "$BASE_SHA" "$HEAD_SHA" \
+               | grep -qE '^plugins/op-obsidian/src/(pluginVarRegistry|modelRegistry)\.ts$|^scripts/check-workflow-docs\.mjs$|^docs/workflow-modules/reference/|^\.github/workflows/op-obsidian-pr-checks\.yml$'; then
+            echo "relevant=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "relevant=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Setup Node
+        if: steps.docs_changes.outputs.relevant == 'true'
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      # Regenerates the auto-generated tables in docs/workflow-modules/reference/
+      # from the registry sources, then `git diff --exit-code`s the affected
+      # paths. Fails CI when the registry was edited without running the
+      # generator — prevents the "single source of truth" claim from drifting.
+      - name: check-workflow-docs --check
+        if: steps.docs_changes.outputs.relevant == 'true'
+        run: node scripts/check-workflow-docs.mjs --check

--- a/docs/workflow-modules/reference/README.md
+++ b/docs/workflow-modules/reference/README.md
@@ -1,0 +1,72 @@
+# Workflow Modules — Reference
+
+This folder holds the canonical reference for the workflow-modules
+subsystem. Three categories of page:
+
+- **Auto-generated tables** that ride alongside hand-written prose. The
+  tables come from a registry source in `plugins/op-obsidian/src/` and
+  are kept in sync by `scripts/check-workflow-docs.mjs`. Editing the
+  table by hand will be undone the next time the script runs.
+- **Hand-written cheat-sheets** that point at the canonical specs in
+  `docs/specs/` for the deep field-by-field contract.
+- **Hand-written precedence and tag references** that explain how the
+  pieces compose at runtime.
+
+## Pages
+
+- [`plugin-vars.md`](./plugin-vars.md) — every always-on plugin variable
+  the renderer surfaces (`{{id}}`, `{{title}}`, `{{branch}}`, …),
+  generated from `pluginVarRegistry.ts`.
+- [`module-schema.md`](./module-schema.md) — workflow-module frontmatter
+  cheat-sheet and diagnostic codes. Points at
+  [`workflow-module-schema.md`](../../specs/workflow-module-schema.md)
+  for the canonical contract.
+- [`workflow-schema.md`](./workflow-schema.md) — workflow-file frontmatter
+  cheat-sheet, plus the auto-generated **model registry** of allowed
+  per-agent aliases and canonical versioned ids. Points at
+  [`workflow-file-schema.md`](../../specs/workflow-file-schema.md) for
+  the canonical contract.
+- [`precedence.md`](./precedence.md) — the four-layer precedence chain
+  (Module → Global → Project → Launch) with worked examples for each
+  layer.
+- [`scope-tags.md`](./scope-tags.md) — the conventional `scope:` values
+  (`kickoff`, `mode:*`, `always`) and the gating fields (`agent:`,
+  `project:`).
+
+## How regeneration works
+
+```
+$ node scripts/check-workflow-docs.mjs
+unchanged docs/workflow-modules/reference/plugin-vars.md
+unchanged docs/workflow-modules/reference/workflow-schema.md
+```
+
+The generator reads `pluginVarRegistry.ts` and `modelRegistry.ts` as
+text, pulls the literal initializer entries via narrow regexes, and
+rewrites each page between paired sentinel comments:
+
+```
+<!-- AUTO-GENERATED:plugin-vars-table -->
+| Variable | Example | Description |
+…
+<!-- /AUTO-GENERATED:plugin-vars-table -->
+```
+
+Every other byte of the page is hand-written and never touched by the
+script. To edit a table by hand, edit the registry source — the table
+is the projection.
+
+## CI guard
+
+`.github/workflows/op-obsidian-pr-checks.yml` runs the script in
+`--check` mode whenever a PR touches the registry sources, the script
+itself, or any reference page. The check regenerates and then
+`git diff --exit-code`s — drift fails CI with the offending diff and
+the exact recovery command.
+
+To regenerate locally before pushing:
+
+```
+node scripts/check-workflow-docs.mjs
+git add docs/workflow-modules/reference/
+```

--- a/docs/workflow-modules/reference/module-schema.md
+++ b/docs/workflow-modules/reference/module-schema.md
@@ -1,0 +1,116 @@
+# Module schema — quick reference
+
+This page is the day-to-day cheat-sheet for authoring a workflow
+module. It does **not** repeat every contract detail — for the full
+field-by-field rules, error semantics, and shadowing model, see
+[`workflow-module-schema.md`](../../specs/workflow-module-schema.md).
+
+## Where modules live
+
+| Location | Path |
+| :--- | :--- |
+| Global (every project) | `Projects/_op-modules/<id>.md` |
+| Per-project (one project only) | `Projects/<slug>/MODULES/<id>.md` |
+
+Files outside these two layouts are ignored. Subdirectories under
+either layout are not loaded — keep modules at the top level of their
+folder.
+
+## Minimal frontmatter
+
+```yaml
+---
+id: branching                      # required, must equal the filename basename
+title: Branching discipline        # required
+type: workflow-module              # required, exact literal
+scope: kickoff                     # required — partition key (see scope-tags.md)
+order: 10                          # optional integer, default 0 — sort within a scope
+project: obsidian-projects         # optional — restrict to one project slug
+agent: claude                      # optional — restrict to one agent id
+vars:                              # optional list of VarDecl
+  - foo                            # bare
+  - bar=baz                        # default-shorthand
+  - qux=                           # explicit empty default
+  - { name: pkg, default: op-obsidian, description: "Package name" }
+---
+
+# Module body — opaque markdown rendered through the {{var}} engine.
+```
+
+## `vars:` shapes
+
+Three forms; all valid in the same list:
+
+| Shape | Example | Default value |
+| :--- | :--- | :--- |
+| Bare | `- foo` | _no default_ — caller must supply via Global / Project / Launch |
+| Default-shorthand | `- bar=baz` | `"baz"` |
+| Empty default-shorthand | `- qux=` | `""` (empty string — distinct from bare) |
+| Object | `- { name: pkg, default: op-obsidian, description: "…" }` | `"op-obsidian"` |
+
+Only the first `=` splits — `expr=a=b=c` yields name `expr`, value
+`a=b=c`. Whitespace inside the value is preserved verbatim; whitespace
+in the name is trimmed.
+
+### YAML auto-coercion gotcha
+
+`- 2026-04-25` parses as a `Date` and is rejected. Quote it
+(`'2026-04-25'`) or use the shorthand (`due=2026-04-25`) so it stays a
+string. The same applies inside object form (`default: '2026-04-25'`,
+not `default: 2026-04-25`).
+
+## Diagnostics
+
+Every loader-emitted error or warning is a `WorkflowDiagnostic`.
+Modules can produce these codes:
+
+| Code | When it fires | Severity |
+| :--- | :--- | :--- |
+| `malformed-frontmatter` | Missing/wrong-type required field, id-vs-filename mismatch, invalid `VarDecl`, duplicate var name within one module, vars list isn't an array, YAML coerced a value to a non-string type. | error |
+| `intra-scope-collision` | Two or more modules at the same `scope:` declare the same variable name (after per-project shadowing). | error |
+
+Diagnostics carry `moduleId`, `varName` (when applicable), and
+`extra.path` so downstream surfaces can name the offending file.
+
+The canonical home for the full diagnostic list across the whole
+subsystem (workflow files included) is the spec at
+[`workflow-module-schema.md`](../../specs/workflow-module-schema.md)
+and [`workflow-file-schema.md`](../../specs/workflow-file-schema.md).
+This table is intentionally hand-written rather than auto-generated:
+diagnostic codes are emitted from many call-sites and don't live in a
+single registry, so a generator would have to walk the AST. If the
+list above drifts from the spec, fix the spec first and propagate
+here.
+
+## Identifier rules
+
+- **`id`** must equal the filename basename (without `.md`). A file
+  named `review-and-merge.md` must declare `id: review-and-merge`.
+  Mismatch is `malformed-frontmatter` and the module is dropped.
+- **`scope`** is open-ended — author whatever names you need. The
+  composer just buckets modules by scope and stitches them in at the
+  matching step. See [`scope-tags.md`](./scope-tags.md) for the
+  conventions emerging in shipped fixtures.
+- **`vars` names** that contain hyphens or start with a digit will
+  load fine but won't be expanded by the renderer (the regex is
+  `[a-zA-Z_][a-zA-Z0-9_]*`). Stick to that shape unless you have a
+  reason not to.
+
+## Shadowing
+
+A per-project module shadows a same-id global module **silently** —
+only the per-project copy is loaded; the global is discarded. Use this
+to override or disable a shipped global for one project. If a global
+appears to have stopped applying to one project, check whether that
+project has a same-id file under `Projects/<slug>/MODULES/`.
+
+## See also
+
+- [`workflow-module-schema.md`](../../specs/workflow-module-schema.md)
+  — full contract: every field, every diagnostic, every gotcha.
+- [`scope-tags.md`](./scope-tags.md) — what the conventional `scope:`
+  values mean and when each fires.
+- [`plugin-vars.md`](./plugin-vars.md) — every always-on variable
+  available without a `vars:` declaration.
+- [`precedence.md`](./precedence.md) — how a module's `vars:` defaults
+  interact with Global / Project / Launch overrides.

--- a/docs/workflow-modules/reference/plugin-vars.md
+++ b/docs/workflow-modules/reference/plugin-vars.md
@@ -1,0 +1,102 @@
+# Plugin variables — full reference
+
+Plugin variables (also called *always-on vars*) are the named values
+the workflow renderer substitutes into every module body without the
+author having to declare them. They live exclusively at the
+**Launch-override** layer of the precedence chain — every plugin var is
+computed per-launch from the launch context and shadows any same-named
+lower-precedence value. Module-declared user vars (`{{vars.<name>}}`)
+are a separate namespace, distinguished by token shape; the renderer
+never confuses them.
+
+The single source of truth is
+`plugins/op-obsidian/src/pluginVarRegistry.ts`. The table below is
+**generated** from that file — to add, remove, or rename a variable,
+edit the registry and run:
+
+```
+node scripts/check-workflow-docs.mjs
+```
+
+## How vars are spelled in module bodies
+
+```
+The issue id is {{id}} — branch is {{branch}}, today is {{today}}.
+```
+
+- Token shape is `{{<name>}}` with optional whitespace inside the
+  braces (`{{ id }}` works too).
+- Names are case-sensitive.
+- A token whose name is **not** in the registry below leaves the
+  literal `{{name}}` in the rendered output and emits a `missing-var`
+  diagnostic.
+- Some vars are **always populated** for any launch (`id`, `title`,
+  `today`, `agent`, `mode`); others are populated only when the launch
+  context can supply them (`branch` is empty before the worktree
+  exists; `pr_url` is empty before the PR opens). Optional vars whose
+  source is missing render as the literal `{{name}}` and emit
+  `missing-var` — that's a soft failure: the workflow does not abort.
+
+## Registry
+
+<!-- AUTO-GENERATED:plugin-vars-table -->
+| Variable | Example | Description |
+| :--- | :--- | :--- |
+| `{{id}}` | `OP-194` | The issue's canonical id (e.g., OP-194). |
+| `{{title}}` | `Generic {{var}} renderer + context builder` | The issue's title from its frontmatter. |
+| `{{project}}` | `obsidian-projects` | The project slug the issue belongs to. |
+| `{{status}}` | `in-progress` | The issue's lifecycle status (open, in-progress, blocked, resolved, wontfix). |
+| `{{priority}}` | `high` | The issue's priority (low, med, high) — undefined if not set. |
+| `{{parent}}` | `OP-184` | The parent issue id from frontmatter, or `(none — this is a top-level issue)` when no parent is set. |
+| `{{pr_url}}` | `https://github.com/earchibald/obsidian-projects/pull/232` | The pull-request URL once the issue has one — undefined before the PR opens. |
+| `{{github_issue}}` | `https://github.com/earchibald/obsidian-projects/issues/232` | The mirrored GitHub issue URL when the issue is GH-linked — undefined when local-only. |
+| `{{repo_path}}` | `/Users/you/Projects/obsidian-projects` | Absolute path to the project's code repository — undefined for meta-only projects. |
+| `{{vault_path}}` | `/Users/you/work/Agent-Vault` | Absolute path to the active Obsidian vault. |
+| `{{vault_name}}` | `Agent-Vault` | Display name of the active Obsidian vault. |
+| `{{branch}}` | `worktree-OP-194` | The git branch the agent is operating on — undefined before the worktree exists or for meta-only projects. |
+| `{{today}}` | `2026-04-26` | Today's date in ISO YYYY-MM-DD form, computed by the launching surface. |
+| `{{agent}}` | `claude` | The agent id launching this session (claude, gemini, copilot). |
+| `{{model}}` | `claude-opus-4-7` | The resolved model id for this launch — undefined if the agent has no per-launch model selection. |
+| `{{mode}}` | `implement` | The launch mode (evaluate, plan, implement, review, finalize). |
+
+Sentinel for an issue with no parent: **`(none — this is a top-level issue)`** — emitted as the rendered value of `{{parent}}` when the issue's frontmatter has no `parent:` field.
+<!-- /AUTO-GENERATED:plugin-vars-table -->
+
+## Why a sentinel, not an empty string
+
+`{{parent}}` is special: a top-level issue genuinely has no parent, but
+emitting an empty string for the var would produce dangling prose like
+"the parent is ." in any module that references it. The registry
+substitutes a human-readable sentinel instead, so module authors don't
+have to write conditional templates and so agents reading the rendered
+prompt see a clear "this is a top-level issue" signal rather than an
+unrendered `{{parent}}` token or an empty hole.
+
+If you author a module that needs to behave differently for top-level
+vs. parented issues, branch on the sentinel string in your prose
+("when applicable, mention the parent issue ({{parent}}); for
+top-level issues, the value will read `(none — this is a top-level
+issue)`") rather than expecting an empty render.
+
+## Adding a new always-on var
+
+1. Add an entry to `PLUGIN_VAR_REGISTRY` in
+   `plugins/op-obsidian/src/pluginVarRegistry.ts`. The keys, in order,
+   are `name`, `description`, `example`, `compute`.
+2. If the var draws on a value not already in `RenderContext`, add the
+   field to that interface and to `LaunchContext` if it's per-launch,
+   then thread it through `buildRenderContext` and the launch
+   call-sites.
+3. Run `node scripts/check-workflow-docs.mjs` to regenerate the table
+   above.
+4. Commit the registry change and the regenerated doc together — the
+   CI guard rejects partial updates.
+
+## See also
+
+- [`workflow-module-schema.md`](../../specs/workflow-module-schema.md)
+  — the full contract for module frontmatter, including how
+  module-declared user vars (`{{vars.<name>}}`) interact with plugin
+  vars.
+- [`precedence.md`](./precedence.md) — where plugin vars sit in the
+  four-layer precedence chain and what shadowing rules apply.

--- a/docs/workflow-modules/reference/precedence.md
+++ b/docs/workflow-modules/reference/precedence.md
@@ -1,0 +1,207 @@
+# Precedence — Module / Global / Project / Launch
+
+Workflow-module composition resolves variable values through a
+four-layer precedence chain. **Later layers shadow earlier ones**:
+
+```
+   Module      (lowest precedence — module's own `vars:` defaults)
+   ▼
+   Global      (vault-wide user vars, settings.workflowVars)
+   ▼
+   Project     (per-project user vars, STATUS.md `vars:` map)
+   ▼
+   Launch      (per-launch overrides — UI, URI, CLI)  (highest precedence)
+```
+
+Two distinct token namespaces live on top of this:
+
+- **Plugin vars** — `{{id}}`, `{{branch}}`, `{{today}}`, … live
+  exclusively at **Launch**. They are computed per-launch from the
+  render context and shadow any same-named lower-precedence value. See
+  [`plugin-vars.md`](./plugin-vars.md).
+- **User vars** — `{{vars.<name>}}` walk the full chain above. They
+  are declared by modules and bound by Global / Project / Launch
+  layers.
+
+The two namespaces are disjoint by token shape (`{{id}}` vs.
+`{{vars.id}}`), so a user-named var can never accidentally shadow a
+plugin var like `{{branch}}`.
+
+## Layer 1 — Module (defaults declared with the module)
+
+A module's `vars:` list may carry inline defaults. These are the
+lowest-precedence binding for that variable name.
+
+```yaml
+# Projects/_op-modules/welcome.md
+vars:
+  - greeting=hello
+  - target=world
+```
+
+```
+Module body: "{{vars.greeting}}, {{vars.target}}!"
+Rendered:    "hello, world!"
+```
+
+If a different module at the same scope also declares the same name
+with a default, that's an `intra-scope-collision` diagnostic — the
+schema treats two modules at one scope owning the same var as a
+conflict. Across **different** scopes the same name is fine.
+
+If only one module declares the var, its default is the value seen
+when no higher layer binds anything.
+
+## Layer 2 — Global (vault-wide)
+
+Global user vars live in the plugin settings (`settings.workflowVars`)
+and apply to every project. Use them for values that are
+vault-personal but project-stable: your name, your default reviewer,
+your preferred PR template path.
+
+```
+settings.workflowVars = { greeting: "hi", reviewer: "@earchibald" }
+```
+
+```
+Module body: "{{vars.greeting}}, {{vars.target}}! cc {{vars.reviewer}}"
+Rendered:    "hi, world! cc @earchibald"
+```
+
+Note: `target` is still resolved from the module default (`"world"`)
+because the global layer didn't bind it; `greeting` is shadowed.
+
+## Layer 3 — Project (per-project)
+
+Per-project user vars live in `STATUS.md`'s frontmatter `vars:` map and
+apply only to issues in that project. Use them for values the project
+varies on but the rest of your vault doesn't care about: a project's
+package name, its CI workflow id, its primary slack channel.
+
+```yaml
+# Projects/obsidian-projects/STATUS.md
+vars:
+  pkg: op-obsidian
+  reviewer: "@plugin-reviewers"
+```
+
+```
+Module body: "Building {{vars.pkg}}, cc {{vars.reviewer}}"
+Rendered:    "Building op-obsidian, cc @plugin-reviewers"
+```
+
+The `reviewer` from Project shadows Global; `pkg` was unbound at
+Module/Global so Project supplies it.
+
+## Layer 4 — Launch (per-launch overrides)
+
+Launch overrides come from whatever launch surface you used:
+
+- **Launch modal** — the "Vars" section of `op-open-agent` lets you
+  override any var for this single launch.
+- **`obsidian://op-open-agent` URI** — `&var.<name>=<value>` query
+  params (URL-encoded).
+- **CLI** — `obsidian op-open-agent var.<name>=<value> …`.
+
+Launch wins over everything below.
+
+```
+launch override: { reviewer: "@hot-fix-reviewer" }
+```
+
+```
+Module body: "Building {{vars.pkg}}, cc {{vars.reviewer}}"
+Rendered:    "Building op-obsidian, cc @hot-fix-reviewer"
+```
+
+`pkg` still comes from Project (no launch override); `reviewer` is now
+the launch value, even though Global and Project both bound it.
+
+## Combined worked example
+
+Let's resolve every layer at once.
+
+**Sources:**
+
+```yaml
+# Projects/_op-modules/welcome.md  (Module)
+vars:
+  - greeting=hello
+  - target=world
+  - reviewer=
+```
+
+```
+settings.workflowVars                 # Global
+  greeting: hi
+  reviewer: "@earchibald"
+```
+
+```yaml
+# Projects/obsidian-projects/STATUS.md  (Project)
+vars:
+  pkg: op-obsidian
+  reviewer: "@plugin-reviewers"
+```
+
+```
+launch overrides                      # Launch
+  reviewer: "@hot-fix-reviewer"
+```
+
+**Module body:**
+
+```
+Hi {{vars.greeting}} — building {{vars.pkg}} for {{vars.target}}, cc {{vars.reviewer}}.
+```
+
+**Resolution per var:**
+
+| Var | Module | Global | Project | Launch | Resolved |
+| :--- | :--- | :--- | :--- | :--- | :--- |
+| `greeting` | `hello` | `hi` | _unbound_ | _unbound_ | **`hi`** (Global) |
+| `target` | `world` | _unbound_ | _unbound_ | _unbound_ | **`world`** (Module) |
+| `pkg` | _undeclared_ | _unbound_ | `op-obsidian` | _unbound_ | **`op-obsidian`** (Project) |
+| `reviewer` | `` (empty default) | `@earchibald` | `@plugin-reviewers` | `@hot-fix-reviewer` | **`@hot-fix-reviewer`** (Launch) |
+
+**Rendered:**
+
+```
+Hi hi — building op-obsidian for world, cc @hot-fix-reviewer.
+```
+
+## What the dry-run preview shows
+
+The launch modal's "▶ Composed prompt preview" disclosure renders the
+final string. The same data is available structurally — the composer
+returns a `perVarSourceMap` whose entries record both the resolved
+value **and** the supplying scope (`module` / `global` / `project` /
+`launch`). Surfaces that want to display "this value came from
+Project, not Module" read the source map directly.
+
+## Edge cases
+
+- **Bare module declaration with no upper-layer binding.** A module
+  declaring `- foo` (bare, no default) leaves `{{vars.foo}}` unbound
+  if no Global / Project / Launch layer supplies it. The renderer
+  emits `missing-var` (warning) and leaves the literal token in the
+  rendered output. Never aborts — soft failure.
+- **Undeclared-but-referenced.** A module body that mentions
+  `{{vars.bar}}` without any module ever declaring `bar` is a
+  separate diagnostic (`malformed-frontmatter` warning) — distinct
+  from "declared somewhere but no value resolved". This catches typos
+  early.
+- **Plugin-var name collision.** A user var named `id` would still
+  render as a separate token because the plugin-var token is `{{id}}`
+  but the user-var token is `{{vars.id}}`. Both are valid; they are
+  not the same token.
+
+## See also
+
+- [`plugin-vars.md`](./plugin-vars.md) — every always-on plugin var
+  surfaced at the Launch layer.
+- [`module-schema.md`](./module-schema.md) — `vars:` declaration
+  shapes (bare / shorthand / object).
+- [`workflow-schema.md`](./workflow-schema.md) — `extends:` and
+  per-step `agent:`/`model:` overrides (these are workflow-level
+  overrides, not user-var overrides — they sit alongside this chain).

--- a/docs/workflow-modules/reference/scope-tags.md
+++ b/docs/workflow-modules/reference/scope-tags.md
@@ -1,0 +1,137 @@
+# Scope tags and gating fields
+
+A workflow module's `scope:` field decides **when** its body reaches
+the agent; the optional `agent:` and `project:` fields decide **for
+which launches** the module is even considered. Together these are
+the gating surface that lets you write modules with narrow
+applicability without touching the workflow file each time.
+
+The loader does **not** enforce a fixed enum of `scope:` values —
+authors invent the names they need. This page documents the
+conventions emerging in shipped fixtures and the patterns the launch
+surface understands.
+
+## `scope:` — partition key
+
+`scope:` is the partition key used to:
+
+1. Decide **which step** in the workflow file's `steps:` list a module
+   participates in. A module with `scope: kickoff` is only considered
+   for steps whose `step:` id matches `kickoff`.
+2. Detect intra-scope variable collisions. Two modules at the same
+   scope declaring the same `vars:` name is an
+   `intra-scope-collision` error. Across different scopes the same
+   name is fine.
+
+A module's scope must match a `step:` id in the active workflow file
+for the module to actually fire. Modules with a scope no step
+references are loaded but never injected — useful for migration (drop
+the module first, wire the step later) but easy to forget about. The
+launch modal's "▶ Composed prompt preview" disclosure shows you
+exactly what's about to be injected.
+
+## Conventional scope values
+
+| Scope | Convention | Use for |
+| :--- | :--- | :--- |
+| `kickoff` | Injected once at the start of the agent's first prompt. | Orientation rules: branching discipline, where the issue note lives, which test command to run. |
+| `plan` | Injected when the agent enters plan mode. | "Before implementing, write the plan section" / planning-stage hints. |
+| `review` | Injected when the agent reaches the review step. | "Request adversarial review before merging" / merge-gate checklists. |
+| `finalize` | Injected at workflow end. | Resolve / cleanup / retro instructions. |
+| `mode:<launch-mode>` | Injected only when the launch mode (`{{mode}}`) matches. | Mode-specific prompts: `mode:plan` for plan-mode-only guidance, `mode:implement` for implement-only guidance. The launch surface and workflow file must agree on the spelling — this is a convention, not a built-in match rule. |
+| `always` | Conventional name for "every step". | Truly cross-cutting reminders. To make `always` actually inject everywhere, the workflow file's every `step:` must list the `always`-scoped module's id in its `modules:`. There is no automatic broadcast — the workflow file is explicit. |
+
+The composer doesn't care what scope is called; it just buckets modules
+by scope and stitches them in at the matching step. A project could
+just as easily have `triage` or `qa-handoff` — invent what you need.
+
+## `agent:` — agent gating
+
+A module may declare `agent: <id>` to restrict it to one agent.
+Common values today: `claude`, `gemini`, `copilot`. The loader does
+**not** filter on this field — the consumer (the composer) does. Use
+it for prose that only makes sense for a specific agent (model-
+specific tool quirks, agent-specific memory recipes).
+
+```yaml
+---
+id: claude-skill-cache
+title: Claude — using the Skill cache
+type: workflow-module
+scope: kickoff
+agent: claude
+---
+
+# Body — Claude-only orientation
+```
+
+A module without `agent:` applies to every agent. An empty or
+whitespace-only `agent:` (`agent: ""`) is silently treated as absent
+— some authors write that to mean "no restriction"; we honor that.
+
+## `project:` — project gating
+
+For **global** modules (`Projects/_op-modules/<id>.md`), `project:`
+restricts the module to one project slug, even though the file lives
+in the global folder.
+
+```yaml
+---
+id: op-obsidian-vault-prep
+title: op-obsidian — vault prep
+type: workflow-module
+scope: kickoff
+project: obsidian-projects
+---
+
+# Body — only injected for the obsidian-projects project
+```
+
+Per-project modules already live under `Projects/<slug>/MODULES/` so
+they don't need this field. If a per-project module sets `project:` to
+a value that disagrees with its enclosing folder, the module is
+filtered out at load time.
+
+Same empty-string rule as `agent:` — `project: ""` is treated as
+absent.
+
+## Combining gates
+
+Gates are AND-combined. A module with all four:
+
+```yaml
+scope: review
+agent: claude
+project: obsidian-projects
+order: 50
+```
+
+… participates only when (a) the active workflow file has a `review`
+step, (b) that step's `modules:` list names this module, (c) the
+launch agent is `claude`, and (d) the project slug is
+`obsidian-projects`. Within those launches it sorts by `order` (lower
+first; default 0).
+
+## Choosing a scope
+
+- Start with `kickoff` for any rule the agent needs upfront (branch
+  policy, where to find the issue note, test command).
+- Promote rules to a stage-specific scope (`plan`, `review`,
+  `finalize`) once you find yourself writing "before <stage>, do X".
+- Use `mode:<mode>` only when the rule is genuinely mode-specific
+  and **the launch surface threads `mode:` through to the workflow
+  file's `step:` ids**. This is a convention; verify it works in your
+  setup with the launch preview before relying on it.
+- Reach for `agent:` / `project:` gating only when the rule truly
+  doesn't generalize. Most rules either apply everywhere or are
+  better split into smaller scope-specific modules.
+
+## See also
+
+- [`module-schema.md`](./module-schema.md) — full module frontmatter
+  contract.
+- [`workflow-schema.md`](./workflow-schema.md) — how the workflow
+  file's `steps:` list selects modules by scope.
+- [`workflow-module-schema.md`](../../specs/workflow-module-schema.md)
+  — canonical spec; covers loader behavior, shadowing, and every
+  diagnostic.

--- a/docs/workflow-modules/reference/workflow-schema.md
+++ b/docs/workflow-modules/reference/workflow-schema.md
@@ -1,0 +1,124 @@
+# Workflow schema — quick reference
+
+This page is the day-to-day cheat-sheet for authoring a workflow
+file. It does **not** repeat every contract detail — for the full
+field-by-field rules, the `extends:` merge semantics, and the legacy
+`WORKFLOW.md` fallback ladder, see
+[`workflow-file-schema.md`](../../specs/workflow-file-schema.md).
+
+## Where workflow files live
+
+| Location | Path |
+| :--- | :--- |
+| Per-project | `Projects/<slug>/WORKFLOW.md` |
+| Global default (opt-in via `extends:`) | `Projects/_op-workflow.md` |
+
+The loader does not auto-merge the global — a project must opt in
+explicitly with `extends: Projects/_op-workflow.md`.
+
+## Minimal frontmatter
+
+```yaml
+---
+type: workflow                       # required, exact literal
+schema: 1                            # required integer; locks the contract
+project: obsidian-projects           # required string (project slug)
+default_agent: claude                # list-or-scalar
+default_model: opus                  # list-or-scalar-or-keyed-map
+extends: Projects/_op-workflow.md    # optional, vault-relative; one level only
+steps:                               # required (in modern shape)
+  - step: kickoff                    # required, unique within the workflow
+    modules: [orient, branching]     # list of module ids; may be empty
+    agent: claude                    # optional override (list-or-scalar)
+    model: opus                      # optional override (list-or-scalar-or-keyed-map)
+  - step: review
+    modules: [review-and-merge]
+---
+```
+
+## `default_agent` and step `agent:`
+
+List-or-scalar:
+
+- Scalar: `default_agent: claude` ≡ `[claude]`.
+- List: `default_agent: [claude, gemini]`. The launch context picks one
+  at runtime.
+
+Lists deduplicate (preserving order). Empty / whitespace-only / non-
+string entries emit `malformed-frontmatter` and the workflow is
+dropped.
+
+## `default_model` and step `model:`
+
+Three accepted shapes:
+
+- **Scalar** — `default_model: opus`. Applies to every agent in the
+  surrounding agent list.
+- **List** — `default_model: [opus, sonnet]`. Same: applies to every
+  agent, with multiple alternatives.
+- **Keyed map (per-agent)** — `default_model: { claude: opus, gemini: pro }`.
+  Each value is itself list-or-scalar.
+
+A keyed map referencing an agent absent from `default_agent` emits a
+warning-severity diagnostic — usually a typo.
+
+## Model registry
+
+A model name validates if it is either an **alias** (the ergonomic
+shorthand) or a **canonical versioned id** for the relevant agent.
+Aliases resolve to a single canonical id; versioned ids pass through
+unchanged.
+
+The single source of truth is
+`plugins/op-obsidian/src/modelRegistry.ts`. The table below is
+**generated** from that file — to add or remove a model, edit the
+registry and run:
+
+```
+node scripts/check-workflow-docs.mjs
+```
+
+<!-- AUTO-GENERATED:model-registry-table -->
+| Agent | Aliases (alias → canonical) | Versioned ids |
+| :--- | :--- | :--- |
+| `claude` | `opus` → `claude-opus-4-7`<br>`sonnet` → `claude-sonnet-4-6`<br>`haiku` → `claude-haiku-4-5-20251001` | `claude-opus-4-7`<br>`claude-opus-4-6`<br>`claude-opus-4-5`<br>`claude-sonnet-4-6`<br>`claude-sonnet-4-5`<br>`claude-haiku-4-5`<br>`claude-haiku-4-5-20251001` |
+| `gemini` | `pro` → `gemini-2.5-pro`<br>`flash` → `gemini-2.5-flash` | `gemini-2.5-pro`<br>`gemini-2.5-flash`<br>`gemini-2.0-pro`<br>`gemini-2.0-flash` |
+| `copilot` | `default` → `gpt-5` | `gpt-5`<br>`gpt-4.1` |
+<!-- /AUTO-GENERATED:model-registry-table -->
+
+### Adding a new model
+
+- **New ergonomic alias**: add the `alias → canonical` mapping to that
+  agent's `aliases` AND add the canonical id to `versioned`. Aliases
+  must resolve to a known versioned id; the test suite enforces this
+  invariant via `validateRegistryShape`.
+- **New pinned version**: add the canonical id to `versioned` only.
+- **New agent**: add a top-level entry. The pure registry doesn't
+  enforce the agent id against the runtime `AgentId` enum — that's a
+  separate concern.
+
+After editing, run `node scripts/check-workflow-docs.mjs` to
+regenerate the table; the CI guard rejects partial updates.
+
+## `steps:` and `extends:`
+
+- Each step has a unique `step:` id within a workflow.
+  `modules:` is required (may be empty).
+- `agent:` and `model:` are optional per-step overrides.
+- `extends:` points at one parent workflow file. **One level only** — a
+  parent declaring its own `extends:` emits a warning and the
+  grandparent is ignored. Child step ids replace the parent's at the
+  same slot; child steps with new ids append.
+
+Detailed merge semantics, model validation diagnostics, and the
+six-shape legacy fallback ladder live in the spec:
+[`workflow-file-schema.md`](../../specs/workflow-file-schema.md).
+
+## See also
+
+- [`workflow-file-schema.md`](../../specs/workflow-file-schema.md) —
+  full contract: `extends:` merge, legacy ladder, every diagnostic.
+- [`module-schema.md`](./module-schema.md) — module file contract this
+  workflow file's `steps:` references by id.
+- [`precedence.md`](./precedence.md) — how step-level overrides
+  interact with global / project / launch user vars.

--- a/scripts/check-workflow-docs.mjs
+++ b/scripts/check-workflow-docs.mjs
@@ -56,6 +56,12 @@ const MODEL_REGISTRY_PATH =
 
 const REFERENCE_DIR = join(REPO_ROOT, "docs/workflow-modules/reference");
 
+// Sentinel patterns reused by the balance pre-check and the replacement engine.
+// A key is one or more word characters or hyphens: `[\w-]+`.
+const SENTINEL_OPEN_RE = /<!-- AUTO-GENERATED:([\w-]+) -->/g;
+const SENTINEL_CLOSE_RE = /<!-- \/AUTO-GENERATED:([\w-]+) -->/g;
+const SENTINEL_BLOCK_RE = /<!-- AUTO-GENERATED:([\w-]+) -->([\s\S]*?)<!-- \/AUTO-GENERATED:\1 -->/g;
+
 // ---------------------------------------------------------------------------
 // Source extraction — pluginVarRegistry.ts
 // ---------------------------------------------------------------------------
@@ -128,6 +134,8 @@ function extractPluginVars(src, sentinels) {
   // entries than there are `compute:` fields, some entries were skipped because
   // their keys are in a different order — that's a silent partial failure that
   // the `entries.length === 0` guard alone would not catch.
+  // Note: TypeScript object literals use bare (unquoted) property names, so
+  // `compute:` always appears without quotes — the \b word boundary is correct.
   const computeCount = (block.match(/\bcompute\s*:/g) || []).length;
   if (entries.length === 0) {
     fail(
@@ -269,6 +277,8 @@ function extractModelRegistry(src) {
   // agent entries. Each agent record has exactly one `versioned:` field.
   // Fewer captured agents than `versioned:` fields means a partial extraction
   // due to key ordering — the `agents.length === 0` guard alone misses this.
+  // Note: TypeScript object literals use bare (unquoted) property names, so
+  // `versioned:` always appears without quotes — the \b word boundary is correct.
   const versionedCount = (block.match(/\bversioned\s*:/g) || []).length;
   if (agents.length === 0) {
     fail(
@@ -355,11 +365,15 @@ function renderModelRegistryTable(agents) {
 }
 
 function escapeCell(s) {
+  // Escape in HTML-safe order: & first, then < and >, then Markdown chars.
+  // If & were last, a description containing e.g. "&lt;" would become
+  // "&amp;lt;" (double-escaped) instead of the expected "&amp;lt;".
   return s
-    .replaceAll("|", "\\|")
-    .replaceAll("\n", " ")
+    .replaceAll("&", "&amp;")
     .replaceAll("<", "&lt;")
-    .replaceAll(">", "&gt;");
+    .replaceAll(">", "&gt;")
+    .replaceAll("|", "\\|")
+    .replaceAll("\n", " ");
 }
 
 // ---------------------------------------------------------------------------
@@ -391,11 +405,11 @@ function rewriteOnePage(path, content, blocks) {
   // Pre-check: every open sentinel must have a matching close and vice versa.
   // The replacement regex below only matches complete open/close pairs, so an
   // open marker without a close is silently skipped — unless we check here.
-  const openRe = /<!-- AUTO-GENERATED:([\w-]+) -->/g;
-  const closeRe = /<!-- \/AUTO-GENERATED:([\w-]+) -->/g;
   const balance = {};
-  for (const m of content.matchAll(openRe)) balance[m[1]] = (balance[m[1]] || 0) + 1;
-  for (const m of content.matchAll(closeRe)) balance[m[1]] = (balance[m[1]] || 0) - 1;
+  for (const m of content.matchAll(new RegExp(SENTINEL_OPEN_RE.source, "g")))
+    balance[m[1]] = (balance[m[1]] || 0) + 1;
+  for (const m of content.matchAll(new RegExp(SENTINEL_CLOSE_RE.source, "g")))
+    balance[m[1]] = (balance[m[1]] || 0) - 1;
   for (const [key, delta] of Object.entries(balance)) {
     if (delta !== 0) {
       const dir = delta > 0 ? "open marker without a matching close" : "close marker without a matching open";
@@ -403,7 +417,7 @@ function rewriteOnePage(path, content, blocks) {
     }
   }
 
-  const re = /<!-- AUTO-GENERATED:([\w-]+) -->([\s\S]*?)<!-- \/AUTO-GENERATED:\1 -->/g;
+  const re = new RegExp(SENTINEL_BLOCK_RE.source, "g");
   let found = 0;
   const seen = new Set();
   const out = content.replace(re, (full, key) => {

--- a/scripts/check-workflow-docs.mjs
+++ b/scripts/check-workflow-docs.mjs
@@ -123,10 +123,23 @@ function extractPluginVars(src, sentinels) {
     });
   }
 
+  // Count `compute:` occurrences in the block as a proxy for the number of
+  // entries. Each entry has exactly one `compute:` field. If we captured fewer
+  // entries than there are `compute:` fields, some entries were skipped because
+  // their keys are in a different order — that's a silent partial failure that
+  // the `entries.length === 0` guard alone would not catch.
+  const computeCount = (block.match(/\bcompute\s*:/g) || []).length;
   if (entries.length === 0) {
     fail(
       `${rel(PLUGIN_VAR_REGISTRY_PATH)}: PLUGIN_VAR_REGISTRY parsed to zero entries — the regex no longer matches the source shape. ` +
         `Update extractPluginVars().`,
+    );
+  }
+  if (entries.length < computeCount) {
+    fail(
+      `${rel(PLUGIN_VAR_REGISTRY_PATH)}: extracted ${entries.length} of ${computeCount} entries — ` +
+        `some entries have keys in the wrong order (expected: name, description, example, compute). ` +
+        `Reorder the keys or update extractPluginVars() if the registry shape changed.`,
     );
   }
   return entries;
@@ -170,8 +183,15 @@ function renderStringOrTemplate(raw, subs) {
           out += "\r";
           break;
         default:
-          // Unknown escape — preserve verbatim so the failure mode is visible.
-          out += "\\" + next;
+          // Unknown escape — fail loudly rather than passing through the raw
+          // `\X` text, which would produce broken or misleading table content.
+          // Either decode the escape in renderStringOrTemplate() or replace
+          // the template literal with a plain string.
+          fail(
+            `${rel(PLUGIN_VAR_REGISTRY_PATH)}: unrecognized escape sequence \`\\${next}\` ` +
+              `in template literal: ${JSON.stringify(raw)}. ` +
+              `Add the escape to renderStringOrTemplate(), or replace the template with a plain string.`,
+          );
       }
       i += 2;
       continue;
@@ -245,10 +265,22 @@ function extractModelRegistry(src) {
     });
   }
 
+  // Count `versioned:` occurrences in the block as a proxy for the number of
+  // agent entries. Each agent record has exactly one `versioned:` field.
+  // Fewer captured agents than `versioned:` fields means a partial extraction
+  // due to key ordering — the `agents.length === 0` guard alone misses this.
+  const versionedCount = (block.match(/\bversioned\s*:/g) || []).length;
   if (agents.length === 0) {
     fail(
       `${rel(MODEL_REGISTRY_PATH)}: MODEL_REGISTRY parsed to zero agents — the regex no longer matches the source shape. ` +
         `Update extractModelRegistry().`,
+    );
+  }
+  if (agents.length < versionedCount) {
+    fail(
+      `${rel(MODEL_REGISTRY_PATH)}: extracted ${agents.length} of ${versionedCount} agents — ` +
+        `some agent records have keys in the wrong order (expected: aliases, versioned). ` +
+        `Reorder the keys or update extractModelRegistry() if the registry shape changed.`,
     );
   }
   return agents;
@@ -323,7 +355,11 @@ function renderModelRegistryTable(agents) {
 }
 
 function escapeCell(s) {
-  return s.replaceAll("|", "\\|").replaceAll("\n", " ");
+  return s
+    .replaceAll("|", "\\|")
+    .replaceAll("\n", " ")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;");
 }
 
 // ---------------------------------------------------------------------------
@@ -352,6 +388,21 @@ function rewritePages(pages, blocks) {
 }
 
 function rewriteOnePage(path, content, blocks) {
+  // Pre-check: every open sentinel must have a matching close and vice versa.
+  // The replacement regex below only matches complete open/close pairs, so an
+  // open marker without a close is silently skipped — unless we check here.
+  const openRe = /<!-- AUTO-GENERATED:([\w-]+) -->/g;
+  const closeRe = /<!-- \/AUTO-GENERATED:([\w-]+) -->/g;
+  const balance = {};
+  for (const m of content.matchAll(openRe)) balance[m[1]] = (balance[m[1]] || 0) + 1;
+  for (const m of content.matchAll(closeRe)) balance[m[1]] = (balance[m[1]] || 0) - 1;
+  for (const [key, delta] of Object.entries(balance)) {
+    if (delta !== 0) {
+      const dir = delta > 0 ? "open marker without a matching close" : "close marker without a matching open";
+      fail(`${rel(path)}: AUTO-GENERATED:${key} has an unmatched ${dir}.`);
+    }
+  }
+
   const re = /<!-- AUTO-GENERATED:([\w-]+) -->([\s\S]*?)<!-- \/AUTO-GENERATED:\1 -->/g;
   let found = 0;
   const seen = new Set();

--- a/scripts/check-workflow-docs.mjs
+++ b/scripts/check-workflow-docs.mjs
@@ -1,0 +1,544 @@
+#!/usr/bin/env node
+//
+// Regenerate the auto-generated tables inside docs/workflow-modules/reference/
+// from the canonical TypeScript sources (`pluginVarRegistry.ts`,
+// `modelRegistry.ts`).
+//
+// Default: rewrite the affected pages between sentinel markers and exit 0.
+// `--check`: rewrite, then `git diff --exit-code` against the affected paths
+// and exit non-zero if anything moved — the CI guard for OP-213.
+//
+// Sentinel markers in markdown:
+//
+//   <!-- AUTO-GENERATED:<key> -->
+//   ...table content...
+//   <!-- /AUTO-GENERATED:<key> -->
+//
+// Everything outside the sentinels is hand-written and never touched. Adding
+// a new key: add a `BLOCKS[<key>] = …` entry below and a matching pair of
+// sentinel comments in the target page. Forgetting one half is a hard error.
+//
+// We deliberately do NOT load TypeScript via tsx/esbuild — the generator
+// reads the source file as text and pulls the literal initializer entries
+// via narrow regexes. This keeps the script dependency-free and matches the
+// ergonomics of `bump-version.mjs`. A future refactor of the registry shape
+// will break this script loudly (with a pointer at the expected pattern)
+// rather than silently — which is the desired failure mode.
+
+import { execFileSync } from "node:child_process";
+import { readFileSync, writeFileSync } from "node:fs";
+import { dirname, join, relative, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const REPO_ROOT = resolve(__dirname, "..");
+
+// ---------------------------------------------------------------------------
+// CLI parsing
+// ---------------------------------------------------------------------------
+
+const args = process.argv.slice(2);
+const checkMode = args.includes("--check");
+const unknown = args.filter((a) => a !== "--check");
+if (unknown.length > 0) {
+  fail(`Unknown argument(s): ${unknown.join(" ")}\nUsage: node scripts/check-workflow-docs.mjs [--check]`);
+}
+
+// Tests can override the registry source paths by setting these env vars.
+// Production CI never sets them.
+const PLUGIN_VAR_REGISTRY_PATH =
+  process.env.OP_DOCS_PLUGIN_VAR_REGISTRY ||
+  join(REPO_ROOT, "plugins/op-obsidian/src/pluginVarRegistry.ts");
+const MODEL_REGISTRY_PATH =
+  process.env.OP_DOCS_MODEL_REGISTRY ||
+  join(REPO_ROOT, "plugins/op-obsidian/src/modelRegistry.ts");
+
+const REFERENCE_DIR = join(REPO_ROOT, "docs/workflow-modules/reference");
+
+// ---------------------------------------------------------------------------
+// Source extraction — pluginVarRegistry.ts
+// ---------------------------------------------------------------------------
+
+/**
+ * Pull the `PARENT_NONE_SENTINEL` string constant verbatim. The constant is a
+ * single-line literal — `export const PARENT_NONE_SENTINEL = "...";`.
+ */
+function extractParentNoneSentinel(src) {
+  const m = src.match(/export const PARENT_NONE_SENTINEL\s*=\s*"((?:[^"\\]|\\.)*)";/);
+  if (!m) {
+    fail(
+      `${rel(PLUGIN_VAR_REGISTRY_PATH)}: could not find \`export const PARENT_NONE_SENTINEL = "...";\`. ` +
+        `If the constant was renamed, update this generator's extractParentNoneSentinel().`,
+    );
+  }
+  return JSON.parse(`"${m[1]}"`);
+}
+
+/**
+ * Walk the `PLUGIN_VAR_REGISTRY = Object.freeze({ … })` initializer and pull
+ * one record per entry. Each entry has the literal shape:
+ *
+ *   <key>: {
+ *     name: "...",
+ *     description: "..." | `template ${WITH_INTERP}`,
+ *     example: "...",
+ *     compute: (ctx) => ...,
+ *   },
+ *
+ * `description` may be a template-literal that interpolates a constant
+ * (currently only `${PARENT_NONE_SENTINEL}`). The generator resolves the
+ * known constants and renders the string verbatim. Unknown interpolations
+ * are an error — the generator should never produce ambiguous output.
+ */
+function extractPluginVars(src, sentinels) {
+  const startKey = /export const PLUGIN_VAR_REGISTRY[^=]*=\s*Object\.freeze\(\s*\{/;
+  const startMatch = src.match(startKey);
+  if (!startMatch) {
+    fail(
+      `${rel(PLUGIN_VAR_REGISTRY_PATH)}: could not find \`export const PLUGIN_VAR_REGISTRY = Object.freeze({\`. ` +
+        `If the registry shape changed, update this generator's extractPluginVars().`,
+    );
+  }
+  const startIdx = startMatch.index + startMatch[0].length;
+  const block = sliceBalanced(src, startIdx - 1, "{", "}");
+
+  const entries = [];
+  // Match each entry: <name>: { name: "...", description: <str>, example: "...", compute: <expr>, },
+  //
+  // The trailing compute expression is a single arrow body. We don't need its
+  // value — only the metadata fields. Conservative regex: `name`, `description`,
+  // `example` keys with string-or-template-literal values, in that order.
+  const entryRe =
+    /(?<key>\w+)\s*:\s*\{\s*name\s*:\s*"(?<name>(?:[^"\\]|\\.)*)"\s*,\s*description\s*:\s*(?<descRaw>"(?:[^"\\]|\\.)*"|`(?:[^`\\]|\\.)*`)\s*,\s*example\s*:\s*"(?<example>(?:[^"\\]|\\.)*)"\s*,\s*compute\s*:/g;
+
+  let m;
+  while ((m = entryRe.exec(block)) !== null) {
+    const description = renderStringOrTemplate(m.groups.descRaw, sentinels);
+    entries.push({
+      key: m.groups.key,
+      name: JSON.parse(`"${m.groups.name}"`),
+      description,
+      example: JSON.parse(`"${m.groups.example}"`),
+    });
+  }
+
+  if (entries.length === 0) {
+    fail(
+      `${rel(PLUGIN_VAR_REGISTRY_PATH)}: PLUGIN_VAR_REGISTRY parsed to zero entries — the regex no longer matches the source shape. ` +
+        `Update extractPluginVars().`,
+    );
+  }
+  return entries;
+}
+
+/**
+ * Render a JS string literal or backtick-template literal verbatim. Only the
+ * named template-substitution constants in `subs` are honored; any other
+ * `${…}` expression is an error so we never silently emit a broken table.
+ */
+function renderStringOrTemplate(raw, subs) {
+  if (raw.startsWith('"')) {
+    return JSON.parse(raw);
+  }
+  // Template literal: strip the backticks, walk char-by-char so backslash
+  // escapes (`\``, `\\`, `\$`, `\n`, `\t`) are decoded the same way the JS
+  // engine would and `${EXPR}` substitutions are resolved against `subs`.
+  // Order matters: a raw-text replace pass would misinterpret an escaped
+  // `\${literal}`. Walking eats one escape at a time and only treats an
+  // unescaped `${…}` as a substitution.
+  const inner = raw.slice(1, -1);
+  let out = "";
+  let i = 0;
+  while (i < inner.length) {
+    const c = inner[i];
+    if (c === "\\" && i + 1 < inner.length) {
+      const next = inner[i + 1];
+      switch (next) {
+        case "`":
+        case "\\":
+        case "$":
+          out += next;
+          break;
+        case "n":
+          out += "\n";
+          break;
+        case "t":
+          out += "\t";
+          break;
+        case "r":
+          out += "\r";
+          break;
+        default:
+          // Unknown escape — preserve verbatim so the failure mode is visible.
+          out += "\\" + next;
+      }
+      i += 2;
+      continue;
+    }
+    if (c === "$" && inner[i + 1] === "{") {
+      const end = inner.indexOf("}", i + 2);
+      if (end === -1) {
+        fail(
+          `${rel(PLUGIN_VAR_REGISTRY_PATH)}: unterminated \${…} substitution in template literal: ${JSON.stringify(raw)}.`,
+        );
+      }
+      const name = inner.slice(i + 2, end).trim();
+      if (!Object.prototype.hasOwnProperty.call(subs, name)) {
+        fail(
+          `${rel(PLUGIN_VAR_REGISTRY_PATH)}: template literal references \${${name}} but the generator does not know how to resolve it. ` +
+            `Add it to the substitution map in extractPluginVars(), or replace the template with a plain string.`,
+        );
+      }
+      out += subs[name];
+      i = end + 1;
+      continue;
+    }
+    out += c;
+    i++;
+  }
+  return out;
+}
+
+// ---------------------------------------------------------------------------
+// Source extraction — modelRegistry.ts
+// ---------------------------------------------------------------------------
+
+/**
+ * Pull `{ <agent>: { aliases: { … }, versioned: <SET_NAME> } }` from
+ * `MODEL_REGISTRY` and resolve each `versioned: SET_NAME` against the
+ * top-level `const SET_NAME = new Set<string>([ … ])` declarations.
+ */
+function extractModelRegistry(src) {
+  const versionedSets = extractVersionedSets(src);
+
+  const startKey = /export const MODEL_REGISTRY[^=]*=\s*\{/;
+  const startMatch = src.match(startKey);
+  if (!startMatch) {
+    fail(
+      `${rel(MODEL_REGISTRY_PATH)}: could not find \`export const MODEL_REGISTRY = {\`. ` +
+        `Update extractModelRegistry() if the registry shape changed.`,
+    );
+  }
+  const startIdx = startMatch.index + startMatch[0].length;
+  const block = sliceBalanced(src, startIdx - 1, "{", "}");
+
+  // Per-agent records: <agent>: { aliases: { ... }, versioned: SET_NAME, },
+  const agents = [];
+  const agentRe =
+    /(?<agent>\w+)\s*:\s*\{\s*aliases\s*:\s*\{(?<aliases>[^{}]*)\}\s*,\s*versioned\s*:\s*(?<setName>\w+)\s*,?\s*\}/g;
+
+  let m;
+  while ((m = agentRe.exec(block)) !== null) {
+    const aliasMap = parseAliasMap(m.groups.aliases, m.groups.agent);
+    const versioned = versionedSets[m.groups.setName];
+    if (!versioned) {
+      fail(
+        `${rel(MODEL_REGISTRY_PATH)}: agent \`${m.groups.agent}\` references versioned set \`${m.groups.setName}\` ` +
+          `but no top-level \`const ${m.groups.setName} = new Set<string>([ … ])\` was found.`,
+      );
+    }
+    agents.push({
+      agent: m.groups.agent,
+      aliases: aliasMap,
+      versioned,
+    });
+  }
+
+  if (agents.length === 0) {
+    fail(
+      `${rel(MODEL_REGISTRY_PATH)}: MODEL_REGISTRY parsed to zero agents — the regex no longer matches the source shape. ` +
+        `Update extractModelRegistry().`,
+    );
+  }
+  return agents;
+}
+
+function extractVersionedSets(src) {
+  const out = {};
+  const re = /const\s+(\w+)\s*=\s*new Set<string>\(\s*\[([\s\S]*?)\]\s*\)/g;
+  let m;
+  while ((m = re.exec(src)) !== null) {
+    const setName = m[1];
+    const body = m[2];
+    const ids = [];
+    const idRe = /"((?:[^"\\]|\\.)*)"/g;
+    let idMatch;
+    while ((idMatch = idRe.exec(body)) !== null) {
+      ids.push(JSON.parse(`"${idMatch[1]}"`));
+    }
+    out[setName] = ids;
+  }
+  return out;
+}
+
+function parseAliasMap(raw, agentForError) {
+  const aliases = [];
+  const re = /(\w+)\s*:\s*"((?:[^"\\]|\\.)*)"/g;
+  let m;
+  while ((m = re.exec(raw)) !== null) {
+    aliases.push({ alias: m[1], canonical: JSON.parse(`"${m[2]}"`) });
+  }
+  if (aliases.length === 0) {
+    fail(
+      `${rel(MODEL_REGISTRY_PATH)}: agent \`${agentForError}\` has an empty or unparseable \`aliases:\` map.`,
+    );
+  }
+  return aliases;
+}
+
+// ---------------------------------------------------------------------------
+// Markdown rendering
+// ---------------------------------------------------------------------------
+
+function renderPluginVarsTable(entries, parentSentinel) {
+  const lines = [];
+  lines.push("| Variable | Example | Description |");
+  lines.push("| :--- | :--- | :--- |");
+  for (const e of entries) {
+    lines.push(
+      `| \`{{${e.name}}}\` | \`${escapeCell(e.example)}\` | ${escapeCell(e.description)} |`,
+    );
+  }
+  lines.push("");
+  lines.push(`Sentinel for an issue with no parent: **\`${escapeCell(parentSentinel)}\`** ` +
+    `— emitted as the rendered value of \`{{parent}}\` when the issue's frontmatter has no \`parent:\` field.`);
+  return lines.join("\n");
+}
+
+function renderModelRegistryTable(agents) {
+  const lines = [];
+  lines.push("| Agent | Aliases (alias → canonical) | Versioned ids |");
+  lines.push("| :--- | :--- | :--- |");
+  for (const a of agents) {
+    const aliases = a.aliases.length
+      ? a.aliases.map((x) => `\`${x.alias}\` → \`${x.canonical}\``).join("<br>")
+      : "_(none)_";
+    const versioned = a.versioned.length
+      ? a.versioned.map((v) => `\`${v}\``).join("<br>")
+      : "_(none)_";
+    lines.push(`| \`${a.agent}\` | ${aliases} | ${versioned} |`);
+  }
+  return lines.join("\n");
+}
+
+function escapeCell(s) {
+  return s.replaceAll("|", "\\|").replaceAll("\n", " ");
+}
+
+// ---------------------------------------------------------------------------
+// Sentinel-replacement engine
+// ---------------------------------------------------------------------------
+
+/**
+ * Rewrite every `<!-- AUTO-GENERATED:<key> -->...<!-- /AUTO-GENERATED:<key> -->`
+ * block in `pages` using the rendered content from `blocks[key]`. Throws if a
+ * page has unmatched markers, an unknown key, or no markers at all.
+ *
+ * Returns the list of (path, before, after) so the caller can summarise
+ * what changed.
+ */
+function rewritePages(pages, blocks) {
+  const summary = [];
+  for (const path of pages) {
+    const before = readFileSync(path, "utf8");
+    const after = rewriteOnePage(path, before, blocks);
+    if (before !== after) {
+      writeFileSync(path, after, "utf8");
+    }
+    summary.push({ path, changed: before !== after });
+  }
+  return summary;
+}
+
+function rewriteOnePage(path, content, blocks) {
+  const re = /<!-- AUTO-GENERATED:([\w-]+) -->([\s\S]*?)<!-- \/AUTO-GENERATED:\1 -->/g;
+  let found = 0;
+  const seen = new Set();
+  const out = content.replace(re, (full, key) => {
+    found++;
+    if (seen.has(key)) {
+      fail(`${rel(path)}: AUTO-GENERATED:${key} appears more than once. Each key must appear at most once per page.`);
+    }
+    seen.add(key);
+    if (!Object.prototype.hasOwnProperty.call(blocks, key)) {
+      fail(
+        `${rel(path)}: unknown AUTO-GENERATED key \`${key}\`. Known keys: ${Object.keys(blocks).join(", ") || "(none)"}.`,
+      );
+    }
+    return `<!-- AUTO-GENERATED:${key} -->\n${blocks[key]}\n<!-- /AUTO-GENERATED:${key} -->`;
+  });
+  if (found === 0) {
+    fail(
+      `${rel(path)}: no AUTO-GENERATED sentinels found. Each managed page needs at least one ` +
+        `<!-- AUTO-GENERATED:<key> -->...<!-- /AUTO-GENERATED:<key> --> block. ` +
+        `If this page is not meant to carry generated content, remove it from the PAGES list in scripts/check-workflow-docs.mjs.`,
+    );
+  }
+  return out;
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Find the matching closing brace for the opening brace at `openIdx` and
+ * return the slice between them, exclusive of the braces. Walks character-by-
+ * character so it survives nested braces inside the literal.
+ *
+ * Strings (single, double, backtick) and line/block comments are skipped so
+ * a `}` inside `"foo}"` doesn't terminate the scan.
+ */
+function sliceBalanced(src, openIdx, openCh, closeCh) {
+  if (src[openIdx] !== openCh) {
+    fail(`Internal error: sliceBalanced expected '${openCh}' at index ${openIdx}, got '${src[openIdx]}'.`);
+  }
+  let depth = 0;
+  let i = openIdx;
+  let inString = null; // '"' | "'" | "`" | null
+  let templateDepth = 0;
+  while (i < src.length) {
+    const c = src[i];
+    const c2 = src[i + 1];
+
+    if (inString === null) {
+      // Skip line comments.
+      if (c === "/" && c2 === "/") {
+        const nl = src.indexOf("\n", i + 2);
+        i = nl === -1 ? src.length : nl + 1;
+        continue;
+      }
+      // Skip block comments.
+      if (c === "/" && c2 === "*") {
+        const end = src.indexOf("*/", i + 2);
+        i = end === -1 ? src.length : end + 2;
+        continue;
+      }
+      if (c === '"' || c === "'" || c === "`") {
+        inString = c;
+        i++;
+        continue;
+      }
+      if (c === openCh) {
+        depth++;
+        i++;
+        continue;
+      }
+      if (c === closeCh) {
+        depth--;
+        if (depth === 0) {
+          return src.slice(openIdx + 1, i);
+        }
+        i++;
+        continue;
+      }
+      i++;
+      continue;
+    }
+
+    // Inside a string.
+    if (c === "\\") {
+      i += 2;
+      continue;
+    }
+    if (inString === "`" && c === "$" && c2 === "{") {
+      // Template substitution: `…${expr}…`
+      // Walk until the matching `}` (these don't count toward our outer depth).
+      templateDepth++;
+      i += 2;
+      while (templateDepth > 0 && i < src.length) {
+        if (src[i] === "{") templateDepth++;
+        else if (src[i] === "}") templateDepth--;
+        i++;
+      }
+      continue;
+    }
+    if (c === inString) {
+      inString = null;
+      i++;
+      continue;
+    }
+    i++;
+  }
+  fail(`Internal error: sliceBalanced ran off the end of the source without finding a matching '${closeCh}'.`);
+}
+
+function rel(p) {
+  return relative(REPO_ROOT, p);
+}
+
+function fail(message) {
+  console.error(`check-workflow-docs: ${message}`);
+  process.exit(2);
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+function main() {
+  const pluginVarSrc = readFileSync(PLUGIN_VAR_REGISTRY_PATH, "utf8");
+  const modelSrc = readFileSync(MODEL_REGISTRY_PATH, "utf8");
+
+  const parentSentinel = extractParentNoneSentinel(pluginVarSrc);
+  const pluginVars = extractPluginVars(pluginVarSrc, {
+    PARENT_NONE_SENTINEL: parentSentinel,
+  });
+  const modelAgents = extractModelRegistry(modelSrc);
+
+  const blocks = {
+    "plugin-vars-table": renderPluginVarsTable(pluginVars, parentSentinel),
+    "model-registry-table": renderModelRegistryTable(modelAgents),
+  };
+
+  // Pages that carry one or more sentinel blocks. Adding a new managed page:
+  // create the file, drop in the sentinel pair(s), and append the path here.
+  const pages = [
+    join(REFERENCE_DIR, "plugin-vars.md"),
+    join(REFERENCE_DIR, "workflow-schema.md"),
+  ];
+
+  const summary = rewritePages(pages, blocks);
+  for (const s of summary) {
+    const tag = s.changed ? "wrote" : "unchanged";
+    console.log(`${tag} ${rel(s.path)}`);
+  }
+
+  if (checkMode) {
+    runCheckGuard(pages);
+  }
+}
+
+function runCheckGuard(pages) {
+  const relPaths = pages.map(rel);
+  let diff;
+  try {
+    diff = execFileSync("git", ["diff", "--", ...relPaths], {
+      cwd: REPO_ROOT,
+      encoding: "utf8",
+    });
+  } catch (e) {
+    fail(`git diff failed: ${e.message}`);
+  }
+  if (diff.trim().length > 0) {
+    console.error("");
+    console.error("Reference docs are stale. The auto-generated tables in these pages drifted from the registry sources:");
+    console.error("");
+    for (const p of relPaths) {
+      console.error(`  - ${p}`);
+    }
+    console.error("");
+    console.error("Fix:");
+    console.error("  node scripts/check-workflow-docs.mjs");
+    console.error("  git add docs/workflow-modules/reference/");
+    console.error("  git commit -m '<your subject>'");
+    console.error("");
+    console.error("--- diff ---");
+    console.error(diff);
+    process.exit(1);
+  }
+  console.log("workflow-docs check: ok");
+}
+
+main();


### PR DESCRIPTION
## Summary

- Adds `docs/workflow-modules/reference/` with six pages — README index, plugin-vars, module-schema, workflow-schema, precedence, scope-tags. Plugin-vars and workflow-schema carry auto-generated tables sourced from `pluginVarRegistry.ts` (every always-on var + the resolved `PARENT_NONE_SENTINEL`) and `modelRegistry.ts` (per-agent aliases + canonical versioned ids). Hand-written pages defer to `docs/specs/workflow-{module,file}-schema.md` for the canonical field-by-field contracts.
- Adds `scripts/check-workflow-docs.mjs` — dependency-free Node script that reads the two TypeScript registries as text, pulls the literal initializer entries via narrow regex + a balanced-brace walker, and rewrites the auto-generated blocks in place between `<!-- AUTO-GENERATED:<key> -->...<!-- /AUTO-GENERATED:<key> -->` sentinels. `--check` regenerates and `git diff --exit-code`s the affected paths so drift fails CI.
- Adds a `workflow-docs-drift` job to `.github/workflows/op-obsidian-pr-checks.yml`. Always-runs shape with step-level `if:` gating on touching the registry sources, the script, the reference docs, or the workflow file itself.

Closes the OP-193 (Child 10) grandchild **10c** — see umbrella for sibling work (10a/OP-211 conceptual overview + quickstart already merged; 10b/OP-212 authoring tutorials in flight; 10d/OP-214 sharing/migration; 10e troubleshooting; 10f worked examples).

No `plugins/op-obsidian/` source edits — docs + script + CI only. No version bump.

## Test plan

- [x] `node scripts/check-workflow-docs.mjs` — first run wrote `plugin-vars.md`, second run unchanged. Idempotent.
- [x] `node scripts/check-workflow-docs.mjs --check` on clean tree — exit 0, "workflow-docs check: ok".
- [x] Drift simulation — copied registry to `/tmp`, inserted a synthetic `fake_drift_var`, pointed generator via `OP_DOCS_PLUGIN_VAR_REGISTRY`. `--check` exited 1 with a structured message naming the page + the recovery command + the diff. Restored clean afterward.
- [x] Hard-error path — renamed `PARENT_NONE_SENTINEL` in a fake registry; script exited 2 with a precise "could not find … update extractParentNoneSentinel()" pointer.
- [x] Hard-error path — stripped sentinels from a managed page; script exited 2 with "no AUTO-GENERATED sentinels found …".
- [ ] CI: confirm the new `workflow-docs-drift` job runs (and is gated correctly — should run on this PR since it adds the docs and the script, but not on PRs that don't touch the registries/docs/script).

## @copilot adversarial review

Pressure test:

1. **Sentinel-marker robustness.** Could a hand-written page with a malformed sentinel (extra whitespace, wrong-cased key, missing closing marker) produce a corrupted file that *still passes* `--check`? E.g. a single open marker with no close — does the regex skip it silently or fail loudly? What about nested markers (`AUTO-GENERATED:a` containing another `AUTO-GENERATED:b`)? Should they be allowed?
2. **Regex extraction fragility.** `extractPluginVars`'s entry regex requires keys in the exact order `name, description, example, compute`. Is a key reorder in `pluginVarRegistry.ts` a silent miss (entries not found, table empty) or a loud failure (the `entries.length === 0` check fires)? Same for `extractModelRegistry`'s `aliases:` then `versioned:` ordering. If silent: harden it.
3. **Template-literal escape coverage.** `renderStringOrTemplate` decodes `\``, `\\`, `\$`, `\n`, `\t`, `\r`. What if a future registry entry uses `é` or `\xff`? The "unknown escape" branch preserves the literal `\u` — does that produce a broken table cell? Should I either decode them or fail loudly instead of silently passing through?
4. **Markdown cell escaping.** `escapeCell` only escapes `|` and `\n`. A description containing literal `<` or HTML-like content would render as raw HTML in some markdown processors. Acceptable? If the registry adds a `description: "use <foo> here"` entry, would that produce surprising output?
5. **`git diff --exit-code` behavior in `--check`.** What if the working tree has *unstaged* edits to the reference docs that aren't drift (e.g. a hand-written prose change in the same PR)? The script regenerates first then diffs, so any working-tree drift — generated or hand-edited — fails the check. Is that the right semantic? Could it produce false-positive CI failures on PRs that legitimately edit prose around the auto-gen block?
6. **CI gate path-filter completeness.** The `workflow-docs-drift` step-level `if:` gates on the four file patterns. Is there any path where the registry could change *without* one of those files appearing in the diff (e.g. via a refactor that moves `MODEL_REGISTRY` to a new file)? The CI should follow.
7. **Drift reset symmetry.** If a CI run regenerates files in the runner's checkout, the runner's working tree is now dirty — but CI doesn't push back. Confirm that `--check` is purely *read*ing the diff (no commit, no push) and that the runner's mutation is harmless.
8. **Backslash-escape interpretation.** Verify that the `parent` var's description `\`(none — …)\`` renders as literal backticks `\`(none — …)\`` in the generated table (forming an inline code span on render), not as the two characters `\\\``. The fix in this PR walks the template literal char-by-char to decode escapes; sanity-check that no other entry in the registry trips this path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)