### PR TITLE
OP-215: 10e — troubleshooting + FAQ + settings reference + in-product help links

### DIFF
--- a/docs/workflow-modules/03-troubleshooting.md
+++ b/docs/workflow-modules/03-troubleshooting.md
@@ -1,0 +1,275 @@
+# Workflow Modules — Troubleshooting
+
+Every error and warning the workflow-modules engine emits is a
+`WorkflowDiagnostic` — one shape, one formatter, every surface. This page
+walks each diagnostic code, explains what it means in plain English, and
+shows how to fix it.
+
+## Where the same diagnostic shows up
+
+A single diagnostic record (one `WorkflowDiagnostic`) appears in multiple
+surfaces — they all read it through the unified formatter
+(`workflowDiagnosticFormat.ts`), so the prose is byte-identical no matter
+where you encounter it:
+
+- **Settings → Workflows panel.** The module list shows per-module
+  diagnostics inline (badge + label + location + message + hint).
+- **`op-explain-workflow` / `op-list-vars` CLIs.** The structured payload
+  in `Projects/_scratch/op-last-response.md` carries `diagnosticLines`
+  (one-line) and `diagnosticBlocks` (multi-line); the stdout summary
+  reports per-severity counts.
+- **Editor squiggles.** Saving a `WORKFLOW.md` or module file runs the
+  loader and renders diagnostics as red/yellow underlines with the same
+  message and a status-footer count.
+- **Dry-run preview banner** (launch modal). The `▶ Composed prompt
+  preview` disclosure header shows the diagnostic count next to the
+  module count and char count.
+
+If a fix below says "edit the module" and you're staring at the Settings
+panel, you can open the file straight from the diagnostic row's location
+breadcrumb — clicking opens the file in the active leaf.
+
+## Severity legend
+
+- **Error** (`E`) — the workflow won't compose, or the module/file is
+  dropped from the load. Block-and-fix.
+- **Warning** (`W`) — composition continues, but something looks wrong
+  enough that the agent might do the wrong thing. Worth investigating.
+- **Info** (`I`) — advisory; the surface is showing you a guardrail or a
+  size notice. Not a failure.
+
+## The codes
+
+### `bad-model`
+
+**What it means.** A model name in the workflow file isn't on the agent's
+allow-list. The model registry (`modelRegistry.ts`) maintains the
+canonical aliases (`opus`, `sonnet`, `haiku`) and the versioned ids
+(`claude-opus-4-7`, `claude-sonnet-4-6`, …). A typo (`oups`), a model
+that's been retired, or a model paired with the wrong agent (e.g.
+`gemini` with `opus`) all emit this.
+
+**How to fix.**
+
+1. Open the workflow file (`Projects/<slug>/WORKFLOW.md`).
+2. Find the offending field — `default_model:`, or a step-level `model:`
+   override. The diagnostic's `stepId` points at it (`<defaults>` for the
+   workflow-level field).
+3. Replace the bad value with one of the diagnostic's listed allowed
+   aliases or versioned ids.
+
+If you'd rather not edit the file by hand, the **bad-model recovery
+dialog** (OP-205) opens automatically when an `op-open-agent` launch hits
+this diagnostic — it offers a one-click swap, writes a `.bak`, and shows
+the diff before applying.
+
+**Cross-reference.** Allowed model lists per agent live in
+[`workflow-file-schema.md` § Models](../specs/workflow-file-schema.md#default_model-list-or-scalar-or-keyed-map).
+
+### `missing-var`
+
+**What it means.** A module body references a `{{var_name}}` whose value
+the composer couldn't resolve at any precedence layer. The four layers
+(Module default → Global default → Project default → Launch override)
+are walked top-to-bottom; if every layer comes up empty, the var is
+unresolved and the prose injected reads literally (`{{var_name}}` —
+which is almost always the wrong thing for an agent to see).
+
+**How to fix.**
+
+Pick the layer that should own the value:
+
+- **Module default.** Add a default to the module's `vars:` block:
+  `- name=value` (shorthand) or `- { name: name, default: value }`.
+  Right when the value is intrinsic to the module's behavior.
+- **Global default.** Edit
+  `Projects/_op-modules/_overrides.md`'s `vars:` block. Right when the
+  value is vault-wide policy.
+- **Project default.** Edit `Projects/<slug>/MODULES/_overrides.md`.
+  Right when the value differs per project.
+- **Launch override.** Fill it in the launch modal's variables panel
+  (OP-204). Right for one-off launches.
+
+The diagnostic's `varName` field tells you which name is unresolved; the
+`scopeLabel` (when present) tells you the lowest layer the composer
+actually checked, so you know how high you need to push the value.
+
+**Cross-reference.** [`workflow-module-schema.md` § Vars
+declarations](../specs/workflow-module-schema.md#vars-declarations) covers
+the three `VarDecl` shapes.
+
+### `unknown-module`
+
+**What it means.** A workflow file's `steps:` list names a module id that
+didn't load. Either the file doesn't exist, the filename basename
+doesn't match its `id:` field, or the module's `type:` isn't the literal
+`workflow-module`.
+
+**How to fix.**
+
+1. **Check the spelling.** `steps: [{ step: kickoff, modules: [branchin] }]`
+   silently fails when the file is named `branching.md`.
+2. **Confirm the file exists.** Modules live one level deep:
+   `Projects/_op-modules/<id>.md` (global) or
+   `Projects/<slug>/MODULES/<id>.md` (per-project). Files in
+   subdirectories (`Projects/_op-modules/sub/foo.md`) are ignored.
+3. **Confirm filename matches `id:`.** A module file at `branching.md`
+   must declare `id: branching`. Mismatches emit
+   `malformed-frontmatter` and the module is dropped — which then
+   surfaces as `unknown-module` from the workflow file that names it.
+4. **Confirm `type: workflow-module`** is set in frontmatter (exact
+   literal). Anything else and the loader silently skips the file.
+
+**Cross-reference.**
+[`workflow-module-schema.md` § Where modules live](../specs/workflow-module-schema.md#where-modules-live).
+
+### `schema-mismatch`
+
+**What it means.** A workflow or module file declares a `schema:`
+version this loader doesn't support. Today the loader supports
+`schema: 1` only; declaring `schema: 2` (or anything other than `1`)
+emits this and the file is dropped.
+
+The same code is also emitted (warning severity) when an `extends:` chain
+goes more than one level deep — `extends:` is "one level only" by design.
+
+**How to fix.**
+
+- For a `schema:` mismatch: bump the file back to `schema: 1`. Future
+  schema versions will ship with explicit migration paths and a `schema:
+  2` upgrade.
+- For an `extends:` chain too deep: flatten the chain. The grandparent's
+  fields can move into the parent (or directly into the project's
+  workflow file).
+
+**Cross-reference.**
+[`workflow-file-schema.md` § `type` and `schema`](../specs/workflow-file-schema.md#type-and-schema)
+and [§ `extends:` (one level only)](../specs/workflow-file-schema.md#extends-optional-one-level-only).
+
+### `import-collision`
+
+**What it means.** Two modules contribute the same variable name at the
+same scope after the composer merges them. Modules at the same scope
+share a variable namespace; declaring `vars: [- pkg]` in two
+`scope: kickoff` modules collides because nothing in the layered model
+tells the composer which one wins.
+
+**How to fix.**
+
+- **Rename one.** If the two modules really are talking about different
+  things, give the variables distinct names (`module_a_pkg`,
+  `module_b_pkg`).
+- **Merge the modules.** If the duplication means "these two modules
+  belong together", consolidate them — one module per concept is the
+  authoring guideline.
+- **Move it up a layer.** If the variable is genuinely shared (same
+  meaning, same value), declare it once in the project or global
+  override file and drop the per-module declarations. The composer
+  shadows lower scopes silently.
+
+### `intra-scope-collision`
+
+**What it means.** Two modules at the same `scope:` declare the same
+variable name *within their own bodies* — not after composition, but at
+load time. The diagnostic is emitted by the loader before composition
+runs, so it always fires regardless of which workflow names them.
+
+**How to fix.**
+
+- **Make scope strings distinct.** If the two modules really represent
+  different stages, set `scope: kickoff-orient` and `scope: kickoff-rules`
+  (workflow files reference them by name in `steps:`, so the rename
+  cascades through the workflow file too).
+- **Merge the modules.** Same authoring guideline as `import-collision`
+  — one concept per file makes the override surface predictable.
+
+The diagnostic's `extra.scope` and `extra.moduleIds` fields tell you the
+scope key and the colliding module ids (sorted, for stable output).
+
+### `malformed-frontmatter`
+
+**What it means.** The catch-all for "this file's frontmatter doesn't
+match the schema". Examples:
+
+- Missing or wrong-type required field (e.g. `id:` is absent, or `vars:`
+  is a string instead of a list).
+- Filename basename doesn't match `id:` field.
+- A `VarDecl` is malformed (object form missing `name:`, both shorthand
+  and object form mixed within one entry, …).
+- A `default:` is a non-string type (commonly: YAML coerced an ISO date
+  to a `Date`).
+- Duplicate `name:` entries within one module's `vars:`.
+
+**How to fix.**
+
+The diagnostic carries `extra.path`, `extra.field`, `extra.expected`,
+and `extra.actual` so the surface can show you exactly which field is
+wrong and what the loader expected.
+
+**Common gotcha — YAML date coercion.** A bare `- 2026-04-25` in a
+`vars:` list parses as a `Date`, not a string, and is rejected. Fix:
+quote the value (`'2026-04-25'`) or use the shorthand
+(`name=2026-04-25`).
+
+**Common gotcha — typo in a `default:` key.** Object-form unknown keys
+are silently tolerated for forward-compat. So `defualt:` (typo) doesn't
+emit a diagnostic — but the default also doesn't apply. If a default is
+"missing" in practice, double-check the key spelling.
+
+**Cross-reference.**
+[`workflow-module-schema.md` § `vars:` declarations](../specs/workflow-module-schema.md#vars-declarations).
+
+### `size-budget`
+
+**What it means.** The composed prompt — the prose the agent will
+actually receive — exceeds the recommended character budget
+(`maxWorkflowChars`, default 32 768). This is **info-only**; the launch
+proceeds. Modern models tolerate the size comfortably; the cap is a
+guardrail that surfaces "this got bigger than you might have expected"
+rather than a constraint that blocks the launch.
+
+**When to act.**
+
+If you're seeing this routinely, the workflow has likely grown beyond
+its useful scope:
+
+- **Split the workflow.** A monolithic kickoff prompt with rules for
+  every situation is harder for an agent to follow than three smaller
+  scopes (`kickoff`, `plan`, `review`) injected at the matching step.
+- **Trim verbose modules.** The composer shows per-chunk size in the
+  `op-explain-workflow` payload — use it to find the heaviest
+  contributors.
+- **Move detail into reference docs.** "Read `docs/foo.md`" + a vault
+  link is often as effective as inlining the full text.
+
+If latency hasn't visibly increased, you can also raise
+`maxWorkflowChars` in Settings → Advanced → Injection. The cap is
+informational, not enforced.
+
+## Diagnostic surfaces vs. the recovery dialog
+
+A few diagnostics open dedicated recovery UI rather than just rendering
+through the formatter:
+
+- **`bad-model`** — at launch time, the recovery dialog (OP-205) offers
+  a one-click swap with a `.bak` and a diff before writing.
+- **(All codes) editor save** — the editor validator (OP-207) renders
+  diagnostics as squiggles in the open file plus a status-bar footer.
+
+The recovery dialog and the editor squiggles read the same
+`WorkflowDiagnostic` records the Settings panel and CLIs do — so a fix
+applied via any surface clears the diagnostic everywhere on next reload.
+
+## Where to next
+
+- [01-overview.md](./01-overview.md) — concept doc: precedence chain,
+  kickoff vs per-step injection.
+- [02-quickstart.md](./02-quickstart.md) — five-minute walkthrough.
+- [04-faq.md](./04-faq.md) — common questions about authoring,
+  variables, and module sharing.
+- [05-settings-reference.md](./05-settings-reference.md) — Workflows
+  group + Available variables panel + retired Injection inline-cap row.
+- [`workflow-module-schema.md`](../specs/workflow-module-schema.md) —
+  module file format reference.
+- [`workflow-file-schema.md`](../specs/workflow-file-schema.md) —
+  workflow file format reference.

--- a/docs/workflow-modules/04-faq.md
+++ b/docs/workflow-modules/04-faq.md
@@ -1,0 +1,196 @@
+# Workflow Modules — FAQ
+
+The four questions users hit most often. For diagnostic-by-diagnostic
+fixes, see [03-troubleshooting.md](./03-troubleshooting.md). For the
+underlying file formats, see
+[`workflow-module-schema.md`](../specs/workflow-module-schema.md) and
+[`workflow-file-schema.md`](../specs/workflow-file-schema.md).
+
+## Why is `{{vars.foo}}` rendering literally in the agent's prompt?
+
+**Short answer.** The composer found no value for `vars.foo` at any
+precedence layer — Module default → Global default → Project default →
+Launch override. The renderer leaves unresolved tokens verbatim so the
+diagnostic is visible in the agent's first message rather than silently
+dropped, and it emits a `missing-var` `WorkflowDiagnostic` to surface
+the failure in the Workflows panel and the dry-run preview banner.
+
+**How to diagnose.**
+
+1. Open `op: explain workflow` from the command palette (or run `obsidian
+   op-explain-workflow issue=<PREFIX>-<N> mode=kickoff`). The CLI writes
+   a structured payload to `Projects/_scratch/op-last-response.md`.
+2. Find the `vars:` array in the payload. Each row carries a `name`,
+   `value`, and `scope` (the layer that supplied the value, or `null`
+   when nothing did).
+3. Locate the row for `foo`. If `scope: null`, no layer had a value —
+   that's the cause.
+
+**How to fix.** Pick the layer that should own the value:
+
+| Where | Edit | Use when |
+| :--- | :--- | :--- |
+| Module default | The module's `vars:` block (`- foo=value`). | Value is intrinsic to the module's behavior. |
+| Global default | `Projects/_op-modules/_overrides.md`'s `vars:`. | Vault-wide policy. |
+| Project default | `Projects/<slug>/MODULES/_overrides.md`'s `vars:`. | Differs per project. |
+| Launch override | The launch modal's variables panel (OP-204). | One-off launch. |
+
+**Two common mistakes.**
+
+- **The variable name doesn't match `[a-zA-Z_][a-zA-Z0-9_]*`.** Names
+  with hyphens or leading digits parse and load successfully but the
+  renderer never matches them — the `{{var}}` pattern is `[a-zA-Z_]
+  [a-zA-Z0-9_]*` per OP-194. Rename to a valid identifier.
+- **A typo in `default:` (object form).** `defualt:` is silently
+  accepted as an unknown key for forward-compat, but the value never
+  reaches the composer. Fix the key spelling.
+
+**Why doesn't the composer just use the empty string?** Because
+"unresolved" and "intentionally empty" are different. The shorthand
+`name=` (with a trailing `=`) declares the empty string as a default; a
+bare `name` declares "the caller must supply a value". Treating
+"missing" as "empty" would make the second form impossible to express.
+
+## Why didn't my workflow advance to the next step?
+
+The workflow-modules engine composes the prompt for each step on demand
+— it doesn't itself drive step-to-step progression. Two engines do
+that, depending on your setup:
+
+**1. Flow chaining (Settings → Advanced → Flow chaining).**
+
+When on, op auto-advances the issue's stage based on its current state:
+`evaluate → planning → implementation → review → finalize`. Off by
+default; opt in if you want auto-advance.
+
+If you expected it to advance and it didn't:
+
+- **Confirm "Auto-advance" is on.** Settings → Advanced → Flow chaining
+  → "Auto-advance flow stages on status changes". Off by default.
+- **Confirm the issue's `flow:` frontmatter matches expectations.** The
+  next-stage resolver reads `flow:` and the issue's `status:` to decide
+  what runs. A missing `flow:` field stops the chain at the current
+  step.
+- **Watch the developer console.** The chain emits warnings on hard
+  stops (`[op-obsidian] flow:auto-advance: blocked because …`).
+- **Open `op: explain flow`** if you have it installed (or check the
+  flow runner's logs in the same `_scratch/` payload).
+
+**2. Workflow modules don't drive progression themselves.**
+
+Modules are composition-only — each module declares "what to inject at
+this step". They don't decide *when* the agent moves on. If an agent
+seemed to "stop in the middle of a step", the cause is almost always:
+
+- The agent followed the module's instructions and stopped because the
+  step's prose said to (e.g. "wait for sign-off").
+- The launch was for a single step (`mode=plan`) and the next step
+  needs a separate launch.
+- A `bad-model` or `missing-var` diagnostic blocked the launch entirely
+  — see the launch modal's preview banner or the developer console.
+
+**Quick diagnostic.**
+
+Run `obsidian op-explain-workflow issue=<id> mode=<step>` for the step
+you expected to compose. If the payload's `composed.text` is empty or
+the `diagnostics` array is non-empty, the engine has more to say —
+usually one of the codes in [03-troubleshooting.md](./03-troubleshooting.md).
+
+## How do I use a different model just for one step?
+
+Workflow files support per-step model overrides — you don't need a
+separate workflow per launch.
+
+```yaml
+---
+type: workflow
+schema: 1
+project: myproject
+default_agent: claude
+default_model: opus
+steps:
+  - step: kickoff
+    modules: [orient]
+  - step: plan
+    modules: [planner]
+    model: sonnet           # ← per-step override
+  - step: review
+    modules: [review-and-merge]
+    model: { claude: opus, gemini: pro }   # ← per-agent override
+---
+```
+
+The override shape mirrors `default_model:` — list-or-scalar (applies
+to every agent) or keyed-map (per-agent).
+
+**For a one-off launch.**
+
+If the change is "just for this run", you don't need to edit the file —
+the launch modal's agent/model picker (OP-200) is the right surface.
+Pick the model from the dropdown; the override applies to that launch
+only and the workflow file stays unchanged.
+
+**Validation.** A model name not on the agent's allow-list emits
+`bad-model` at workflow load time. The error message lists the allowed
+aliases and versioned ids — copy one of those into the field. The
+recovery dialog (OP-205) can do the swap for you with a `.bak`.
+
+**Cross-reference.**
+[`workflow-file-schema.md` § Steps](../specs/workflow-file-schema.md#steps-required).
+
+## How do I share my modules with a teammate?
+
+Two patterns, depending on how often the modules need to update:
+
+**1. Check them into the project's git repo.** This is the default for
+projects that already version their `Projects/<slug>/` folder. Drop the
+module under `Projects/<slug>/MODULES/<id>.md`, commit it, and pushing
+to your shared remote propagates to your teammate's vault on next pull.
+
+**Pros.** Standard git workflow; review via PR; conflicts surface
+naturally; per-project shadowing means one teammate can locally
+override without affecting others.
+
+**Cons.** Teammates need write access to the same repo; one-off shares
+("hey try this prompt") aren't worth a commit.
+
+**2. Use `op-export-module` / `op-import-module`** (when these CLIs
+land — tracked under OP-214). The exporter packages a module with its
+`vars:` defaults; the importer pre-fills `name=VALUE` prompts so the
+recipient sees what to supply.
+
+**The OP-Test → Agent-Vault hand-off.** This is the canonical share
+loop for the plugin's own developers — author and test in OP-Test, then
+publish to Agent-Vault via the exporter. The full walkthrough lives in
+[`docs/workflow-modules/sharing/share-modules.md`](./sharing/share-modules.md)
+once OP-214 ships.
+
+**Until then, the manual recipe.**
+
+```bash
+# In the source vault:
+cp <vault>/Projects/_op-modules/<id>.md /tmp/<id>.md
+
+# In the target vault:
+cp /tmp/<id>.md <vault>/Projects/_op-modules/<id>.md
+# Reload the plugin so the loader picks up the new file:
+obsidian plugin:reload id=op-obsidian
+```
+
+The Settings → Workflows panel re-renders the module list on reload;
+diagnostics surface immediately if anything went wrong (most often a
+`malformed-frontmatter` from a YAML coercion of an ISO-date default).
+
+## Where to next
+
+- [01-overview.md](./01-overview.md) — concept doc: precedence chain,
+  kickoff vs per-step injection.
+- [02-quickstart.md](./02-quickstart.md) — five-minute walkthrough.
+- [03-troubleshooting.md](./03-troubleshooting.md) — every diagnostic
+  code with what-it-means + how-to-fix.
+- [05-settings-reference.md](./05-settings-reference.md) — Workflows
+  settings group + Available variables panel.
+- [`workflow-module-schema.md`](../specs/workflow-module-schema.md) —
+  module file reference.
+- [`workflow-file-schema.md`](../specs/workflow-file-schema.md) —
+  workflow file reference.

--- a/docs/workflow-modules/05-settings-reference.md
+++ b/docs/workflow-modules/05-settings-reference.md
@@ -1,0 +1,260 @@
+# Workflow Modules — Settings Tab Reference
+
+A walk through the op-obsidian Settings tab as it relates to workflow
+modules. Two surfaces the migration introduced — the top-level
+**Workflows** group and the **Available variables** panel — plus a
+call-out for the **Injection** subsection that the migration partially
+retires.
+
+ASCII layout sketches (clearer than screenshots — versionable, no PNG
+drift). Each sketch reflects the panel's actual content; the
+`[data-op-section]` selectors line up with what `app.setting.openTabById`
+renders, so you can verify against your own install.
+
+## Where to find it
+
+```
+Obsidian → Settings (⌘,) → op-obsidian
+```
+
+The tab is laid out in three groups, top-to-bottom:
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│  [ Search settings… ]                                           │
+├─────────────────────────────────────────────────────────────────┤
+│  ## Daily                                                       │
+│  · Default agent       (claude / gemini / copilot)              │
+│  · Terminal app        (iTerm / Terminal)                       │
+│  · Sidebar default tab (Issues / In flight / Recently resolved) │
+│  · Onboarding README   [Open README]                            │
+│  · Apply preset        [Apply hotkey preset]                    │
+├─────────────────────────────────────────────────────────────────┤
+│  ## Workflows         ← introduced in OP-201 (3a)               │
+│  ... module list / empty state ...                              │
+│  ▷ Available variables (collapsed)                              │
+├─────────────────────────────────────────────────────────────────┤
+│  ## Advanced                                                    │
+│  ▷ Injection (collapsed)            [data-op-section=injection] │
+│  ▷ Working dirs & project order      [...=workingDirs]          │
+│  ▷ iTerm layout orchestrator         [...=orchestrator]         │
+│  ▷ Profile overlays (JSON per agent) [...=profileOverlays]      │
+│  ▷ Agent worktree enforcement        [...=worktreeEnforcement]  │
+│  ▷ Flow chaining                     [...=flowChaining]         │
+│  ▷ GitHub integration                [...=github]               │
+│  ▷ Developer commands                [...=developer]            │
+│                                                                 │
+│  ▷ Glossary — tmux, orchestrator, overlay, worktree             │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+The fuzzy search box at the top auto-expands any collapsible whose rows
+match.
+
+## The Workflows group
+
+Top-level group between Daily and Advanced — its own H2, not buried in
+Advanced as a 9th collapsible. The reasoning, captured in OP-201:
+modules surface module-level diagnostics, the "Available variables"
+reference panel, and an empty-state install button — too important and
+too referenced to bury.
+
+The group's data attribute on the wrapper:
+
+```
+[data-op-section="workflows"]
+```
+
+### Empty state — no modules loaded
+
+What you see when the loader returned zero modules (a fresh vault,
+modules disabled, or every file failed to parse):
+
+```
+═══ Workflows ════════════════════════════════════════════════════
+Workflow modules compose the prompt the launched agent sees. Loaded
+modules appear here with their diagnostics; the Available variables
+panel lists tokens you can reference in module bodies via {{name}}.
+
+  ┌───────────────────────────────────────────────────────────┐
+  │  No modules yet                                           │
+  │  Open the [5-min Quickstart](…), or install the example   │
+  │  library below to get a working modules tree in one click.│
+  │                                                           │
+  │  Install example library                                  │
+  │  Writes 6 starter modules into Projects/_op-modules/.     │
+  │  Existing files are never overwritten — safe to click     │
+  │  again. Open the installed files to see complete, valid   │
+  │  module shape.                              [ Install ]   │
+  └───────────────────────────────────────────────────────────┘
+
+  Preview composed prompt
+  Open a read-only modal that renders the fully-composed launch
+  prompt for a chosen (issue, mode, agent) tuple — the exact string
+  the launcher would pass to the agent.       [ Open preview ]
+
+  Auto-expand launch preview                            [ on ●]
+
+  ▷ Available variables                                          
+══════════════════════════════════════════════════════════════════
+```
+
+The empty-state quickstart link goes to
+`docs/workflow-modules/02-quickstart.md` on GitHub. The "Install
+example library" button writes the OP-212 starter modules into
+`Projects/_op-modules/` (idempotent — never overwrites; safe to click
+again).
+
+### Module list — modules loaded
+
+What you see once the loader has parsed at least one module:
+
+```
+═══ Workflows ════════════════════════════════════════════════════
+Workflow modules compose the prompt the launched agent sees. …
+
+  ┌──────────────────────────────────────────────────────────────┐
+  │ branching      Branching discipline   global       [ ok ]    │
+  │                                                  [ Explain ] │
+  ├──────────────────────────────────────────────────────────────┤
+  │ review-and-merge  Review and merge   project: ip   [E1]      │
+  │   E  Missing variable   foo not declared at any layer        │
+  │      Launch override                                         │
+  │                                                  [ Explain ] │
+  ├──────────────────────────────────────────────────────────────┤
+  │ planner       Planner module         global        [W1] [I1] │
+  │   W  Bad model spec     "oups" for agent "claude" at <…>     │
+  │   I  Workflow size notice  composed prompt is 38k chars      │
+  │                                                  [ Explain ] │
+  └──────────────────────────────────────────────────────────────┘
+
+  Unattributed diagnostics                ← rendered only when present
+  Diagnostics from modules that failed to parse, or that don't bind
+  to a single module.
+    E  Malformed frontmatter  …
+
+  Preview composed prompt                       [ Open preview ]
+  Auto-expand launch preview                            [ on ●]
+  ▷ Available variables
+══════════════════════════════════════════════════════════════════
+```
+
+**Anatomy of a row.**
+
+- **Module id** + title + source label (`global` or `project: <slug>`).
+- **Severity badges** — `Ek` / `Wk` / `Ik` count diagnostics by
+  severity (or a green `ok` chip when none). Tooltip on the badge shows
+  the full `codeLabel` ("Missing variable", "Bad model spec") — never
+  the single-letter abbreviation in primary copy (per OP-201
+  contract).
+- **Diagnostic lines** — one per diagnostic, formatted through the
+  unified `formatDiagnostic`. Code label, message, and (when present)
+  the canonical scope name ("Launch override").
+- **Explain button** — opens a modal with the multi-line block
+  rendering for every diagnostic on the module. Renders even when
+  there are zero diagnostics so users can verify they're looking at
+  the right module.
+
+**Footer — Unattributed diagnostics** appears only when a diagnostic
+can't bind to a loaded module — most commonly a parse failure where
+the file never made it to the modules list. Without this footer, those
+diagnostics would silently vanish.
+
+### Available variables panel
+
+Collapsed by default, expanded by clicking the `▷` caret:
+
+```
+▼ Available variables                  [data-op-section=workflowsVars]
+
+  Tokens you can reference in a module body via {{name}}. These are
+  computed per-launch from the issue, the agent profile, and the
+  launch context — they sit at Launch override (the highest
+  precedence). User-declared {{vars.<name>}} are a separate namespace
+  declared in a module's `vars:` block.
+
+  {{issue_id}}        e.g. OP-215
+    Issue id, e.g. "OP-211".
+  {{issue_title}}     e.g. 10e: Troubleshooting + FAQ + …
+    Issue title.
+  {{issue_path}}      e.g. Projects/obsidian-projects/ISSUES/…
+    Vault-relative issue path.
+  {{project}}         e.g. obsidian-projects
+    Project slug from the issue's frontmatter.
+  {{repo_path}}       e.g. /Users/you/Projects/obsidian-projects
+    Project's repo path (from STATUS.md repo_path:, optional).
+  {{agent}}           e.g. claude
+    Resolved agent id for this launch.
+  {{mode}}            e.g. kickoff
+    Workflow step the composer is rendering.
+  {{today}}           e.g. 2026-04-26
+    ISO date the launch was composed (UTC).
+  …more rows from PLUGIN_VAR_REGISTRY…
+```
+
+Two things worth knowing:
+
+- These variables sit at **Launch override** in the precedence chain
+  — the highest precedence. A module's own `vars:` default cannot
+  shadow them.
+- `{{name}}` and `{{vars.name}}` are **different namespaces**.
+  `{{repo_path}}` is a plugin-supplied launch variable; `{{vars.foo}}`
+  is a user-declared module variable. Mixing them up is the most
+  common cause of literal-render failures (see
+  [04-faq.md § literal vars](./04-faq.md#why-is-varsfoo-rendering-literally-in-the-agents-prompt)).
+
+## Injection — what the migration changed
+
+Open this collapsible to see the legacy controls that drove the
+pre-modules injection blob:
+
+```
+▼ Injection                                  [data-op-section=injection]
+
+  · Inject issue body                                       [ on ●]
+  · Max body characters                                       8000
+  · Inject linked TASKS                                      [ on ●]
+  · Inject recent commits                                    [ on ●]
+    Max recent commits                                          12
+  · Workflow inline cap (chars)         ← will retire (OP-208)
+    32768
+    When the issue's project has a Projects/<slug>/WORKFLOW.md, inline
+    its contents up to this many characters.
+  · Extra preamble                                       [ … textarea ]
+```
+
+The bold takeaway:
+
+- **`Workflow inline cap (chars)`** is the legacy single-row cap on the
+  whole-`WORKFLOW.md` inline blob. Once OP-208 ("Cutover") ships, this
+  row is removed — the modules engine has its own per-launch
+  `maxWorkflowChars` accounting (surfaced as the `size-budget` info
+  diagnostic), and the dual surface created confusion. Until then both
+  controls coexist; the modules engine ignores this row.
+- **`workflowMode`** is the master toggle — `"legacy"` uses the
+  inline-cap path; `"modules"` uses the OP-201 module engine. There's
+  no UI toggle yet; until OP-186 lands, flip it by editing
+  `<vault>/.obsidian/plugins/op-obsidian/data.json` (see
+  [02-quickstart.md § step 1](./02-quickstart.md#1-switch-to-modules-mode-30-seconds)).
+  After OP-208, the default flips from `"legacy"` to `"modules"` — but
+  vaults that already have `workflowMode: "legacy"` set stay on legacy
+  (the migration treats an explicit value as user opt-in).
+
+If you've never edited `data.json` directly, the safe order is: quit
+Obsidian first (or fully disable op-obsidian) → edit → re-enable. The
+running plugin caches settings in memory and overwrites manual edits on
+its next save.
+
+## Where to next
+
+- [01-overview.md](./01-overview.md) — concept doc: precedence chain,
+  kickoff vs per-step injection.
+- [02-quickstart.md](./02-quickstart.md) — five-minute walkthrough.
+- [03-troubleshooting.md](./03-troubleshooting.md) — every diagnostic
+  code with what-it-means + how-to-fix.
+- [04-faq.md](./04-faq.md) — common questions: literal `{{vars.foo}}`,
+  workflow not advancing, per-step model, sharing modules.
+- [`workflow-module-schema.md`](../specs/workflow-module-schema.md) —
+  module file reference.
+- [`workflow-file-schema.md`](../specs/workflow-file-schema.md) —
+  workflow file reference.

--- a/plugins/op-obsidian/manifest.json
+++ b/plugins/op-obsidian/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "op-obsidian",
   "name": "Obsidian Projects (op)",
-  "version": "0.74.1",
+  "version": "0.74.2",
   "minAppVersion": "1.5.0",
   "description": "Jira-lite issue tracker for Obsidian vaults — deterministic commands backing the op workflow.",
   "author": "Eugene Archibald",

--- a/plugins/op-obsidian/package-lock.json
+++ b/plugins/op-obsidian/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "op-obsidian",
-  "version": "0.74.1",
+  "version": "0.74.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "op-obsidian",
-      "version": "0.74.1",
+      "version": "0.74.2",
       "license": "MIT",
       "dependencies": {
         "protobufjs": "^8.0.1"

--- a/plugins/op-obsidian/package.json
+++ b/plugins/op-obsidian/package.json
@@ -1,6 +1,6 @@
 {
   "name": "op-obsidian",
-  "version": "0.74.1",
+  "version": "0.74.2",
   "description": "Obsidian plugin that owns the deterministic half of the op workflow.",
   "main": "main.js",
   "scripts": {

--- a/plugins/op-obsidian/src/docLinks.test.ts
+++ b/plugins/op-obsidian/src/docLinks.test.ts
@@ -1,0 +1,152 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import {
+  allDocAnchors,
+  allDocFiles,
+  diagnosticDocAnchor,
+  docUrl,
+  sectionDocAnchor,
+  type DocAnchor,
+} from "./docLinks";
+
+// CI guard for OP-215: every (file, anchor) the in-product help-link
+// registry references MUST exist in the doc tree. A doc rename or a
+// heading rewrite that drops an anchor surfaces here as a unit-test
+// failure rather than a broken "?" icon noticed in production.
+//
+// Anchor extraction follows GitHub's slugger rules (the slugs Obsidian
+// previews and GitHub produce on push):
+//   1. Lowercase.
+//   2. Strip characters that aren't alphanumeric, `-`, `_`, ` `, or
+//      certain unicode letters. (We approximate with ASCII rules
+//      because every heading in this repo is ASCII.)
+//   3. Collapse runs of whitespace into single spaces.
+//   4. Replace spaces with `-`. (Em-dash gets stripped in step 2; the
+//      surrounding spaces survive and become consecutive hyphens —
+//      GitHub does NOT collapse those.)
+
+const REPO_ROOT = resolve(__dirname, "../../..");
+
+function readDoc(file: string): string {
+  return readFileSync(resolve(REPO_ROOT, file), "utf8");
+}
+
+/**
+ * Approximate github-slugger. Sufficient for ASCII headings; we don't
+ * model unicode-letter retention because no heading in this repo uses
+ * one. Backticks and other punctuation are stripped.
+ */
+function slugify(heading: string): string {
+  // Mirror github-slugger's per-character whitespace replacement (each
+  // run-of-1 whitespace becomes one `-`, NOT collapsed). An em-dash
+  // (`—`) gets stripped in the punctuation pass; the spaces that
+  // surrounded it survive and become consecutive hyphens, which is
+  // why "Injection — foo" → "injection--foo" (double hyphen).
+  return heading
+    .toLowerCase()
+    .replace(/[^\w\- ]+/g, "") // strip punctuation, backticks, em-dashes, …
+    .replace(/^\s+|\s+$/g, "")
+    .replace(/ /g, "-");
+}
+
+/**
+ * Pull every H1/H2/H3/H4/H5/H6 line from a markdown file and emit its
+ * GitHub-anchored slug. Skips fenced code blocks so a `# comment` line
+ * inside ```ts doesn't get mis-parsed as a heading.
+ */
+function extractAnchors(markdown: string): Set<string> {
+  const out = new Set<string>();
+  let inFence = false;
+  for (const line of markdown.split("\n")) {
+    if (line.startsWith("```")) {
+      inFence = !inFence;
+      continue;
+    }
+    if (inFence) continue;
+    const m = /^(#{1,6})\s+(.+?)\s*$/.exec(line);
+    if (!m) continue;
+    out.add(slugify(m[2]));
+  }
+  return out;
+}
+
+describe("docLinks registry", () => {
+  it("references at least one doc file", () => {
+    expect(allDocFiles().length).toBeGreaterThan(0);
+  });
+
+  it("every referenced doc file exists on disk and is non-empty", () => {
+    for (const file of allDocFiles()) {
+      const content = readDoc(file);
+      expect(content.length, `doc file ${file} is empty`).toBeGreaterThan(0);
+    }
+  });
+
+  it("every (file, anchor) pair resolves to a heading in the doc", () => {
+    const anchorsByFile = new Map<string, Set<string>>();
+    for (const file of allDocFiles()) {
+      anchorsByFile.set(file, extractAnchors(readDoc(file)));
+    }
+    const broken: string[] = [];
+    for (const target of allDocAnchors()) {
+      const anchors = anchorsByFile.get(target.file);
+      if (!anchors) {
+        broken.push(`${target.file} (file not loaded)`);
+        continue;
+      }
+      if (!anchors.has(target.anchor)) {
+        broken.push(`${target.file}#${target.anchor}`);
+      }
+    }
+    if (broken.length > 0) {
+      // Surface the full list so a single test failure tells you every
+      // anchor that needs a fix, not just the first one.
+      throw new Error(
+        `Missing doc anchors:\n  - ${broken.join("\n  - ")}\n` +
+          `Either add the heading to the doc, or update docLinks.ts to point at an existing one.`,
+      );
+    }
+  });
+
+  it("section help links target real anchors", () => {
+    const ids = ["workflows", "workflowsVars", "injection"] as const;
+    for (const id of ids) {
+      const target = sectionDocAnchor(id);
+      expect(target.file).toMatch(/^docs\/workflow-modules\//);
+      expect(target.anchor).toMatch(/^[a-z0-9_-]+$/);
+    }
+  });
+
+  it("every diagnostic code in the registry has a docFooter target", () => {
+    const codes = [
+      "bad-model",
+      "missing-var",
+      "unknown-module",
+      "schema-mismatch",
+      "import-collision",
+      "intra-scope-collision",
+      "malformed-frontmatter",
+      "size-budget",
+    ] as const;
+    for (const code of codes) {
+      const target = diagnosticDocAnchor(code);
+      expect(target.file).toBe(
+        "docs/workflow-modules/03-troubleshooting.md",
+      );
+      // Anchor is the kebab-case code itself — keep this contract because
+      // that's what the troubleshooting doc declares per H3.
+      expect(target.anchor).toBe(code);
+    }
+  });
+
+  it("docUrl composes a public GitHub URL", () => {
+    const target: DocAnchor = {
+      file: "docs/workflow-modules/03-troubleshooting.md",
+      anchor: "missing-var",
+    };
+    expect(docUrl(target)).toBe(
+      "https://github.com/earchibald/obsidian-projects/blob/main/docs/workflow-modules/03-troubleshooting.md#missing-var",
+    );
+  });
+});

--- a/plugins/op-obsidian/src/docLinks.test.ts
+++ b/plugins/op-obsidian/src/docLinks.test.ts
@@ -6,6 +6,7 @@ import {
   allDocFiles,
   diagnosticDocAnchor,
   docUrl,
+  hasSectionDocLink,
   sectionDocAnchor,
   type DocAnchor,
 } from "./docLinks";
@@ -107,6 +108,17 @@ describe("docLinks registry", () => {
           `Either add the heading to the doc, or update docLinks.ts to point at an existing one.`,
       );
     }
+  });
+
+  it("hasSectionDocLink type guard — known ids return true, unknown ids return false", () => {
+    expect(hasSectionDocLink("workflows")).toBe(true);
+    expect(hasSectionDocLink("workflowsVars")).toBe(true);
+    expect(hasSectionDocLink("injection")).toBe(true);
+    // Advanced sections that don't have a doc target yet.
+    expect(hasSectionDocLink("workingDirs")).toBe(false);
+    expect(hasSectionDocLink("orchestrator")).toBe(false);
+    expect(hasSectionDocLink("")).toBe(false);
+    expect(hasSectionDocLink("__proto__")).toBe(false);
   });
 
   it("section help links target real anchors", () => {

--- a/plugins/op-obsidian/src/docLinks.ts
+++ b/plugins/op-obsidian/src/docLinks.ts
@@ -104,6 +104,16 @@ export function diagnosticDocAnchor(code: DocLinkDiagnosticCode): DocAnchor {
 }
 
 /**
+ * Type guard: returns true when `id` has a registered (file, anchor) target
+ * in this registry. Lets call sites skip maintaining a parallel `Set` — a
+ * section only needs to be listed once (in `SECTION_LINKS` here) for the `?`
+ * icon to appear.
+ */
+export function hasSectionDocLink(id: string): id is DocLinkSectionId {
+  return Object.prototype.hasOwnProperty.call(SECTION_LINKS, id);
+}
+
+/**
  * Compose the public URL for a (file, anchor) pair. Use this everywhere a
  * URL is needed — never hand-concatenate, so a future swap to a versioned
  * URL or a docs site is one edit here.

--- a/plugins/op-obsidian/src/docLinks.ts
+++ b/plugins/op-obsidian/src/docLinks.ts
@@ -1,0 +1,134 @@
+// Pure registry of in-product help-link targets. OP-215 (10e).
+//
+// Single source of truth for every "?" icon in the Settings tab and every
+// docFooter line stamped on `op-explain-workflow` / `op-list-vars` payloads.
+// The `docLinks.test.ts` CI guard parses the relevant docs under
+// `docs/workflow-modules/` and asserts every (file, anchor) referenced here
+// exists — so a doc rename or anchor change shows up as a unit-test failure
+// rather than a broken in-product link.
+//
+// Pure: no Obsidian imports, no I/O. Strings only.
+
+/**
+ * Section ids that may carry a help link. Mirrors `SectionId` from
+ * `settings.ts` plus the synthetic `workflowsVars` (the Available
+ * variables collapsible) so `addDocLink(parentEl, "workflowsVars")` is
+ * type-safe at the call site.
+ */
+export type DocLinkSectionId =
+  | "workflows"
+  | "workflowsVars"
+  | "injection";
+
+/**
+ * Diagnostic-code subset that gets a docFooter in CLI payloads. Not every
+ * `WorkflowDiagnosticCode` rates a footer — `size-budget` is a notice, not
+ * a failure mode users typically chase docs for — but every code listed
+ * here MUST have a corresponding anchor in
+ * `docs/workflow-modules/03-troubleshooting.md`.
+ */
+export type DocLinkDiagnosticCode =
+  | "bad-model"
+  | "missing-var"
+  | "unknown-module"
+  | "schema-mismatch"
+  | "import-collision"
+  | "intra-scope-collision"
+  | "malformed-frontmatter"
+  | "size-budget";
+
+/**
+ * Vault-relative paths to the docs we link to. Single point of update if
+ * the docs reorganize.
+ */
+const DOC_PATHS = {
+  troubleshooting: "docs/workflow-modules/03-troubleshooting.md",
+  faq: "docs/workflow-modules/04-faq.md",
+  settingsReference: "docs/workflow-modules/05-settings-reference.md",
+} as const;
+
+/**
+ * Public GitHub URL prefix used for "?" icons. Matches the pattern
+ * `firstRunReadme.ts` already established in OP-211 — stable URL, no
+ * Obsidian-relative-link rendering hassles.
+ */
+export const DOC_URL_PREFIX =
+  "https://github.com/earchibald/obsidian-projects/blob/main/";
+
+export interface DocAnchor {
+  /** Vault-relative doc path. */
+  file: string;
+  /** GitHub-flavored markdown anchor (lowercase + dashes; no leading `#`). */
+  anchor: string;
+}
+
+const SECTION_LINKS: Readonly<Record<DocLinkSectionId, DocAnchor>> = Object.freeze({
+  workflows: {
+    file: DOC_PATHS.settingsReference,
+    anchor: "the-workflows-group",
+  },
+  workflowsVars: {
+    file: DOC_PATHS.settingsReference,
+    anchor: "available-variables-panel",
+  },
+  injection: {
+    file: DOC_PATHS.settingsReference,
+    anchor: "injection--what-the-migration-changed",
+  },
+});
+
+const DIAGNOSTIC_LINKS: Readonly<Record<DocLinkDiagnosticCode, DocAnchor>> =
+  Object.freeze({
+    "bad-model": { file: DOC_PATHS.troubleshooting, anchor: "bad-model" },
+    "missing-var": { file: DOC_PATHS.troubleshooting, anchor: "missing-var" },
+    "unknown-module": { file: DOC_PATHS.troubleshooting, anchor: "unknown-module" },
+    "schema-mismatch": { file: DOC_PATHS.troubleshooting, anchor: "schema-mismatch" },
+    "import-collision": { file: DOC_PATHS.troubleshooting, anchor: "import-collision" },
+    "intra-scope-collision": {
+      file: DOC_PATHS.troubleshooting,
+      anchor: "intra-scope-collision",
+    },
+    "malformed-frontmatter": {
+      file: DOC_PATHS.troubleshooting,
+      anchor: "malformed-frontmatter",
+    },
+    "size-budget": { file: DOC_PATHS.troubleshooting, anchor: "size-budget" },
+  });
+
+export function sectionDocAnchor(id: DocLinkSectionId): DocAnchor {
+  return SECTION_LINKS[id];
+}
+
+export function diagnosticDocAnchor(code: DocLinkDiagnosticCode): DocAnchor {
+  return DIAGNOSTIC_LINKS[code];
+}
+
+/**
+ * Compose the public URL for a (file, anchor) pair. Use this everywhere a
+ * URL is needed — never hand-concatenate, so a future swap to a versioned
+ * URL or a docs site is one edit here.
+ */
+export function docUrl(target: DocAnchor): string {
+  return `${DOC_URL_PREFIX}${target.file}#${target.anchor}`;
+}
+
+/**
+ * Iterables for the CI guard. Returns every (file, anchor) pair the
+ * registry references; the test asserts each anchor exists in its file.
+ */
+export function allDocAnchors(): readonly DocAnchor[] {
+  return [
+    ...Object.values(SECTION_LINKS),
+    ...Object.values(DIAGNOSTIC_LINKS),
+  ];
+}
+
+/**
+ * Doc files referenced by the registry — the CI guard reads each once and
+ * builds an anchor set per file, so we expose the unique list.
+ */
+export function allDocFiles(): readonly string[] {
+  const set = new Set<string>();
+  for (const anchor of allDocAnchors()) set.add(anchor.file);
+  return [...set];
+}

--- a/plugins/op-obsidian/src/settings.ts
+++ b/plugins/op-obsidian/src/settings.ts
@@ -18,6 +18,7 @@ import { EXAMPLE_MODULES, installExampleLibrary } from "./workflowExamples";
 import { PreviewWorkflowModal } from "./previewWorkflowModal";
 import {
   docUrl,
+  hasSectionDocLink,
   sectionDocAnchor,
   type DocLinkSectionId,
 } from "./docLinks";
@@ -98,15 +99,6 @@ type SectionId =
 
 /** Subset of SectionId covering only the collapsible Advanced subsections. */
 type AdvancedSectionId = (typeof ADVANCED_SECTIONS)[number]["id"];
-
-/**
- * Advanced section ids that have a registered help-link target in
- * `docLinks.ts`. Listed explicitly (not derived) so adding a new doc
- * mapping is a single-file edit in `docLinks.ts` plus this constant.
- */
-const ADVANCED_SECTIONS_WITH_DOCS: ReadonlySet<AdvancedSectionId> = new Set([
-  "injection",
-]);
 
 const ADVANCED_SECTIONS: ReadonlyArray<{
   id: SectionId;
@@ -250,10 +242,10 @@ export class OpSettingsTab extends PluginSettingTab {
       // de-densifies setDesc strings without losing the glossary context.
       addHelpExpandable(collapsible.body, "What is this?", section.blurb);
       // OP-215: in-product help link for sections registered in
-      // `docLinks.ts`. Only sections with a registered (file, anchor)
-      // get a "?" icon — others stay link-less.
-      if (ADVANCED_SECTIONS_WITH_DOCS.has(section.id)) {
-        addDocLink(collapsible.header, section.id as DocLinkSectionId);
+      // `docLinks.ts`. Derived via `hasSectionDocLink` so only
+      // `docLinks.ts` needs updating when a new section gets a doc target.
+      if (hasSectionDocLink(section.id)) {
+        addDocLink(collapsible.header, section.id);
       }
       this.mountSection(collapsible.body, section.id, (el) => this.renderAdvancedSection(section.id, el));
       // Tag the wrapper for the smoke-test recipe (CLAUDE.md): tests can
@@ -1783,6 +1775,9 @@ function addDocLink(parentEl: HTMLElement, sectionId: DocLinkSectionId): void {
   link.setAttribute("rel", "noopener");
   link.setAttribute("aria-label", `Open the docs for this section`);
   link.setAttribute("title", "Open the docs for this section ↗");
+  // Prevent the click from bubbling to a parent role=button (e.g. a
+  // collapsible header) and toggling the collapsible as a side-effect.
+  link.addEventListener("click", (e) => e.stopPropagation());
 }
 
 function addHelpExpandable(parentEl: HTMLElement, title: string, body: string): void {

--- a/plugins/op-obsidian/src/settings.ts
+++ b/plugins/op-obsidian/src/settings.ts
@@ -17,6 +17,11 @@ import type { WorkflowDiagnostic } from "./workflowDiagnostic";
 import { EXAMPLE_MODULES, installExampleLibrary } from "./workflowExamples";
 import { PreviewWorkflowModal } from "./previewWorkflowModal";
 import {
+  docUrl,
+  sectionDocAnchor,
+  type DocLinkSectionId,
+} from "./docLinks";
+import {
   applyPreset,
   defaultPreset,
   revertPreset,
@@ -93,6 +98,15 @@ type SectionId =
 
 /** Subset of SectionId covering only the collapsible Advanced subsections. */
 type AdvancedSectionId = (typeof ADVANCED_SECTIONS)[number]["id"];
+
+/**
+ * Advanced section ids that have a registered help-link target in
+ * `docLinks.ts`. Listed explicitly (not derived) so adding a new doc
+ * mapping is a single-file edit in `docLinks.ts` plus this constant.
+ */
+const ADVANCED_SECTIONS_WITH_DOCS: ReadonlySet<AdvancedSectionId> = new Set([
+  "injection",
+]);
 
 const ADVANCED_SECTIONS: ReadonlyArray<{
   id: SectionId;
@@ -204,7 +218,9 @@ export class OpSettingsTab extends PluginSettingTab {
       cls: "op-settings__group op-settings__group--workflows",
     });
     workflows.dataset.opSection = "workflows";
-    workflows.createEl("h2", { text: "Workflows" });
+    const workflowsHeading = workflows.createDiv({ cls: "op-settings__heading-row" });
+    workflowsHeading.createEl("h2", { text: "Workflows" });
+    addDocLink(workflowsHeading, "workflows");
     workflows.createEl("p", {
       cls: "setting-item-description op-settings__group-blurb",
       text:
@@ -233,6 +249,12 @@ export class OpSettingsTab extends PluginSettingTab {
       // "What is this?" expandable directly under the H2 — short blurb that
       // de-densifies setDesc strings without losing the glossary context.
       addHelpExpandable(collapsible.body, "What is this?", section.blurb);
+      // OP-215: in-product help link for sections registered in
+      // `docLinks.ts`. Only sections with a registered (file, anchor)
+      // get a "?" icon — others stay link-less.
+      if (ADVANCED_SECTIONS_WITH_DOCS.has(section.id)) {
+        addDocLink(collapsible.header, section.id as DocLinkSectionId);
+      }
       this.mountSection(collapsible.body, section.id, (el) => this.renderAdvancedSection(section.id, el));
       // Tag the wrapper for the smoke-test recipe (CLAUDE.md): tests can
       // querySelector('[data-op-section="workingDirs"]') and click the
@@ -537,6 +559,7 @@ export class OpSettingsTab extends PluginSettingTab {
       { startOpen: false },
     );
     varsCollapsible.root.dataset.opSection = "workflowsVars";
+    addDocLink(varsCollapsible.header, "workflowsVars");
     addHelpExpandable(
       varsCollapsible.body,
       "What is this?",
@@ -1741,6 +1764,27 @@ function detectionSummary(plugin: OpPlugin): string {
  * Keyboard-accessible: head has `role="button"` / `tabindex="0"` and
  * responds to Enter and Space, matching the ARIA Button pattern.
  */
+/**
+ * Render a small "?" icon link that opens the relevant doc anchor on
+ * GitHub in a new tab. Used to wire OP-215 in-product help links from
+ * settings sections to `docs/workflow-modules/`. The link's (file,
+ * anchor) target lives in the central `docLinks.ts` registry — the
+ * `docLinks.test.ts` CI guard asserts every anchor exists in the doc
+ * tree, so a doc rename surfaces as a unit-test failure here.
+ */
+function addDocLink(parentEl: HTMLElement, sectionId: DocLinkSectionId): void {
+  const target = sectionDocAnchor(sectionId);
+  const link = parentEl.createEl("a", {
+    cls: "op-doc-link",
+    text: "?",
+    href: docUrl(target),
+  });
+  link.setAttribute("target", "_blank");
+  link.setAttribute("rel", "noopener");
+  link.setAttribute("aria-label", `Open the docs for this section`);
+  link.setAttribute("title", "Open the docs for this section ↗");
+}
+
 function addHelpExpandable(parentEl: HTMLElement, title: string, body: string): void {
   const wrap = parentEl.createDiv({ cls: "op-help-expandable" });
   const head = wrap.createDiv({ cls: "op-help-expandable__head" });

--- a/plugins/op-obsidian/src/workflowDiagnosticFormat.test.ts
+++ b/plugins/op-obsidian/src/workflowDiagnosticFormat.test.ts
@@ -296,8 +296,10 @@ describe("diagnosticToBlock", () => {
   it("omits the location line when there is no location info", () => {
     const block = diagnosticToBlock(diag());
     const lines = block.split("\n");
-    // Expected lines: codeLabel+severity, message, hint. No location.
-    expect(lines).toHaveLength(3);
+    // Expected lines (OP-215): codeLabel+severity, message, hint, More:.
+    // No location, no scope.
+    expect(lines).toHaveLength(4);
+    expect(lines.some((l) => l.startsWith("More: "))).toBe(true);
   });
 
   it("omits the scope line when no precedence scope is attached", () => {

--- a/plugins/op-obsidian/src/workflowDiagnosticFormat.ts
+++ b/plugins/op-obsidian/src/workflowDiagnosticFormat.ts
@@ -24,6 +24,11 @@ import {
   type WorkflowDiagnosticCode,
   type WorkflowDiagnosticSeverity,
 } from "./workflowDiagnostic";
+import {
+  diagnosticDocAnchor,
+  docUrl,
+  type DocLinkDiagnosticCode,
+} from "./docLinks";
 
 /**
  * Variable-resolution precedence stack. Higher level wins. Source of truth
@@ -139,6 +144,14 @@ export interface FormattedDiagnostic {
    * Surface it as a secondary line in modals; omit in compact contexts.
    */
   hint?: string;
+  /**
+   * OP-215: deep link to the troubleshooting doc anchor for this code.
+   * Populated for every code that has a registered (file, anchor) target
+   * in `docLinks.ts` (every WorkflowDiagnosticCode does today). UI
+   * surfaces stamp it as a footer on the multi-line block; one-line CLI
+   * output skips it for compactness.
+   */
+  helpUrl?: string;
 }
 
 const CODE_LABELS: Readonly<Record<WorkflowDiagnosticCode, string>> = Object.freeze({
@@ -213,6 +226,7 @@ function buildFormatted(d: WorkflowDiagnostic): FormattedDiagnostic {
     message: d.message,
     location: buildLocation(d),
     hint: HINTS[d.code],
+    helpUrl: docUrl(diagnosticDocAnchor(d.code as DocLinkDiagnosticCode)),
   };
   if (d.moduleId) out.moduleId = d.moduleId;
   if (d.varName) out.varName = d.varName;
@@ -265,6 +279,7 @@ export function diagnosticToLine(d: WorkflowDiagnostic): string {
  *   <scope label>          ← omitted when no scope
  *   <message>
  *   Hint: <hint>           ← omitted when no hint
+ *   More: <helpUrl>        ← omitted when no helpUrl (OP-215)
  */
 export function diagnosticToBlock(d: WorkflowDiagnostic): string {
   const f = formatDiagnostic(d);
@@ -274,5 +289,6 @@ export function diagnosticToBlock(d: WorkflowDiagnostic): string {
   if (f.scopeLabel) lines.push(f.scopeLabel);
   lines.push(f.message);
   if (f.hint) lines.push(`Hint: ${f.hint}`);
+  if (f.helpUrl) lines.push(`More: ${f.helpUrl}`);
   return lines.join("\n");
 }

--- a/plugins/op-obsidian/styles.css
+++ b/plugins/op-obsidian/styles.css
@@ -1399,3 +1399,38 @@ a.op-sidebar__agent:hover {
   overflow: hidden;
   text-overflow: ellipsis;
 }
+
+/* OP-215: in-product help-link "?" icon next to settings section headers. */
+.op-settings__heading-row {
+  display: flex;
+  align-items: baseline;
+  gap: 0.5rem;
+}
+
+.op-doc-link {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 1.4em;
+  height: 1.4em;
+  padding: 0 0.4em;
+  border-radius: 999px;
+  border: 1px solid var(--background-modifier-border);
+  background: var(--background-secondary);
+  color: var(--text-muted);
+  text-decoration: none;
+  font-size: var(--font-ui-smaller, 0.8rem);
+  font-weight: 600;
+  line-height: 1;
+}
+
+.op-doc-link:hover {
+  color: var(--text-normal);
+  background: var(--background-modifier-hover);
+  text-decoration: none;
+}
+
+.op-doc-link:focus-visible {
+  outline: 2px solid var(--interactive-accent);
+  outline-offset: 2px;
+}

--- a/plugins/op/.claude-plugin/plugin.json
+++ b/plugins/op/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "op",
   "description": "Obsidian Projects workflow — schema, slash commands, and agent skill for running a Jira-lite issue tracker inside an Obsidian vault.",
-  "version": "0.74.1",
+  "version": "0.74.2",
   "author": {
     "name": "Eugene Archibald"
   },


### PR DESCRIPTION
## Summary

- Three new docs under `docs/workflow-modules/` (troubleshooting, FAQ, settings-tab reference). Troubleshooting has one section per shipped `WorkflowDiagnosticCode` (8 codes — the issue's three ghost codes don't exist in the plugin); settings-reference uses ASCII layouts per the OP-211 "no screenshots" precedent.
- In-product help links: a `?` icon on the Workflows H2, the Available variables collapsible header, and the Injection collapsible header opens the relevant doc anchor on GitHub. `FormattedDiagnostic` gains a `helpUrl` field so `diagnosticToBlock` auto-stamps a `More: <url>` footer in CLI / editor / preview surfaces.
- CI guard: `plugins/op-obsidian/src/docLinks.test.ts` parses every doc the registry references and fails on any missing anchor (github-slugger semantics — em-dash collapses to consecutive hyphens, no whitespace collapse).
- Bumped 0.74.1 → 0.74.2 (patch — additive doc + UI affordance, no behavior change).

## Test plan

- [x] `npx vitest run` (full suite): 1438 pass, 0 fail
- [x] OP-Test smoke: `app.setting.openTabById("op-obsidian")` shows 3 `.op-doc-link` icons with the right hrefs (`workflows`, `workflowsVars`, `injection` anchors).
- [x] OP-Test console clean after the settings panel render.
- [x] Existing `data-op-section` selectors still work (8 advanced collapsibles, 5 daily rows, Workflows H2 intact).

## Notes for review

`@copilot` — focus pressure points:
1. The github-slugger approximation in `docLinks.test.ts` — does it correctly model anchors with em-dashes (`Injection — what the migration changed` → `injection--what-the-migration-changed`, double hyphen)? Verify against any other em-dash heading.
2. `helpUrl` was added to `FormattedDiagnostic` and threaded through `diagnosticToBlock` only — not the one-line `diagnosticToLine`. Is the asymmetry justified, or should the one-line surface also stamp a footer?
3. `addDocLink(parentEl, sectionId)` opens the URL in a new tab via `target=_blank rel=noopener`. Is the `?` glyph + `aria-label` sufficient for accessibility?
4. The Injection collapsible's `?` icon is wired via `ADVANCED_SECTIONS_WITH_DOCS: Set<AdvancedSectionId>` rather than checking `sectionDocAnchor` for membership. Is that registry-vs-set duplication worth removing in favor of a try/catch on the lookup?
5. Scope reconciliation — the issue scope listed 3 diagnostic codes (`screenshot-permission`, `stalled`, `orchestrator-degraded`) that don't exist in `WorkflowDiagnosticCode`. The PR ships docs for the 8 real codes only. Sound?

🤖 Generated with [Claude Code](https://claude.com/claude-code)