### PR TITLE
OP-216: 10f — worked-example library at docs/examples/workflow-library/

### DIFF
--- a/docs/examples/README.md
+++ b/docs/examples/README.md
@@ -8,11 +8,12 @@ ship to CI to keep the docs from drifting away from the engine.
 
 ## What's here
 
-| Subtree | Tutorial it backs | What it shows |
+| Subtree | Backs | What it shows |
 | :--- | :--- | :--- |
-| [`author-first-module/`](./author-first-module/) | [03 — Author your first module](../workflow-modules/03-author-your-first-module.md) | A single global module, no vars, no workflow file. The minimum viable file. |
-| [`compose-first-workflow/`](./compose-first-workflow/) | [04 — Compose your first workflow](../workflow-modules/04-compose-your-first-workflow.md) | Global default workflow + a per-project workflow that `extends:` it, with two modules and a per-step agent override. |
-| [`variables-and-templating/`](./variables-and-templating/) | [05 — Use variables and templating](../workflow-modules/05-variables-and-templating.md) | Plugin vars (`{{branch}}`, `{{today}}`, `{{repo_path}}`), user vars (`{{vars.package_name}}`), `name=VALUE` inline defaults, and the precedence chain in action. |
+| [`author-first-module/`](./author-first-module/) | Tutorial: [03 — Author your first module](../workflow-modules/03-author-your-first-module.md) | A single global module, no vars, no workflow file. The minimum viable file. |
+| [`compose-first-workflow/`](./compose-first-workflow/) | Tutorial: [04 — Compose your first workflow](../workflow-modules/04-compose-your-first-workflow.md) | Global default workflow + a per-project workflow that `extends:` it, with two modules and a per-step agent override. |
+| [`variables-and-templating/`](./variables-and-templating/) | Tutorial: [05 — Use variables and templating](../workflow-modules/05-variables-and-templating.md) | Plugin vars (`{{branch}}`, `{{today}}`, `{{repo_path}}`), user vars (`{{vars.package_name}}`), `name=VALUE` inline defaults, and the precedence chain in action. |
+| [`workflow-library/`](./workflow-library/) | Curated reusable library | Eight `vars:`-driven modules distilled from this project's `WORKFLOW.md` (branching, tmux safety, PR-required, version cadence, GH issue close, adversarial review, commit mapping, orient) plus three reference workflows (global default + extends-default + standalone docs-only). Copy into your own vault to bootstrap a project. |
 
 ## How the layouts map onto your vault
 

--- a/docs/examples/workflow-library/Projects/_op-modules/adversarial-review.md
+++ b/docs/examples/workflow-library/Projects/_op-modules/adversarial-review.md
@@ -1,0 +1,51 @@
+---
+id: adversarial-review
+title: Adversarial AI review before merge
+type: workflow-module
+scope: review
+order: 20
+vars:
+  - reviewer_handle=@copilot
+  - { name: bypass_criteria, default: "all", description: "How many bypass criteria must apply to skip review — 'all' (every criterion) or 'any' (any single one). 'all' is conservative; 'any' is unsafe." }
+---
+
+Every PR gets an adversarial review from {{vars.reviewer_handle}} (or
+equivalent reviewer agent) **before** merge, unless the diff meets the
+bypass criteria below.
+
+### Bypass criteria — `{{vars.bypass_criteria}}` must apply, or no bypass
+
+1. **No runtime behavior change.** Pure formatting, comment-only,
+   docstring tweak, log-string clarification, removal of provably
+   unreachable dead code.
+2. **No control flow changes.** No added or removed branches, loops,
+   exception handlers; no edits to existing ones.
+3. **No new dependencies.** No new `import`, `require`, package, API
+   call, shell binary, or environment variable read.
+4. **No public surface change.** No CLI param, slash command, palette
+   command, frontmatter field, settings tab field, or exported function
+   signature.
+5. **No security or permission impact.** Doesn't touch auth, hooks,
+   command execution, file-write paths, or anything the user has to
+   trust.
+6. **Reversible in one commit.** `git revert <sha>` alone fully restores
+   prior state.
+7. **Single concern.** One logical area; not bundled as a drive-by
+   alongside a real change.
+
+When in doubt, request the review. It costs minutes; a slipped
+regression costs much more.
+
+### How to request
+
+1. Comment on the PR mentioning {{vars.reviewer_handle}} with
+   **concrete pressure-test prompts** — specific edge cases, conflict
+   cases, backward-compat, concurrency, schema drift, cleanup symmetry,
+   param validation. Generic "please review" yields a generic answer.
+2. Watch the PR timeline for the reviewer's start/finish events and any
+   pushed fix commits.
+3. If the reviewer pushes a fix commit, fast-forward it into your
+   worktree and re-run the test suite. Treat the fix as evidence, not
+   gospel — review it before accepting.
+4. Don't merge until findings are evaluated and addressed (or waived in
+   the PR comments with rationale).

--- a/docs/examples/workflow-library/Projects/_op-modules/branching.md
+++ b/docs/examples/workflow-library/Projects/_op-modules/branching.md
@@ -1,0 +1,27 @@
+---
+id: branching
+title: Branching discipline
+type: workflow-module
+scope: kickoff
+order: 10
+vars:
+  - default_branch=main
+  - branch_strategy=worktree
+---
+
+Always isolate work from `{{vars.default_branch}}` before making changes
+— even one-line tweaks. The branch strategy for this project is
+`{{vars.branch_strategy}}`:
+
+- `worktree` — create an isolated git worktree (e.g. via your harness's
+  `EnterWorktree` tool, or `git worktree add`). The delegating agent's
+  checkout and yours can coexist on the same repo without conflict.
+- `feature-branch` — create a feature branch off
+  `{{vars.default_branch}}` and push only to that branch. Never push
+  directly to `{{vars.default_branch}}`.
+
+Override `vars.branch_strategy` in your project's `STATUS.md` `vars:`
+block (project scope) if your team prefers feature branches over
+worktrees. The default is `worktree` because it's the only strategy that
+lets multiple agents work on the same checkout in parallel without
+fighting over `HEAD`.

--- a/docs/examples/workflow-library/Projects/_op-modules/commit-mapping.md
+++ b/docs/examples/workflow-library/Projects/_op-modules/commit-mapping.md
@@ -1,0 +1,30 @@
+---
+id: commit-mapping
+title: Commit-to-issue mapping
+type: workflow-module
+scope: implement
+order: 10
+vars:
+  - commit_command=op-append-commit
+  - commit_field=commits
+---
+
+After every commit on this issue's branch, append the short sha and
+subject to the issue note's `{{vars.commit_field}}:` list. Cadence is
+**per-commit, not batched** — `{{vars.commit_field}}:` is the durable
+record of what shipped, and a missing entry is a permanent gap.
+
+Use:
+
+```
+sha=$(git rev-parse --short=7 HEAD)
+sub=$(git log -1 --pretty=%s)
+obsidian {{vars.commit_command}} issue={{id}} sha="$sha" subject="$sub"
+```
+
+If the command fails (vault unreachable, plugin disabled, issue file
+moved mid-session), record the `<sha7> <subject>` pair in your scratch
+notes and batch-append at resolve time — don't block the commit cadence
+on vault health.
+
+Skip this rule entirely for meta-only projects with no git repo.

--- a/docs/examples/workflow-library/Projects/_op-modules/gh-issue-close.md
+++ b/docs/examples/workflow-library/Projects/_op-modules/gh-issue-close.md
@@ -1,0 +1,30 @@
+---
+id: gh-issue-close
+title: GitHub issue close on resolve
+type: workflow-module
+scope: finalize
+order: 20
+vars:
+  - { name: auto_close_setting_path, default: "closeGithubIssueOnResolve", description: "Plugin settings key (or dotted path) that controls whether op-resolve also closes the linked GH issue." }
+---
+
+If this issue mirrors a GitHub issue (the issue note has a
+`github_issue:` URL), do **not** close the GH issue manually before
+running `op-resolve`. The plugin closes it atomically as part of the
+resolve transition when its `{{vars.auto_close_setting_path}}` setting
+is on, and a manual close beforehand makes the JSON response confusing
+("`githubClosed: true`" vs. "already closed by user").
+
+After running `op-resolve`, read the JSON payload at
+`Projects/_scratch/op-last-response.md` and check `githubClosed` and
+`githubCloseError`. Don't try to predict what the setting is set to —
+agents semi-consistently misread it (in this codebase the flag lives
+under `settings.github`, not the top level, and a wrong-path probe
+returns `=> {}` which looks like "off"). Read the actual response
+instead, and report what happened.
+
+If `githubCloseError` is set, retry the close manually
+(`gh issue close <url>`) and surface the error to the user.
+
+Skip this rule for projects without a GitHub remote, or for issues that
+don't carry a `github_issue:` URL.

--- a/docs/examples/workflow-library/Projects/_op-modules/orient.md
+++ b/docs/examples/workflow-library/Projects/_op-modules/orient.md
@@ -1,0 +1,17 @@
+---
+id: orient
+title: Orient yourself before touching code
+type: workflow-module
+scope: kickoff
+order: 0
+---
+
+You're working on **{{id}}** ({{title}}) on branch `{{branch}}`. Read the
+issue note before doing anything else. Confirm the scope, scan for prior
+commits or open PRs on this branch, and surface any ambiguity in the
+requirements before writing code.
+
+If the scope section is empty or one line, treat it as ambiguous — state
+your interpretation and ask for confirmation before implementing, even
+when running in auto mode. The cost of a 30-second confirm is far below
+the cost of building the wrong thing.

--- a/docs/examples/workflow-library/Projects/_op-modules/pr-required.md
+++ b/docs/examples/workflow-library/Projects/_op-modules/pr-required.md
@@ -1,0 +1,32 @@
+---
+id: pr-required
+title: PR-required gate
+type: workflow-module
+scope: review
+order: 10
+vars:
+  - default_branch=main
+  - { name: pr_title_pattern, default: "<ID>: <subject>", description: "Required PR title shape; <ID> is the issue id, <subject> is the imperative-mood summary." }
+  - merge_command=gh pr merge --squash --delete-branch
+---
+
+Pull requests are required to merge to `{{vars.default_branch}}` — no
+direct pushes. Title format is `{{vars.pr_title_pattern}}`; for this
+issue that means a title shaped like `{{id}}: <imperative summary>`.
+
+Before merging:
+
+- Tests are green and the CI status check is passing.
+- The PR description matches what the diff actually does (don't ship a
+  diff whose summary lies about its scope).
+- No untracked files belong with the change.
+- Any adversarial review (see the matching review module) has been
+  evaluated and addressed, or explicitly waived in the PR comments with
+  a rationale.
+
+Merge with `{{vars.merge_command}}`. If the local fast-forward fails
+because another worktree holds `{{vars.default_branch}}`, that's
+expected — verify the merge landed on the remote (e.g.
+`gh pr view <#> --json state,mergedAt`) and then delete the remote
+branch and tear down the worktree manually. The merge itself is on the
+server; only the local cleanup needs the manual touch.

--- a/docs/examples/workflow-library/Projects/_op-modules/tmux-safety.md
+++ b/docs/examples/workflow-library/Projects/_op-modules/tmux-safety.md
@@ -1,0 +1,39 @@
+---
+id: tmux-safety
+title: Tmux safety — never target shared sessions
+type: workflow-module
+scope: kickoff
+order: 20
+vars:
+  - { name: protected_session_prefixes, default: "op-agents-,view-", description: "Comma-separated list of tmux session-name prefixes that must never receive destructive commands." }
+  - experiment_session_pattern=op-experiment-$$
+---
+
+When experimenting with tmux — installing hooks, killing windows,
+overriding options — **never** target a session whose name starts with
+any of `{{vars.protected_session_prefixes}}`. Those sessions host live
+agent state; a mis-targeted `kill-session` or `set-hook` wipes every
+parallel agent's window and forces a multi-agent restart.
+
+Rules:
+
+- **Experiment in a disposable session you created yourself.** Use a
+  name that cannot prefix-match any protected prefix — the convention is
+  `{{vars.experiment_session_pattern}}` (the `$$` expands to your shell
+  PID, so each experiment is in its own session). Tear it down with
+  `tmux kill-session -t =<your-name>` (the `=` forces exact match).
+- **Use exact-match `=name` targets in any tmux command you run.**
+  Without `=`, tmux session/window names match by prefix —
+  `kill-session -t view-X` would silently match `view-X-something-else`
+  if both exist.
+- **Read shared state, don't mutate it.** `tmux list-sessions`,
+  `tmux list-windows -a`, `tmux show-hooks`, `tmux show-options` are
+  safe. `kill-*`, `set-hook`, `set-option`, `rename-*` against shared
+  targets are not.
+- **For automated tests, use the orchestrator's pure-function exports**
+  with a stubbed tmux binary. Never drive real tmux from a unit test.
+
+If you accidentally take down a shared session, surface the failure to
+the user immediately — don't try to silently restart agents to cover for
+it. Recovery is "every affected agent restarts; uncommitted work in
+those agents' worktrees is what's still on disk."

--- a/docs/examples/workflow-library/Projects/_op-modules/version-cadence.md
+++ b/docs/examples/workflow-library/Projects/_op-modules/version-cadence.md
@@ -1,0 +1,39 @@
+---
+id: version-cadence
+title: Version bump cadence
+type: workflow-module
+scope: finalize
+order: 10
+vars:
+  - package_name=op-obsidian
+  - bump_command=node scripts/bump-version.mjs
+---
+
+Every issue that ships code bumps the project's version file in
+lockstep — one bump per issue, recorded as `version:` on the issue note.
+
+Run from the repo root:
+
+```
+{{vars.bump_command}} <patch|minor|major>
+```
+
+The script for this project moves
+`plugins/{{vars.package_name}}/manifest.json`,
+`plugins/{{vars.package_name}}/package.json`, and any matching
+`.claude-plugin/plugin.json` together so the three never drift.
+
+Pick the bump level by judgment:
+
+- **patch** — docs, bug fixes, internal refactors.
+- **minor** — new user-facing behavior (new command, new optional field,
+  additive arg).
+- **major** — breaking change (removed/renamed field, removed verb,
+  schema migration). Confirm with the user before bumping major.
+
+Pre-`1.0.0` projects MAY treat breakage as minor; prefer explicit major
+once the schema stabilizes. Skip entirely for meta-only projects with no
+version file.
+
+Override `vars.package_name` in your project's `STATUS.md` `vars:` block
+to point this rule at a different package without forking the module.

--- a/docs/examples/workflow-library/Projects/_op-workflow.md
+++ b/docs/examples/workflow-library/Projects/_op-workflow.md
@@ -1,0 +1,47 @@
+---
+type: workflow
+schema: 1
+project: _global
+default_agent: claude
+default_model: opus
+steps:
+  - step: evaluate
+    modules: [orient]
+  - step: plan
+    modules: []
+  - step: implement
+    modules: [commit-mapping]
+  - step: review
+    modules: [adversarial-review, pr-required]
+  - step: finalize
+    modules: [version-cadence, gh-issue-close]
+---
+
+# Global default workflow — `evaluate → plan → implement → review → finalize`
+
+This is the historical five-step sequence that every project's
+per-project `WORKFLOW.md` can inherit by declaring
+`extends: Projects/_op-workflow.md`.
+
+The five steps:
+
+- **evaluate** — orient, read the issue note, surface ambiguity. Wired
+  through the `orient` module.
+- **plan** — write the `## Plan` section before touching code. Empty
+  module list by default; projects with a planning checklist or
+  pre-flight runbook can drop their own `plan`-scoped modules in
+  `Projects/<slug>/MODULES/` and reference them here.
+- **implement** — actually write the code, with per-commit mapping back
+  to the issue note.
+- **review** — open a PR, request adversarial review, gate merge on
+  green CI and a clean review.
+- **finalize** — bump the version file at resolve time, let the plugin
+  close the linked GitHub issue atomically.
+
+The kickoff-scoped library modules (`branching`, `tmux-safety`) are
+**not** wired into a step here on purpose — those are vault-wide rules
+that fire at agent launch via the kickoff injection path, not as part
+of any one step. Per-project workflows that want them in `evaluate`
+instead can list them by id in their own `evaluate` step's `modules:`
+list (which replaces this file's `evaluate` step at the same slot
+under `extends:` semantics).

--- a/docs/examples/workflow-library/Projects/code-project/WORKFLOW.md
+++ b/docs/examples/workflow-library/Projects/code-project/WORKFLOW.md
@@ -1,0 +1,49 @@
+---
+type: workflow
+schema: 1
+project: code-project
+default_agent: claude
+default_model: opus
+extends: Projects/_op-workflow.md
+steps: []
+---
+
+# Full code-project workflow — inherits the global default
+
+This per-project workflow `extends:` the global default at
+`Projects/_op-workflow.md` and declares an empty `steps: []` — so it
+inherits the complete five-step sequence
+(`evaluate → plan → implement → review → finalize`) verbatim, including
+every module reference. Empty `steps:` is the right shape for "inherit
+the parent verbatim with no overrides"; child step ids replace parent
+steps at the same slot, and an empty list adds no replacements.
+
+(The `steps:` field is required by the schema even when extending —
+the loader treats files without `steps:` as the legacy fallback shape,
+not as modern files inheriting unchanged.)
+
+This is the canonical setup for a "real code" project: the per-project
+file exists primarily to declare `project: code-project`, which the
+loader uses to scope per-project modules under
+`Projects/code-project/MODULES/<id>.md`. A project with no per-project
+modules and no per-step overrides could in principle skip declaring its
+own `WORKFLOW.md` once the loader's project inference is in place — but
+authoring an explicit per-project file is the documented happy path
+because it makes the project's intent visible alongside the rest of its
+files.
+
+To override a single step (e.g. swap the `review` step to run under a
+different agent), repeat that step's id in a `steps:` list:
+
+```yaml
+steps:
+  - step: review
+    agent: copilot
+    model: gpt-5
+    modules: [adversarial-review, pr-required]
+```
+
+Child step ids replace parent steps at the same slot; child steps with
+new ids append. There is no "remove inherited step" semantics — see the
+sibling `docs-project/WORKFLOW.md` for the standalone-without-`extends:`
+pattern when you need to omit inherited steps entirely.

--- a/docs/examples/workflow-library/Projects/docs-project/WORKFLOW.md
+++ b/docs/examples/workflow-library/Projects/docs-project/WORKFLOW.md
@@ -1,0 +1,44 @@
+---
+type: workflow
+schema: 1
+project: docs-project
+default_agent: claude
+default_model: opus
+steps:
+  - step: evaluate
+    modules: [orient]
+  - step: plan
+    modules: []
+  - step: implement
+    modules: [commit-mapping]
+---
+
+# Docs-only project workflow — three steps, no review or finalize
+
+This per-project workflow is **standalone** — it does not declare
+`extends:` and so does not inherit anything from the global default at
+`Projects/_op-workflow.md`. The intent is to demonstrate a domain-
+flavored variant: a docs-only project where the merge gate and version-
+bump steps don't apply because there is no code to ship and no version
+file to move.
+
+Why standalone instead of `extends:` with a "remove `review` and
+`finalize`" override? The workflow file format has no remove semantics —
+child step ids replace parent steps at the same slot, and child steps
+with new ids append, but there's no syntax for "drop step X from the
+parent." When a project genuinely needs a shorter step list, the
+cleanest expression is a standalone file that lists exactly the steps it
+wants — which is what this file does.
+
+Tradeoffs:
+
+- **Standalone**: full control over the step list at the cost of
+  re-declaring `default_agent` / `default_model` and re-listing every
+  step, even those that are identical to the global default.
+- **`extends:`**: inherit everything for free; override individual
+  steps; cannot remove an inherited step without falling back to
+  standalone.
+
+If your project starts as docs-only but later grows code, switch it to
+`extends:` and add the `review` / `finalize` steps via standard merge
+semantics — no migration of the per-project module files required.

--- a/docs/examples/workflow-library/README.md
+++ b/docs/examples/workflow-library/README.md
@@ -1,0 +1,129 @@
+# Workflow Library — reusable modules for any project
+
+This subtree is a **library of reusable workflow modules** distilled
+from the historical `WORKFLOW.md` of this very project, with all
+per-project specifics swapped out for `vars:` defaults so a different
+project can copy the modules verbatim and have them work.
+
+It is shaped like a real Obsidian vault — copy any module file into
+your own vault under the same path and the loader picks it up:
+
+```
+docs/examples/workflow-library/   ← vault root
+├── README.md                      ← this file (not loaded by the engine)
+└── Projects/
+    ├── _op-modules/               ← global modules — apply to every project
+    │   ├── orient.md
+    │   ├── branching.md
+    │   ├── tmux-safety.md
+    │   ├── commit-mapping.md
+    │   ├── pr-required.md
+    │   ├── adversarial-review.md
+    │   ├── version-cadence.md
+    │   └── gh-issue-close.md
+    ├── _op-workflow.md            ← global default workflow (5 steps)
+    ├── code-project/
+    │   └── WORKFLOW.md            ← extends the global default verbatim
+    └── docs-project/
+        └── WORKFLOW.md            ← standalone 3-step variant (no review/finalize)
+```
+
+## What's inside
+
+### Modules (8)
+
+| Module | Scope | Vars (with inline defaults) | Source — what it codifies |
+| :--- | :--- | :--- | :--- |
+| `orient.md` | `kickoff` | _none_ | Read the issue note; surface ambiguity before coding. |
+| `branching.md` | `kickoff` | `default_branch=main`, `branch_strategy=worktree` | Always isolate from the default branch — worktree or feature branch. |
+| `tmux-safety.md` | `kickoff` | `protected_session_prefixes=op-agents-,view-`, `experiment_session_pattern=op-experiment-$$` | Don't kill shared tmux sessions; experiment in a disposable one. |
+| `commit-mapping.md` | `implement` | `commit_command=op-append-commit`, `commit_field=commits` | Append every commit to the issue note's commits list, per-commit not batched. |
+| `pr-required.md` | `review` | `default_branch=main`, `pr_title_pattern="<ID>: <subject>"`, `merge_command=gh pr merge --squash --delete-branch` | PRs gate merges; PR title carries the issue id. |
+| `adversarial-review.md` | `review` | `reviewer_handle=@copilot`, `bypass_criteria=all` | Request adversarial review with concrete pressure-test prompts; bypass only when *all* criteria apply. |
+| `version-cadence.md` | `finalize` | `package_name=op-obsidian`, `bump_command=node scripts/bump-version.mjs` | Bump version files in lockstep at resolve time. |
+| `gh-issue-close.md` | `finalize` | `auto_close_setting_path=closeGithubIssueOnResolve` | Don't close the linked GH issue manually — let `op-resolve` handle it; read the JSON response. |
+
+Every module declares its `vars:` block in one of the three documented
+shapes (bare, shorthand `name=VALUE`, or object form with
+`description:`). Together the eight modules exercise all three shapes
+at least once, so the file collection doubles as a vars-syntax
+reference.
+
+The kickoff-scoped modules (`orient`, `branching`, `tmux-safety`) are
+declared with `scope: kickoff` so they fire at agent launch via the
+kickoff injection path. The other modules are wired into the matching
+step in the workflow files below — see [the scope-tags
+reference](../../workflow-modules/reference/scope-tags.md) for the
+conventions.
+
+### Workflows (3)
+
+| File | Shape | Use for |
+| :--- | :--- | :--- |
+| `Projects/_op-workflow.md` | Global default — 5 steps (`evaluate, plan, implement, review, finalize`). | The canonical sequence. Every per-project workflow can `extends:` this file to inherit it wholesale. |
+| `Projects/code-project/WORKFLOW.md` | Per-project — `extends:` the global default with no overrides. | Real code projects: inherits the full five-step pipeline verbatim. |
+| `Projects/docs-project/WORKFLOW.md` | Per-project — standalone, three steps (`evaluate, plan, implement`). | Domain-flavored variant for docs-only projects with no merge gate / version bump / GH issue close to apply. |
+
+The `code-project` and `docs-project` files together demonstrate the
+two ways a per-project workflow can declare its step list:
+`extends:`-and-inherit (when the per-project shape matches the global
+default), or standalone (when a step needs to be removed, since the
+file format has no "remove inherited step" semantics).
+
+## How to copy this into your vault
+
+The library is designed to be cherry-picked, not adopted wholesale.
+
+1. **Pick the modules you want.** Copy individual `.md` files from
+   `Projects/_op-modules/` into your vault's `Projects/_op-modules/`
+   directory. The filename and the frontmatter `id:` must match — keep
+   them in sync if you rename.
+2. **Drop the workflow file you want.** Either copy
+   `Projects/_op-workflow.md` to your vault's
+   `Projects/_op-workflow.md` and `extends:` it from each project's
+   `WORKFLOW.md`, or copy one of the per-project examples to
+   `Projects/<your-slug>/WORKFLOW.md` and edit the `project:` field.
+3. **Override defaults at the right precedence layer.** The `vars:`
+   defaults declared in each module are the lowest-precedence layer.
+   To customize without forking the module, set the same name in:
+   - the global module-vars layer (a higher-precedence layer for vars
+     that apply across every project),
+   - the project's `STATUS.md` `vars:` block (project scope), or
+   - the launch-modal override panel (launch scope, OP-204).
+
+   See [`docs/workflow-modules/reference/precedence.md`](../../workflow-modules/reference/precedence.md)
+   for the full precedence chain.
+4. **Run `op: explain workflow`** in the command palette (or
+   `obsidian op-explain-workflow id=<your-issue-id> mode=kickoff`) to
+   confirm zero diagnostics. Any error there tells you exactly what's
+   wrong.
+
+## Verifying — CI keeps the library honest
+
+`plugins/op-obsidian/src/docsExamples.test.ts` walks every file in
+this subtree, runs it through the same loader and composer the runtime
+uses, and asserts zero error-severity diagnostics for both the
+`code-project` and `docs-project` slugs at every step they declare. If
+a future engine change breaks the schema, this test goes red — the docs
+and the engine stay in sync via the merge gate.
+
+## How the workflow-library differs from the tutorial trees
+
+The other three subtrees under `docs/examples/` (`author-first-module`,
+`compose-first-workflow`, `variables-and-templating`) back the
+[OP-212 tutorials](../../workflow-modules/) and are intentionally
+minimal — each illustrates one concept. **This subtree is the curated
+library** — the files that have proven useful in production and that a
+real project might cherry-pick from on day one. Treat them as a
+starting point, not gospel: edit, fork, override, delete.
+
+## Note on var-name reuse across libraries
+
+A few var names appear in both this library and the `variables-and-templating/`
+tutorial tree (e.g. `package_name`). They live in different example
+subtrees, which the test loads independently — the loader sees one set
+of declarations at a time, so there is no collision. If you copy
+modules from both libraries into the same vault, the loader's
+`intra-scope-collision` rule kicks in only when two modules at the same
+`scope:` declare the same var name; cross-scope or cross-tree
+duplicates compose fine.

--- a/plugins/op-obsidian/manifest.json
+++ b/plugins/op-obsidian/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "op-obsidian",
   "name": "Obsidian Projects (op)",
-  "version": "0.74.1",
+  "version": "0.74.2",
   "minAppVersion": "1.5.0",
   "description": "Jira-lite issue tracker for Obsidian vaults — deterministic commands backing the op workflow.",
   "author": "Eugene Archibald",

--- a/plugins/op-obsidian/package.json
+++ b/plugins/op-obsidian/package.json
@@ -1,6 +1,6 @@
 {
   "name": "op-obsidian",
-  "version": "0.74.1",
+  "version": "0.74.2",
   "description": "Obsidian plugin that owns the deterministic half of the op workflow.",
   "main": "main.js",
   "scripts": {

--- a/plugins/op-obsidian/src/docsExamples.test.ts
+++ b/plugins/op-obsidian/src/docsExamples.test.ts
@@ -105,6 +105,31 @@ const EXAMPLES: ExampleSpec[] = [
   },
 ];
 
+// The workflow-library subtree ships two project slugs side-by-side
+// (`code-project` extends the global default; `docs-project` is
+// standalone with a shorter step list). Each slug needs its own
+// fake-vault load + compose pass, so we expand them as two manifest
+// entries rather than overloading `ExampleSpec` with multi-project
+// support. The on-disk-vs-manifest parity test below treats both
+// entries as collapsing to the same `workflow-library` directory.
+EXAMPLES.push(
+  {
+    name: "workflow-library",
+    project: "code-project",
+    // The library's `plan` step is intentionally `modules: []` (a slot
+    // for projects to fill in their own planning checklist), so we
+    // don't compose at it — assertExampleClean asserts non-empty
+    // composed text per step, and an empty modules list is, correctly,
+    // empty.
+    composeAtSteps: ["evaluate", "implement", "review", "finalize"],
+  },
+  {
+    name: "workflow-library",
+    project: "docs-project",
+    composeAtSteps: ["evaluate", "implement"],
+  },
+);
+
 const EXAMPLES_ROOT = resolve(__dirname, "..", "..", "..", "docs", "examples");
 
 // --------------------------------------------------------------------------
@@ -322,7 +347,11 @@ async function assertExampleClean(spec: ExampleSpec) {
 
 describe("docs/examples — every shipped tutorial example loads + composes cleanly", () => {
   for (const spec of EXAMPLES) {
-    it(`example "${spec.name}" produces zero error-severity diagnostics`, async () => {
+    // Some example trees ship multiple project slugs (e.g. workflow-library
+    // ships `code-project` and `docs-project` side-by-side); include the
+    // slug in the test label so duplicates remain distinguishable.
+    const label = spec.project ? `${spec.name} (${spec.project})` : spec.name;
+    it(`example "${label}" produces zero error-severity diagnostics`, async () => {
       await assertExampleClean(spec);
     });
   }
@@ -334,7 +363,9 @@ describe("docs/examples — manifest is in sync with the filesystem", () => {
       .filter((d) => d.isDirectory())
       .map((d) => d.name)
       .sort();
-    const inManifest = EXAMPLES.map((e) => e.name).sort();
+    // Dedupe — a single example tree may have multiple manifest entries
+    // when it ships multiple project slugs (see workflow-library).
+    const inManifest = Array.from(new Set(EXAMPLES.map((e) => e.name))).sort();
     expect(onDisk).toEqual(inManifest);
   });
 });

--- a/plugins/op/.claude-plugin/plugin.json
+++ b/plugins/op/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "op",
   "description": "Obsidian Projects workflow — schema, slash commands, and agent skill for running a Jira-lite issue tracker inside an Obsidian vault.",
-  "version": "0.74.1",
+  "version": "0.74.2",
   "author": {
     "name": "Eugene Archibald"
   },


### PR DESCRIPTION
## Summary

Ships the **worked-example library** for OP-193's Child 10 (user docs umbrella) — a curated set of reusable workflow modules + reference workflows under `docs/examples/workflow-library/`, distilled from this project's `WORKFLOW.md` with per-project specifics swapped out for `vars:` defaults so any project can copy the modules in verbatim.

**8 modules** (within the 6–10 target):

| File | Scope | Vars (with defaults) | Codifies |
| :--- | :--- | :--- | :--- |
| `orient.md` | `kickoff` | _none_ | Read the issue note, surface ambiguity. |
| `branching.md` | `kickoff` | `default_branch=main`, `branch_strategy=worktree` | Branch / worktree discipline. |
| `tmux-safety.md` | `kickoff` | `protected_session_prefixes`, `experiment_session_pattern` | Don't kill shared tmux sessions. |
| `commit-mapping.md` | `implement` | `commit_command`, `commit_field` | Per-commit append to issue's commits list. |
| `pr-required.md` | `review` | `default_branch`, `pr_title_pattern`, `merge_command` | PR-required gate; squash-merge cadence. |
| `adversarial-review.md` | `review` | `reviewer_handle=@copilot`, `bypass_criteria=all` | Adversarial review with concrete pressure-test prompts; bypass criteria. |
| `version-cadence.md` | `finalize` | `package_name`, `bump_command` | Lockstep version bump at resolve time. |
| `gh-issue-close.md` | `finalize` | `auto_close_setting_path` | Don't close GH issue manually — let `op-resolve` handle it. |

Every module declares its `vars:` in one of the three documented shapes (bare / shorthand / object); together they exercise all three at least once, so the collection doubles as a vars-syntax reference.

**3 reference workflows**:

- `Projects/_op-workflow.md` — global default. Five steps (`evaluate → plan → implement → review → finalize`) — the historical OP-188 sequence.
- `Projects/code-project/WORKFLOW.md` — `extends:` the global default with `steps: []` (the canonical "inherit verbatim" shape).
- `Projects/docs-project/WORKFLOW.md` — standalone domain variant. Three steps; explicitly omits `review`/`finalize` because the format has no "remove inherited step" semantics.

## CI

`plugins/op-obsidian/src/docsExamples.test.ts` grows two `ExampleSpec` entries for the library (one per project slug). The manifest-parity test now dedupes so multiple slugs in one subtree are tolerated. The library's `plan` step ships intentionally empty (slot for projects to fill in their own planning checklist), so the test composes at every step *except* `plan`.

Full vitest run: 1438 pass / 0 fail.

## Version

op-obsidian 0.74.1 → 0.74.2 (patch — additive docs + test, no runtime change).

## Test plan

- [x] `npx vitest run` — 1438 pass / 0 fail
- [x] `node scripts/bump-version.mjs patch` — version files in lockstep, main.js fresher than manifest
- [x] `node scripts/dev-sync.mjs` — plugin reloaded into OP-Test
- [x] `obsidian vault=OP-Test eval code='app.plugins.plugins["op-obsidian"]?.manifest?.version'` — returns `0.74.2`
- [x] OP-Test dev console clean after reload (no errors logged on plugin load)

🤖 Generated with [Claude Code](https://claude.com/claude-code)