### PR TITLE
OP-188: replace flowOrchestrator hardcoded matrix with workflow-file reader

### DIFF
--- a/plugins/op-obsidian/manifest.json
+++ b/plugins/op-obsidian/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "op-obsidian",
   "name": "Obsidian Projects (op)",
-  "version": "0.74.2",
+  "version": "0.75.0",
   "minAppVersion": "1.5.0",
   "description": "Jira-lite issue tracker for Obsidian vaults — deterministic commands backing the op workflow.",
   "author": "Eugene Archibald",

--- a/plugins/op-obsidian/manifest.json
+++ b/plugins/op-obsidian/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "op-obsidian",
   "name": "Obsidian Projects (op)",
-  "version": "0.75.0",
+  "version": "0.75.1",
   "minAppVersion": "1.5.0",
   "description": "Jira-lite issue tracker for Obsidian vaults — deterministic commands backing the op workflow.",
   "author": "Eugene Archibald",

--- a/plugins/op-obsidian/package.json
+++ b/plugins/op-obsidian/package.json
@@ -1,6 +1,6 @@
 {
   "name": "op-obsidian",
-  "version": "0.74.2",
+  "version": "0.75.0",
   "description": "Obsidian plugin that owns the deterministic half of the op workflow.",
   "main": "main.js",
   "scripts": {

--- a/plugins/op-obsidian/package.json
+++ b/plugins/op-obsidian/package.json
@@ -1,6 +1,6 @@
 {
   "name": "op-obsidian",
-  "version": "0.75.0",
+  "version": "0.75.1",
   "description": "Obsidian plugin that owns the deterministic half of the op workflow.",
   "main": "main.js",
   "scripts": {

--- a/plugins/op-obsidian/src/cliHandlers.test.ts
+++ b/plugins/op-obsidian/src/cliHandlers.test.ts
@@ -164,8 +164,16 @@ describe("parseSetFlowParams", () => {
     const r = parseSetFlowParams({ id: "OP-1", flow: "planning", complexity: "complex" });
     expect(r.ok && r.value).toEqual({ id: "OP-1", flow: "planning", complexity: "complex" });
   });
-  it("rejects invalid flow enum", () => {
-    const r = parseSetFlowParams({ id: "OP-1", flow: "wat" });
+  it("accepts free-form flow values (workflow walker enforces at advance time)", () => {
+    // OP-188: post-modules, parseSetFlowParams accepts any non-empty step id
+    // — the orchestrator's workflow-file walker decides what's valid for the
+    // project's actual workflow. Values not in the workflow simply produce
+    // a no-op auto-advance.
+    const r = parseSetFlowParams({ id: "OP-1", flow: "kickoff" });
+    expect(r.ok && r.value).toEqual({ id: "OP-1", flow: "kickoff" });
+  });
+  it("rejects whitespace-only flow value", () => {
+    const r = parseSetFlowParams({ id: "OP-1", flow: "   " });
     expect(r.ok).toBe(false);
     if (!r.ok) expect(r.error).toMatch(/invalid --flow/);
   });

--- a/plugins/op-obsidian/src/cliHandlers.test.ts
+++ b/plugins/op-obsidian/src/cliHandlers.test.ts
@@ -177,6 +177,12 @@ describe("parseSetFlowParams", () => {
     expect(r.ok).toBe(false);
     if (!r.ok) expect(r.error).toMatch(/invalid --flow/);
   });
+  it("rejects flow value containing embedded newlines", () => {
+    // URI-encoded newlines (%0A) in CLI params must be caught at parse time.
+    const r = parseSetFlowParams({ id: "OP-1", flow: "plan\nevil_key: value" });
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.error).toMatch(/invalid --flow.*newlines/);
+  });
   it("rejects invalid complexity enum", () => {
     const r = parseSetFlowParams({ id: "OP-1", complexity: "epic" });
     expect(r.ok).toBe(false);

--- a/plugins/op-obsidian/src/cliHandlers.ts
+++ b/plugins/op-obsidian/src/cliHandlers.ts
@@ -63,14 +63,16 @@ export function parseSetEvaluationParams(
   return { ok: true, value: { id, evaluation } };
 }
 
-const FLOW_ENUM = ["evaluate", "planning", "implementation", "review", "finalization", "done"] as const;
+// OP-188: `flow:` accepts any non-empty step id (the workflow-file walker at
+// auto-advance time enforces "step exists in the workflow"). Complexity stays
+// a closed two-value enum.
 const COMPLEXITY_ENUM = ["simple", "complex"] as const;
 
 export function parseSetFlowParams(
   params: Record<string, string>,
 ): ParamsResult<{
   id: string;
-  flow?: (typeof FLOW_ENUM)[number] | null;
+  flow?: string | null;
   complexity?: (typeof COMPLEXITY_ENUM)[number] | null;
 }> {
   const id = params.issue ?? params.id;
@@ -85,19 +87,19 @@ export function parseSetFlowParams(
   }
   const out: {
     id: string;
-    flow?: (typeof FLOW_ENUM)[number] | null;
+    flow?: string | null;
     complexity?: (typeof COMPLEXITY_ENUM)[number] | null;
   } = { id };
   if (hasFlow) {
     const v = params.flow;
     if (v === "" || v === "null") {
       out.flow = null;
-    } else if ((FLOW_ENUM as readonly string[]).includes(v)) {
-      out.flow = v as (typeof FLOW_ENUM)[number];
+    } else if (typeof v === "string" && v.trim().length > 0) {
+      out.flow = v.trim();
     } else {
       return {
         ok: false,
-        error: `op-set-flow failed: invalid --flow ${JSON.stringify(v)} (expected ${FLOW_ENUM.join("|")})`,
+        error: `op-set-flow failed: invalid --flow ${JSON.stringify(v)} (expected a non-empty step id string)`,
       };
     }
   }

--- a/plugins/op-obsidian/src/cliHandlers.ts
+++ b/plugins/op-obsidian/src/cliHandlers.ts
@@ -95,6 +95,12 @@ export function parseSetFlowParams(
     if (v === "" || v === "null") {
       out.flow = null;
     } else if (typeof v === "string" && v.trim().length > 0) {
+      if (/[\r\n]/.test(v)) {
+        return {
+          ok: false,
+          error: `op-set-flow failed: invalid --flow ${JSON.stringify(v)} (must not contain newlines)`,
+        };
+      }
       out.flow = v.trim();
     } else {
       return {

--- a/plugins/op-obsidian/src/flowOrchestrator.test.ts
+++ b/plugins/op-obsidian/src/flowOrchestrator.test.ts
@@ -1,86 +1,354 @@
 import { describe, it, expect } from "vitest";
 import {
   flowAdvanceDecision,
+  legacyFlowAdvanceDecision,
   modeFromAgentLaunchMode,
+  LEGACY_FLOW_ALIAS,
 } from "./flowOrchestrator";
+import type { WorkflowFile, WorkflowStep } from "./workflowFilePure";
 
-describe("flowAdvanceDecision", () => {
-  it("evaluate + simple → implementation/implement", () => {
-    expect(
-      flowAdvanceDecision({ flow: "evaluate", complexity: "simple", exitStatus: "clean" }),
-    ).toEqual({ nextFlow: "implementation", nextMode: "implement" });
-  });
+// ---------------------------------------------------------------------------
+// Workflow fixture builders
+// ---------------------------------------------------------------------------
 
-  it("evaluate + complex → planning/plan", () => {
-    expect(
-      flowAdvanceDecision({ flow: "evaluate", complexity: "complex", exitStatus: "clean" }),
-    ).toEqual({ nextFlow: "planning", nextMode: "plan" });
-  });
+function makeWorkflow(stepIds: string[], opts: { isLegacy?: boolean } = {}): WorkflowFile {
+  const steps: WorkflowStep[] = stepIds.map((id) => ({ step: id, modules: [] }));
+  return {
+    source: {
+      path: "Projects/x/WORKFLOW.md",
+      project: "x",
+      isLegacy: opts.isLegacy ?? false,
+    },
+    type: "workflow",
+    schema: 1,
+    project: "x",
+    defaultAgent: ["claude"],
+    defaultModel: { kind: "all", values: ["opus"] },
+    extendsPath: null,
+    steps,
+  };
+}
 
-  it("evaluate without complexity → null (await user decision)", () => {
-    expect(flowAdvanceDecision({ flow: "evaluate", exitStatus: "clean" })).toBeNull();
-    expect(
-      flowAdvanceDecision({ flow: "evaluate", complexity: null, exitStatus: "clean" }),
-    ).toBeNull();
-  });
+const CANONICAL = makeWorkflow(["evaluate", "plan", "implement", "review", "finalize"]);
 
-  it("planning → implementation/implement", () => {
-    expect(flowAdvanceDecision({ flow: "planning", exitStatus: "clean" })).toEqual({
-      nextFlow: "implementation",
-      nextMode: "implement",
+describe("flowAdvanceDecision (workflow-file walker)", () => {
+  describe("canonical step ids in workflow + canonical input flow", () => {
+    it("evaluate + simple → implement (skips plan)", () => {
+      expect(
+        flowAdvanceDecision({
+          workflow: CANONICAL,
+          flow: "evaluate",
+          complexity: "simple",
+          exitStatus: "clean",
+        }),
+      ).toEqual({ nextStep: "implement", nextMode: "implement", nextFlow: "implement" });
+    });
+
+    it("evaluate + complex → plan", () => {
+      expect(
+        flowAdvanceDecision({
+          workflow: CANONICAL,
+          flow: "evaluate",
+          complexity: "complex",
+          exitStatus: "clean",
+        }),
+      ).toEqual({ nextStep: "plan", nextMode: "plan", nextFlow: "plan" });
+    });
+
+    it("evaluate without complexity → null (await user)", () => {
+      expect(
+        flowAdvanceDecision({ workflow: CANONICAL, flow: "evaluate", exitStatus: "clean" }),
+      ).toBeNull();
+      expect(
+        flowAdvanceDecision({
+          workflow: CANONICAL,
+          flow: "evaluate",
+          complexity: null,
+          exitStatus: "clean",
+        }),
+      ).toBeNull();
+    });
+
+    it("plan → implement", () => {
+      expect(
+        flowAdvanceDecision({ workflow: CANONICAL, flow: "plan", exitStatus: "clean" }),
+      ).toEqual({ nextStep: "implement", nextMode: "implement", nextFlow: "implement" });
+    });
+
+    it("implement → review", () => {
+      expect(
+        flowAdvanceDecision({ workflow: CANONICAL, flow: "implement", exitStatus: "clean" }),
+      ).toEqual({ nextStep: "review", nextMode: "review", nextFlow: "review" });
+    });
+
+    it("review → finalize", () => {
+      expect(
+        flowAdvanceDecision({ workflow: CANONICAL, flow: "review", exitStatus: "clean" }),
+      ).toEqual({ nextStep: "finalize", nextMode: "finalize", nextFlow: "finalize" });
+    });
+
+    it("finalize → null (terminal — last step in workflow)", () => {
+      expect(
+        flowAdvanceDecision({ workflow: CANONICAL, flow: "finalize", exitStatus: "clean" }),
+      ).toBeNull();
     });
   });
 
-  it("implementation → review/review", () => {
-    expect(flowAdvanceDecision({ flow: "implementation", exitStatus: "clean" })).toEqual({
-      nextFlow: "review",
-      nextMode: "review",
+  describe("legacy enum input on a canonical workflow (alias map)", () => {
+    it("planning → implement", () => {
+      expect(
+        flowAdvanceDecision({ workflow: CANONICAL, flow: "planning", exitStatus: "clean" }),
+      ).toEqual({ nextStep: "implement", nextMode: "implement", nextFlow: "implement" });
+    });
+
+    it("implementation → review", () => {
+      expect(
+        flowAdvanceDecision({ workflow: CANONICAL, flow: "implementation", exitStatus: "clean" }),
+      ).toEqual({ nextStep: "review", nextMode: "review", nextFlow: "review" });
+    });
+
+    it("finalization → null (terminal under canonical workflow)", () => {
+      expect(
+        flowAdvanceDecision({ workflow: CANONICAL, flow: "finalization", exitStatus: "clean" }),
+      ).toBeNull();
+    });
+
+    it("done → null", () => {
+      expect(
+        flowAdvanceDecision({ workflow: CANONICAL, flow: "done", exitStatus: "clean" }),
+      ).toBeNull();
     });
   });
 
-  it("review → finalization/finalize", () => {
-    expect(flowAdvanceDecision({ flow: "review", exitStatus: "clean" })).toEqual({
-      nextFlow: "finalization",
-      nextMode: "finalize",
-    });
-  });
-
-  it("finalization → null (terminal)", () => {
-    expect(flowAdvanceDecision({ flow: "finalization", exitStatus: "clean" })).toBeNull();
-  });
-
-  it("done → null", () => {
-    expect(flowAdvanceDecision({ flow: "done", exitStatus: "clean" })).toBeNull();
-  });
-
-  it("flow unset / null → null", () => {
-    expect(flowAdvanceDecision({ exitStatus: "clean" })).toBeNull();
-    expect(flowAdvanceDecision({ flow: null, exitStatus: "clean" })).toBeNull();
-  });
-
-  it("abnormal exit → null regardless of flow", () => {
-    for (const flow of [
+  describe("legacy step ids in the workflow file (alias map applied to file)", () => {
+    const LEGACY_FILE = makeWorkflow([
       "evaluate",
       "planning",
       "implementation",
       "review",
       "finalization",
-      "done",
-    ] as const) {
-      expect(flowAdvanceDecision({ flow, exitStatus: "abnormal" })).toBeNull();
-    }
+    ]);
+
+    it("legacy input + legacy file → canonical output", () => {
+      expect(
+        flowAdvanceDecision({
+          workflow: LEGACY_FILE,
+          flow: "planning",
+          exitStatus: "clean",
+        }),
+      ).toEqual({ nextStep: "implement", nextMode: "implement", nextFlow: "implement" });
+    });
+
+    it("canonical input + legacy file → canonical output", () => {
+      expect(
+        flowAdvanceDecision({
+          workflow: LEGACY_FILE,
+          flow: "implement",
+          exitStatus: "clean",
+        }),
+      ).toEqual({ nextStep: "review", nextMode: "review", nextFlow: "review" });
+    });
+  });
+
+  describe("custom step ids and missing-step handling", () => {
+    it("step missing from workflow → null", () => {
+      // Issue's frontmatter says it's at `plan`, but the workflow only has
+      // [evaluate, implement, review] (no plan step). Walker returns null
+      // rather than guessing.
+      const SKIPS_PLAN = makeWorkflow(["evaluate", "implement", "review"]);
+      expect(
+        flowAdvanceDecision({
+          workflow: SKIPS_PLAN,
+          flow: "plan",
+          exitStatus: "clean",
+        }),
+      ).toBeNull();
+    });
+
+    it("non-canonical input flow id → null (kickoff doesn't alias-resolve)", () => {
+      const CUSTOM = makeWorkflow(["kickoff", "evaluate", "plan", "implement", "review", "finalize"]);
+      expect(
+        flowAdvanceDecision({ workflow: CUSTOM, flow: "kickoff", exitStatus: "clean" }),
+      ).toBeNull();
+    });
+
+    it("workflow with extra leading step still walks canonical chain from a canonical input", () => {
+      const CUSTOM = makeWorkflow(["kickoff", "evaluate", "plan", "implement", "review", "finalize"]);
+      expect(
+        flowAdvanceDecision({ workflow: CUSTOM, flow: "implement", exitStatus: "clean" }),
+      ).toEqual({ nextStep: "review", nextMode: "review", nextFlow: "review" });
+    });
+  });
+
+  describe("evaluate complexity skip behavior with extra steps between evaluate and plan", () => {
+    const WITH_LINT = makeWorkflow([
+      "evaluate",
+      "lint-pass",
+      "plan",
+      "implement",
+      "review",
+      "finalize",
+    ]);
+
+    it("evaluate + complex → next step (lint-pass non-canonical → null)", () => {
+      // `complex` advances by exactly one slot — the next slot is
+      // `lint-pass`, which doesn't alias to a canonical mode → null.
+      expect(
+        flowAdvanceDecision({
+          workflow: WITH_LINT,
+          flow: "evaluate",
+          complexity: "complex",
+          exitStatus: "clean",
+        }),
+      ).toBeNull();
+    });
+
+    it("evaluate + simple → first non-plan step (lint-pass; non-canonical → null)", () => {
+      // The simple branch scans forward for the first non-`plan` step. The
+      // first non-plan slot is `lint-pass` (non-canonical) → null. The
+      // walker doesn't keep scanning past a non-canonical id.
+      expect(
+        flowAdvanceDecision({
+          workflow: WITH_LINT,
+          flow: "evaluate",
+          complexity: "simple",
+          exitStatus: "clean",
+        }),
+      ).toBeNull();
+    });
+  });
+
+  describe("abnormal exit", () => {
+    it("never advances regardless of flow", () => {
+      for (const flow of ["evaluate", "plan", "implement", "review", "finalize", "done"]) {
+        expect(
+          flowAdvanceDecision({ workflow: CANONICAL, flow, exitStatus: "abnormal" }),
+        ).toBeNull();
+      }
+      expect(
+        flowAdvanceDecision({
+          workflow: CANONICAL,
+          flow: "evaluate",
+          complexity: "simple",
+          exitStatus: "abnormal",
+        }),
+      ).toBeNull();
+    });
+  });
+
+  describe("flow unset / null", () => {
+    it("returns null", () => {
+      expect(flowAdvanceDecision({ workflow: CANONICAL, exitStatus: "clean" })).toBeNull();
+      expect(
+        flowAdvanceDecision({ workflow: CANONICAL, flow: null, exitStatus: "clean" }),
+      ).toBeNull();
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Legacy fallback path
+// ---------------------------------------------------------------------------
+
+describe("legacy fallback (workflow null or isLegacy)", () => {
+  it("workflow=null → uses hardcoded matrix; planning → implement", () => {
     expect(
-      flowAdvanceDecision({ flow: "evaluate", complexity: "simple", exitStatus: "abnormal" }),
+      flowAdvanceDecision({ workflow: null, flow: "planning", exitStatus: "clean" }),
+    ).toEqual({ nextStep: "implement", nextMode: "implement", nextFlow: "implement" });
+  });
+
+  it("workflow=null + canonical input → canonical output", () => {
+    expect(
+      flowAdvanceDecision({ workflow: null, flow: "plan", exitStatus: "clean" }),
+    ).toEqual({ nextStep: "implement", nextMode: "implement", nextFlow: "implement" });
+  });
+
+  it("workflow.source.isLegacy=true → routes through legacy matrix even though steps exist", () => {
+    // Synthesized legacy workflow: one synthetic kickoff step. The walker
+    // would return null for any canonical input (currentStep not in steps),
+    // but the legacy fallback bypasses that and uses the hardcoded matrix.
+    const SYNTH = makeWorkflow(["kickoff"], { isLegacy: true });
+    expect(
+      flowAdvanceDecision({ workflow: SYNTH, flow: "implementation", exitStatus: "clean" }),
+    ).toEqual({ nextStep: "review", nextMode: "review", nextFlow: "review" });
+  });
+
+  it("legacy fallback handles evaluate+complexity branching", () => {
+    expect(
+      flowAdvanceDecision({
+        workflow: null,
+        flow: "evaluate",
+        complexity: "simple",
+        exitStatus: "clean",
+      }),
+    ).toEqual({ nextStep: "implement", nextMode: "implement", nextFlow: "implement" });
+    expect(
+      flowAdvanceDecision({
+        workflow: null,
+        flow: "evaluate",
+        complexity: "complex",
+        exitStatus: "clean",
+      }),
+    ).toEqual({ nextStep: "plan", nextMode: "plan", nextFlow: "plan" });
+    expect(
+      flowAdvanceDecision({ workflow: null, flow: "evaluate", exitStatus: "clean" }),
     ).toBeNull();
   });
 
-  it("ignores complexity outside the evaluate branch", () => {
+  it("legacy fallback finalize/finalization/done → null", () => {
     expect(
-      flowAdvanceDecision({ flow: "planning", complexity: "complex", exitStatus: "clean" }),
-    ).toEqual({ nextFlow: "implementation", nextMode: "implement" });
+      flowAdvanceDecision({ workflow: null, flow: "finalization", exitStatus: "clean" }),
+    ).toBeNull();
     expect(
-      flowAdvanceDecision({ flow: "implementation", complexity: "simple", exitStatus: "clean" }),
-    ).toEqual({ nextFlow: "review", nextMode: "review" });
+      flowAdvanceDecision({ workflow: null, flow: "finalize", exitStatus: "clean" }),
+    ).toBeNull();
+    expect(flowAdvanceDecision({ workflow: null, flow: "done", exitStatus: "clean" })).toBeNull();
+  });
+
+  it("legacy fallback abnormal-exit always null", () => {
+    expect(
+      flowAdvanceDecision({ workflow: null, flow: "planning", exitStatus: "abnormal" }),
+    ).toBeNull();
+  });
+
+  it("legacyFlowAdvanceDecision is the same on the public API surface", () => {
+    expect(
+      legacyFlowAdvanceDecision({ flow: "planning", complexity: null, exitStatus: "clean" }),
+    ).toEqual({ nextStep: "implement", nextMode: "implement", nextFlow: "implement" });
+    expect(
+      legacyFlowAdvanceDecision({
+        flow: "evaluate",
+        complexity: "complex",
+        exitStatus: "clean",
+      }),
+    ).toEqual({ nextStep: "plan", nextMode: "plan", nextFlow: "plan" });
+  });
+
+  it("legacyFlowAdvanceDecision normalizes legacy enum to canonical output", () => {
+    // The legacy matrix accepts both forms on input but always emits
+    // canonical step ids on output (matching "new writes use canonical ids
+    // only").
+    expect(
+      legacyFlowAdvanceDecision({ flow: "implementation", complexity: null, exitStatus: "clean" }),
+    ).toEqual({ nextStep: "review", nextMode: "review", nextFlow: "review" });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+describe("LEGACY_FLOW_ALIAS", () => {
+  it("maps every legacy enum value to its canonical form (or terminal)", () => {
+    expect(LEGACY_FLOW_ALIAS.evaluate).toBe("evaluate");
+    expect(LEGACY_FLOW_ALIAS.planning).toBe("plan");
+    expect(LEGACY_FLOW_ALIAS.plan).toBe("plan");
+    expect(LEGACY_FLOW_ALIAS.implementation).toBe("implement");
+    expect(LEGACY_FLOW_ALIAS.implement).toBe("implement");
+    expect(LEGACY_FLOW_ALIAS.review).toBe("review");
+    expect(LEGACY_FLOW_ALIAS.finalization).toBe("finalize");
+    expect(LEGACY_FLOW_ALIAS.finalize).toBe("finalize");
+    expect(LEGACY_FLOW_ALIAS.done).toBe("done");
   });
 });
 

--- a/plugins/op-obsidian/src/flowOrchestrator.ts
+++ b/plugins/op-obsidian/src/flowOrchestrator.ts
@@ -1,16 +1,32 @@
-// Pure state machine that decides the next workflow stage when a delegated
-// agent's SessionEnd hook fires. Inputs come from the issue's frontmatter
-// (`flow`, `complexity`) plus the session's exit status; output is the
-// next `{flow, mode}` pair to launch — or `null` when no automatic
-// advancement is possible (terminal stage, missing complexity, abnormal
-// exit). Intentionally Obsidian-free so the matrix is unit-testable.
+// Workflow-aware state machine that decides the next workflow stage when a
+// delegated agent's SessionEnd hook fires. Inputs come from the issue's
+// frontmatter (`flow`, `complexity`), the session's exit status, and the
+// project's loaded `WorkflowFile` (parsed via `loadWorkflowFile` /
+// `parseWorkflowFile`). Output is the next `{step, mode}` pair to launch — or
+// `null` when no automatic advancement is possible (terminal stage, missing
+// complexity, abnormal exit, or the issue's current step is no longer in the
+// workflow).
+//
+// Intentionally Obsidian-free so the matrix is unit-testable. The IO seam
+// (loading the workflow file) lives in `main.ts:advanceFlowAndLaunch`.
+//
+// OP-188: replaced the hardcoded transition matrix with a walker over
+// `WorkflowFile.steps`. Pre-modules projects (synthesised legacy workflow, or
+// no workflow file at all) fall back to the historical matrix via
+// `legacyFlowAdvanceDecision` so already-running issues keep auto-advancing
+// until OP-189 migrates per-project workflows to the modules schema.
 
 import type { Flow, Complexity } from "./setFlow";
 import type { AgentLaunchMode } from "./agentProfiles";
+import type { WorkflowFile, WorkflowStep } from "./workflowFilePure";
 
 export type FlowExitStatus = "clean" | "abnormal";
 
 export interface FlowAdvanceInput {
+  /** Loaded workflow for the issue's project, or `null` when none could be
+   *  parsed. `null` (and `source.isLegacy === true`) trigger the legacy
+   *  hardcoded-matrix fallback. */
+  workflow?: WorkflowFile | null;
   flow?: Flow | null;
   complexity?: Complexity | null;
   exitStatus: FlowExitStatus;
@@ -22,35 +38,171 @@ export interface FlowAdvanceInput {
 export type FlowAdvanceMode = "evaluate" | "plan" | "implement" | "review" | "finalize";
 
 export interface FlowAdvanceOutput {
-  nextFlow: Flow;
+  /** Canonical step id chosen for the next launch. New writes always use the
+   *  alias-resolved canonical name, even when the input `flow` was a legacy
+   *  enum value. */
+  nextStep: FlowAdvanceMode;
+  /** Same value as `nextStep`. Carried as a separate field so the launch
+   *  surface can branch on the launch mode without re-deriving it. */
   nextMode: FlowAdvanceMode;
+  /** Backwards-compatible alias for `nextStep`. Pre-OP-188 callers in
+   *  `main.ts` and the URI/CLI response payloads referenced `nextFlow`; the
+   *  field stays so the wire format and existing log strings don't shift. */
+  nextFlow: FlowAdvanceMode;
+}
+
+/**
+ * Permanent legacy → canonical alias map for the `flow:` enum. Pre-OP-188
+ * issues had `flow: planning | implementation | finalization`; canonical step
+ * ids in the workflow-modules schema are `plan | implement | finalize`.
+ *
+ * The map is applied in two places: when reading the issue's current `flow:`
+ * value and when reading step ids from a workflow file (so workflows that
+ * still use legacy ids walk cleanly). New writes always emit the canonical
+ * id — this map is one-way decoder, never an encoder.
+ *
+ * `evaluate`, `review`, and `done` are passthrough — they're already
+ * canonical or terminal sentinels.
+ */
+export const LEGACY_FLOW_ALIAS: Readonly<Record<string, FlowAdvanceMode | "done">> = Object.freeze(
+  {
+    evaluate: "evaluate",
+    planning: "plan",
+    plan: "plan",
+    implementation: "implement",
+    implement: "implement",
+    review: "review",
+    finalization: "finalize",
+    finalize: "finalize",
+    done: "done",
+  },
+);
+
+/** Returns the canonical name for a legacy or canonical step id, or `null`
+ *  when the id is unrecognized (custom step ids on user-authored workflows). */
+function aliasResolve(stepId: string | null): FlowAdvanceMode | "done" | null {
+  if (stepId === null) return null;
+  return Object.prototype.hasOwnProperty.call(LEGACY_FLOW_ALIAS, stepId)
+    ? LEGACY_FLOW_ALIAS[stepId]
+    : null;
+}
+
+const CANONICAL_MODES: ReadonlySet<FlowAdvanceMode> = new Set([
+  "evaluate",
+  "plan",
+  "implement",
+  "review",
+  "finalize",
+]);
+
+function isCanonicalMode(s: string | null): s is FlowAdvanceMode {
+  return s !== null && CANONICAL_MODES.has(s as FlowAdvanceMode);
 }
 
 export function flowAdvanceDecision(input: FlowAdvanceInput): FlowAdvanceOutput | null {
   if (input.exitStatus !== "clean") return null;
   const flow = input.flow ?? null;
   if (flow === null) return null;
-  switch (flow) {
+
+  // Workflow missing or synthesised from a legacy WORKFLOW.md — fall back to
+  // the historical hardcoded matrix. Pre-modules projects keep auto-advancing
+  // until their per-project WORKFLOW.md is migrated (OP-189).
+  const workflow = input.workflow ?? null;
+  if (workflow === null || workflow.source.isLegacy) {
+    return legacyFlowAdvanceDecision({
+      flow,
+      complexity: input.complexity ?? null,
+      exitStatus: input.exitStatus,
+    });
+  }
+
+  // Walk the workflow file's step list. Resolve aliases on both sides so a
+  // legacy `flow:` value still locates its slot in a canonical workflow, and
+  // a legacy step id baked into the workflow file still matches a canonical
+  // `flow:` value.
+  const currentCanonical = aliasResolve(flow);
+  if (currentCanonical === null || currentCanonical === "done") return null;
+
+  const stepIndex = findStepIndex(workflow.steps, currentCanonical);
+  if (stepIndex === -1) return null; // current step missing from the workflow
+
+  // Evaluate-step branching: complexity decides whether to skip `plan`.
+  if (currentCanonical === "evaluate") {
+    const complexity = input.complexity ?? null;
+    if (complexity === null) return null; // await user decision
+    if (complexity === "simple") {
+      // Skip the next step iff it aliases to `plan`. Concretely: scan
+      // forward from `stepIndex+1` and pick the first step whose canonical
+      // id is not `plan`. This keeps the historical evaluate→implement
+      // fast-path even when the workflow file has extra steps inserted
+      // between evaluate and plan.
+      for (let i = stepIndex + 1; i < workflow.steps.length; i++) {
+        const canon = aliasResolve(workflow.steps[i].step);
+        if (canon === "plan") continue;
+        return outputFor(canon);
+      }
+      return null;
+    }
+    // complex → advance by one (canonical evaluate → plan, but the workflow
+    // file's actual ordering is what governs).
+    return outputFor(aliasResolve(stepFor(workflow.steps, stepIndex + 1)));
+  }
+
+  // All other steps → advance by one slot in the workflow.
+  return outputFor(aliasResolve(stepFor(workflow.steps, stepIndex + 1)));
+}
+
+function findStepIndex(steps: ReadonlyArray<WorkflowStep>, canonical: FlowAdvanceMode): number {
+  for (let i = 0; i < steps.length; i++) {
+    if (aliasResolve(steps[i].step) === canonical) return i;
+  }
+  return -1;
+}
+
+function stepFor(steps: ReadonlyArray<WorkflowStep>, index: number): string | null {
+  return index < steps.length ? steps[index].step : null;
+}
+
+function outputFor(canonical: FlowAdvanceMode | "done" | null): FlowAdvanceOutput | null {
+  if (!isCanonicalMode(canonical)) return null;
+  return { nextStep: canonical, nextMode: canonical, nextFlow: canonical };
+}
+
+/**
+ * Historical hardcoded transition matrix. Used as a fallback when the
+ * project's `WORKFLOW.md` is missing or synthesised from a legacy shape (no
+ * `steps:` list) — without this fallback every pre-modules project's
+ * auto-advance would break the moment OP-188 ships.
+ *
+ * Output uses canonical step ids (`plan`, `implement`, `finalize`) regardless
+ * of whether the input `flow:` arrived as a legacy enum value, matching the
+ * "new writes use canonical ids" rule.
+ */
+export function legacyFlowAdvanceDecision(input: {
+  flow: Flow | null;
+  complexity: Complexity | null;
+  exitStatus: FlowExitStatus;
+}): FlowAdvanceOutput | null {
+  if (input.exitStatus !== "clean") return null;
+  if (input.flow === null) return null;
+  const canonical = aliasResolve(input.flow);
+  switch (canonical) {
     case "evaluate":
-      if (input.complexity === "simple") {
-        return { nextFlow: "implementation", nextMode: "implement" };
-      }
-      if (input.complexity === "complex") {
-        return { nextFlow: "planning", nextMode: "plan" };
-      }
+      if (input.complexity === "simple") return outputFor("implement");
+      if (input.complexity === "complex") return outputFor("plan");
       return null;
-    case "planning":
-      return { nextFlow: "implementation", nextMode: "implement" };
-    case "implementation":
-      return { nextFlow: "review", nextMode: "review" };
+    case "plan":
+      return outputFor("implement");
+    case "implement":
+      return outputFor("review");
     case "review":
-      return { nextFlow: "finalization", nextMode: "finalize" };
-    case "finalization":
-      return null;
+      return outputFor("finalize");
+    case "finalize":
     case "done":
+    case null:
       return null;
     default: {
-      const _exhaustive: never = flow;
+      const _exhaustive: never = canonical;
       void _exhaustive;
       return null;
     }

--- a/plugins/op-obsidian/src/main.ts
+++ b/plugins/op-obsidian/src/main.ts
@@ -2591,6 +2591,7 @@ export default class OpPlugin extends Plugin {
       projectFolder: res.projectFolder,
       basePath: res.basePath,
       statusPath: res.statusPath,
+      workflowPath: res.workflowPath,
       seedIssueId: res.seed?.id,
       seedPath: res.seed?.path,
     };
@@ -2608,6 +2609,7 @@ export default class OpPlugin extends Plugin {
         projectFolder: res.projectFolder,
         basePath: res.basePath,
         statusPath: res.statusPath,
+        workflowPath: res.workflowPath,
         seedIssueId: res.seed?.id,
         seedPath: res.seed?.path,
       });
@@ -3960,7 +3962,13 @@ export default class OpPlugin extends Plugin {
     exitStatus: FlowExitStatus,
   ): Promise<FlowAdvanceOutput | null> {
     const { flow, complexity } = this.readFlowState(entry.path);
-    const decision = flowAdvanceDecision({ flow, complexity, exitStatus });
+    // OP-188: load the project's workflow file so flowAdvanceDecision can
+    // walk its `steps:` list. `loadWorkflowFile` returns `null` for missing
+    // files and `isLegacy: true` for synthesised legacy shapes — both cases
+    // route through the orchestrator's hardcoded-matrix fallback so
+    // pre-modules projects keep auto-advancing until OP-189 migrates them.
+    const { workflow } = await loadWorkflowFile(this.app, entry.project);
+    const decision = flowAdvanceDecision({ workflow, flow, complexity, exitStatus });
     if (!decision) return null;
     await setFlow(this.app, entry, { flow: decision.nextFlow });
     // Yield once so the metadataCache `changed` event has a chance to fan

--- a/plugins/op-obsidian/src/scaffoldProject.ts
+++ b/plugins/op-obsidian/src/scaffoldProject.ts
@@ -18,6 +18,12 @@ export interface ScaffoldProjectResult {
   projectFolder: string;
   basePath: string;
   statusPath: string;
+  /** OP-188: every new project lands with a default `WORKFLOW.md` that ships
+   *  the canonical evaluate → plan → implement → review → finalize sequence,
+   *  matching the pre-OP-188 hardcoded `flowOrchestrator` matrix. The file is
+   *  self-contained (no `extends:`) so the project doesn't depend on a global
+   *  `_op-workflow.md` the plugin doesn't auto-install. */
+  workflowPath: string;
   seed?: CreateIssueResult;
 }
 
@@ -69,6 +75,14 @@ export async function scaffoldProject(
   const statusPath = normalizePath(`${projectFolder}/STATUS.md`);
   await app.vault.create(statusPath, renderStatus(slug, prefix, repoPath));
 
+  // OP-188: seed the default workflow file so the orchestrator's
+  // workflow-file walker (flowOrchestrator.ts) finds a canonical step list
+  // for this project the first time auto-advance fires. Self-contained
+  // (no `extends:`) — keeps new projects working without depending on a
+  // global `_op-workflow.md` that the plugin doesn't auto-install.
+  const workflowPath = normalizePath(`${projectFolder}/WORKFLOW.md`);
+  await app.vault.create(workflowPath, renderDefaultWorkflow(slug));
+
   let seed: CreateIssueResult | undefined;
   const seedTitle = input.seedTitle?.trim();
   if (seedTitle) {
@@ -83,7 +97,7 @@ export async function scaffoldProject(
     });
   }
 
-  return { slug, prefix, projectFolder, basePath, statusPath, seed };
+  return { slug, prefix, projectFolder, basePath, statusPath, workflowPath, seed };
 }
 
 async function retryCreateSeed(
@@ -138,6 +152,49 @@ function renderStatus(slug: string, prefix: string, repoPath?: string): string {
 
 function renderBase(slug: string): string {
   return DEFAULT_BASE_TEMPLATE.replaceAll("<slug>", slug);
+}
+
+/**
+ * OP-188: default workflow file for a freshly-scaffolded project. Ships the
+ * canonical 5-step sequence — evaluate → plan → implement → review →
+ * finalize — that the pre-OP-188 `flowOrchestrator` hardcoded matrix
+ * encoded. Empty `modules: []` per step: this issue's scope is the
+ * orchestration sequence, not the module library.
+ *
+ * `default_agent: claude` and `default_model: opus` mirror the project's
+ * pre-modules defaults (see `agentProfiles.ts`). Projects that prefer a
+ * different agent or model set can edit this file via `op-edit-workflow`.
+ */
+function renderDefaultWorkflow(slug: string): string {
+  return [
+    "---",
+    "type: workflow",
+    "schema: 1",
+    `project: ${slug}`,
+    "default_agent: claude",
+    "default_model: opus",
+    "steps:",
+    "  - step: evaluate",
+    "    modules: []",
+    "  - step: plan",
+    "    modules: []",
+    "  - step: implement",
+    "    modules: []",
+    "  - step: review",
+    "    modules: []",
+    "  - step: finalize",
+    "    modules: []",
+    "---",
+    "",
+    `# ${slug} — workflow`,
+    "",
+    "Default 5-step sequence shipped at scaffold time. Edit this file to add",
+    "modules to a step (`modules: [<id>]`), override the agent or model on a",
+    "specific step, or insert custom steps. Auto-advance walks `steps:` in",
+    "order; complexity decides whether `evaluate` skips `plan` (`simple` →",
+    "evaluate jumps to `implement`; `complex` → evaluate → plan).",
+    "",
+  ].join("\n");
 }
 
 const DEFAULT_BASE_TEMPLATE = `filters:

--- a/plugins/op-obsidian/src/setFlow.test.ts
+++ b/plugins/op-obsidian/src/setFlow.test.ts
@@ -101,6 +101,17 @@ describe("setFlow", () => {
     await expect(setFlow(app, issue(), { flow: "   " })).rejects.toThrow(/Invalid flow/);
   });
 
+  it("rejects flow values containing embedded newlines", async () => {
+    const { app } = makeApp({});
+    // OP-188 security: a URI-encoded newline (%0A) in a flow parameter must
+    // not reach frontmatter — it can't match any workflow step id and could
+    // produce multi-line YAML strings on round-trip.
+    await expect(setFlow(app, issue(), { flow: "plan\nevil_key: value" })).rejects.toThrow(
+      /newlines/,
+    );
+    await expect(setFlow(app, issue(), { flow: "plan\revil" })).rejects.toThrow(/newlines/);
+  });
+
   it("rejects invalid complexity values", async () => {
     const { app } = makeApp({});
     await expect(
@@ -139,6 +150,8 @@ describe("validation helpers", () => {
     }
     expect(() => validateFlow("")).toThrow();
     expect(() => validateFlow("   ")).toThrow();
+    expect(() => validateFlow("plan\nevil")).toThrow(/newlines/);
+    expect(() => validateFlow("plan\revil")).toThrow(/newlines/);
   });
 
   it("accepts every schema complexity value", () => {

--- a/plugins/op-obsidian/src/setFlow.test.ts
+++ b/plugins/op-obsidian/src/setFlow.test.ts
@@ -88,9 +88,17 @@ describe("setFlow", () => {
     await expect(setFlow(app, issue(), {})).rejects.toThrow(/at least one of flow or complexity/);
   });
 
-  it("rejects invalid flow values", async () => {
+  it("accepts free-form flow values (post-OP-188 workflow walker enforces)", async () => {
+    const { app, fm } = makeApp({});
+    // Custom step id from a user-authored workflow file. Pre-OP-188 this
+    // would have thrown; post-OP-188 the orchestrator's workflow-file walker
+    // is what decides whether the step is valid for the project.
+    await setFlow(app, issue(), { flow: "kickoff" });
+    expect(fm.flow).toBe("kickoff");
+  });
+  it("rejects whitespace-only flow values", async () => {
     const { app } = makeApp({});
-    await expect(setFlow(app, issue(), { flow: "wat" as any })).rejects.toThrow(/Invalid flow/);
+    await expect(setFlow(app, issue(), { flow: "   " })).rejects.toThrow(/Invalid flow/);
   });
 
   it("rejects invalid complexity values", async () => {
@@ -108,11 +116,29 @@ describe("setFlow", () => {
 });
 
 describe("validation helpers", () => {
-  it("accepts every schema flow value", () => {
-    for (const v of ["evaluate", "planning", "implementation", "review", "finalization", "done"]) {
+  it("accepts both legacy and canonical flow step ids and any user-defined id", () => {
+    // OP-188: the validator is intentionally lax — it only enforces non-empty
+    // trim. Both legacy enum values (`planning`, `implementation`,
+    // `finalization`) and canonical ids (`plan`, `implement`, `finalize`) and
+    // user-defined ids (e.g. `kickoff`, `lint-pass`) all pass. The workflow
+    // walker is the actual semantic gate.
+    for (const v of [
+      "evaluate",
+      "planning",
+      "plan",
+      "implementation",
+      "implement",
+      "review",
+      "finalization",
+      "finalize",
+      "done",
+      "kickoff",
+      "lint-pass",
+    ]) {
       expect(() => validateFlow(v)).not.toThrow();
     }
-    expect(() => validateFlow("other")).toThrow();
+    expect(() => validateFlow("")).toThrow();
+    expect(() => validateFlow("   ")).toThrow();
   });
 
   it("accepts every schema complexity value", () => {

--- a/plugins/op-obsidian/src/setFlow.ts
+++ b/plugins/op-obsidian/src/setFlow.ts
@@ -1,15 +1,20 @@
 import { App, TFile } from "obsidian";
 import type { IssueEntry } from "./types";
 
-export const FLOW_VALUES = [
-  "evaluate",
-  "planning",
-  "implementation",
-  "review",
-  "finalization",
-  "done",
-] as const;
-export type Flow = (typeof FLOW_VALUES)[number];
+// OP-188: `Flow` is a free-form step id. The pre-OP-188 closed enum
+// (`evaluate | planning | … | done`) was retired when the orchestrator moved
+// from a hardcoded transition matrix to a workflow-file walker — the walker
+// itself enforces "is this step in the workflow," and the legacy alias map
+// in `flowOrchestrator.ts:LEGACY_FLOW_ALIAS` keeps pre-OP-188 frontmatter
+// parseable.
+//
+// `validateFlow` keeps the minimum guard: trim non-empty so writers can't
+// silently land a blank `flow:` value. Step ids that don't appear in the
+// project's workflow surface as no-op auto-advances at orchestrator time
+// rather than as setFlow-time rejections — matching the "schema-conformant
+// writes, walker-enforced semantics" split the workflow-modules engine uses
+// elsewhere.
+export type Flow = string;
 
 export const COMPLEXITY_VALUES = ["simple", "complex"] as const;
 export type Complexity = (typeof COMPLEXITY_VALUES)[number];
@@ -78,10 +83,8 @@ export async function setFlow(
 }
 
 export function validateFlow(v: string): asserts v is Flow {
-  if (!(FLOW_VALUES as readonly string[]).includes(v)) {
-    throw new Error(
-      `Invalid flow: ${JSON.stringify(v)} — expected one of ${FLOW_VALUES.join(", ")}`,
-    );
+  if (typeof v !== "string" || v.trim() === "") {
+    throw new Error(`Invalid flow: ${JSON.stringify(v)} — expected a non-empty step id string`);
   }
 }
 

--- a/plugins/op-obsidian/src/setFlow.ts
+++ b/plugins/op-obsidian/src/setFlow.ts
@@ -86,6 +86,11 @@ export function validateFlow(v: string): asserts v is Flow {
   if (typeof v !== "string" || v.trim() === "") {
     throw new Error(`Invalid flow: ${JSON.stringify(v)} — expected a non-empty step id string`);
   }
+  if (/[\r\n]/.test(v)) {
+    throw new Error(
+      `Invalid flow: ${JSON.stringify(v)} — step id must not contain newlines`,
+    );
+  }
 }
 
 export function validateComplexity(v: string): asserts v is Complexity {

--- a/plugins/op-obsidian/src/uriHandlers.test.ts
+++ b/plugins/op-obsidian/src/uriHandlers.test.ts
@@ -208,9 +208,17 @@ describe("handleOpSetFlowUri", () => {
       complexity: "complex",
     });
   });
-  it("rejects unknown flow value", async () => {
-    await expect(handleOpSetFlowUri(makeDeps(), { id: "OP-1", flow: "wat" })).rejects.toThrow(
-      /flow must be one of/,
+  it("accepts free-form flow values (workflow walker enforces, not setFlow)", async () => {
+    // OP-188: post-modules, the orchestrator walks the workflow file's step
+    // list at advance time. Step ids that don't appear simply produce a
+    // no-op auto-advance — they aren't rejected at write time so the user
+    // can still set `flow: kickoff` (or any other workflow-defined step).
+    const r = await handleOpSetFlowUri(makeDeps(), { id: "OP-1", flow: "kickoff" });
+    expect(r).toMatchObject({ ok: true, flow: "kickoff" });
+  });
+  it("rejects whitespace-only flow value", async () => {
+    await expect(handleOpSetFlowUri(makeDeps(), { id: "OP-1", flow: "   " })).rejects.toThrow(
+      /non-empty step id/,
     );
   });
   it("passes 'null' through as null to clear", async () => {

--- a/plugins/op-obsidian/src/uriHandlers.test.ts
+++ b/plugins/op-obsidian/src/uriHandlers.test.ts
@@ -221,6 +221,12 @@ describe("handleOpSetFlowUri", () => {
       /non-empty step id/,
     );
   });
+  it("rejects flow value containing embedded newlines", async () => {
+    // URI-encoded newline (%0A → \n) must not reach frontmatter.
+    await expect(
+      handleOpSetFlowUri(makeDeps(), { id: "OP-1", flow: "plan\nevil_key: value" }),
+    ).rejects.toThrow(/must not contain newlines/);
+  });
   it("passes 'null' through as null to clear", async () => {
     const r = await handleOpSetFlowUri(makeDeps(), { id: "OP-1", flow: "null" });
     expect(r.flow).toBeUndefined();

--- a/plugins/op-obsidian/src/uriHandlers.ts
+++ b/plugins/op-obsidian/src/uriHandlers.ts
@@ -206,6 +206,11 @@ export async function handleOpSetFlowUri(
     if (v === "" || v === "null") {
       input.flow = null;
     } else if (typeof v === "string" && v.trim().length > 0) {
+      if (/[\r\n]/.test(v)) {
+        throw new Error(
+          `op-set-flow URI flow must not contain newlines`,
+        );
+      }
       input.flow = v.trim() as Flow;
     } else {
       throw new Error(

--- a/plugins/op-obsidian/src/uriHandlers.ts
+++ b/plugins/op-obsidian/src/uriHandlers.ts
@@ -163,7 +163,10 @@ export async function handleOpSetPrUri(
   };
 }
 
-const FLOW_ENUM = ["evaluate", "planning", "implementation", "review", "finalization", "done"] as const;
+// OP-188: `flow:` accepts any non-empty step id (the orchestrator walks the
+// workflow file at advance time and a step missing from the workflow simply
+// stops auto-advance — `setFlow` is no longer the validator). Complexity
+// stays a closed two-value enum.
 const COMPLEXITY_ENUM = ["simple", "complex"] as const;
 
 export async function handleOpSetEvaluationUri(
@@ -202,11 +205,11 @@ export async function handleOpSetFlowUri(
     const v = params.flow;
     if (v === "" || v === "null") {
       input.flow = null;
-    } else if ((FLOW_ENUM as readonly string[]).includes(v)) {
-      input.flow = v as Flow;
+    } else if (typeof v === "string" && v.trim().length > 0) {
+      input.flow = v.trim() as Flow;
     } else {
       throw new Error(
-        `op-set-flow URI flow must be one of ${FLOW_ENUM.join("|")} (or "null" to clear)`,
+        `op-set-flow URI flow must be a non-empty step id string (or "null" to clear)`,
       );
     }
   }

--- a/plugins/op/.claude-plugin/plugin.json
+++ b/plugins/op/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "op",
   "description": "Obsidian Projects workflow — schema, slash commands, and agent skill for running a Jira-lite issue tracker inside an Obsidian vault.",
-  "version": "0.75.0",
+  "version": "0.75.1",
   "author": {
     "name": "Eugene Archibald"
   },

--- a/plugins/op/.claude-plugin/plugin.json
+++ b/plugins/op/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "op",
   "description": "Obsidian Projects workflow — schema, slash commands, and agent skill for running a Jira-lite issue tracker inside an Obsidian vault.",
-  "version": "0.74.2",
+  "version": "0.75.0",
   "author": {
     "name": "Eugene Archibald"
   },


### PR DESCRIPTION
## Summary

- Replace `flowOrchestrator.ts`'s hardcoded transition matrix with a walker over the project's loaded `WorkflowFile.steps`. Permanent `LEGACY_FLOW_ALIAS` map (`planning → plan`, `implementation → implement`, `finalization → finalize`) keeps existing in-flight issues' frontmatter parseable; new writes use canonical step ids only.
- Legacy fallback: when `workflow === null` or `workflow.source.isLegacy === true`, delegate to a private `legacyFlowAdvanceDecision` that runs the pre-OP-188 hardcoded matrix. Pre-modules projects keep auto-advancing until OP-189 migrates their WORKFLOW.md to the modules schema.
- `scaffoldProject.ts` seeds every new project with a default `WORKFLOW.md` shipping the canonical evaluate → plan → implement → review → finalize sequence.
- `setFlow.ts` `Flow` type becomes a free-form non-empty string — the workflow-file walker is now the semantic gate. `uriHandlers.ts` and `cliHandlers.ts` drop their hardcoded `FLOW_ENUM` rejection.
- `main.ts:advanceFlowAndLaunch` loads the project's workflow via `loadWorkflowFile` before invoking the orchestrator. Level-4 launch override carry-forward is unchanged.
- Bump op-obsidian to **0.75.0** (additive feature).

## Test plan

- [x] `npx vitest run` — 1466/1466 passing in op-obsidian (full suite, includes 30+ new flowOrchestrator tests covering canonical / legacy / custom workflows + legacy-fallback path).
- [x] `node scripts/bump-version.mjs minor` — manifest/package/plugin.json all at 0.75.0; build green.
- [x] `node scripts/dev-sync.mjs` to OP-Test; plugin reload confirmed.
- [x] `obsidian vault=OP-Test op-scaffold slug=op188-smoke prefix=SMK title=...` — verified `Projects/op188-smoke/WORKFLOW.md` lands with the canonical 5-step sequence and parses cleanly via `op-get-workflow`.
- [x] `op-set-flow flow=kickoff` (free-form id) and `flow=plan` (canonical) both accepted; whitespace-only rejected.

## Adversarial review pressure-test prompts (for @copilot)

1. **Alias map applied to both seams.** Verify `LEGACY_FLOW_ALIAS` is consulted both when reading the issue's `flow:` value AND when matching workflow file step ids. Confirm a `flow: planning` issue against a workflow file with `step: plan` advances correctly, and the reverse (`flow: plan` against `step: planning`) also walks.
2. **Evaluate-step skip semantics with non-canonical intervening steps.** `flowOrchestrator.test.ts:WITH_LINT` covers a workflow with `evaluate → lint-pass → plan → …`. The walker returns `null` (not `lint-pass`) when complexity is `simple` because `lint-pass` doesn't alias-resolve. Is that the right behavior, or should the walker scan further?
3. **Legacy fallback boundary.** When `workflow.source.isLegacy === true` but `steps:` happens to exist (synthesized kickoff), the fallback path runs the hardcoded matrix instead of the walker. Does this hide a real configuration error from the user? Should it emit a diagnostic?
4. **Race between `loadWorkflowFile` and `metadataCache`.** `advanceFlowAndLaunch` calls `loadWorkflowFile` immediately after `setFlow` writes the new flow value. `loadWorkflowFile` reads the workflow via `metadataCache`, which may not have flushed the post-`setFlow` rename if the issue file is being moved (it's not in this code path, but verify).
5. **Scaffold seed when project has zero step modules.** A workflow with all-empty `modules: []` step lists composes to an empty injection. Per OP-197 / OP-199, that's expected (no-op composition), but verify the module-injection chain doesn't error on an empty modules list — particularly the kickoff-fallback path in `composeWorkflowSection`.
6. **Loosened `setFlow` validation security/UX.** Now that `flow:` accepts any non-empty trimmed string, can a malicious or fat-fingered URI value land something problematic in frontmatter (e.g. `flow:\n  type: evil`)? `processFrontMatter` writes a string scalar so YAML injection is bounded — but verify `op-set-flow URI` doesn't accept embedded newlines.
7. **`nextFlow` field rename impact.** The `FlowAdvanceOutput` type adds `nextStep` and keeps `nextFlow` as an alias for wire-format compat. Verify no consumer reads `nextFlow` expecting the legacy enum names (e.g. `planning`); the field always carries canonical ids now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)