### PR TITLE
OP-187: op-export-module / op-import-module / op-undo-last-import

### DIFF
--- a/plugins/op-obsidian/manifest.json
+++ b/plugins/op-obsidian/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "op-obsidian",
   "name": "Obsidian Projects (op)",
-  "version": "0.74.1",
+  "version": "0.75.0",
   "minAppVersion": "1.5.0",
   "description": "Jira-lite issue tracker for Obsidian vaults — deterministic commands backing the op workflow.",
   "author": "Eugene Archibald",

--- a/plugins/op-obsidian/manifest.json
+++ b/plugins/op-obsidian/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "op-obsidian",
   "name": "Obsidian Projects (op)",
-  "version": "0.75.1",
+  "version": "0.76.0",
   "minAppVersion": "1.5.0",
   "description": "Jira-lite issue tracker for Obsidian vaults — deterministic commands backing the op workflow.",
   "author": "Eugene Archibald",

--- a/plugins/op-obsidian/package.json
+++ b/plugins/op-obsidian/package.json
@@ -1,6 +1,6 @@
 {
   "name": "op-obsidian",
-  "version": "0.75.1",
+  "version": "0.76.0",
   "description": "Obsidian plugin that owns the deterministic half of the op workflow.",
   "main": "main.js",
   "scripts": {

--- a/plugins/op-obsidian/package.json
+++ b/plugins/op-obsidian/package.json
@@ -1,6 +1,6 @@
 {
   "name": "op-obsidian",
-  "version": "0.74.1",
+  "version": "0.75.0",
   "description": "Obsidian plugin that owns the deterministic half of the op workflow.",
   "main": "main.js",
   "scripts": {

--- a/plugins/op-obsidian/src/cliHandlers.test.ts
+++ b/plugins/op-obsidian/src/cliHandlers.test.ts
@@ -15,6 +15,8 @@ import {
   parseGetSkillParams,
   parseExplainWorkflowParams,
   parseListVarsParams,
+  parseExportModuleParams,
+  parseImportModuleParams,
 } from "./cliHandlers";
 
 describe("parseWorkParams", () => {
@@ -356,5 +358,71 @@ describe("parseListVarsParams", () => {
     expect(r.ok && r.value).toEqual({ project: "obsidian-projects", issue: "OP-1" });
     const blank = parseListVarsParams({ project: "   ", issue: "   " });
     expect(blank.ok && blank.value).toEqual({});
+  });
+});
+
+describe("parseExportModuleParams", () => {
+  it("requires id or project", () => {
+    const r = parseExportModuleParams({});
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.error).toMatch(/--id or --project/);
+  });
+  it("accepts id mode", () => {
+    const r = parseExportModuleParams({ id: "orient" });
+    expect(r.ok && r.value).toEqual({ mode: "id", moduleId: "orient" });
+  });
+  it("accepts project mode", () => {
+    const r = parseExportModuleParams({ project: "foo" });
+    expect(r.ok && r.value).toEqual({ mode: "project", projectSlug: "foo" });
+  });
+  it("rejects both id and project", () => {
+    const r = parseExportModuleParams({ id: "orient", project: "foo" });
+    expect(r.ok).toBe(false);
+  });
+});
+
+describe("parseImportModuleParams", () => {
+  it("requires path", () => {
+    const r = parseImportModuleParams({});
+    expect(r.ok).toBe(false);
+  });
+  it("accepts a bare path with no scope (caller resolves)", () => {
+    const r = parseImportModuleParams({ path: "Projects/_op-export/x.md" });
+    expect(r.ok && r.value).toEqual({
+      sourcePath: "Projects/_op-export/x.md",
+      varAnswers: {},
+    });
+  });
+  it("requires project when scope=project", () => {
+    const r = parseImportModuleParams({ path: "x.md", scope: "project" });
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.error).toMatch(/--project is required/);
+  });
+  it("rejects an invalid scope", () => {
+    const r = parseImportModuleParams({ path: "x.md", scope: "weird" });
+    expect(r.ok).toBe(false);
+  });
+  it("collects per-var prefix-keyed answers", () => {
+    const r = parseImportModuleParams({
+      path: "x.md",
+      "var.tone": "loud",
+      "var.lang": "fr",
+    });
+    expect(r.ok && r.value.varAnswers).toEqual({ tone: "loud", lang: "fr" });
+  });
+  it("collects packed vars=", () => {
+    const r = parseImportModuleParams({
+      path: "x.md",
+      vars: "tone=loud\nlang=fr",
+    });
+    expect(r.ok && r.value.varAnswers).toEqual({ tone: "loud", lang: "fr" });
+  });
+  it("packed vars beat per-var keys (last-wins)", () => {
+    const r = parseImportModuleParams({
+      path: "x.md",
+      "var.tone": "loud",
+      vars: "tone=quiet",
+    });
+    expect(r.ok && r.value.varAnswers.tone).toBe("quiet");
   });
 });

--- a/plugins/op-obsidian/src/cliHandlers.ts
+++ b/plugins/op-obsidian/src/cliHandlers.ts
@@ -302,6 +302,93 @@ export function parseExplainWorkflowParams(
   return { ok: true, value: out };
 }
 
+export function parseExportModuleParams(
+  params: Record<string, string>,
+): ParamsResult<
+  | { mode: "id"; moduleId: string }
+  | { mode: "project"; projectSlug: string }
+> {
+  const moduleId = nonEmptyTrim(params.id ?? params.module);
+  const projectSlug = nonEmptyTrim(params.project ?? params.slug);
+  if (moduleId && projectSlug) {
+    return {
+      ok: false,
+      error:
+        "op-export-module failed: pass either --id (single module) or --project (bundle), not both.",
+    };
+  }
+  if (moduleId) return { ok: true, value: { mode: "id", moduleId } };
+  if (projectSlug) return { ok: true, value: { mode: "project", projectSlug } };
+  return {
+    ok: false,
+    error: "op-export-module failed: --id or --project is required.",
+  };
+}
+
+export function parseImportModuleParams(
+  params: Record<string, string>,
+): ParamsResult<{
+  sourcePath: string;
+  scope?: "global" | "project";
+  project?: string;
+  varAnswers: Record<string, string>;
+}> {
+  const sourcePath = nonEmptyTrim(params.path ?? params.source);
+  if (!sourcePath) {
+    return { ok: false, error: "op-import-module failed: --path is required." };
+  }
+  let scope: "global" | "project" | undefined;
+  if (params.scope !== undefined) {
+    const v = params.scope.trim().toLowerCase();
+    if (v !== "global" && v !== "project") {
+      return {
+        ok: false,
+        error: `op-import-module failed: --scope must be \"global\" or \"project\" (got ${JSON.stringify(params.scope)}).`,
+      };
+    }
+    scope = v;
+  }
+  const project = nonEmptyTrim(params.project ?? params.slug);
+  if (scope === "project" && !project) {
+    return {
+      ok: false,
+      error: "op-import-module failed: --project is required when --scope=project.",
+    };
+  }
+  // Per-var prefix-keyed answers (var.<name>=<value>) and packed `vars=name=val\nname2=val2`.
+  // Both forms accepted (matches OP-204's parseLaunchVarsFromUri pattern); the
+  // CLI surface shares the contract with the URI handler.
+  const varAnswers: Record<string, string> = {};
+  const nameRe = /^[A-Za-z_][A-Za-z0-9_-]*$/;
+  for (const [k, v] of Object.entries(params)) {
+    if (!k.startsWith("var.")) continue;
+    const name = k.slice(4);
+    if (!name || !nameRe.test(name)) continue;
+    if (typeof v !== "string") continue;
+    varAnswers[name] = v;
+  }
+  // Packed form via `vars=` packed list.
+  const packed = nonEmptyTrim(params.vars);
+  if (packed) {
+    for (const entry of packed.split(/[\n,]/).map((s) => s.trim()).filter(Boolean)) {
+      const eq = entry.indexOf("=");
+      if (eq <= 0) continue;
+      const name = entry.slice(0, eq).trim();
+      if (!nameRe.test(name)) continue;
+      varAnswers[name] = entry.slice(eq + 1);
+    }
+  }
+  const out: {
+    sourcePath: string;
+    scope?: "global" | "project";
+    project?: string;
+    varAnswers: Record<string, string>;
+  } = { sourcePath, varAnswers };
+  if (scope) out.scope = scope;
+  if (project) out.project = project;
+  return { ok: true, value: out };
+}
+
 export function parseListVarsParams(
   params: Record<string, string>,
 ): ParamsResult<{ project?: string; issue?: string }> {

--- a/plugins/op-obsidian/src/exportImportPure.test.ts
+++ b/plugins/op-obsidian/src/exportImportPure.test.ts
@@ -390,6 +390,38 @@ describe("planImport", () => {
     expect(plan.overwrite).toBe(true);
     expect(plan.backupRelPath).toBe("Projects/_op-modules/orient.md");
   });
+
+  it("exposes targetScope on the plan — global import keeps targetScope=global even when module has a project: field", () => {
+    // Bug guard: a per-project module imported globally must carry
+    // targetScope="global" on the plan so commitImport routes prompted vars
+    // to workflowVars, not to a project STATUS.md.
+    const perProjectModule = mod({ project: "some-project" });
+    const plan = planImport({
+      module: perProjectModule,
+      body: "Use {{vars.tone}}.",
+      targetScope: "global",
+      globalVars: {},
+      projectVars: {},
+    });
+    expect(plan.targetScope).toBe("global");
+    // rewrittenProject preserves the source project: field for the module
+    // frontmatter — this is NOT the scope indicator.
+    expect(plan.rewrittenProject).toBe("some-project");
+    // The target path is still the global modules directory.
+    expect(plan.targetPath).toBe("Projects/_op-modules/orient.md");
+  });
+
+  it("exposes targetScope=project on a project-scope plan", () => {
+    const plan = planImport({
+      module: mod(),
+      body: "x",
+      targetScope: "project",
+      targetProjectSlug: "demo",
+      globalVars: {},
+      projectVars: {},
+    });
+    expect(plan.targetScope).toBe("project");
+  });
 });
 
 describe("transaction record round-trip", () => {
@@ -406,7 +438,7 @@ describe("transaction record round-trip", () => {
         originalProject: "bar",
         rewrittenProject: "foo",
         overwrote: true,
-        backupPath: "Projects/_op-import-history/20260426-120000.bak/Projects/foo/MODULES/x.md",
+        backupPath: "Projects/_op-import-history/20260426-120000-000.bak/Projects/foo/MODULES/x.md",
       },
     ],
     varsWritten: [
@@ -442,10 +474,12 @@ describe("transaction record round-trip", () => {
 });
 
 describe("transactionFilename", () => {
-  it("formats local timestamp with second resolution", () => {
+  it("formats local timestamp with millisecond resolution", () => {
     // Construct a fixed local-time date — verify the components without
     // depending on the test runner's TZ.
-    const d = new Date(2026, 3, 26, 9, 5, 7); // April 26 2026 09:05:07 local
-    expect(transactionFilename(d)).toBe("20260426-090507");
+    const d = new Date(2026, 3, 26, 9, 5, 7); // April 26 2026 09:05:07 local, 0ms
+    expect(transactionFilename(d)).toBe("20260426-090507-000");
+    const d2 = new Date(2026, 3, 26, 9, 5, 7, 42);
+    expect(transactionFilename(d2)).toBe("20260426-090507-042");
   });
 });

--- a/plugins/op-obsidian/src/exportImportPure.test.ts
+++ b/plugins/op-obsidian/src/exportImportPure.test.ts
@@ -1,0 +1,451 @@
+import { describe, it, expect } from "vitest";
+import {
+  extractVarReferences,
+  formatExportFile,
+  parseImportFile,
+  parseTransaction,
+  planImport,
+  serializeTransaction,
+  transactionFilename,
+  type TransactionRecord,
+} from "./exportImportPure";
+import type { WorkflowModule } from "./workflowModulePure";
+
+// All tests are pure: no Obsidian, no vault, no I/O. The `parseImportFile`
+// suite injects a tiny YAML parser so we don't pull a real one in.
+
+const SOURCE = { kind: "global" as const, path: "Projects/_op-modules/orient.md" };
+
+function mod(over: Partial<WorkflowModule> = {}): WorkflowModule {
+  return {
+    id: "orient",
+    title: "Orient",
+    scope: "kickoff",
+    project: undefined,
+    agent: undefined,
+    order: 0,
+    vars: [],
+    source: SOURCE,
+    ...over,
+  };
+}
+
+describe("formatExportFile", () => {
+  it("emits required-only frontmatter for a minimal module", () => {
+    const out = formatExportFile({ module: mod(), body: "Hello, world.\n" });
+    expect(out).toBe(
+      [
+        "---",
+        "id: orient",
+        "title: Orient",
+        "type: workflow-module",
+        "scope: kickoff",
+        "---",
+        "",
+        "Hello, world.",
+        "",
+      ].join("\n"),
+    );
+  });
+
+  it("includes optional fields only when populated", () => {
+    const out = formatExportFile({
+      module: mod({ project: "demo", agent: "claude", order: 5 }),
+      body: "Body.\n",
+    });
+    expect(out).toContain("project: demo");
+    expect(out).toContain("agent: claude");
+    expect(out).toContain("order: 5");
+  });
+
+  it("emits each VarDecl form in canonical YAML", () => {
+    const out = formatExportFile({
+      module: mod({
+        vars: [
+          { kind: "bare", name: "alpha" },
+          { kind: "default", name: "beta", value: "two" },
+          { kind: "default", name: "empty", value: "" },
+          { kind: "object", name: "gamma", default: "three", description: "Tone" },
+          { kind: "object", name: "delta" },
+        ],
+      }),
+      body: "x",
+    });
+    expect(out).toContain("- alpha");
+    expect(out).toContain("- beta=two");
+    expect(out).toContain("- empty=");
+    expect(out).toContain('- { name: gamma, default: three, description: Tone }');
+    expect(out).toContain("- { name: delta }");
+  });
+
+  it("quotes title containing a colon", () => {
+    const out = formatExportFile({
+      module: mod({ title: "Edge: case" }),
+      body: "x",
+    });
+    expect(out).toContain('title: "Edge: case"');
+  });
+
+  it("respects overrideProject (clear via null, set via string)", () => {
+    const cleared = formatExportFile({
+      module: mod({ project: "old-slug" }),
+      body: "x",
+      overrideProject: null,
+    });
+    expect(cleared).not.toContain("project:");
+
+    const renamed = formatExportFile({
+      module: mod({ project: "old-slug" }),
+      body: "x",
+      overrideProject: "new-slug",
+    });
+    expect(renamed).toContain("project: new-slug");
+  });
+});
+
+describe("extractVarReferences", () => {
+  it("returns distinct names in document order", () => {
+    expect(
+      extractVarReferences("Hello {{vars.tone}} and {{vars.lang}}—again {{vars.tone}}!"),
+    ).toEqual(["tone", "lang"]);
+  });
+
+  it("tolerates whitespace inside the braces", () => {
+    expect(extractVarReferences("see {{ vars.foo }}")).toEqual(["foo"]);
+  });
+
+  it("ignores plugin-var refs without the vars. prefix", () => {
+    expect(extractVarReferences("ID is {{id}} but tone {{vars.tone}}")).toEqual(["tone"]);
+  });
+
+  it("returns empty list for an empty body", () => {
+    expect(extractVarReferences("")).toEqual([]);
+  });
+});
+
+describe("parseImportFile", () => {
+  // A toy YAML parser that handles only what these tests need: scalar
+  // key:value lines, type: workflow-module, and the small `vars:` shapes the
+  // export bundles produce.
+  function tinyYaml(block: string): Record<string, unknown> | null {
+    const out: Record<string, unknown> = {};
+    let i = 0;
+    const lines = block.split("\n");
+    while (i < lines.length) {
+      const line = lines[i];
+      if (!line || /^\s*#/.test(line)) {
+        i++;
+        continue;
+      }
+      const m = /^([A-Za-z_][A-Za-z0-9_-]*)\s*:\s*(.*)$/.exec(line);
+      if (!m) {
+        i++;
+        continue;
+      }
+      const key = m[1];
+      const rest = m[2];
+      if (rest === "" && key === "vars") {
+        const arr: unknown[] = [];
+        i++;
+        while (i < lines.length && /^\s*-\s+/.test(lines[i])) {
+          const item = lines[i].replace(/^\s*-\s+/, "");
+          if (item.startsWith("{")) {
+            // toy object form: { name: foo, default: "bar", description: baz }
+            const obj: Record<string, string> = {};
+            const inner = item.replace(/^\{|\}$/g, "");
+            for (const pair of inner.split(/,\s*/)) {
+              const km = /^([A-Za-z_]+)\s*:\s*(.*)$/.exec(pair.trim());
+              if (km) obj[km[1]] = unquote(km[2].trim());
+            }
+            arr.push(obj);
+          } else {
+            arr.push(item);
+          }
+          i++;
+        }
+        out[key] = arr;
+        continue;
+      }
+      out[key] = unquote(rest);
+      // YAML auto-coerce integers (matches obsidian metadataCache for `order:`)
+      if (/^-?\d+$/.test(rest)) out[key] = Number(rest);
+      i++;
+    }
+    return out;
+  }
+  function unquote(v: string): string {
+    if (v.startsWith('"') && v.endsWith('"')) {
+      return v.slice(1, -1).replace(/\\"/g, '"').replace(/\\\\/g, "\\");
+    }
+    return v;
+  }
+
+  it("parses a freshly-formatted bundle round-trippably", () => {
+    const original = mod({
+      title: "Orient",
+      vars: [
+        { kind: "bare", name: "reviewer" },
+        { kind: "default", name: "tone", value: "concise" },
+      ],
+    });
+    const raw = formatExportFile({
+      module: original,
+      body: "Hello {{vars.tone}} {{vars.reviewer}}.\n",
+    });
+    const parsed = parseImportFile({
+      sourcePath: "in.md",
+      raw,
+      parseFrontmatter: tinyYaml,
+    });
+    expect(parsed.module).not.toBeNull();
+    expect(parsed.module!.id).toBe("orient");
+    expect(parsed.module!.scope).toBe("kickoff");
+    expect(parsed.referencedVars).toEqual(["tone", "reviewer"]);
+    expect(parsed.diagnostics).toEqual([]);
+    expect(parsed.body.trim()).toBe("Hello {{vars.tone}} {{vars.reviewer}}.");
+  });
+
+  it("emits a malformed-frontmatter diagnostic when the fence is missing", () => {
+    const parsed = parseImportFile({
+      sourcePath: "no-fm.md",
+      raw: "no frontmatter here\n",
+      parseFrontmatter: tinyYaml,
+    });
+    expect(parsed.module).toBeNull();
+    expect(parsed.diagnostics[0]?.code).toBe("malformed-frontmatter");
+    expect(parsed.diagnostics[0]?.extra?.path).toBe("no-fm.md");
+  });
+
+  it("returns null module + diagnostic when type is not workflow-module", () => {
+    const raw = ["---", "id: x", "title: Y", "type: workflow", "scope: k", "---", "", "body"].join(
+      "\n",
+    );
+    const parsed = parseImportFile({
+      sourcePath: "wrong-type.md",
+      raw,
+      parseFrontmatter: tinyYaml,
+    });
+    expect(parsed.module).toBeNull();
+    expect(parsed.diagnostics.some((d) => /must be `workflow-module`/.test(d.message))).toBe(true);
+  });
+});
+
+describe("planImport", () => {
+  const baseModule = mod({
+    vars: [
+      { kind: "default", name: "tone", value: "concise" },
+      { kind: "bare", name: "reviewer" },
+      { kind: "object", name: "lang", default: "en", description: "ISO code" },
+    ],
+  });
+  const baseBody = "Hi {{vars.tone}} {{vars.reviewer}} ({{vars.lang}}).";
+
+  it("targets the global path when scope=global", () => {
+    const plan = planImport({
+      module: baseModule,
+      body: baseBody,
+      targetScope: "global",
+      globalVars: {},
+      projectVars: {},
+    });
+    expect(plan.targetPath).toBe("Projects/_op-modules/orient.md");
+    expect(plan.rewrittenProject).toBeNull();
+    expect(plan.originalProject).toBeNull();
+  });
+
+  it("targets the per-project path and rewrites project: when scope=project", () => {
+    const plan = planImport({
+      module: mod({ project: "old-slug" }),
+      body: baseBody,
+      targetScope: "project",
+      targetProjectSlug: "new-slug",
+      globalVars: {},
+      projectVars: {},
+    });
+    expect(plan.targetPath).toBe("Projects/new-slug/MODULES/orient.md");
+    expect(plan.originalProject).toBe("old-slug");
+    expect(plan.rewrittenProject).toBe("new-slug");
+  });
+
+  it("throws when scope=project lacks a slug", () => {
+    expect(() =>
+      planImport({
+        module: baseModule,
+        body: baseBody,
+        targetScope: "project",
+        globalVars: {},
+        projectVars: {},
+      }),
+    ).toThrow(/targetProjectSlug is required/);
+  });
+
+  it("prompts for vars with no higher-precedence value, pre-filled from inline default", () => {
+    const plan = planImport({
+      module: baseModule,
+      body: baseBody,
+      targetScope: "global",
+      globalVars: {},
+      projectVars: {},
+    });
+    const names = plan.promptsNeeded.map((p) => p.name).sort();
+    expect(names).toEqual(["lang", "reviewer", "tone"]);
+    const tone = plan.promptsNeeded.find((p) => p.name === "tone")!;
+    expect(tone.prefill).toBe("concise");
+    expect(tone.hasModuleDefault).toBe(true);
+    const reviewer = plan.promptsNeeded.find((p) => p.name === "reviewer")!;
+    expect(reviewer.prefill).toBe("");
+    expect(reviewer.hasModuleDefault).toBe(false);
+    const lang = plan.promptsNeeded.find((p) => p.name === "lang")!;
+    expect(lang.description).toBe("ISO code");
+  });
+
+  it("project precedence shadows the prompt, recorded as preexisting", () => {
+    const plan = planImport({
+      module: baseModule,
+      body: baseBody,
+      targetScope: "project",
+      targetProjectSlug: "demo",
+      globalVars: { reviewer: "global-rev" },
+      projectVars: { tone: "playful" },
+    });
+    const namesPrompted = plan.promptsNeeded.map((p) => p.name);
+    // tone shadowed by projectVars; reviewer shadowed by globalVars; only lang remains.
+    expect(namesPrompted).toEqual(["lang"]);
+    const writes = plan.varsToWrite.sort((a, b) => a.name.localeCompare(b.name));
+    expect(writes).toEqual([
+      {
+        name: "reviewer",
+        value: "global-rev",
+        scopeKind: "global",
+        preexisting: true,
+      },
+      {
+        name: "tone",
+        value: "playful",
+        scopeKind: "project",
+        projectSlug: "demo",
+        preexisting: true,
+      },
+    ]);
+  });
+
+  it("uses supplied varAnswers instead of prompting; lands them at target scope", () => {
+    const plan = planImport({
+      module: baseModule,
+      body: baseBody,
+      targetScope: "project",
+      targetProjectSlug: "demo",
+      varAnswers: { tone: "loud", reviewer: "@me", lang: "fr" },
+      globalVars: {},
+      projectVars: {},
+    });
+    expect(plan.promptsNeeded).toEqual([]);
+    const writes = plan.varsToWrite.sort((a, b) => a.name.localeCompare(b.name));
+    expect(writes).toEqual([
+      { name: "lang", value: "fr", scopeKind: "project", projectSlug: "demo", preexisting: false },
+      {
+        name: "reviewer",
+        value: "@me",
+        scopeKind: "project",
+        projectSlug: "demo",
+        preexisting: false,
+      },
+      { name: "tone", value: "loud", scopeKind: "project", projectSlug: "demo", preexisting: false },
+    ]);
+  });
+
+  it("preserves an empty-string answer as a real value", () => {
+    const plan = planImport({
+      module: baseModule,
+      body: baseBody,
+      targetScope: "global",
+      varAnswers: { tone: "", reviewer: "x", lang: "y" },
+      globalVars: {},
+      projectVars: {},
+    });
+    expect(plan.varsToWrite.find((v) => v.name === "tone")?.value).toBe("");
+  });
+
+  it("flags undeclared body refs without aborting the plan", () => {
+    const plan = planImport({
+      module: mod({ vars: [] }),
+      body: "Use {{vars.unknown}}.",
+      targetScope: "global",
+      globalVars: {},
+      projectVars: {},
+    });
+    expect(plan.undeclaredVarRefs).toEqual(["unknown"]);
+    expect(plan.promptsNeeded).toEqual([]);
+  });
+
+  it("records overwrite + backupRelPath when a target file already exists", () => {
+    const plan = planImport({
+      module: mod(),
+      body: "x",
+      targetScope: "global",
+      globalVars: {},
+      projectVars: {},
+      existingTargetPath: "Projects/_op-modules/orient.md",
+    });
+    expect(plan.overwrite).toBe(true);
+    expect(plan.backupRelPath).toBe("Projects/_op-modules/orient.md");
+  });
+});
+
+describe("transaction record round-trip", () => {
+  const sample: TransactionRecord = {
+    version: 1,
+    timestamp: "2026-04-26T12:00:00.000Z",
+    command: "op-import-module",
+    modulesLanded: [
+      {
+        sourcePath: "/tmp/in.md",
+        targetPath: "Projects/foo/MODULES/x.md",
+        scopeKind: "project",
+        projectSlug: "foo",
+        originalProject: "bar",
+        rewrittenProject: "foo",
+        overwrote: true,
+        backupPath: "Projects/_op-import-history/20260426-120000.bak/Projects/foo/MODULES/x.md",
+      },
+    ],
+    varsWritten: [
+      { name: "tone", value: "concise", scopeKind: "global", preexisting: false },
+      {
+        name: "reviewer",
+        value: "alice",
+        scopeKind: "project",
+        projectSlug: "foo",
+        preexisting: false,
+      },
+    ],
+  };
+
+  it("serializes and parses faithfully", () => {
+    const raw = serializeTransaction(sample);
+    const result = parseTransaction(raw);
+    expect(result.error).toBeUndefined();
+    expect(result.record).toEqual(sample);
+  });
+
+  it("rejects unknown versions", () => {
+    const result = parseTransaction(JSON.stringify({ ...sample, version: 99 }));
+    expect(result.record).toBeNull();
+    expect(result.error).toMatch(/version/);
+  });
+
+  it("rejects malformed JSON", () => {
+    const result = parseTransaction("{not json");
+    expect(result.record).toBeNull();
+    expect(result.error).toMatch(/JSON/);
+  });
+});
+
+describe("transactionFilename", () => {
+  it("formats local timestamp with second resolution", () => {
+    // Construct a fixed local-time date — verify the components without
+    // depending on the test runner's TZ.
+    const d = new Date(2026, 3, 26, 9, 5, 7); // April 26 2026 09:05:07 local
+    expect(transactionFilename(d)).toBe("20260426-090507");
+  });
+});

--- a/plugins/op-obsidian/src/exportImportPure.ts
+++ b/plugins/op-obsidian/src/exportImportPure.ts
@@ -345,6 +345,13 @@ export interface PlannedVarWrite {
 export interface ImportPlan {
   /** Vault-relative path the module file lands at. */
   targetPath: string;
+  /**
+   * The scope this import targets. Authoritative for var-write routing — do
+   * NOT use `rewrittenProject` as a proxy, because a global import of a
+   * per-project module has `rewrittenProject !== null` even though vars must
+   * land at global scope.
+   */
+  targetScope: ImportScopeKind;
   /** Slug rewritten into the module's `project:` field (or `null` to clear). */
   rewrittenProject: string | null;
   /** Original `project:` from the import (or `null` if absent). */
@@ -469,6 +476,7 @@ export function planImport(args: PlanImportArgs): ImportPlan {
 
   const plan: ImportPlan = {
     targetPath,
+    targetScope,
     rewrittenProject,
     originalProject,
     overwrite: !!existingTargetPath,
@@ -633,15 +641,19 @@ export function parseTransaction(raw: string): ParseTransactionResult {
 
 /**
  * Compose a timestamp filename for `Projects/_op-import-history/<ts>.json`.
- * Uses local time, dash-separated, second resolution. Caller picks the date.
+ * Uses local time, dash-separated, millisecond resolution. Milliseconds
+ * prevent the `vault.create` collision that two back-to-back imports in the
+ * same wall-clock second would otherwise cause. Caller picks the date.
  */
 export function transactionFilename(date: Date): string {
   const pad = (n: number) => n.toString().padStart(2, "0");
+  const pad3 = (n: number) => n.toString().padStart(3, "0");
   const y = date.getFullYear();
   const mo = pad(date.getMonth() + 1);
   const d = pad(date.getDate());
   const h = pad(date.getHours());
   const mi = pad(date.getMinutes());
   const s = pad(date.getSeconds());
-  return `${y}${mo}${d}-${h}${mi}${s}`;
+  const ms = pad3(date.getMilliseconds());
+  return `${y}${mo}${d}-${h}${mi}${s}-${ms}`;
 }

--- a/plugins/op-obsidian/src/exportImportPure.ts
+++ b/plugins/op-obsidian/src/exportImportPure.ts
@@ -1,0 +1,647 @@
+// Pure helpers for OP-187 (Child 4 of OP-181): module export / import / undo.
+// No I/O, no Obsidian imports — every input flows in via arguments. The IO
+// seams (`exportModule.ts`, `importModule.ts`, `undoLastImport.ts`) wire vault
+// reads and writes around these primitives.
+//
+// Surfaces:
+//   - `formatExportFile`           — re-serialize a `WorkflowModule` + body as
+//                                    a self-contained markdown file. Round-
+//                                    trippable through `parseImportFile`.
+//   - `parseImportFile`            — read a markdown blob into frontmatter +
+//                                    body + parsed module + referenced vars.
+//   - `extractVarReferences`       — list `{{vars.NAME}}` references in a body.
+//   - `planImport`                 — decide target path, scope rewrites, which
+//                                    vars need user input, what gets backed up.
+//   - `serializeTransaction` /
+//     `parseTransaction`           — read/write the transaction-record JSON.
+//
+// Schema doc: see `docs/plans/OP-181-workflow-modules.md` §"Export / import —
+// modules are just markdown" and OP-187's issue body Plan section.
+
+import {
+  parseModule,
+  type ModuleSource,
+  type VarDecl,
+  type WorkflowModule,
+} from "./workflowModulePure";
+import type { WorkflowDiagnostic } from "./workflowDiagnostic";
+
+// ---------------------------------------------------------------------------
+// Export bundle file shape
+// ---------------------------------------------------------------------------
+
+export interface FormatExportArgs {
+  /** Parsed source module (frontmatter + identity). */
+  module: WorkflowModule;
+  /** The module body (frontmatter stripped). */
+  body: string;
+  /**
+   * When set, overrides the `project:` frontmatter field in the exported
+   * file. Useful for batch exports that re-target a slug that doesn't
+   * exist in the destination vault — though the recommended path is to
+   * leave the export faithful and let `op-import-module` rewrite at land
+   * time. Default: preserve the source module's `project:` field.
+   */
+  overrideProject?: string | null;
+}
+
+/**
+ * Serialize a workflow module as a self-contained markdown file: YAML
+ * frontmatter (only the required + populated optional fields) followed by the
+ * module body. Round-trips byte-equivalent through `parseImportFile` provided
+ * the source body had no leading/trailing whitespace.
+ *
+ * Var declarations are written in their canonical form:
+ *   - `kind: "bare"`     → `- name`
+ *   - `kind: "default"`  → `- name=value`           (preserves empty value as `name=`)
+ *   - `kind: "object"`   → `- { name: foo, default: "bar", description: "…" }`
+ *
+ * The object form quotes string values so YAML auto-coercion (Date, number)
+ * can't bite a round-trip — see `workflowModulePure.ts` `parseObjectVarDecl`.
+ */
+export function formatExportFile(args: FormatExportArgs): string {
+  const { module, body, overrideProject } = args;
+  const lines: string[] = [];
+  lines.push("---");
+  lines.push(`id: ${module.id}`);
+  lines.push(`title: ${yamlString(module.title)}`);
+  lines.push("type: workflow-module");
+  lines.push(`scope: ${yamlString(module.scope)}`);
+
+  const project =
+    overrideProject !== undefined ? overrideProject : (module.project ?? null);
+  if (project !== null && project !== "") {
+    lines.push(`project: ${yamlString(project)}`);
+  }
+  if (module.agent) {
+    lines.push(`agent: ${yamlString(module.agent)}`);
+  }
+  if (module.order !== 0) {
+    lines.push(`order: ${module.order}`);
+  }
+  if (module.vars.length > 0) {
+    lines.push("vars:");
+    for (const decl of module.vars) {
+      lines.push(`  - ${formatVarDecl(decl)}`);
+    }
+  }
+  lines.push("---");
+  lines.push("");
+  lines.push(body.replace(/\s+$/, ""));
+  lines.push("");
+  return lines.join("\n");
+}
+
+function formatVarDecl(decl: VarDecl): string {
+  if (decl.kind === "bare") return decl.name;
+  if (decl.kind === "default") return `${decl.name}=${decl.value}`;
+  // object form
+  const fragments: string[] = [`name: ${yamlString(decl.name)}`];
+  if (decl.default !== undefined) {
+    fragments.push(`default: ${yamlString(decl.default)}`);
+  }
+  if (decl.description !== undefined) {
+    fragments.push(`description: ${yamlString(decl.description)}`);
+  }
+  return `{ ${fragments.join(", ")} }`;
+}
+
+/**
+ * Quote any string that needs YAML quoting for safety. We over-quote rather
+ * than try to be clever — the cost of an extra `"` per field is nothing, the
+ * cost of a YAML round-trip surprise (a `2026-04-26` value silently parsing
+ * as a Date) is real.
+ */
+function yamlString(value: string): string {
+  // Empty string must be quoted to be distinguishable from null in YAML.
+  if (value === "") return '""';
+  // Quote anything containing characters that are unsafe as bare YAML scalars.
+  const needsQuote =
+    /^[?\-:!*&|>%@`#]/.test(value) ||
+    /[:#\n\r\t"'\\{}\[\],&*!|>%@?]/.test(value) ||
+    /^(?:true|false|null|yes|no|on|off|~)$/i.test(value) ||
+    /^-?\d/.test(value) ||
+    value.startsWith(" ") ||
+    value.endsWith(" ");
+  if (!needsQuote) return value;
+  // Use double quotes with backslash escapes for `"` and `\`.
+  return `"${value.replace(/\\/g, "\\\\").replace(/"/g, '\\"')}"`;
+}
+
+// ---------------------------------------------------------------------------
+// Import-side parse
+// ---------------------------------------------------------------------------
+
+export interface ParseImportFileArgs {
+  /** Vault-relative or absolute path the raw text was read from — diagnostics tag this. */
+  sourcePath: string;
+  /** Full file content including the YAML frontmatter fence. */
+  raw: string;
+  /**
+   * Frontmatter parser — Obsidian's `metadataCache` exposes a YAML→object
+   * function; tests inject a thin one. Receives the *contents* of the
+   * frontmatter (between the `---` fences, no fences) and returns either an
+   * object (parsed YAML root mapping) or `null` (unparseable).
+   */
+  parseFrontmatter: (yamlBlock: string) => Record<string, unknown> | null;
+}
+
+export interface ParseImportFileResult {
+  /** Parsed module if frontmatter validates; `null` otherwise. */
+  module: WorkflowModule | null;
+  /** Body with frontmatter stripped (frontmatter-less files = whole raw). */
+  body: string;
+  /** Distinct names referenced as `{{vars.<name>}}` in the body. */
+  referencedVars: string[];
+  diagnostics: WorkflowDiagnostic[];
+}
+
+/**
+ * Parse an import-bundle file into its constituent pieces. The source file is
+ * assumed to be a workflow-module export (or any module markdown) — the
+ * frontmatter MUST declare `type: workflow-module`. Frontmatter problems
+ * surface as diagnostics rather than throws so callers can present them as
+ * Notice + structured payload.
+ */
+export function parseImportFile(args: ParseImportFileArgs): ParseImportFileResult {
+  const { sourcePath, raw, parseFrontmatter } = args;
+  const diagnostics: WorkflowDiagnostic[] = [];
+
+  const split = splitFrontmatter(raw);
+  if (!split) {
+    return {
+      module: null,
+      body: raw,
+      referencedVars: [],
+      diagnostics: [
+        {
+          code: "malformed-frontmatter",
+          severity: "error",
+          message: `${sourcePath}: missing YAML frontmatter — expected leading \`---\` fence with \`type: workflow-module\`.`,
+          extra: { path: sourcePath },
+        },
+      ],
+    };
+  }
+  const frontmatter = parseFrontmatter(split.frontmatter);
+  if (!frontmatter) {
+    return {
+      module: null,
+      body: split.body,
+      referencedVars: [],
+      diagnostics: [
+        {
+          code: "malformed-frontmatter",
+          severity: "error",
+          message: `${sourcePath}: failed to parse YAML frontmatter.`,
+          extra: { path: sourcePath },
+        },
+      ],
+    };
+  }
+
+  // Filename basename (without `.md`) is what `parseModule` uses as the id
+  // identity check. For import we don't have a vault filename yet — fall back
+  // to the frontmatter id when available, else a placeholder that will fail
+  // the id-required check.
+  const fallbackId =
+    typeof frontmatter.id === "string" && frontmatter.id.trim().length > 0
+      ? frontmatter.id.trim()
+      : "(unknown-id)";
+
+  const source: ModuleSource = { kind: "global", path: sourcePath };
+  const parseResult = parseModule({
+    id: fallbackId,
+    frontmatter,
+    source,
+  });
+  diagnostics.push(...parseResult.diagnostics);
+
+  return {
+    module: parseResult.module,
+    body: split.body,
+    referencedVars: extractVarReferences(split.body),
+    diagnostics,
+  };
+}
+
+/**
+ * Split a markdown blob into `{ frontmatter, body }` if it begins with a
+ * `---` fence; returns `null` otherwise. The frontmatter is the inner YAML
+ * (no fences); the body is everything after the closing fence (one trailing
+ * newline consumed).
+ */
+function splitFrontmatter(
+  raw: string,
+): { frontmatter: string; body: string } | null {
+  if (!raw.startsWith("---")) return null;
+  // Allow `---\n` or `---\r\n`.
+  const firstNl = raw.indexOf("\n");
+  if (firstNl === -1) return null;
+  // Search for `\n---` followed by EOL or EOF.
+  let from = firstNl + 1;
+  while (from < raw.length) {
+    const idx = raw.indexOf("\n---", from);
+    if (idx === -1) return null;
+    const after = idx + 4;
+    if (after === raw.length || raw[after] === "\n" || raw[after] === "\r") {
+      const frontmatter = raw.slice(firstNl + 1, idx).replace(/\r$/, "");
+      // Body = everything after the closing fence's terminating newline.
+      const bodyStart =
+        after === raw.length
+          ? raw.length
+          : raw[after] === "\r"
+            ? after + 2 // skip \r\n
+            : after + 1; // skip \n
+      const body = raw.slice(bodyStart);
+      return { frontmatter, body };
+    }
+    from = after;
+  }
+  return null;
+}
+
+const VAR_REF_RE = /\{\{\s*vars\.([A-Za-z_][A-Za-z0-9_-]*)\s*\}\}/g;
+
+/**
+ * Distinct ordered list of `{{vars.<name>}}` references in a body. Matches
+ * the renderer's `vars.<name>` syntax (see OP-194 / `renderTemplate.ts`).
+ * Whitespace inside the braces is tolerated to match the renderer.
+ */
+export function extractVarReferences(body: string): string[] {
+  const seen = new Set<string>();
+  const out: string[] = [];
+  for (const match of body.matchAll(VAR_REF_RE)) {
+    const name = match[1];
+    if (!name || seen.has(name)) continue;
+    seen.add(name);
+    out.push(name);
+  }
+  return out;
+}
+
+// ---------------------------------------------------------------------------
+// Import planning
+// ---------------------------------------------------------------------------
+
+export type ImportScopeKind = "global" | "project";
+
+export interface PlanImportArgs {
+  /** Parsed module (output of `parseImportFile`). Must be non-null at planning time. */
+  module: WorkflowModule;
+  /** Body of the import (frontmatter stripped). */
+  body: string;
+  /** Where the import lands. */
+  targetScope: ImportScopeKind;
+  /** Required when `targetScope === "project"`. */
+  targetProjectSlug?: string;
+  /**
+   * The user's pre-supplied answers for any var the importer would otherwise
+   * prompt for. Keyed by var name. Empty string is preserved as a real answer.
+   */
+  varAnswers?: Record<string, string>;
+  /**
+   * Vault-wide vars (`settings.workflowVars`). Keys present here at import
+   * time skip the prompt because Global precedence already supplies them.
+   */
+  globalVars: Record<string, string>;
+  /**
+   * Per-project vars from the *target* project's STATUS.md. Keys present
+   * here skip the prompt because Project precedence already supplies them.
+   * Empty `{}` for global imports.
+   */
+  projectVars: Record<string, string>;
+  /**
+   * Vault-relative path of an existing module file at the chosen target,
+   * if any. When set, the existing file is backed up and overwritten at
+   * import time. Pure: caller pre-resolves; we only branch on its presence.
+   */
+  existingTargetPath?: string;
+}
+
+export interface VarPromptDescriptor {
+  name: string;
+  /** Pre-fill for the prompt. Empty string is a valid pre-fill (explicit `name=`). */
+  prefill: string;
+  /** Whether the module declared an inline default for this var. */
+  hasModuleDefault: boolean;
+  /** Optional description from object-form declarations. */
+  description?: string;
+}
+
+export interface PlannedVarWrite {
+  name: string;
+  value: string;
+  scopeKind: ImportScopeKind;
+  projectSlug?: string;
+  /**
+   * `false` for vars this import will write; `true` for vars that already
+   * existed at higher precedence and were skipped (recorded for traceability
+   * only — undo never touches `preexisting=true` rows).
+   */
+  preexisting: boolean;
+}
+
+export interface ImportPlan {
+  /** Vault-relative path the module file lands at. */
+  targetPath: string;
+  /** Slug rewritten into the module's `project:` field (or `null` to clear). */
+  rewrittenProject: string | null;
+  /** Original `project:` from the import (or `null` if absent). */
+  originalProject: string | null;
+  /** Whether overwrite + backup will happen. */
+  overwrite: boolean;
+  /** When `overwrite=true`, the relative path under `<ts>.bak/` we'll back the original up to. */
+  backupRelPath?: string;
+  /** Vars the importer must prompt the user for (no higher-precedence value, no answer supplied). */
+  promptsNeeded: VarPromptDescriptor[];
+  /** Vars the importer will write to settings/STATUS at land time. */
+  varsToWrite: PlannedVarWrite[];
+  /** Vars referenced in the body but missing from any module's `vars:` declaration. Surfaced as warnings. */
+  undeclaredVarRefs: string[];
+}
+
+/**
+ * Plan the import: figure out target path, project rewrites, what to back up,
+ * what vars to prompt for, what vars to write at land time.
+ *
+ * Pure — caller supplies the "exists?" check via `existingTargetPath` and the
+ * higher-precedence var maps.
+ */
+export function planImport(args: PlanImportArgs): ImportPlan {
+  const {
+    module,
+    body,
+    targetScope,
+    targetProjectSlug,
+    varAnswers = {},
+    globalVars,
+    projectVars,
+    existingTargetPath,
+  } = args;
+
+  if (targetScope === "project" && !targetProjectSlug?.trim()) {
+    throw new Error("planImport: targetProjectSlug is required when targetScope=project");
+  }
+
+  const targetPath =
+    targetScope === "global"
+      ? `Projects/_op-modules/${module.id}.md`
+      : `Projects/${targetProjectSlug!.trim()}/MODULES/${module.id}.md`;
+
+  // Project rewrite: per-project landings always set `project:` to the slug
+  // they land under. Global landings preserve the source `project:` field.
+  const originalProject = module.project ?? null;
+  const rewrittenProject =
+    targetScope === "project" ? targetProjectSlug!.trim() : (module.project ?? null);
+
+  const declarations = new Map<string, VarDecl>();
+  for (const decl of module.vars) {
+    declarations.set(decl.name, decl);
+  }
+
+  const referenced = extractVarReferences(body);
+  const promptsNeeded: VarPromptDescriptor[] = [];
+  const varsToWrite: PlannedVarWrite[] = [];
+  const undeclaredVarRefs: string[] = [];
+
+  for (const name of referenced) {
+    const decl = declarations.get(name);
+    if (!decl) {
+      undeclaredVarRefs.push(name);
+      continue;
+    }
+
+    // Higher-precedence sources shadow Module-default. Project beats Global.
+    if (Object.prototype.hasOwnProperty.call(projectVars, name)) {
+      varsToWrite.push({
+        name,
+        value: projectVars[name],
+        scopeKind: "project",
+        projectSlug: targetProjectSlug?.trim(),
+        preexisting: true,
+      });
+      continue;
+    }
+    if (Object.prototype.hasOwnProperty.call(globalVars, name)) {
+      varsToWrite.push({
+        name,
+        value: globalVars[name],
+        scopeKind: "global",
+        preexisting: true,
+      });
+      continue;
+    }
+
+    // No higher-precedence value. We need an answer from either varAnswers
+    // (already supplied) or a prompt.
+    const hasAnswer = Object.prototype.hasOwnProperty.call(varAnswers, name);
+    const prefill = pickPrefill(decl);
+
+    if (hasAnswer) {
+      const answer = varAnswers[name];
+      if (targetScope === "project") {
+        varsToWrite.push({
+          name,
+          value: answer,
+          scopeKind: "project",
+          projectSlug: targetProjectSlug!.trim(),
+          preexisting: false,
+        });
+      } else {
+        varsToWrite.push({
+          name,
+          value: answer,
+          scopeKind: "global",
+          preexisting: false,
+        });
+      }
+      continue;
+    }
+
+    promptsNeeded.push({
+      name,
+      prefill,
+      hasModuleDefault: prefill !== "" || hasExplicitDefault(decl),
+      description: decl.kind === "object" ? decl.description : undefined,
+    });
+  }
+
+  const plan: ImportPlan = {
+    targetPath,
+    rewrittenProject,
+    originalProject,
+    overwrite: !!existingTargetPath,
+    promptsNeeded,
+    varsToWrite,
+    undeclaredVarRefs,
+  };
+  if (existingTargetPath) {
+    plan.backupRelPath = existingTargetPath;
+  }
+  return plan;
+}
+
+function pickPrefill(decl: VarDecl): string {
+  if (decl.kind === "default") return decl.value;
+  if (decl.kind === "object" && typeof decl.default === "string") return decl.default;
+  return "";
+}
+
+function hasExplicitDefault(decl: VarDecl): boolean {
+  if (decl.kind === "default") return true;
+  if (decl.kind === "object") return typeof decl.default === "string";
+  return false;
+}
+
+// ---------------------------------------------------------------------------
+// Transaction record
+// ---------------------------------------------------------------------------
+
+export const TRANSACTION_HISTORY_DIR = "Projects/_op-import-history";
+export const TRANSACTION_VERSION = 1;
+
+export interface TransactionModuleEntry {
+  /** Original import source (vault-relative or absolute path passed to op-import-module). */
+  sourcePath: string;
+  /** Vault-relative path the module landed at. */
+  targetPath: string;
+  scopeKind: ImportScopeKind;
+  projectSlug?: string;
+  originalProject?: string | null;
+  rewrittenProject?: string | null;
+  overwrote: boolean;
+  /** Set iff `overwrote=true`: vault-relative path of the backup copy. */
+  backupPath?: string;
+}
+
+export interface TransactionVarEntry {
+  name: string;
+  value: string;
+  scopeKind: ImportScopeKind;
+  projectSlug?: string;
+  /**
+   * `false` for vars this import added (undo prunes them); `true` for vars
+   * that already existed (undo leaves them alone).
+   */
+  preexisting: boolean;
+}
+
+export interface TransactionRecord {
+  version: number;
+  /** ISO 8601 UTC. */
+  timestamp: string;
+  /** Always "op-import-module" today; future commands may extend this. */
+  command: "op-import-module";
+  modulesLanded: TransactionModuleEntry[];
+  varsWritten: TransactionVarEntry[];
+}
+
+export function serializeTransaction(record: TransactionRecord): string {
+  return JSON.stringify(record, null, 2);
+}
+
+export interface ParseTransactionResult {
+  record: TransactionRecord | null;
+  error?: string;
+}
+
+/**
+ * Parse a transaction-record JSON blob. Validates the shape strictly so a
+ * corrupted history file surfaces a clear error rather than half-undoing
+ * something. Forward-compat: unknown future versions are rejected.
+ */
+export function parseTransaction(raw: string): ParseTransactionResult {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (e) {
+    return { record: null, error: `transaction record is not valid JSON: ${(e as Error).message}` };
+  }
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+    return { record: null, error: "transaction record is not an object" };
+  }
+  const obj = parsed as Record<string, unknown>;
+  if (obj.version !== TRANSACTION_VERSION) {
+    return {
+      record: null,
+      error: `transaction record version ${JSON.stringify(obj.version)} is not supported (expected ${TRANSACTION_VERSION})`,
+    };
+  }
+  if (typeof obj.timestamp !== "string" || obj.command !== "op-import-module") {
+    return { record: null, error: "transaction record missing timestamp/command fields" };
+  }
+  if (!Array.isArray(obj.modulesLanded) || !Array.isArray(obj.varsWritten)) {
+    return { record: null, error: "transaction record missing modulesLanded/varsWritten arrays" };
+  }
+  // Trust-but-verify each entry shape.
+  const modulesLanded: TransactionModuleEntry[] = [];
+  for (const entry of obj.modulesLanded) {
+    if (!entry || typeof entry !== "object") continue;
+    const e = entry as Record<string, unknown>;
+    if (typeof e.sourcePath !== "string" || typeof e.targetPath !== "string") {
+      return { record: null, error: "modulesLanded entry missing sourcePath/targetPath" };
+    }
+    if (e.scopeKind !== "global" && e.scopeKind !== "project") {
+      return { record: null, error: "modulesLanded entry has invalid scopeKind" };
+    }
+    const out: TransactionModuleEntry = {
+      sourcePath: e.sourcePath,
+      targetPath: e.targetPath,
+      scopeKind: e.scopeKind,
+      overwrote: e.overwrote === true,
+    };
+    if (typeof e.projectSlug === "string") out.projectSlug = e.projectSlug;
+    if (typeof e.originalProject === "string" || e.originalProject === null) {
+      out.originalProject = e.originalProject as string | null;
+    }
+    if (typeof e.rewrittenProject === "string" || e.rewrittenProject === null) {
+      out.rewrittenProject = e.rewrittenProject as string | null;
+    }
+    if (typeof e.backupPath === "string") out.backupPath = e.backupPath;
+    modulesLanded.push(out);
+  }
+  const varsWritten: TransactionVarEntry[] = [];
+  for (const entry of obj.varsWritten) {
+    if (!entry || typeof entry !== "object") continue;
+    const e = entry as Record<string, unknown>;
+    if (typeof e.name !== "string" || typeof e.value !== "string") {
+      return { record: null, error: "varsWritten entry missing name/value" };
+    }
+    if (e.scopeKind !== "global" && e.scopeKind !== "project") {
+      return { record: null, error: "varsWritten entry has invalid scopeKind" };
+    }
+    const out: TransactionVarEntry = {
+      name: e.name,
+      value: e.value,
+      scopeKind: e.scopeKind,
+      preexisting: e.preexisting === true,
+    };
+    if (typeof e.projectSlug === "string") out.projectSlug = e.projectSlug;
+    varsWritten.push(out);
+  }
+  return {
+    record: {
+      version: TRANSACTION_VERSION,
+      timestamp: obj.timestamp,
+      command: "op-import-module",
+      modulesLanded,
+      varsWritten,
+    },
+  };
+}
+
+/**
+ * Compose a timestamp filename for `Projects/_op-import-history/<ts>.json`.
+ * Uses local time, dash-separated, second resolution. Caller picks the date.
+ */
+export function transactionFilename(date: Date): string {
+  const pad = (n: number) => n.toString().padStart(2, "0");
+  const y = date.getFullYear();
+  const mo = pad(date.getMonth() + 1);
+  const d = pad(date.getDate());
+  const h = pad(date.getHours());
+  const mi = pad(date.getMinutes());
+  const s = pad(date.getSeconds());
+  return `${y}${mo}${d}-${h}${mi}${s}`;
+}

--- a/plugins/op-obsidian/src/exportModule.test.ts
+++ b/plugins/op-obsidian/src/exportModule.test.ts
@@ -1,0 +1,221 @@
+import { describe, it, expect, vi } from "vitest";
+
+vi.mock("obsidian", () => {
+  class TFile {
+    path = "";
+    basename = "";
+    name = "";
+  }
+  return {
+    TFile,
+    normalizePath: (p: string) => p.replace(/\/+/g, "/"),
+  };
+});
+
+import { TFile } from "obsidian";
+import { exportModules, EXPORT_DIR } from "./exportModule";
+
+interface FakeFile {
+  path: string;
+  raw: string;
+  frontmatter: Record<string, unknown> | null;
+}
+
+function makeTFile(path: string): TFile {
+  const f = new TFile();
+  const basename = path.split("/").pop()!.replace(/\.md$/, "");
+  Object.assign(f, { path, basename, name: `${basename}.md` });
+  return f;
+}
+
+interface FakeVaultState {
+  files: Map<string, FakeFile>;
+  folders: Set<string>;
+  writes: Array<{ path: string; content: string }>;
+  modifies: Array<{ path: string; content: string }>;
+  createdFolders: string[];
+}
+
+function fakeApp(initial: FakeFile[]) {
+  const state: FakeVaultState = {
+    files: new Map(initial.map((f) => [f.path, f])),
+    folders: new Set(),
+    writes: [],
+    modifies: [],
+    createdFolders: [],
+  };
+
+  const tfileFor = (path: string) => makeTFile(path);
+
+  const app = {
+    vault: {
+      getMarkdownFiles: () =>
+        [...state.files.values()].map((f) => tfileFor(f.path)),
+      getAbstractFileByPath: (p: string) => {
+        if (state.files.has(p)) return tfileFor(p);
+        if (state.folders.has(p)) return { path: p }; // folder marker
+        return null;
+      },
+      read: async (file: TFile) => {
+        const f = state.files.get(file.path);
+        if (!f) throw new Error(`fake vault: no file at ${file.path}`);
+        return f.raw;
+      },
+      create: async (path: string, content: string) => {
+        if (state.files.has(path)) {
+          throw new Error(`fake vault: ${path} already exists`);
+        }
+        state.files.set(path, { path, raw: content, frontmatter: null });
+        state.writes.push({ path, content });
+        return tfileFor(path);
+      },
+      modify: async (file: TFile, content: string) => {
+        const f = state.files.get(file.path);
+        if (!f) throw new Error(`fake vault: no file at ${file.path}`);
+        f.raw = content;
+        state.modifies.push({ path: file.path, content });
+      },
+      createFolder: async (path: string) => {
+        state.folders.add(path);
+        state.createdFolders.push(path);
+      },
+    },
+    metadataCache: {
+      getFileCache: (file: TFile) => {
+        const f = state.files.get(file.path);
+        return f && f.frontmatter ? { frontmatter: f.frontmatter } : null;
+      },
+    },
+  } as any;
+
+  return { app, state };
+}
+
+const moduleFm = (over: Record<string, unknown> = {}) => ({
+  type: "workflow-module",
+  title: "Sample",
+  scope: "kickoff",
+  ...over,
+});
+
+const moduleFile = (path: string, fm: Record<string, unknown>, body: string): FakeFile => ({
+  path,
+  frontmatter: fm,
+  raw:
+    "---\n" +
+    Object.entries(fm)
+      .map(([k, v]) => `${k}: ${JSON.stringify(v)}`)
+      .join("\n") +
+    "\n---\n" +
+    body,
+});
+
+describe("exportModules — single id mode", () => {
+  it("writes a single export file at Projects/_op-export/<id>.md", async () => {
+    const { app, state } = fakeApp([
+      moduleFile(
+        "Projects/_op-modules/orient.md",
+        moduleFm({ id: "orient" }),
+        "Hello body.\n",
+      ),
+    ]);
+    const r = await exportModules(app, { kind: "id", moduleId: "orient" });
+    expect(r.files).toHaveLength(1);
+    expect(r.files[0]).toMatchObject({
+      moduleId: "orient",
+      sourcePath: "Projects/_op-modules/orient.md",
+      exportPath: "Projects/_op-export/orient.md",
+      sourceScope: "global",
+    });
+    const written = state.writes.find((w) => w.path === "Projects/_op-export/orient.md");
+    expect(written).toBeDefined();
+    expect(written!.content).toContain("type: workflow-module");
+    expect(written!.content).toContain("Hello body.");
+    expect(state.createdFolders).toContain(EXPORT_DIR);
+  });
+
+  it("throws when the requested id is not in the vault", async () => {
+    const { app } = fakeApp([]);
+    await expect(exportModules(app, { kind: "id", moduleId: "missing" })).rejects.toThrow(
+      /no module with id "missing"/,
+    );
+  });
+
+  it("overwrites an existing export file via vault.modify", async () => {
+    const { app, state } = fakeApp([
+      moduleFile("Projects/_op-modules/orient.md", moduleFm({ id: "orient" }), "Body v2"),
+      // pre-existing export file at the destination
+      {
+        path: "Projects/_op-export/orient.md",
+        frontmatter: null,
+        raw: "old export",
+      },
+    ]);
+    await exportModules(app, { kind: "id", moduleId: "orient" });
+    const mod = state.modifies.find((m) => m.path === "Projects/_op-export/orient.md");
+    expect(mod).toBeDefined();
+    expect(mod!.content).toContain("Body v2");
+  });
+});
+
+describe("exportModules — project mode", () => {
+  it("bundles per-project modules + globals targeting that slug into a subfolder", async () => {
+    const { app, state } = fakeApp([
+      moduleFile(
+        "Projects/foo/MODULES/local-a.md",
+        moduleFm({ id: "local-a" }),
+        "A",
+      ),
+      moduleFile(
+        "Projects/foo/MODULES/local-b.md",
+        moduleFm({ id: "local-b" }),
+        "B",
+      ),
+      moduleFile(
+        "Projects/_op-modules/global-tagged.md",
+        moduleFm({ id: "global-tagged", project: "foo" }),
+        "G",
+      ),
+      moduleFile(
+        "Projects/_op-modules/global-untagged.md",
+        moduleFm({ id: "global-untagged" }),
+        "U",
+      ),
+      moduleFile(
+        "Projects/bar/MODULES/other.md",
+        moduleFm({ id: "other" }),
+        "X",
+      ),
+    ]);
+    const r = await exportModules(app, { kind: "project", projectSlug: "foo" });
+    const ids = r.files.map((f) => f.moduleId).sort();
+    expect(ids).toEqual(["global-tagged", "local-a", "local-b"]);
+    for (const f of r.files) {
+      expect(f.exportPath.startsWith("Projects/_op-export/foo/")).toBe(true);
+    }
+    expect(state.createdFolders).toContain("Projects/_op-export/foo");
+  });
+
+  it("throws when no modules match the project", async () => {
+    const { app } = fakeApp([]);
+    await expect(
+      exportModules(app, { kind: "project", projectSlug: "missing" }),
+    ).rejects.toThrow(/no modules found for project "missing"/);
+  });
+});
+
+describe("exportModules — vault hygiene", () => {
+  it("aborts when an existing module has a frontmatter error", async () => {
+    const { app } = fakeApp([
+      // Wrong type — loadModules produces an error diagnostic.
+      {
+        path: "Projects/_op-modules/bad.md",
+        frontmatter: { type: "not-a-module", id: "bad" },
+        raw: "---\ntype: not-a-module\nid: bad\n---\n",
+      },
+    ]);
+    await expect(exportModules(app, { kind: "id", moduleId: "bad" })).rejects.toThrow(
+      /module-loading error/,
+    );
+  });
+});

--- a/plugins/op-obsidian/src/exportModule.ts
+++ b/plugins/op-obsidian/src/exportModule.ts
@@ -1,0 +1,143 @@
+import { App, TFile, normalizePath } from "obsidian";
+import { loadModules } from "./workflowModule";
+import type { WorkflowModule } from "./workflowModulePure";
+import { formatExportFile } from "./exportImportPure";
+
+// IO seam for `op-export-module` (OP-187 / Child 4 of OP-181).
+// Reads source modules from the vault, formats them via the pure layer, and
+// writes the bundle into `Projects/_op-export/`.
+//
+// Two modes:
+//   - `id=<id>`        → write a single module to `Projects/_op-export/<id>.md`.
+//   - `project=<slug>` → write every module visible to that project (per-
+//                        project modules + globals carrying that `project:`)
+//                        to `Projects/_op-export/<slug>/<id>.md`.
+
+export const EXPORT_DIR = "Projects/_op-export";
+
+export interface ExportSingleArgs {
+  kind: "id";
+  moduleId: string;
+}
+
+export interface ExportProjectArgs {
+  kind: "project";
+  projectSlug: string;
+}
+
+export type ExportArgs = ExportSingleArgs | ExportProjectArgs;
+
+export interface ExportedFile {
+  /** Source module id. */
+  moduleId: string;
+  /** Where the source module lives in the vault. */
+  sourcePath: string;
+  /** Where the export file was written (vault-relative). */
+  exportPath: string;
+  /** Source module scope (global vs project) — copied for surfaces that report. */
+  sourceScope: "global" | "project";
+  /** Source project slug, if the module came from a per-project folder. */
+  sourceProjectSlug?: string;
+}
+
+export interface ExportResult {
+  files: ExportedFile[];
+}
+
+/**
+ * Run the export. Throws when the target module/project doesn't exist; that's
+ * a usage error worth surfacing as a hard `Error` (the URI/CLI handler turns
+ * it into a structured response). Other partial failures (one module fails to
+ * read mid-bundle) propagate the same way — we'd rather abort than ship a
+ * half-written bundle.
+ */
+export async function exportModules(app: App, args: ExportArgs): Promise<ExportResult> {
+  const { modules: discovered, diagnostics } = loadModules(app);
+  const fatal = diagnostics.filter((d) => d.severity === "error");
+  if (fatal.length > 0) {
+    throw new Error(
+      `op-export-module: vault has ${fatal.length} module-loading error(s). Fix them with op-edit-module before exporting. First: ${fatal[0].message}`,
+    );
+  }
+
+  const targets = pickTargets(discovered, args);
+  if (targets.length === 0) {
+    throw new Error(
+      args.kind === "id"
+        ? `op-export-module: no module with id "${args.moduleId}" found in the vault.`
+        : `op-export-module: no modules found for project "${args.projectSlug}".`,
+    );
+  }
+
+  await ensureFolder(app, EXPORT_DIR);
+  const subfolder = args.kind === "project" ? `${EXPORT_DIR}/${args.projectSlug}` : null;
+  if (subfolder) await ensureFolder(app, subfolder);
+
+  const out: ExportedFile[] = [];
+  for (const module of targets) {
+    const tfile = app.vault.getAbstractFileByPath(module.source.path);
+    if (!(tfile instanceof TFile)) {
+      throw new Error(
+        `op-export-module: module "${module.id}" path ${module.source.path} no longer resolves to a file.`,
+      );
+    }
+    const raw = await app.vault.read(tfile);
+    const body = stripFrontmatter(raw);
+    const exportPath = normalizePath(
+      subfolder ? `${subfolder}/${module.id}.md` : `${EXPORT_DIR}/${module.id}.md`,
+    );
+    const content = formatExportFile({ module, body });
+    await writeFile(app, exportPath, content);
+    out.push({
+      moduleId: module.id,
+      sourcePath: module.source.path,
+      exportPath,
+      sourceScope: module.source.kind,
+      sourceProjectSlug:
+        module.source.kind === "project" ? module.source.projectSlug : undefined,
+    });
+  }
+
+  return { files: out };
+}
+
+function pickTargets(
+  discovered: WorkflowModule[],
+  args: ExportArgs,
+): WorkflowModule[] {
+  if (args.kind === "id") {
+    const hit = discovered.find((m) => m.id === args.moduleId);
+    return hit ? [hit] : [];
+  }
+  const slug = args.projectSlug;
+  return discovered.filter((m) => {
+    if (m.source.kind === "project" && m.source.projectSlug === slug) return true;
+    if (m.source.kind === "global" && m.project === slug) return true;
+    return false;
+  });
+}
+
+async function ensureFolder(app: App, path: string): Promise<void> {
+  const norm = normalizePath(path);
+  if (!app.vault.getAbstractFileByPath(norm)) {
+    await app.vault.createFolder(norm);
+  }
+}
+
+async function writeFile(app: App, path: string, content: string): Promise<void> {
+  const norm = normalizePath(path);
+  const existing = app.vault.getAbstractFileByPath(norm);
+  if (existing instanceof TFile) {
+    await app.vault.modify(existing, content);
+  } else {
+    await app.vault.create(norm, content);
+  }
+}
+
+function stripFrontmatter(raw: string): string {
+  if (!raw.startsWith("---")) return raw;
+  const end = raw.indexOf("\n---", 3);
+  if (end === -1) return raw;
+  const after = raw.indexOf("\n", end + 4);
+  return after === -1 ? "" : raw.slice(after + 1);
+}

--- a/plugins/op-obsidian/src/importModule.test.ts
+++ b/plugins/op-obsidian/src/importModule.test.ts
@@ -195,7 +195,7 @@ describe("commitImport", () => {
     });
     expect(result.targetPath).toBe("Projects/_op-modules/orient.md");
     expect(result.transactionPath).toBe(
-      "Projects/_op-import-history/20260426-120000.json",
+      "Projects/_op-import-history/20260426-120000-000.json",
     );
     expect(state.files.has("Projects/_op-modules/orient.md")).toBe(true);
     expect(state.files.has(result.transactionPath)).toBe(true);
@@ -225,7 +225,7 @@ describe("commitImport", () => {
     });
     expect(result.overwrote).toBe(true);
     expect(result.backupPath).toBe(
-      "Projects/_op-import-history/20260426-120000.bak/Projects/_op-modules/orient.md",
+      "Projects/_op-import-history/20260426-120000-000.bak/Projects/_op-modules/orient.md",
     );
     expect(state.files.get(result.backupPath!)?.raw).toBe("previous version");
   });
@@ -286,5 +286,38 @@ describe("commitImport", () => {
     await expect(
       commitImport(app, settings, async () => {}, { prepared }),
     ).rejects.toThrow(/missing answer for var\(s\): tone/);
+  });
+
+  it("lands prompted vars at global scope even when the module has a project: field (scope bug guard)", async () => {
+    // A per-project module imported globally: rewrittenProject is set (it
+    // mirrors the module's project: field for the landing frontmatter), but
+    // prompted vars MUST still land in workflowVars, not in a STATUS.md.
+    const importPath = "Projects/_op-export/orient.md";
+    const bundleWithProject = moduleBundle({ project: "some-project" });
+    const { app, state } = fakeApp([{ path: importPath, raw: bundleWithProject }]);
+    const settings = baseSettings();
+    const prepared = await prepareImport(app, settings, {
+      sourcePath: importPath,
+      targetScope: "global", // ← importing globally despite module.project being set
+    });
+    // Sanity: the plan preserves the module's project: in rewrittenProject but
+    // still targets the global path.
+    expect(prepared.plan.rewrittenProject).toBe("some-project");
+    expect(prepared.plan.targetPath).toBe("Projects/_op-modules/orient.md");
+    expect(prepared.plan.targetScope).toBe("global");
+
+    const result = await commitImport(app, settings, async () => {}, {
+      prepared,
+      varAnswers: { tone: "loud" },
+      now: () => new Date(2026, 3, 26, 12, 0, 0),
+    });
+    // Var must land in global workflowVars, NOT in a project STATUS.md.
+    expect(settings.workflowVars).toEqual({ tone: "loud" });
+    expect(state.varsByStatus.size).toBe(0);
+    // Transaction record must reflect global scope for the var.
+    const tx = JSON.parse(state.files.get(result.transactionPath)!.raw);
+    expect(tx.varsWritten).toEqual([
+      { name: "tone", value: "loud", scopeKind: "global", preexisting: false },
+    ]);
   });
 });

--- a/plugins/op-obsidian/src/importModule.test.ts
+++ b/plugins/op-obsidian/src/importModule.test.ts
@@ -1,0 +1,290 @@
+import { describe, it, expect, vi } from "vitest";
+import { parse as parseYaml } from "yaml";
+
+vi.mock("obsidian", () => {
+  class TFile {
+    path = "";
+    basename = "";
+    name = "";
+  }
+  return {
+    TFile,
+    normalizePath: (p: string) => p.replace(/\/+/g, "/"),
+    parseYaml: (yaml: string) => parseYaml(yaml),
+  };
+});
+
+import { TFile } from "obsidian";
+import { commitImport, prepareImport } from "./importModule";
+import type { OpSettings } from "./settingsPure";
+
+interface FakeFile {
+  path: string;
+  raw: string;
+  frontmatter?: Record<string, unknown> | null;
+}
+
+interface FakeState {
+  files: Map<string, FakeFile>;
+  folders: Set<string>;
+  varsByStatus: Map<string, Record<string, string>>;
+}
+
+function tfile(path: string): TFile {
+  const f = new TFile();
+  const basename = path.split("/").pop()!.replace(/\.md$/, "");
+  Object.assign(f, { path, basename, name: `${basename}.md` });
+  return f;
+}
+
+function fakeApp(initial: FakeFile[] = []) {
+  const state: FakeState = {
+    files: new Map(initial.map((f) => [f.path, f])),
+    folders: new Set(),
+    varsByStatus: new Map(),
+  };
+
+  const app = {
+    vault: {
+      getMarkdownFiles: () => [...state.files.values()].map((f) => tfile(f.path)),
+      getAbstractFileByPath: (p: string) => {
+        if (state.files.has(p)) return tfile(p);
+        if (state.folders.has(p)) return { path: p };
+        return null;
+      },
+      read: async (file: TFile) => {
+        const f = state.files.get(file.path);
+        if (!f) throw new Error(`fake vault: no file at ${file.path}`);
+        return f.raw;
+      },
+      create: async (path: string, content: string) => {
+        if (state.files.has(path)) throw new Error(`fake vault: ${path} already exists`);
+        state.files.set(path, { path, raw: content });
+        return tfile(path);
+      },
+      modify: async (file: TFile, content: string) => {
+        const f = state.files.get(file.path);
+        if (!f) throw new Error(`fake vault: no file at ${file.path}`);
+        f.raw = content;
+      },
+      createFolder: async (path: string) => {
+        state.folders.add(path);
+      },
+    },
+    metadataCache: {
+      getFileCache: (file: TFile) => {
+        // Used by readProjectVars — return the persisted vars map.
+        const path = file.path;
+        if (!path.endsWith("/STATUS.md")) return null;
+        const vars = state.varsByStatus.get(path);
+        return vars ? { frontmatter: { vars: { ...vars } } } : { frontmatter: {} };
+      },
+    },
+    fileManager: {
+      processFrontMatter: async (
+        file: TFile,
+        mutator: (fm: Record<string, unknown>) => void,
+      ) => {
+        const fmInitial: Record<string, unknown> = state.varsByStatus.has(file.path)
+          ? { vars: { ...state.varsByStatus.get(file.path)! } }
+          : {};
+        mutator(fmInitial);
+        if (fmInitial.vars && typeof fmInitial.vars === "object") {
+          state.varsByStatus.set(file.path, { ...(fmInitial.vars as Record<string, string>) });
+        }
+      },
+    },
+  } as any;
+
+  return { app, state };
+}
+
+const baseSettings = (): OpSettings =>
+  ({
+    workflowVars: {} as Record<string, string>,
+    // Other fields aren't read by the import path; cast through any.
+  }) as unknown as OpSettings;
+
+const moduleBundle = (over: Record<string, unknown> = {}, body = "Hi {{vars.tone}}!\n") =>
+  [
+    "---",
+    "id: orient",
+    "title: Orient",
+    "type: workflow-module",
+    "scope: kickoff",
+    ...Object.entries(over).map(([k, v]) =>
+      typeof v === "string" ? `${k}: ${v}` : `${k}: ${JSON.stringify(v)}`,
+    ),
+    "vars:",
+    "  - tone=concise",
+    "---",
+    "",
+    body,
+  ].join("\n");
+
+describe("prepareImport", () => {
+  it("plans a fresh global import that needs the tone prompt", async () => {
+    const importPath = "Projects/_op-export/orient.md";
+    const { app } = fakeApp([{ path: importPath, raw: moduleBundle() }]);
+    const prepared = await prepareImport(app, baseSettings(), {
+      sourcePath: importPath,
+      targetScope: "global",
+    });
+    expect(prepared.module.id).toBe("orient");
+    expect(prepared.plan.targetPath).toBe("Projects/_op-modules/orient.md");
+    expect(prepared.plan.promptsNeeded.map((p) => p.name)).toEqual(["tone"]);
+    expect(prepared.plan.promptsNeeded[0].prefill).toBe("concise");
+  });
+
+  it("rewrites project: when scope=project + slug differs from source", async () => {
+    const importPath = "Projects/_op-export/orient.md";
+    const { app } = fakeApp([
+      { path: importPath, raw: moduleBundle({ project: "old-slug" }) },
+      { path: "Projects/new-slug/STATUS.md", raw: "---\n---\n" },
+    ]);
+    const prepared = await prepareImport(app, baseSettings(), {
+      sourcePath: importPath,
+      targetScope: "project",
+      targetProjectSlug: "new-slug",
+    });
+    expect(prepared.plan.originalProject).toBe("old-slug");
+    expect(prepared.plan.rewrittenProject).toBe("new-slug");
+    expect(prepared.plan.targetPath).toBe("Projects/new-slug/MODULES/orient.md");
+  });
+
+  it("flags an existing-target overwrite", async () => {
+    const importPath = "Projects/_op-export/orient.md";
+    const { app } = fakeApp([
+      { path: importPath, raw: moduleBundle() },
+      { path: "Projects/_op-modules/orient.md", raw: "old" },
+    ]);
+    const prepared = await prepareImport(app, baseSettings(), {
+      sourcePath: importPath,
+      targetScope: "global",
+    });
+    expect(prepared.plan.overwrite).toBe(true);
+    expect(prepared.plan.backupRelPath).toBe("Projects/_op-modules/orient.md");
+  });
+
+  it("throws when the source can't be parsed as a workflow module", async () => {
+    const { app } = fakeApp([
+      { path: "Projects/_op-export/junk.md", raw: "no frontmatter\n" },
+    ]);
+    await expect(
+      prepareImport(app, baseSettings(), {
+        sourcePath: "Projects/_op-export/junk.md",
+        targetScope: "global",
+      }),
+    ).rejects.toThrow(/failed to parse/);
+  });
+});
+
+describe("commitImport", () => {
+  it("writes the module, sets the var, and appends a transaction record", async () => {
+    const importPath = "Projects/_op-export/orient.md";
+    const { app, state } = fakeApp([{ path: importPath, raw: moduleBundle() }]);
+    const settings = baseSettings();
+    const prepared = await prepareImport(app, settings, {
+      sourcePath: importPath,
+      targetScope: "global",
+    });
+    const result = await commitImport(app, settings, async () => {}, {
+      prepared,
+      varAnswers: { tone: "loud" },
+      now: () => new Date(2026, 3, 26, 12, 0, 0),
+    });
+    expect(result.targetPath).toBe("Projects/_op-modules/orient.md");
+    expect(result.transactionPath).toBe(
+      "Projects/_op-import-history/20260426-120000.json",
+    );
+    expect(state.files.has("Projects/_op-modules/orient.md")).toBe(true);
+    expect(state.files.has(result.transactionPath)).toBe(true);
+    expect(settings.workflowVars).toEqual({ tone: "loud" });
+    const tx = JSON.parse(state.files.get(result.transactionPath)!.raw);
+    expect(tx.varsWritten).toEqual([
+      { name: "tone", value: "loud", scopeKind: "global", preexisting: false },
+    ]);
+    expect(tx.modulesLanded[0].overwrote).toBe(false);
+  });
+
+  it("backs up an existing target before overwriting", async () => {
+    const importPath = "Projects/_op-export/orient.md";
+    const { app, state } = fakeApp([
+      { path: importPath, raw: moduleBundle() },
+      { path: "Projects/_op-modules/orient.md", raw: "previous version" },
+    ]);
+    const settings = baseSettings();
+    const prepared = await prepareImport(app, settings, {
+      sourcePath: importPath,
+      targetScope: "global",
+    });
+    const result = await commitImport(app, settings, async () => {}, {
+      prepared,
+      varAnswers: { tone: "loud" },
+      now: () => new Date(2026, 3, 26, 12, 0, 0),
+    });
+    expect(result.overwrote).toBe(true);
+    expect(result.backupPath).toBe(
+      "Projects/_op-import-history/20260426-120000.bak/Projects/_op-modules/orient.md",
+    );
+    expect(state.files.get(result.backupPath!)?.raw).toBe("previous version");
+  });
+
+  it("writes per-project vars into STATUS.md via processFrontMatter", async () => {
+    const importPath = "Projects/_op-export/orient.md";
+    const { app, state } = fakeApp([
+      { path: importPath, raw: moduleBundle() },
+      { path: "Projects/foo/STATUS.md", raw: "---\n---\n" },
+    ]);
+    const settings = baseSettings();
+    const prepared = await prepareImport(app, settings, {
+      sourcePath: importPath,
+      targetScope: "project",
+      targetProjectSlug: "foo",
+    });
+    await commitImport(app, settings, async () => {}, {
+      prepared,
+      varAnswers: { tone: "concise" },
+      now: () => new Date(2026, 3, 26, 12, 0, 0),
+    });
+    expect(state.varsByStatus.get("Projects/foo/STATUS.md")).toEqual({ tone: "concise" });
+    // global settings unchanged
+    expect(settings.workflowVars).toEqual({});
+  });
+
+  it("preserves preexisting higher-precedence vars (recorded but not rewritten)", async () => {
+    const importPath = "Projects/_op-export/orient.md";
+    const { app, state } = fakeApp([
+      { path: importPath, raw: moduleBundle() },
+    ]);
+    const settings = baseSettings();
+    settings.workflowVars = { tone: "already-set" };
+    const prepared = await prepareImport(app, settings, {
+      sourcePath: importPath,
+      targetScope: "global",
+    });
+    expect(prepared.plan.promptsNeeded).toEqual([]);
+    const result = await commitImport(app, settings, async () => {}, {
+      prepared,
+      now: () => new Date(2026, 3, 26, 12, 0, 0),
+    });
+    expect(settings.workflowVars).toEqual({ tone: "already-set" });
+    const tx = JSON.parse(state.files.get(result.transactionPath)!.raw);
+    expect(tx.varsWritten).toEqual([
+      { name: "tone", value: "already-set", scopeKind: "global", preexisting: true },
+    ]);
+  });
+
+  it("aborts when an answer is missing for a needed prompt", async () => {
+    const importPath = "Projects/_op-export/orient.md";
+    const { app } = fakeApp([{ path: importPath, raw: moduleBundle() }]);
+    const settings = baseSettings();
+    const prepared = await prepareImport(app, settings, {
+      sourcePath: importPath,
+      targetScope: "global",
+    });
+    await expect(
+      commitImport(app, settings, async () => {}, { prepared }),
+    ).rejects.toThrow(/missing answer for var\(s\): tone/);
+  });
+});

--- a/plugins/op-obsidian/src/importModule.ts
+++ b/plugins/op-obsidian/src/importModule.ts
@@ -270,7 +270,7 @@ export async function commitImport(
     const w: PlannedVarWrite = pickPromptScope({
       name: p.name,
       value,
-      targetScope: prepared.plan.rewrittenProject ? "project" : "global",
+      targetScope: prepared.plan.targetScope,
       slug: prepared.plan.rewrittenProject ?? undefined,
     });
     await applyVarWrite(app, settings, w);

--- a/plugins/op-obsidian/src/importModule.ts
+++ b/plugins/op-obsidian/src/importModule.ts
@@ -1,0 +1,468 @@
+import { App, TFile, normalizePath, parseYaml } from "obsidian";
+import { promises as fs } from "fs";
+import { isAbsolute } from "path";
+import type { OpSettings } from "./settingsPure";
+import {
+  ImportPlan,
+  ImportScopeKind,
+  PlannedVarWrite,
+  TransactionRecord,
+  TRANSACTION_HISTORY_DIR,
+  TRANSACTION_VERSION,
+  parseImportFile,
+  planImport,
+  serializeTransaction,
+  transactionFilename,
+} from "./exportImportPure";
+import type { WorkflowModule, VarDecl } from "./workflowModulePure";
+
+/**
+ * Read the per-project vars map from `Projects/<slug>/STATUS.md`. Equivalent
+ * to `explainWorkflow.ts:readProjectVars` but inlined here so this module
+ * doesn't transitively pull `openAgent.ts` → `modals.ts` (Modal class) into
+ * a vitest run that mocks `obsidian` minimally.
+ */
+function readProjectVars(app: App, project: string): Record<string, string> {
+  const statusPath = `Projects/${project}/STATUS.md`;
+  const file = app.vault.getAbstractFileByPath(statusPath);
+  if (!(file instanceof TFile)) return {};
+  const fm = app.metadataCache.getFileCache(file)?.frontmatter;
+  if (!fm || typeof fm !== "object") return {};
+  const raw = (fm as Record<string, unknown>).vars;
+  if (!raw || typeof raw !== "object" || Array.isArray(raw)) return {};
+  const out: Record<string, string> = {};
+  for (const [k, v] of Object.entries(raw as Record<string, unknown>)) {
+    if (typeof v === "string") out[k] = v;
+  }
+  return out;
+}
+
+// IO seam for `op-import-module` (OP-187 / Child 4 of OP-181). Two stages:
+//
+//   1. `prepareImport`  — parse the source file, plan the import. No vault
+//                         mutation. Used by URI/CLI to return needs-input
+//                         payloads when scope/project/vars haven't been
+//                         supplied, and by the palette modal flow to drive
+//                         per-var prompts.
+//   2. `commitImport`   — execute the planned writes: backup any existing
+//                         module file, write the new module, write var
+//                         answers to the appropriate scope, append a
+//                         transaction record. Atomicity-best-effort: writes
+//                         are sequenced so a mid-flow failure leaves the
+//                         transaction record absent (so undo refuses to
+//                         touch a half-import — the user fixes and re-runs).
+
+export interface ImportSourceResolved {
+  /** Caller-supplied path. Recorded in the transaction record. */
+  originalPath: string;
+  /** Vault-relative path of the source if it lives in the vault, else null. */
+  vaultPath: string | null;
+  /** Raw file content. */
+  raw: string;
+}
+
+export interface PreparedImport {
+  source: ImportSourceResolved;
+  module: WorkflowModule;
+  body: string;
+  plan: ImportPlan;
+  /** Surface-level diagnostics from parseImportFile (warnings + errors). */
+  diagnostics: ReturnType<typeof parseImportFile>["diagnostics"];
+}
+
+export interface PrepareImportArgs {
+  /** Vault-relative or absolute path to the import bundle file. */
+  sourcePath: string;
+  /** Where the import lands. */
+  targetScope: ImportScopeKind;
+  /** Required when `targetScope === "project"`. */
+  targetProjectSlug?: string;
+  /** Pre-supplied var answers (URI / CLI param `var.<name>=<value>`). */
+  varAnswers?: Record<string, string>;
+  /**
+   * Test seam: read raw file content. Defaults to vault-or-fs read using
+   * the live `app`.
+   */
+  readFile?: (sourcePath: string) => Promise<ImportSourceResolved>;
+}
+
+/**
+ * Stage 1: read + parse + plan. No vault mutation.
+ *
+ * Throws on hard input errors (file unreadable, frontmatter unparseable,
+ * scope=project without slug). Soft errors (unknown var refs, etc.) flow
+ * through `prepared.diagnostics`.
+ */
+export async function prepareImport(
+  app: App,
+  settings: OpSettings,
+  args: PrepareImportArgs,
+): Promise<PreparedImport> {
+  const reader = args.readFile ?? ((p) => readImportSource(app, p));
+  const source = await reader(args.sourcePath);
+
+  const parsed = parseImportFile({
+    sourcePath: source.originalPath,
+    raw: source.raw,
+    parseFrontmatter: (block) => {
+      try {
+        const out = parseYaml(block);
+        return out && typeof out === "object" && !Array.isArray(out)
+          ? (out as Record<string, unknown>)
+          : null;
+      } catch {
+        return null;
+      }
+    },
+  });
+
+  if (!parsed.module) {
+    const first = parsed.diagnostics[0];
+    throw new Error(
+      `op-import-module: failed to parse ${source.originalPath} as a workflow module: ${first?.message ?? "unknown error"}`,
+    );
+  }
+
+  if (args.targetScope === "project" && !args.targetProjectSlug?.trim()) {
+    throw new Error(
+      "op-import-module: targetProjectSlug is required when targetScope=project",
+    );
+  }
+
+  const targetPath =
+    args.targetScope === "global"
+      ? `Projects/_op-modules/${parsed.module.id}.md`
+      : `Projects/${args.targetProjectSlug!.trim()}/MODULES/${parsed.module.id}.md`;
+
+  const existing = app.vault.getAbstractFileByPath(normalizePath(targetPath));
+  const existingTargetPath = existing instanceof TFile ? existing.path : undefined;
+
+  const projectVars =
+    args.targetScope === "project" && args.targetProjectSlug
+      ? readProjectVars(app, args.targetProjectSlug.trim())
+      : {};
+
+  const planArgs: Parameters<typeof planImport>[0] = {
+    module: parsed.module,
+    body: parsed.body,
+    targetScope: args.targetScope,
+    globalVars: settings.workflowVars,
+    projectVars,
+  };
+  if (args.targetProjectSlug) planArgs.targetProjectSlug = args.targetProjectSlug;
+  if (args.varAnswers) planArgs.varAnswers = args.varAnswers;
+  if (existingTargetPath) planArgs.existingTargetPath = existingTargetPath;
+  const plan = planImport(planArgs);
+
+  return {
+    source,
+    module: parsed.module,
+    body: parsed.body,
+    plan,
+    diagnostics: parsed.diagnostics,
+  };
+}
+
+export interface CommitImportArgs {
+  prepared: PreparedImport;
+  /**
+   * Final var answers (must cover every `prepared.plan.promptsNeeded.name`
+   * not also covered by `prepared.plan.varsToWrite`). Empty string is a
+   * valid answer; `undefined` means "skipped" and aborts the commit.
+   */
+  varAnswers?: Record<string, string>;
+  /** Test seam: clock for the transaction filename. Defaults to `new Date()`. */
+  now?: () => Date;
+}
+
+export interface ImportResult {
+  /** Vault-relative path of the transaction record. */
+  transactionPath: string;
+  /** Vault-relative path the module landed at. */
+  targetPath: string;
+  scopeKind: ImportScopeKind;
+  projectSlug?: string;
+  /** Whether an existing file at the target was overwritten + backed up. */
+  overwrote: boolean;
+  /** Vault-relative path of the backup (set iff overwrote=true). */
+  backupPath?: string;
+  /** Vars written to settings/STATUS at land time. */
+  varsWritten: PlannedVarWrite[];
+}
+
+/**
+ * Stage 2: execute the planned writes.
+ *
+ * Strict guard on missing answers. The plan already split prompts vs auto-
+ * fills; the caller must supply an answer for every `promptsNeeded` row
+ * (whatever the user typed in the modal, or whatever the URI/CLI passed via
+ * `var.<name>=`). Skipping is a hard error — partial state is the worst-of-
+ * all-worlds outcome.
+ */
+export async function commitImport(
+  app: App,
+  settings: OpSettings,
+  saveSettings: () => Promise<void>,
+  args: CommitImportArgs,
+): Promise<ImportResult> {
+  const { prepared } = args;
+  const answers = args.varAnswers ?? {};
+  const now = args.now ?? (() => new Date());
+
+  const missing = prepared.plan.promptsNeeded.filter(
+    (p) => !Object.prototype.hasOwnProperty.call(answers, p.name),
+  );
+  if (missing.length > 0) {
+    throw new Error(
+      `op-import-module: missing answer for var(s): ${missing.map((m) => m.name).join(", ")}`,
+    );
+  }
+
+  const date = now();
+  const tsFilename = transactionFilename(date);
+  const backupRoot = `${TRANSACTION_HISTORY_DIR}/${tsFilename}.bak`;
+  const transactionPath = `${TRANSACTION_HISTORY_DIR}/${tsFilename}.json`;
+
+  await ensureFolder(app, TRANSACTION_HISTORY_DIR);
+
+  // 1. Back up an existing file at the target, if any.
+  let backupPath: string | undefined;
+  if (prepared.plan.overwrite && prepared.plan.backupRelPath) {
+    const original = app.vault.getAbstractFileByPath(
+      normalizePath(prepared.plan.backupRelPath),
+    );
+    if (original instanceof TFile) {
+      const originalContent = await app.vault.read(original);
+      backupPath = `${backupRoot}/${prepared.plan.backupRelPath}`;
+      await ensureFolderRecursive(app, backupPath.slice(0, backupPath.lastIndexOf("/")));
+      await app.vault.create(normalizePath(backupPath), originalContent);
+    }
+  }
+
+  // 2. Write the module file (creating parent folders if needed).
+  const targetPath = normalizePath(prepared.plan.targetPath);
+  await ensureFolderRecursive(app, targetPath.slice(0, targetPath.lastIndexOf("/")));
+  const newContent = serializeModuleForLanding({
+    module: prepared.module,
+    body: prepared.body,
+    rewrittenProject: prepared.plan.rewrittenProject,
+  });
+  const existingTarget = app.vault.getAbstractFileByPath(targetPath);
+  if (existingTarget instanceof TFile) {
+    await app.vault.modify(existingTarget, newContent);
+  } else {
+    await app.vault.create(targetPath, newContent);
+  }
+
+  // 3. Write var answers — promptsNeeded + planned writes that weren't
+  //    pre-existing — to the appropriate scope.
+  const varsToCommit: PlannedVarWrite[] = [];
+  for (const w of prepared.plan.varsToWrite) {
+    if (w.preexisting) {
+      varsToCommit.push(w); // recorded for traceability; no write
+      continue;
+    }
+    await applyVarWrite(app, settings, w);
+    varsToCommit.push(w);
+  }
+  for (const p of prepared.plan.promptsNeeded) {
+    const value = answers[p.name];
+    const w: PlannedVarWrite = pickPromptScope({
+      name: p.name,
+      value,
+      targetScope: prepared.plan.rewrittenProject ? "project" : "global",
+      slug: prepared.plan.rewrittenProject ?? undefined,
+    });
+    await applyVarWrite(app, settings, w);
+    varsToCommit.push(w);
+  }
+  await saveSettings();
+
+  // 4. Append the transaction record (last so undo never sees a half-import).
+  const record: TransactionRecord = {
+    version: TRANSACTION_VERSION,
+    timestamp: date.toISOString(),
+    command: "op-import-module",
+    modulesLanded: [
+      {
+        sourcePath: prepared.source.originalPath,
+        targetPath: prepared.plan.targetPath,
+        scopeKind: prepared.plan.rewrittenProject ? "project" : "global",
+        ...(prepared.plan.rewrittenProject
+          ? { projectSlug: prepared.plan.rewrittenProject }
+          : {}),
+        originalProject: prepared.plan.originalProject,
+        rewrittenProject: prepared.plan.rewrittenProject,
+        overwrote: !!prepared.plan.overwrite,
+        ...(backupPath ? { backupPath } : {}),
+      },
+    ],
+    varsWritten: varsToCommit,
+  };
+  await app.vault.create(normalizePath(transactionPath), serializeTransaction(record));
+
+  const out: ImportResult = {
+    transactionPath,
+    targetPath: prepared.plan.targetPath,
+    scopeKind: prepared.plan.rewrittenProject ? "project" : "global",
+    overwrote: !!prepared.plan.overwrite,
+    varsWritten: varsToCommit,
+  };
+  if (prepared.plan.rewrittenProject) out.projectSlug = prepared.plan.rewrittenProject;
+  if (backupPath) out.backupPath = backupPath;
+  return out;
+}
+
+function pickPromptScope(args: {
+  name: string;
+  value: string;
+  targetScope: ImportScopeKind;
+  slug?: string;
+}): PlannedVarWrite {
+  const { name, value, targetScope, slug } = args;
+  if (targetScope === "project" && slug) {
+    return {
+      name,
+      value,
+      scopeKind: "project",
+      projectSlug: slug,
+      preexisting: false,
+    };
+  }
+  return { name, value, scopeKind: "global", preexisting: false };
+}
+
+async function applyVarWrite(
+  app: App,
+  settings: OpSettings,
+  w: PlannedVarWrite,
+): Promise<void> {
+  if (w.scopeKind === "global") {
+    settings.workflowVars[w.name] = w.value;
+    return;
+  }
+  // project scope — write into Projects/<slug>/STATUS.md `vars:` map.
+  if (!w.projectSlug) {
+    throw new Error(`applyVarWrite: project-scope write missing projectSlug for ${w.name}`);
+  }
+  const statusPath = normalizePath(`Projects/${w.projectSlug}/STATUS.md`);
+  const file = app.vault.getAbstractFileByPath(statusPath);
+  if (!(file instanceof TFile)) {
+    throw new Error(
+      `op-import-module: cannot write project var ${w.name} — ${statusPath} is missing.`,
+    );
+  }
+  await app.fileManager.processFrontMatter(file, (fm: Record<string, unknown>) => {
+    const existing = fm.vars;
+    const map: Record<string, string> =
+      existing && typeof existing === "object" && !Array.isArray(existing)
+        ? { ...(existing as Record<string, string>) }
+        : {};
+    map[w.name] = w.value;
+    fm.vars = map;
+  });
+}
+
+/**
+ * Re-serialize the module for landing. Strips the import-source frontmatter,
+ * injects the rewritten `project:`, preserves every other declared field.
+ * Re-uses the same canonical formatting as the export path.
+ */
+function serializeModuleForLanding(args: {
+  module: WorkflowModule;
+  body: string;
+  rewrittenProject: string | null;
+}): string {
+  // Reuse formatExportFile via dynamic import would create a cycle; instead
+  // build the same output here. Mirrors `formatExportFile`'s frontmatter
+  // ordering exactly so a round-trip is identical.
+  const { module, body, rewrittenProject } = args;
+  const lines: string[] = [];
+  lines.push("---");
+  lines.push(`id: ${module.id}`);
+  lines.push(`title: ${quoteYaml(module.title)}`);
+  lines.push("type: workflow-module");
+  lines.push(`scope: ${quoteYaml(module.scope)}`);
+  if (rewrittenProject !== null && rewrittenProject !== "") {
+    lines.push(`project: ${quoteYaml(rewrittenProject)}`);
+  }
+  if (module.agent) lines.push(`agent: ${quoteYaml(module.agent)}`);
+  if (module.order !== 0) lines.push(`order: ${module.order}`);
+  if (module.vars.length > 0) {
+    lines.push("vars:");
+    for (const decl of module.vars) {
+      lines.push(`  - ${formatDecl(decl)}`);
+    }
+  }
+  lines.push("---");
+  lines.push("");
+  lines.push(body.replace(/\s+$/, ""));
+  lines.push("");
+  return lines.join("\n");
+}
+
+function formatDecl(d: VarDecl): string {
+  if (d.kind === "bare") return d.name;
+  if (d.kind === "default") return `${d.name}=${d.value}`;
+  const f: string[] = [`name: ${quoteYaml(d.name)}`];
+  if (d.default !== undefined) f.push(`default: ${quoteYaml(d.default)}`);
+  if (d.description !== undefined) f.push(`description: ${quoteYaml(d.description)}`);
+  return `{ ${f.join(", ")} }`;
+}
+
+function quoteYaml(value: string): string {
+  if (value === "") return '""';
+  const needsQuote =
+    /^[?\-:!*&|>%@`#]/.test(value) ||
+    /[:#\n\r\t"'\\{}\[\],&*!|>%@?]/.test(value) ||
+    /^(?:true|false|null|yes|no|on|off|~)$/i.test(value) ||
+    /^-?\d/.test(value) ||
+    value.startsWith(" ") ||
+    value.endsWith(" ");
+  if (!needsQuote) return value;
+  return `"${value.replace(/\\/g, "\\\\").replace(/"/g, '\\"')}"`;
+}
+
+async function ensureFolder(app: App, path: string): Promise<void> {
+  const norm = normalizePath(path);
+  if (!app.vault.getAbstractFileByPath(norm)) {
+    await app.vault.createFolder(norm);
+  }
+}
+
+async function ensureFolderRecursive(app: App, path: string): Promise<void> {
+  if (!path) return;
+  const norm = normalizePath(path);
+  const parts = norm.split("/");
+  let cumulative = "";
+  for (const part of parts) {
+    if (!part) continue;
+    cumulative = cumulative ? `${cumulative}/${part}` : part;
+    if (!app.vault.getAbstractFileByPath(cumulative)) {
+      await app.vault.createFolder(cumulative);
+    }
+  }
+}
+
+async function readImportSource(
+  app: App,
+  sourcePath: string,
+): Promise<ImportSourceResolved> {
+  // Prefer a vault file (covers vault-relative paths and absolute paths that
+  // happen to live inside the vault). Fall back to fs for absolute paths.
+  const vaultRelative = sourcePath.startsWith("/") ? null : normalizePath(sourcePath);
+  if (vaultRelative) {
+    const file = app.vault.getAbstractFileByPath(vaultRelative);
+    if (file instanceof TFile) {
+      const raw = await app.vault.read(file);
+      return { originalPath: sourcePath, vaultPath: file.path, raw };
+    }
+  }
+  if (isAbsolute(sourcePath)) {
+    const raw = await fs.readFile(sourcePath, "utf8");
+    return { originalPath: sourcePath, vaultPath: null, raw };
+  }
+  throw new Error(
+    `op-import-module: cannot read ${sourcePath} — not found in vault, and not an absolute filesystem path.`,
+  );
+}

--- a/plugins/op-obsidian/src/main.ts
+++ b/plugins/op-obsidian/src/main.ts
@@ -100,6 +100,8 @@ import {
   parseGetSkillParams,
   parseExplainWorkflowParams,
   parseListVarsParams,
+  parseExportModuleParams,
+  parseImportModuleParams,
 } from "./cliHandlers";
 import { explainWorkflow, listVars } from "./explainWorkflow";
 import {
@@ -115,6 +117,9 @@ import { readLaunchVarsFromFrontmatter } from "./varOverridePanelPure";
 import { openLaunchAgentModal } from "./launchAgentModal";
 import { editWorkflow } from "./editWorkflow";
 import { editModule } from "./editModule";
+import { exportModules } from "./exportModule";
+import { commitImport, prepareImport } from "./importModule";
+import { undoLastImport } from "./undoLastImport";
 import { loadModules } from "./workflowModule";
 import { loadWorkflowFile } from "./workflowFile";
 import {
@@ -742,6 +747,25 @@ export default class OpPlugin extends Plugin {
       callback: () => this.runEditModuleCommand(),
     });
 
+    // OP-187: export / import / undo last import.
+    this.addCommand({
+      id: "op-export-module",
+      name: "op: export workflow module(s)",
+      callback: () => void this.runExportModuleCommand(),
+    });
+
+    this.addCommand({
+      id: "op-import-module",
+      name: "op: import workflow module",
+      callback: () => void this.runImportModuleCommand(),
+    });
+
+    this.addCommand({
+      id: "op-undo-last-import",
+      name: "op: undo last workflow-module import",
+      callback: () => void this.runUndoLastImportCommand(),
+    });
+
     // OP-205 (3e): proactive recovery surface — open the dialog without an
     // in-flight launch. Resolves a project, reads its WORKFLOW.md, finds the
     // first bad-model diagnostic, and renders the same modal in advisory
@@ -974,6 +998,24 @@ export default class OpPlugin extends Plugin {
     this.registerObsidianProtocolHandler("op-edit-module", (params) => {
       this.runUri("op-edit-module", normalizeUriParams(params), (p) =>
         this.handleOpEditModuleUri(p),
+      );
+    });
+
+    this.registerObsidianProtocolHandler("op-export-module", (params) => {
+      this.runUri("op-export-module", normalizeUriParams(params), (p) =>
+        this.handleOpExportModuleUri(p),
+      );
+    });
+
+    this.registerObsidianProtocolHandler("op-import-module", (params) => {
+      this.runUri("op-import-module", normalizeUriParams(params), (p) =>
+        this.handleOpImportModuleUri(p),
+      );
+    });
+
+    this.registerObsidianProtocolHandler("op-undo-last-import", (params) => {
+      this.runUri("op-undo-last-import", normalizeUriParams(params), () =>
+        this.handleOpUndoLastImportUri(),
       );
     });
 
@@ -1248,6 +1290,60 @@ export default class OpPlugin extends Plugin {
         },
       },
       (params) => this.handleOpEditModuleCli(params),
+    );
+
+    this.registerCliHandler(
+      "op-export-module",
+      "Export workflow module(s) to Projects/_op-export/. Pass --id <id> for a single module or --project <slug> to bundle all modules visible to that project.",
+      {
+        id: { value: "<id>", description: "Module id (filename basename, no .md). Single-module mode." },
+        project: {
+          value: "<slug>",
+          description:
+            "Project slug. Bundle mode — exports per-project modules + globals carrying that project: tag.",
+        },
+      },
+      (params) => this.handleOpExportModuleCli(params),
+    );
+
+    this.registerCliHandler(
+      "op-import-module",
+      "Import a workflow module from a vault path or absolute filesystem path. Bootstraps missing vars at the chosen scope; backs up any existing target file; writes a transaction record under Projects/_op-import-history/.",
+      {
+        path: {
+          value: "<path>",
+          description:
+            "Vault-relative or absolute path to the bundle file (the .md emitted by op-export-module).",
+        },
+        scope: {
+          value: "<global|project>",
+          description:
+            "Where the module lands. Default: derive from the bundle's project: field (present → project, absent → global).",
+        },
+        project: {
+          value: "<slug>",
+          description:
+            "Project slug. Required when --scope=project; rewrites the bundle's project: field to this value.",
+        },
+        vars: {
+          value: "<name=value\\nname=value>",
+          description:
+            "Packed var answers (newline- or comma-separated). One answer per missing var; empty string is a valid answer.",
+        },
+        "var.<name>": {
+          value: "<value>",
+          description:
+            "Per-var answer (alternative to packed --vars). Use one --var.<name>=<value> per missing var.",
+        },
+      },
+      (params) => this.handleOpImportModuleCli(params),
+    );
+
+    this.registerCliHandler(
+      "op-undo-last-import",
+      "Reverse the most recent op-import-module transaction (one-step undo only).",
+      {},
+      () => this.handleOpUndoLastImportCli(),
     );
 
     this.registerCliHandler(
@@ -3582,6 +3678,298 @@ export default class OpPlugin extends Plugin {
     } catch (err: any) {
       console.error("[op-obsidian] op-edit-module failed", err);
       notify(`op-edit-module failed: ${err?.message ?? err}`);
+    }
+  }
+
+  // -------------------------------------------------------------------------
+  // OP-187 export / import / undo
+  // -------------------------------------------------------------------------
+
+  /**
+   * Palette entry point for op-export-module. Wraps the active project's
+   * working dir as a hint when one is active, otherwise prompts the user via
+   * a tiny modal for `id=<id>` or `project=<slug>`.
+   */
+  private async runExportModuleCommand(): Promise<void> {
+    const { ExportModulePromptModal } = await import("./modals");
+    new ExportModulePromptModal(this.app, async (args) => {
+      try {
+        const result = await exportModules(this.app, args);
+        const summary = result.files.map((f) => f.exportPath).join(", ");
+        notify(
+          `op-export-module: wrote ${result.files.length} file${result.files.length === 1 ? "" : "s"} → ${summary}`,
+        );
+        await writeUriResponse(this.app, {
+          ok: true,
+          command: "op-export-module",
+          mode: args.kind,
+          files: result.files,
+        });
+      } catch (err: any) {
+        console.error("[op-obsidian] op-export-module failed", err);
+        notify(`op-export-module failed: ${err?.message ?? err}`);
+      }
+    }).open();
+  }
+
+  /**
+   * Palette entry point for op-import-module. Prompts for the path + scope,
+   * then for each missing var (one inline prompt with the module-default
+   * pre-filled), then commits.
+   */
+  private async runImportModuleCommand(): Promise<void> {
+    const { ImportModulePromptModal, ImportVarPromptModal } = await import("./modals");
+    new ImportModulePromptModal(this.app, async (input) => {
+      try {
+        const prepared = await prepareImport(this.app, this.settings, {
+          sourcePath: input.sourcePath,
+          targetScope: input.scope,
+          ...(input.projectSlug ? { targetProjectSlug: input.projectSlug } : {}),
+        });
+        const answers: Record<string, string> = {};
+        for (const prompt of prepared.plan.promptsNeeded) {
+          const answer = await new Promise<string | undefined>((resolve) => {
+            new ImportVarPromptModal(this.app, prompt, resolve).open();
+          });
+          if (answer === undefined) {
+            notify("op-import-module: cancelled — no module landed.");
+            return;
+          }
+          answers[prompt.name] = answer;
+        }
+        const result = await commitImport(
+          this.app,
+          this.settings,
+          () => this.saveSettings(),
+          { prepared, varAnswers: answers },
+        );
+        notify(
+          `op-import-module: ${result.targetPath} (${result.varsWritten.length} var${result.varsWritten.length === 1 ? "" : "s"}; tx ${result.transactionPath})`,
+        );
+        await writeUriResponse(this.app, {
+          ok: true,
+          command: "op-import-module",
+          ...result,
+        });
+      } catch (err: any) {
+        console.error("[op-obsidian] op-import-module failed", err);
+        notify(`op-import-module failed: ${err?.message ?? err}`);
+      }
+    }).open();
+  }
+
+  /**
+   * Palette entry point for op-undo-last-import. No prompts — runs immediately
+   * and surfaces a Notice with the result. Idempotent on no-history.
+   */
+  private async runUndoLastImportCommand(): Promise<void> {
+    try {
+      const result = await undoLastImport(
+        this.app,
+        this.settings,
+        () => this.saveSettings(),
+      );
+      if (result.status === "no-history") {
+        notify("op-undo-last-import: no transaction history to undo.");
+      } else {
+        notify(
+          `op-undo-last-import: reverted ${result.modulesReverted.length} module(s), removed ${result.varsRemoved.length} var(s) (${result.varsPreserved.length} preserved as preexisting).`,
+        );
+      }
+      await writeUriResponse(this.app, {
+        ok: true,
+        command: "op-undo-last-import",
+        ...result,
+      });
+    } catch (err: any) {
+      console.error("[op-obsidian] op-undo-last-import failed", err);
+      notify(`op-undo-last-import failed: ${err?.message ?? err}`);
+    }
+  }
+
+  // ---- URI handlers ----
+
+  private async handleOpExportModuleUri(
+    params: Record<string, string>,
+  ): Promise<UriResponsePayload> {
+    const parsed = parseExportModuleParams(params);
+    if (!parsed.ok) throw new Error(parsed.error);
+    const args =
+      parsed.value.mode === "id"
+        ? { kind: "id" as const, moduleId: parsed.value.moduleId }
+        : { kind: "project" as const, projectSlug: parsed.value.projectSlug };
+    const result = await exportModules(this.app, args);
+    return {
+      ok: true,
+      command: "op-export-module",
+      mode: parsed.value.mode,
+      files: result.files,
+    };
+  }
+
+  private async handleOpImportModuleUri(
+    params: Record<string, string>,
+  ): Promise<UriResponsePayload> {
+    const parsed = parseImportModuleParams(params);
+    if (!parsed.ok) throw new Error(parsed.error);
+    // Default scope when unset: derive from the bundle's project: field at
+    // prepare time. For URI/CLI we default to `global` so the call is fully
+    // self-contained — callers that want per-project landing pass
+    // `scope=project&project=<slug>`.
+    const scope = parsed.value.scope ?? "global";
+    if (scope === "project" && !parsed.value.project) {
+      throw new Error("op-import-module: --project is required when scope=project");
+    }
+    const prepared = await prepareImport(this.app, this.settings, {
+      sourcePath: parsed.value.sourcePath,
+      targetScope: scope,
+      ...(parsed.value.project ? { targetProjectSlug: parsed.value.project } : {}),
+      varAnswers: parsed.value.varAnswers,
+    });
+    const missing = prepared.plan.promptsNeeded.filter(
+      (p) => !Object.prototype.hasOwnProperty.call(parsed.value.varAnswers, p.name),
+    );
+    if (missing.length > 0) {
+      // Headless callers can't drive the modal — surface a structured
+      // needs-input payload with each missing var's pre-fill so the caller
+      // can re-dispatch with `var.<name>=<value>` filled in.
+      return {
+        ok: false,
+        command: "op-import-module",
+        status: "needs-input",
+        plan: prepared.plan,
+        needsInput: {
+          vars: missing.map((m) => ({
+            name: m.name,
+            prefill: m.prefill,
+            hasModuleDefault: m.hasModuleDefault,
+            ...(m.description ? { description: m.description } : {}),
+          })),
+        },
+        error: `Missing var answer(s): ${missing.map((m) => m.name).join(", ")}. Re-dispatch with --var.<name>=<value> for each.`,
+      };
+    }
+    const result = await commitImport(
+      this.app,
+      this.settings,
+      () => this.saveSettings(),
+      { prepared, varAnswers: parsed.value.varAnswers },
+    );
+    return {
+      ok: true,
+      command: "op-import-module",
+      ...result,
+    };
+  }
+
+  private async handleOpUndoLastImportUri(): Promise<UriResponsePayload> {
+    const result = await undoLastImport(
+      this.app,
+      this.settings,
+      () => this.saveSettings(),
+    );
+    return {
+      ok: true,
+      command: "op-undo-last-import",
+      ...result,
+    };
+  }
+
+  // ---- CLI handlers (return one-line summary, also write JSON to scratch) ----
+
+  private async handleOpExportModuleCli(params: Record<string, string>): Promise<string> {
+    const command = "op-export-module";
+    try {
+      const parsed = parseExportModuleParams(params);
+      if (!parsed.ok) return parsed.error;
+      const args =
+        parsed.value.mode === "id"
+          ? { kind: "id" as const, moduleId: parsed.value.moduleId }
+          : { kind: "project" as const, projectSlug: parsed.value.projectSlug };
+      const result = await exportModules(this.app, args);
+      await writeUriResponse(this.app, {
+        ok: true,
+        command,
+        mode: parsed.value.mode,
+        files: result.files,
+      });
+      return `${command}: wrote ${result.files.length} file${result.files.length === 1 ? "" : "s"} (${result.files.map((f) => f.exportPath).join(", ")})`;
+    } catch (err: any) {
+      const msg = err?.message ?? String(err);
+      console.error("[op-obsidian]", command, err);
+      await writeUriResponse(this.app, { ok: false, command, error: msg });
+      return `${command} failed: ${msg}`;
+    }
+  }
+
+  private async handleOpImportModuleCli(params: Record<string, string>): Promise<string> {
+    const command = "op-import-module";
+    try {
+      const parsed = parseImportModuleParams(params);
+      if (!parsed.ok) return parsed.error;
+      const scope = parsed.value.scope ?? "global";
+      if (scope === "project" && !parsed.value.project) {
+        return `${command} failed: --project is required when --scope=project`;
+      }
+      const prepared = await prepareImport(this.app, this.settings, {
+        sourcePath: parsed.value.sourcePath,
+        targetScope: scope,
+        ...(parsed.value.project ? { targetProjectSlug: parsed.value.project } : {}),
+        varAnswers: parsed.value.varAnswers,
+      });
+      const missing = prepared.plan.promptsNeeded.filter(
+        (p) => !Object.prototype.hasOwnProperty.call(parsed.value.varAnswers, p.name),
+      );
+      if (missing.length > 0) {
+        const payload = {
+          ok: false,
+          command,
+          status: "needs-input",
+          needsInput: {
+            vars: missing.map((m) => ({
+              name: m.name,
+              prefill: m.prefill,
+              hasModuleDefault: m.hasModuleDefault,
+              ...(m.description ? { description: m.description } : {}),
+            })),
+          },
+          plan: prepared.plan,
+        };
+        await writeUriResponse(this.app, payload);
+        return `${command}: needs-input — supply --var.<name>=<value> for: ${missing.map((m) => m.name).join(", ")}`;
+      }
+      const result = await commitImport(
+        this.app,
+        this.settings,
+        () => this.saveSettings(),
+        { prepared, varAnswers: parsed.value.varAnswers },
+      );
+      await writeUriResponse(this.app, { ok: true, command, ...result });
+      return `${command}: ${result.targetPath} (${result.varsWritten.length} var${result.varsWritten.length === 1 ? "" : "s"}; tx ${result.transactionPath})`;
+    } catch (err: any) {
+      const msg = err?.message ?? String(err);
+      console.error("[op-obsidian]", command, err);
+      await writeUriResponse(this.app, { ok: false, command, error: msg });
+      return `${command} failed: ${msg}`;
+    }
+  }
+
+  private async handleOpUndoLastImportCli(): Promise<string> {
+    const command = "op-undo-last-import";
+    try {
+      const result = await undoLastImport(
+        this.app,
+        this.settings,
+        () => this.saveSettings(),
+      );
+      await writeUriResponse(this.app, { ok: true, command, ...result });
+      if (result.status === "no-history") return `${command}: no transaction history to undo.`;
+      return `${command}: reverted ${result.modulesReverted.length} module(s), removed ${result.varsRemoved.length} var(s).`;
+    } catch (err: any) {
+      const msg = err?.message ?? String(err);
+      console.error("[op-obsidian]", command, err);
+      await writeUriResponse(this.app, { ok: false, command, error: msg });
+      return `${command} failed: ${msg}`;
     }
   }
 

--- a/plugins/op-obsidian/src/modals.ts
+++ b/plugins/op-obsidian/src/modals.ts
@@ -629,3 +629,220 @@ export class FindIssueModal extends Modal {
     this.contentEl.empty();
   }
 }
+
+// ---------------------------------------------------------------------------
+// OP-187: export / import flow modals
+// ---------------------------------------------------------------------------
+
+/**
+ * Pick `id=<id>` (single module) or `project=<slug>` (bundle) and run
+ * `op-export-module`. Lightweight palette-driven entry point — keeps the URI
+ * + CLI surfaces as the durable contract; the modal is just for one-shot use.
+ */
+export class ExportModulePromptModal extends Modal {
+  private mode: "id" | "project" = "id";
+  private value = "";
+  constructor(
+    app: App,
+    private onSubmit: (
+      args: { kind: "id"; moduleId: string } | { kind: "project"; projectSlug: string },
+    ) => void | Promise<void>,
+  ) {
+    super(app);
+  }
+  onOpen(): void {
+    const { contentEl } = this;
+    contentEl.empty();
+    contentEl.createEl("h2", { text: "Export workflow module(s)" });
+    contentEl.createEl("p", {
+      text: "Writes to Projects/_op-export/. Pick id (single module) or project (bundle).",
+    });
+    new Setting(contentEl)
+      .setName("Mode")
+      .addDropdown((d) =>
+        d
+          .addOption("id", "Single module (id=<id>)")
+          .addOption("project", "Project bundle (project=<slug>)")
+          .setValue("id")
+          .onChange((v) => {
+            this.mode = v as "id" | "project";
+          }),
+      );
+    new Setting(contentEl)
+      .setName("Identifier")
+      .setDesc("Module id (no .md) for single-module mode, or project slug for bundle mode.")
+      .addText((t) =>
+        t.setPlaceholder("orient | obsidian-projects").onChange((v) => {
+          this.value = v;
+        }),
+      );
+    new Setting(contentEl).addButton((b) =>
+      b
+        .setButtonText("Export")
+        .setCta()
+        .onClick(() => {
+          const v = this.value.trim();
+          if (!v) {
+            notify("op-export-module: identifier is required");
+            return;
+          }
+          this.close();
+          if (this.mode === "id") {
+            void this.onSubmit({ kind: "id", moduleId: v });
+          } else {
+            void this.onSubmit({ kind: "project", projectSlug: v });
+          }
+        }),
+    );
+  }
+  onClose(): void {
+    this.contentEl.empty();
+  }
+}
+
+/**
+ * Collect path + scope + (optional) project slug for op-import-module.
+ * Var prompts are driven separately by `ImportVarPromptModal` so the UX
+ * is one prompt per missing var rather than a wall of inputs.
+ */
+export class ImportModulePromptModal extends Modal {
+  private sourcePath = "";
+  private targetScope: "global" | "project" = "global";
+  private projectSlug = "";
+  constructor(
+    app: App,
+    private onSubmit: (input: {
+      sourcePath: string;
+      scope: "global" | "project";
+      projectSlug?: string;
+    }) => void | Promise<void>,
+  ) {
+    super(app);
+  }
+  onOpen(): void {
+    const { contentEl } = this;
+    contentEl.empty();
+    contentEl.createEl("h2", { text: "Import workflow module" });
+    contentEl.createEl("p", {
+      text: "Reads from a vault path or absolute filesystem path. Backs up any existing target file and writes a transaction record under Projects/_op-import-history/.",
+    });
+    new Setting(contentEl)
+      .setName("Source path")
+      .setDesc("Vault-relative or absolute path to the bundle .md file.")
+      .addText((t) =>
+        t.setPlaceholder("Projects/_op-export/orient.md").onChange((v) => {
+          this.sourcePath = v;
+        }),
+      );
+    new Setting(contentEl)
+      .setName("Land as")
+      .addDropdown((d) =>
+        d
+          .addOption("global", "Global (Projects/_op-modules/)")
+          .addOption("project", "Per-project (Projects/<slug>/MODULES/)")
+          .setValue("global")
+          .onChange((v) => {
+            this.targetScope = v as "global" | "project";
+          }),
+      );
+    new Setting(contentEl)
+      .setName("Project slug (when per-project)")
+      .setDesc(
+        "Required if Land as = Per-project. Rewrites the bundle's project: field to this slug.",
+      )
+      .addText((t) =>
+        t.setPlaceholder("obsidian-projects").onChange((v) => {
+          this.projectSlug = v;
+        }),
+      );
+    new Setting(contentEl).addButton((b) =>
+      b
+        .setButtonText("Continue")
+        .setCta()
+        .onClick(() => {
+          const source = this.sourcePath.trim();
+          if (!source) {
+            notify("op-import-module: source path is required");
+            return;
+          }
+          if (this.targetScope === "project" && !this.projectSlug.trim()) {
+            notify("op-import-module: project slug is required when landing per-project");
+            return;
+          }
+          this.close();
+          const submission: {
+            sourcePath: string;
+            scope: "global" | "project";
+            projectSlug?: string;
+          } = { sourcePath: source, scope: this.targetScope };
+          if (this.targetScope === "project") submission.projectSlug = this.projectSlug.trim();
+          void this.onSubmit(submission);
+        }),
+    );
+  }
+  onClose(): void {
+    this.contentEl.empty();
+  }
+}
+
+/**
+ * Per-var prompt during the import flow. Pre-fills the input with the
+ * module's inline default (when present) so the user can accept by Enter.
+ */
+export class ImportVarPromptModal extends Modal {
+  private value: string;
+  private submitted = false;
+  constructor(
+    app: App,
+    private prompt: {
+      name: string;
+      prefill: string;
+      hasModuleDefault: boolean;
+      description?: string;
+    },
+    private onSubmit: (value: string | undefined) => void,
+  ) {
+    super(app);
+    this.value = prompt.prefill;
+  }
+  onOpen(): void {
+    const { contentEl } = this;
+    contentEl.empty();
+    contentEl.createEl("h2", { text: `Set value for {{vars.${this.prompt.name}}}` });
+    if (this.prompt.description) {
+      contentEl.createEl("p", { text: this.prompt.description });
+    }
+    contentEl.createEl("p", {
+      text: this.prompt.hasModuleDefault
+        ? "Pre-filled from the module's inline default. Edit and confirm, or accept as-is."
+        : "No module default — supply a value (empty string is allowed).",
+    });
+    new Setting(contentEl).setName(`vars.${this.prompt.name}`).addText((t) =>
+      t.setValue(this.value).onChange((v) => {
+        this.value = v;
+      }),
+    );
+    new Setting(contentEl)
+      .addButton((b) =>
+        b
+          .setButtonText("Skip (cancel import)")
+          .onClick(() => {
+            this.close();
+          }),
+      )
+      .addButton((b) =>
+        b
+          .setButtonText("Use value")
+          .setCta()
+          .onClick(() => {
+            this.submitted = true;
+            this.close();
+            this.onSubmit(this.value);
+          }),
+      );
+  }
+  onClose(): void {
+    this.contentEl.empty();
+    if (!this.submitted) this.onSubmit(undefined);
+  }
+}

--- a/plugins/op-obsidian/src/undoLastImport.test.ts
+++ b/plugins/op-obsidian/src/undoLastImport.test.ts
@@ -1,0 +1,366 @@
+import { describe, it, expect, vi } from "vitest";
+
+vi.mock("obsidian", () => {
+  class TFile {
+    path = "";
+    basename = "";
+    name = "";
+  }
+  class TFolder {
+    path = "";
+  }
+  return {
+    TFile,
+    TFolder,
+    normalizePath: (p: string) => p.replace(/\/+/g, "/"),
+  };
+});
+
+import { TFile, TFolder } from "obsidian";
+import { undoLastImport } from "./undoLastImport";
+import {
+  TRANSACTION_HISTORY_DIR,
+  serializeTransaction,
+  type TransactionRecord,
+} from "./exportImportPure";
+import type { OpSettings } from "./settingsPure";
+
+interface FakeFile {
+  path: string;
+  raw: string;
+}
+
+interface FakeState {
+  files: Map<string, FakeFile>;
+  folders: Set<string>;
+  trashed: string[];
+  varsByStatus: Map<string, Record<string, string>>;
+}
+
+function tfile(path: string): TFile {
+  const f = new TFile();
+  const basename = path.split("/").pop()!.replace(/\.md$/, "").replace(/\.json$/, "");
+  Object.assign(f, { path, basename, name: path.split("/").pop()! });
+  return f;
+}
+
+function makeFolder(path: string, files: TFile[]): TFolder {
+  const folder = new TFolder();
+  Object.assign(folder, { path, children: files });
+  return folder;
+}
+
+function fakeApp(initial: FakeFile[] = [], folders: string[] = []) {
+  const state: FakeState = {
+    files: new Map(initial.map((f) => [f.path, f])),
+    folders: new Set(folders),
+    trashed: [],
+    varsByStatus: new Map(),
+  };
+
+  const childrenByFolder = (folderPath: string) =>
+    [...state.files.values()]
+      .filter((f) => {
+        const dir = f.path.slice(0, f.path.lastIndexOf("/"));
+        return dir === folderPath;
+      })
+      .map((f) => tfile(f.path));
+
+  const app = {
+    vault: {
+      getAbstractFileByPath: (p: string) => {
+        if (state.files.has(p)) return tfile(p);
+        if (state.folders.has(p)) return makeFolder(p, childrenByFolder(p));
+        return null;
+      },
+      read: async (file: TFile) => {
+        const f = state.files.get(file.path);
+        if (!f) throw new Error(`fake vault: no file at ${file.path}`);
+        return f.raw;
+      },
+      create: async (path: string, content: string) => {
+        if (state.files.has(path)) throw new Error(`fake vault: ${path} exists`);
+        state.files.set(path, { path, raw: content });
+        return tfile(path);
+      },
+      modify: async (file: TFile, content: string) => {
+        const f = state.files.get(file.path);
+        if (!f) throw new Error(`fake vault: no file at ${file.path}`);
+        f.raw = content;
+      },
+      createFolder: async (path: string) => {
+        state.folders.add(path);
+      },
+      trash: async (file: TFile | TFolder, _system: boolean) => {
+        const path = (file as TFile).path;
+        if (state.files.has(path)) state.files.delete(path);
+        else if (state.folders.has(path)) {
+          state.folders.delete(path);
+          // Cascade-delete files inside the folder for test sanity.
+          for (const key of [...state.files.keys()]) {
+            if (key.startsWith(path + "/")) state.files.delete(key);
+          }
+        }
+        state.trashed.push(path);
+      },
+    },
+    metadataCache: {
+      getFileCache: (file: TFile) => {
+        if (!file.path.endsWith("/STATUS.md")) return null;
+        const vars = state.varsByStatus.get(file.path);
+        return vars ? { frontmatter: { vars: { ...vars } } } : { frontmatter: {} };
+      },
+    },
+    fileManager: {
+      processFrontMatter: async (
+        file: TFile,
+        mutator: (fm: Record<string, unknown>) => void,
+      ) => {
+        const fm: Record<string, unknown> = state.varsByStatus.has(file.path)
+          ? { vars: { ...state.varsByStatus.get(file.path)! } }
+          : {};
+        mutator(fm);
+        if (fm.vars && typeof fm.vars === "object") {
+          state.varsByStatus.set(file.path, { ...(fm.vars as Record<string, string>) });
+        } else {
+          state.varsByStatus.delete(file.path);
+        }
+      },
+    },
+  } as any;
+
+  return { app, state };
+}
+
+const baseSettings = (overrides: Partial<OpSettings> = {}): OpSettings =>
+  ({
+    workflowVars: {} as Record<string, string>,
+    ...overrides,
+  }) as unknown as OpSettings;
+
+const txRecord = (over: Partial<TransactionRecord> = {}): TransactionRecord => ({
+  version: 1,
+  timestamp: "2026-04-26T12:00:00.000Z",
+  command: "op-import-module",
+  modulesLanded: [],
+  varsWritten: [],
+  ...over,
+});
+
+describe("undoLastImport — empty / no history", () => {
+  it("returns no-history when the history dir is missing", async () => {
+    const { app } = fakeApp();
+    const result = await undoLastImport(app, baseSettings(), async () => {});
+    expect(result.status).toBe("no-history");
+  });
+
+  it("returns no-history when the history dir has no .json files", async () => {
+    const { app } = fakeApp([], [TRANSACTION_HISTORY_DIR]);
+    const result = await undoLastImport(app, baseSettings(), async () => {});
+    expect(result.status).toBe("no-history");
+  });
+});
+
+describe("undoLastImport — fresh import (no overwrite)", () => {
+  it("trashes the imported module and removes the var; trashes the tx record", async () => {
+    const txPath = `${TRANSACTION_HISTORY_DIR}/20260426-120000.json`;
+    const tx = txRecord({
+      modulesLanded: [
+        {
+          sourcePath: "Projects/_op-export/orient.md",
+          targetPath: "Projects/_op-modules/orient.md",
+          scopeKind: "global",
+          originalProject: null,
+          rewrittenProject: null,
+          overwrote: false,
+        },
+      ],
+      varsWritten: [
+        { name: "tone", value: "loud", scopeKind: "global", preexisting: false },
+      ],
+    });
+    const { app, state } = fakeApp(
+      [
+        { path: txPath, raw: serializeTransaction(tx) },
+        { path: "Projects/_op-modules/orient.md", raw: "imported content" },
+      ],
+      [TRANSACTION_HISTORY_DIR],
+    );
+    const settings = baseSettings({ workflowVars: { tone: "loud" } });
+    const result = await undoLastImport(app, settings, async () => {});
+    expect(result.status).toBe("ok");
+    expect(result.modulesReverted).toEqual(["Projects/_op-modules/orient.md"]);
+    expect(result.varsRemoved).toEqual([{ name: "tone", scopeKind: "global" }]);
+    expect(settings.workflowVars).toEqual({});
+    expect(state.trashed).toContain("Projects/_op-modules/orient.md");
+    expect(state.trashed).toContain(txPath);
+  });
+});
+
+describe("undoLastImport — overwrite + backup restore", () => {
+  it("restores the backed-up original to the target path", async () => {
+    const txPath = `${TRANSACTION_HISTORY_DIR}/20260426-120000.json`;
+    const backupPath = `${TRANSACTION_HISTORY_DIR}/20260426-120000.bak/Projects/_op-modules/orient.md`;
+    const tx = txRecord({
+      modulesLanded: [
+        {
+          sourcePath: "import.md",
+          targetPath: "Projects/_op-modules/orient.md",
+          scopeKind: "global",
+          originalProject: null,
+          rewrittenProject: null,
+          overwrote: true,
+          backupPath,
+        },
+      ],
+    });
+    const { app, state } = fakeApp(
+      [
+        { path: txPath, raw: serializeTransaction(tx) },
+        { path: "Projects/_op-modules/orient.md", raw: "new (imported) content" },
+        { path: backupPath, raw: "old (backed-up) content" },
+      ],
+      [
+        TRANSACTION_HISTORY_DIR,
+        `${TRANSACTION_HISTORY_DIR}/20260426-120000.bak`,
+        `${TRANSACTION_HISTORY_DIR}/20260426-120000.bak/Projects`,
+        `${TRANSACTION_HISTORY_DIR}/20260426-120000.bak/Projects/_op-modules`,
+        "Projects",
+        "Projects/_op-modules",
+      ],
+    );
+    const result = await undoLastImport(app, baseSettings(), async () => {});
+    expect(result.originalsRestored).toEqual(["Projects/_op-modules/orient.md"]);
+    expect(state.files.get("Projects/_op-modules/orient.md")?.raw).toBe(
+      "old (backed-up) content",
+    );
+    expect(state.trashed).toContain(`${TRANSACTION_HISTORY_DIR}/20260426-120000.bak`);
+  });
+});
+
+describe("undoLastImport — preexisting vars", () => {
+  it("preserves preexisting=true vars and removes only the import-added ones", async () => {
+    const txPath = `${TRANSACTION_HISTORY_DIR}/20260426-120000.json`;
+    const tx = txRecord({
+      modulesLanded: [
+        {
+          sourcePath: "import.md",
+          targetPath: "Projects/_op-modules/orient.md",
+          scopeKind: "global",
+          originalProject: null,
+          rewrittenProject: null,
+          overwrote: false,
+        },
+      ],
+      varsWritten: [
+        // Pre-existed in workflowVars before import; undo must NOT delete.
+        { name: "tone", value: "calm", scopeKind: "global", preexisting: true },
+        // Added by this import; undo MUST delete.
+        { name: "lang", value: "fr", scopeKind: "global", preexisting: false },
+      ],
+    });
+    const { app, state } = fakeApp(
+      [
+        { path: txPath, raw: serializeTransaction(tx) },
+        { path: "Projects/_op-modules/orient.md", raw: "imported" },
+      ],
+      [TRANSACTION_HISTORY_DIR],
+    );
+    const settings = baseSettings({ workflowVars: { tone: "calm", lang: "fr" } });
+    const result = await undoLastImport(app, settings, async () => {});
+    expect(settings.workflowVars).toEqual({ tone: "calm" });
+    expect(result.varsRemoved).toEqual([{ name: "lang", scopeKind: "global" }]);
+    expect(result.varsPreserved).toEqual([{ name: "tone", scopeKind: "global" }]);
+    expect(state.varsByStatus.size).toBe(0);
+  });
+});
+
+describe("undoLastImport — project-scope vars", () => {
+  it("removes a project-scope var from STATUS.md vars: map", async () => {
+    const txPath = `${TRANSACTION_HISTORY_DIR}/20260426-120000.json`;
+    const tx = txRecord({
+      modulesLanded: [
+        {
+          sourcePath: "import.md",
+          targetPath: "Projects/foo/MODULES/orient.md",
+          scopeKind: "project",
+          projectSlug: "foo",
+          originalProject: null,
+          rewrittenProject: "foo",
+          overwrote: false,
+        },
+      ],
+      varsWritten: [
+        {
+          name: "reviewer",
+          value: "@me",
+          scopeKind: "project",
+          projectSlug: "foo",
+          preexisting: false,
+        },
+      ],
+    });
+    const { app, state } = fakeApp(
+      [
+        { path: txPath, raw: serializeTransaction(tx) },
+        { path: "Projects/foo/MODULES/orient.md", raw: "x" },
+        { path: "Projects/foo/STATUS.md", raw: "---\n---\n" },
+      ],
+      [TRANSACTION_HISTORY_DIR],
+    );
+    state.varsByStatus.set("Projects/foo/STATUS.md", { reviewer: "@me" });
+    const settings = baseSettings();
+    const result = await undoLastImport(app, settings, async () => {});
+    expect(result.varsRemoved).toEqual([
+      { name: "reviewer", scopeKind: "project", projectSlug: "foo" },
+    ]);
+    expect(state.varsByStatus.get("Projects/foo/STATUS.md")).toBeUndefined();
+  });
+});
+
+describe("undoLastImport — picks the latest record", () => {
+  it("reverses the alphabetically-latest filename when multiple records exist", async () => {
+    const older = `${TRANSACTION_HISTORY_DIR}/20260101-000000.json`;
+    const newer = `${TRANSACTION_HISTORY_DIR}/20260426-120000.json`;
+    const olderTx = txRecord({
+      timestamp: "2026-01-01T00:00:00.000Z",
+      modulesLanded: [
+        {
+          sourcePath: "old.md",
+          targetPath: "Projects/_op-modules/old.md",
+          scopeKind: "global",
+          originalProject: null,
+          rewrittenProject: null,
+          overwrote: false,
+        },
+      ],
+    });
+    const newerTx = txRecord({
+      modulesLanded: [
+        {
+          sourcePath: "new.md",
+          targetPath: "Projects/_op-modules/new.md",
+          scopeKind: "global",
+          originalProject: null,
+          rewrittenProject: null,
+          overwrote: false,
+        },
+      ],
+    });
+    const { app, state } = fakeApp(
+      [
+        { path: older, raw: serializeTransaction(olderTx) },
+        { path: newer, raw: serializeTransaction(newerTx) },
+        { path: "Projects/_op-modules/old.md", raw: "old" },
+        { path: "Projects/_op-modules/new.md", raw: "new" },
+      ],
+      [TRANSACTION_HISTORY_DIR],
+    );
+    const result = await undoLastImport(app, baseSettings(), async () => {});
+    expect(result.transactionPath).toBe(newer);
+    expect(state.files.has("Projects/_op-modules/old.md")).toBe(true);
+    expect(state.files.has("Projects/_op-modules/new.md")).toBe(false);
+    expect(state.files.has(newer)).toBe(false);
+    expect(state.files.has(older)).toBe(true);
+  });
+});

--- a/plugins/op-obsidian/src/undoLastImport.test.ts
+++ b/plugins/op-obsidian/src/undoLastImport.test.ts
@@ -163,7 +163,7 @@ describe("undoLastImport — empty / no history", () => {
 
 describe("undoLastImport — fresh import (no overwrite)", () => {
   it("trashes the imported module and removes the var; trashes the tx record", async () => {
-    const txPath = `${TRANSACTION_HISTORY_DIR}/20260426-120000.json`;
+    const txPath = `${TRANSACTION_HISTORY_DIR}/20260426-120000-000.json`;
     const tx = txRecord({
       modulesLanded: [
         {
@@ -199,8 +199,8 @@ describe("undoLastImport — fresh import (no overwrite)", () => {
 
 describe("undoLastImport — overwrite + backup restore", () => {
   it("restores the backed-up original to the target path", async () => {
-    const txPath = `${TRANSACTION_HISTORY_DIR}/20260426-120000.json`;
-    const backupPath = `${TRANSACTION_HISTORY_DIR}/20260426-120000.bak/Projects/_op-modules/orient.md`;
+    const txPath = `${TRANSACTION_HISTORY_DIR}/20260426-120000-000.json`;
+    const backupPath = `${TRANSACTION_HISTORY_DIR}/20260426-120000-000.bak/Projects/_op-modules/orient.md`;
     const tx = txRecord({
       modulesLanded: [
         {
@@ -222,9 +222,9 @@ describe("undoLastImport — overwrite + backup restore", () => {
       ],
       [
         TRANSACTION_HISTORY_DIR,
-        `${TRANSACTION_HISTORY_DIR}/20260426-120000.bak`,
-        `${TRANSACTION_HISTORY_DIR}/20260426-120000.bak/Projects`,
-        `${TRANSACTION_HISTORY_DIR}/20260426-120000.bak/Projects/_op-modules`,
+        `${TRANSACTION_HISTORY_DIR}/20260426-120000-000.bak`,
+        `${TRANSACTION_HISTORY_DIR}/20260426-120000-000.bak/Projects`,
+        `${TRANSACTION_HISTORY_DIR}/20260426-120000-000.bak/Projects/_op-modules`,
         "Projects",
         "Projects/_op-modules",
       ],
@@ -234,13 +234,13 @@ describe("undoLastImport — overwrite + backup restore", () => {
     expect(state.files.get("Projects/_op-modules/orient.md")?.raw).toBe(
       "old (backed-up) content",
     );
-    expect(state.trashed).toContain(`${TRANSACTION_HISTORY_DIR}/20260426-120000.bak`);
+    expect(state.trashed).toContain(`${TRANSACTION_HISTORY_DIR}/20260426-120000-000.bak`);
   });
 });
 
 describe("undoLastImport — preexisting vars", () => {
   it("preserves preexisting=true vars and removes only the import-added ones", async () => {
-    const txPath = `${TRANSACTION_HISTORY_DIR}/20260426-120000.json`;
+    const txPath = `${TRANSACTION_HISTORY_DIR}/20260426-120000-000.json`;
     const tx = txRecord({
       modulesLanded: [
         {
@@ -277,7 +277,7 @@ describe("undoLastImport — preexisting vars", () => {
 
 describe("undoLastImport — project-scope vars", () => {
   it("removes a project-scope var from STATUS.md vars: map", async () => {
-    const txPath = `${TRANSACTION_HISTORY_DIR}/20260426-120000.json`;
+    const txPath = `${TRANSACTION_HISTORY_DIR}/20260426-120000-000.json`;
     const tx = txRecord({
       modulesLanded: [
         {
@@ -321,7 +321,7 @@ describe("undoLastImport — project-scope vars", () => {
 describe("undoLastImport — picks the latest record", () => {
   it("reverses the alphabetically-latest filename when multiple records exist", async () => {
     const older = `${TRANSACTION_HISTORY_DIR}/20260101-000000.json`;
-    const newer = `${TRANSACTION_HISTORY_DIR}/20260426-120000.json`;
+    const newer = `${TRANSACTION_HISTORY_DIR}/20260426-120000-000.json`;
     const olderTx = txRecord({
       timestamp: "2026-01-01T00:00:00.000Z",
       modulesLanded: [

--- a/plugins/op-obsidian/src/undoLastImport.ts
+++ b/plugins/op-obsidian/src/undoLastImport.ts
@@ -1,0 +1,183 @@
+import { App, TFile, TFolder, normalizePath } from "obsidian";
+import type { OpSettings } from "./settingsPure";
+import {
+  TRANSACTION_HISTORY_DIR,
+  parseTransaction,
+  type TransactionRecord,
+} from "./exportImportPure";
+
+// IO seam for `op-undo-last-import` (OP-187 / Child 4 of OP-181).
+// Reverses the most recent transaction record in `Projects/_op-import-history/`:
+//   - Trash imported module files at their landed paths.
+//   - Restore any backed-up originals from `<ts>.bak/<vault-relative-path>`.
+//   - Remove vars this import added (`preexisting=false`); preserve those
+//     flagged `preexisting=true` (they predated the import).
+//   - Trash the transaction record itself + its bak directory so the
+//     **next** undo doesn't replay this one.
+//
+// One-step undo only — older imports require manual revert from the same
+// record format (the spec is explicit on this).
+
+export interface UndoResult {
+  status: "ok" | "no-history";
+  /** Vault-relative path of the transaction record that was reversed (when ok). */
+  transactionPath?: string;
+  /** Modules trashed from their landed paths. */
+  modulesReverted: string[];
+  /** Backed-up originals restored to their pre-import state. */
+  originalsRestored: string[];
+  /** Vars removed (only those with `preexisting=false` in the tx record). */
+  varsRemoved: Array<{ name: string; scopeKind: "global" | "project"; projectSlug?: string }>;
+  /** Vars left alone because they predated the import (`preexisting=true`). */
+  varsPreserved: Array<{ name: string; scopeKind: "global" | "project"; projectSlug?: string }>;
+}
+
+/**
+ * Run the undo. Idempotent in the "no history" branch; on a healthy run, the
+ * transaction record is trashed at the end so a second undo is a no-op.
+ */
+export async function undoLastImport(
+  app: App,
+  settings: OpSettings,
+  saveSettings: () => Promise<void>,
+): Promise<UndoResult> {
+  const latest = await findLatestTransaction(app);
+  if (!latest) {
+    return {
+      status: "no-history",
+      modulesReverted: [],
+      originalsRestored: [],
+      varsRemoved: [],
+      varsPreserved: [],
+    };
+  }
+  const { file, record } = latest;
+
+  // 1. Trash imported module files at their landed paths.
+  const modulesReverted: string[] = [];
+  for (const m of record.modulesLanded) {
+    const target = app.vault.getAbstractFileByPath(normalizePath(m.targetPath));
+    if (target instanceof TFile) {
+      await app.vault.trash(target, true); // system trash
+      modulesReverted.push(m.targetPath);
+    }
+  }
+
+  // 2. Restore originals from the backup directory.
+  const originalsRestored: string[] = [];
+  for (const m of record.modulesLanded) {
+    if (!m.overwrote || !m.backupPath) continue;
+    const backup = app.vault.getAbstractFileByPath(normalizePath(m.backupPath));
+    if (!(backup instanceof TFile)) continue;
+    const restoredContent = await app.vault.read(backup);
+    const targetPath = normalizePath(m.targetPath);
+    // Re-create folders if the trash above (or earlier work) removed them.
+    const dir = targetPath.slice(0, targetPath.lastIndexOf("/"));
+    await ensureFolderRecursive(app, dir);
+    const existing = app.vault.getAbstractFileByPath(targetPath);
+    if (existing instanceof TFile) {
+      await app.vault.modify(existing, restoredContent);
+    } else {
+      await app.vault.create(targetPath, restoredContent);
+    }
+    originalsRestored.push(m.targetPath);
+  }
+
+  // 3. Roll back vars. Only `preexisting=false` rows.
+  const varsRemoved: UndoResult["varsRemoved"] = [];
+  const varsPreserved: UndoResult["varsPreserved"] = [];
+  for (const v of record.varsWritten) {
+    if (v.preexisting) {
+      const entry = { name: v.name, scopeKind: v.scopeKind } as UndoResult["varsPreserved"][number];
+      if (v.projectSlug) entry.projectSlug = v.projectSlug;
+      varsPreserved.push(entry);
+      continue;
+    }
+    if (v.scopeKind === "global") {
+      delete settings.workflowVars[v.name];
+      varsRemoved.push({ name: v.name, scopeKind: "global" });
+      continue;
+    }
+    // project scope
+    if (!v.projectSlug) continue;
+    const statusPath = normalizePath(`Projects/${v.projectSlug}/STATUS.md`);
+    const statusFile = app.vault.getAbstractFileByPath(statusPath);
+    if (!(statusFile instanceof TFile)) continue;
+    await app.fileManager.processFrontMatter(
+      statusFile,
+      (fm: Record<string, unknown>) => {
+        const existing = fm.vars;
+        if (!existing || typeof existing !== "object" || Array.isArray(existing)) return;
+        const map = { ...(existing as Record<string, unknown>) };
+        delete map[v.name];
+        if (Object.keys(map).length === 0) {
+          delete fm.vars;
+        } else {
+          fm.vars = map;
+        }
+      },
+    );
+    varsRemoved.push({ name: v.name, scopeKind: "project", projectSlug: v.projectSlug });
+  }
+  await saveSettings();
+
+  // 4. Trash the transaction record + its bak directory so undo is one-step.
+  await app.vault.trash(file, true);
+  const bakDirPath = file.path.replace(/\.json$/, ".bak");
+  const bakDir = app.vault.getAbstractFileByPath(normalizePath(bakDirPath));
+  if (bakDir && !(bakDir instanceof TFile)) {
+    // TFolder
+    await app.vault.trash(bakDir as TFolder, true);
+  }
+
+  return {
+    status: "ok",
+    transactionPath: file.path,
+    modulesReverted,
+    originalsRestored,
+    varsRemoved,
+    varsPreserved,
+  };
+}
+
+/**
+ * Find the latest transaction record by filename (which sorts naturally
+ * because `transactionFilename` is `YYYYMMDD-HHmmss`). Falls back to mtime
+ * for a stable secondary key.
+ */
+async function findLatestTransaction(
+  app: App,
+): Promise<{ file: TFile; record: TransactionRecord } | null> {
+  const dir = app.vault.getAbstractFileByPath(normalizePath(TRANSACTION_HISTORY_DIR));
+  if (!dir || dir instanceof TFile) return null;
+  // TFolder duck-typed (`children` array).
+  const children = (dir as { children?: Array<unknown> }).children ?? [];
+  const candidates: TFile[] = children.filter(
+    (c): c is TFile => c instanceof TFile && c.path.endsWith(".json"),
+  );
+  if (candidates.length === 0) return null;
+  candidates.sort((a, b) => b.path.localeCompare(a.path));
+  for (const candidate of candidates) {
+    const raw = await app.vault.read(candidate);
+    const result = parseTransaction(raw);
+    if (result.record) return { file: candidate, record: result.record };
+    // Skip corrupted records — try the next-most-recent one. We don't throw
+    // because a stray file in the history dir shouldn't permanently block
+    // undo for legitimate later imports.
+  }
+  return null;
+}
+
+async function ensureFolderRecursive(app: App, path: string): Promise<void> {
+  if (!path) return;
+  const norm = normalizePath(path);
+  const parts = norm.split("/");
+  let cumulative = "";
+  for (const part of parts) {
+    if (!part) continue;
+    cumulative = cumulative ? `${cumulative}/${part}` : part;
+    if (!app.vault.getAbstractFileByPath(cumulative)) {
+      await app.vault.createFolder(cumulative);
+    }
+  }
+}

--- a/plugins/op/.claude-plugin/plugin.json
+++ b/plugins/op/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "op",
   "description": "Obsidian Projects workflow — schema, slash commands, and agent skill for running a Jira-lite issue tracker inside an Obsidian vault.",
-  "version": "0.74.1",
+  "version": "0.75.0",
   "author": {
     "name": "Eugene Archibald"
   },

--- a/plugins/op/.claude-plugin/plugin.json
+++ b/plugins/op/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "op",
   "description": "Obsidian Projects workflow — schema, slash commands, and agent skill for running a Jira-lite issue tracker inside an Obsidian vault.",
-  "version": "0.75.1",
+  "version": "0.76.0",
   "author": {
     "name": "Eugene Archibald"
   },


### PR DESCRIPTION
## Summary

Child 4 of the [OP-181 workflow-modules umbrella](https://github.com/earchibald/obsidian-projects/issues/216). Three thin convenience wrappers around the plain-markdown module file format, plus the import-time bootstrap of missing vars and one-step undo described in `docs/plans/OP-181-workflow-modules.md` §"Export / import — modules are just markdown".

- **`op-export-module id=<id> | project=<slug>`** — writes `Projects/_op-export/<id>.md` (single) or `Projects/_op-export/<slug>/<id>.md` (bundle); preserves every `VarDecl` form (bare / default-shorthand / object).
- **`op-import-module path=<vault-or-abs-path>`** — parses + plans + commits. For each `{{vars.X}}` body reference, walks the precedence chain (Project → Global → Module-default); missing vars trigger either a per-var modal prompt (palette) or an `ok:false status:"needs-input"` payload with each missing var's `prefill`/`hasModuleDefault` (URI/CLI). Vars land in `settings.workflowVars` (global) or `Projects/<slug>/STATUS.md vars:` (project). Existing target files are backed up to `Projects/_op-import-history/<ts>.bak/`. Transaction record at `Projects/_op-import-history/<ts>.json`.
- **`op-undo-last-import`** — reverses the latest transaction (one-step only): trashes imports, restores backups, prunes only the vars this import added (`preexisting=true` rows are preserved), trashes the tx + bak so the next undo is a no-op. `status:"no-history"` (not an error) when nothing to undo.

Architecture follows the existing `*Pure.ts` / `*.ts` split: `exportImportPure.ts` owns all schema-shape decisions; `exportModule.ts` / `importModule.ts` / `undoLastImport.ts` own vault reads/writes. URI senders accept both `var.<name>=<value>` per-key form and packed `vars=name=val\nname2=val2` (matches OP-204's `parseLaunchVarsFromUri` pattern).

**47 new tests, 1494 / 1494 full suite green.** op-obsidian bumped 0.74.0 → 0.75.0 (minor — additive, no breaking change).

## Test plan

- [x] `npx vitest run` — full suite green (1494/1494)
- [x] `npx tsc --noEmit` — no new errors (8 pre-existing on main, unchanged)
- [x] `npm run build` — main.js rebuilt
- [x] `node scripts/dev-sync.mjs` — copied to OP-Test, plugin reloaded; all three commands registered
- [x] Smoke round-trip in OP-Test:
  - export `id=orient` → wrote `Projects/_op-export/orient.md`
  - delete source → import (no var) → `needs-input` payload with `prefill: "git status"` from inline default
  - re-dispatch with `var.preflight='git status -uno'` → module landed, `settings.workflowVars.preflight === "git status -uno"`, transaction record written
  - `op-undo-last-import` → orient gone, `workflowVars: {}`; second invocation returned `status: "no-history"`
  - overwrite branch: import v1 → import v2 (overwrote=true, backupPath set, var marked preexisting=true); undo of v2 restored backup + preserved v1's var
  - project-bundle export wrote `Projects/_op-export/<slug>/<id>.md`

## Adversarial review pressure-tests for @copilot

- **needs-input contract**: does the URI/CLI surface every missing var with the right `prefill` (especially the empty-string case for bare vars vs a real default)?
- **Backup path collision**: what if two imports happen in the same second? Filename is `YYYYMMDD-HHmmss` — does anything misbehave?
- **Project-slug rewrite**: when `scope=project` but the bundle's `project:` already matches the target slug, does `originalProject === rewrittenProject` cause any wasted work?
- **Empty-string answer**: the spec says `name=` is an explicit empty default. Does `varAnswers: { foo: "" }` round-trip correctly through commit + undo?
- **STATUS.md vars: map**: when the project's STATUS.md has no `vars:` field, does the import correctly add it (without disturbing other frontmatter)? When undo prunes the only var, does it remove the now-empty map?
- **Concurrent overwrite**: import v1 → import v2 → import v3 → undo. Does undo correctly reverse only v3 (not v3+v2)?
- **Corrupted history file**: a stray non-JSON file in `Projects/_op-import-history/`. Does undo skip past it to the next-most-recent valid record?
- **Frontmatter quoting**: a module with `title: "Edge: case"` or a `vars: [foo=2026-04-26]` (Date-coercible). Does the export-import round trip survive YAML auto-coercion?

🤖 Generated with [Claude Code](https://claude.com/claude-code)