### PR TITLE
OP-208: cutover — flip workflowMode default to modules + retire legacy injection cap row

### DIFF
--- a/plugins/op-obsidian/manifest.json
+++ b/plugins/op-obsidian/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "op-obsidian",
   "name": "Obsidian Projects (op)",
-  "version": "0.76.0",
+  "version": "0.77.0",
   "minAppVersion": "1.5.0",
   "description": "Jira-lite issue tracker for Obsidian vaults — deterministic commands backing the op workflow.",
   "author": "Eugene Archibald",

--- a/plugins/op-obsidian/package.json
+++ b/plugins/op-obsidian/package.json
@@ -1,6 +1,6 @@
 {
   "name": "op-obsidian",
-  "version": "0.76.0",
+  "version": "0.77.0",
   "description": "Obsidian plugin that owns the deterministic half of the op workflow.",
   "main": "main.js",
   "scripts": {

--- a/plugins/op-obsidian/src/main.ts
+++ b/plugins/op-obsidian/src/main.ts
@@ -1899,53 +1899,52 @@ export default class OpPlugin extends Plugin {
         statusLine: (line) => notify(`op-evaluate ${entry.id}: ${line}`),
         paneStream: (chunk) => console.log(`[op-evaluate ${entry.id}] ${chunk}`),
       });
-      // OP-199 (2b): in modules-mode, compose the workflow's `evaluate` step
-      // and prepend it to the evaluator's prompt. Launch context is best-
-      // effort here (no `wd` resolution because the evaluator runs in-
-      // process, not in a terminal) — `repoPath` from `resolveRepoPath`,
-      // `branch` via `git rev-parse` at that path. Evaluator-step modules
-      // that reference `{{branch}}` etc. resolve to either the real value
-      // or a `missing-var` diagnostic, never break the launch.
-      const composeWorkflowSectionFn =
-        this.settings.workflowMode === "modules"
-          ? async () => {
-              const profile = resolveProfile(this.settings, this.settings.defaultAgent);
-              const repoPath = resolveRepoPath(this.app, this.settings, entry.project);
-              const branch = repoPath ? await gitBranchAt(repoPath) : undefined;
-              const parentRaw = (this.app.metadataCache.getFileCache(
-                this.app.vault.getAbstractFileByPath(entry.path) as TFile,
-              )?.frontmatter as Record<string, unknown> | undefined)?.parent;
-              // Mirrors `readParentId` in openAgent.ts: null on cache miss,
-              // no-cache, or non-string (including YAML arrays for multi-parent).
-              const parentId =
-                typeof parentRaw === "string" && parentRaw.trim().length > 0
-                  ? parentRaw
-                  : null;
-              return composeWorkflowSection(this.app, {
-                entry,
-                profile,
-                // OP-199 (2b): clamp maxWorkflowChars for the evaluator — it's
-                // a quick triage agent that doesn't need the full budget. A long
-                // workflow section would slow the evaluator and could confuse the
-                // COMPLEXITY: trailer parser.
-                injection: {
-                  ...this.settings.injection,
-                  maxWorkflowChars: Math.min(
-                    this.settings.injection.maxWorkflowChars,
-                    EVALUATOR_MAX_WORKFLOW_CHARS,
-                  ),
-                },
-                vaultBasePath: (this.app.vault.adapter as unknown as { basePath?: string }).basePath,
-                mode: "evaluate",
-                workflowMode: this.settings.workflowMode,
-                workflowVars: this.settings.workflowVars,
-                workflowStep: modeToWorkflowStep("evaluate"),
-                repoPath,
-                branch,
-                parentId,
-              });
-            }
-          : undefined;
+      // OP-199 (2b): compose the workflow's `evaluate` step and prepend it
+      // to the evaluator's prompt. Launch context is best-effort here (no `wd`
+      // resolution because the evaluator runs in-process, not in a terminal)
+      // — `repoPath` from `resolveRepoPath`, `branch` via `git rev-parse` at
+      // that path. Evaluator-step modules that reference `{{branch}}` etc.
+      // resolve to either the real value or a `missing-var` diagnostic, never
+      // break the launch. OP-208 (8a, cutover) dropped the `workflowMode ===
+      // "modules"` gate — modules is now the only path; vanilla WORKFLOW.md
+      // routes through the composer's legacy-fallback ladder.
+      const composeWorkflowSectionFn = async () => {
+        const profile = resolveProfile(this.settings, this.settings.defaultAgent);
+        const repoPath = resolveRepoPath(this.app, this.settings, entry.project);
+        const branch = repoPath ? await gitBranchAt(repoPath) : undefined;
+        const parentRaw = (this.app.metadataCache.getFileCache(
+          this.app.vault.getAbstractFileByPath(entry.path) as TFile,
+        )?.frontmatter as Record<string, unknown> | undefined)?.parent;
+        // Mirrors `readParentId` in openAgent.ts: null on cache miss,
+        // no-cache, or non-string (including YAML arrays for multi-parent).
+        const parentId =
+          typeof parentRaw === "string" && parentRaw.trim().length > 0
+            ? parentRaw
+            : null;
+        return composeWorkflowSection(this.app, {
+          entry,
+          profile,
+          // OP-199 (2b): clamp maxWorkflowChars for the evaluator — it's
+          // a quick triage agent that doesn't need the full budget. A long
+          // workflow section would slow the evaluator and could confuse the
+          // COMPLEXITY: trailer parser.
+          injection: {
+            ...this.settings.injection,
+            maxWorkflowChars: Math.min(
+              this.settings.injection.maxWorkflowChars,
+              EVALUATOR_MAX_WORKFLOW_CHARS,
+            ),
+          },
+          vaultBasePath: (this.app.vault.adapter as unknown as { basePath?: string }).basePath,
+          mode: "evaluate",
+          workflowMode: this.settings.workflowMode,
+          workflowVars: this.settings.workflowVars,
+          workflowStep: modeToWorkflowStep("evaluate"),
+          repoPath,
+          branch,
+          parentId,
+        });
+      };
       const result = await runEvaluatorFlow(
         {
           launch: launchHeadlessSubtask,

--- a/plugins/op-obsidian/src/promptBuild.test.ts
+++ b/plugins/op-obsidian/src/promptBuild.test.ts
@@ -320,8 +320,16 @@ function legacyWorkflowFiles(): FakeFile[] {
   ];
 }
 
-describe("buildPrompt — OP-198 (2a)", () => {
-  it("legacy default (workflowMode unset): inlines WORKFLOW.md verbatim — byte-identical reference", async () => {
+describe("buildPrompt — OP-198 (2a) / OP-208 (8a, cutover)", () => {
+  it("OP-208 cutover: vanilla WORKFLOW.md (no workflow-schema frontmatter) routes through the composer's legacy-fallback ladder and inlines the body", async () => {
+    // Pre-OP-208 the buildPrompt legacy `else` branch read WORKFLOW.md
+    // verbatim under a `From <path>:` preamble. Post-cutover that branch is
+    // gone — vanilla WORKFLOW.md is classified as a legacy shape by
+    // `workflowFile.ts` and synthesised into a kickoff step whose
+    // `legacyKickoffBody` is the entire body. The composer splices it
+    // verbatim, so the user-visible workflow content survives the cutover.
+    // The exact byte format differs from the pre-cutover reference (no
+    // `From <path>:` preamble) — that drift is expected and intentional.
     const app = fakeApp(legacyWorkflowFiles());
     const out = await buildPrompt(app, fakeStore(), {
       entry: entry(),
@@ -329,21 +337,20 @@ describe("buildPrompt — OP-198 (2a)", () => {
       injection: injection(),
       vaultBasePath: "/Users/me/vault",
       mode: "work",
-      // workflowMode unset — default 'legacy'.
     });
-    // Reference snapshot for the legacy code path. Drift in this assertion
-    // means the legacy block changed shape, which OP-198 forbids.
-    const REFERENCE_LEGACY =
-      "/op:issue OP-1\n\n" +
-      "## Project workflow\n\n" +
-      "From Projects/demo/WORKFLOW.md:\n\n" +
-      WORKFLOW_BODY +
-      "\n\n" +
-      "Issue: OP-1 — Demo issue\nProject: demo\nStatus: in-progress\nNote: /Users/me/vault/Projects/demo/ISSUES/OP-1.md";
-    expect(out).toBe(REFERENCE_LEGACY);
+    expect(out).toContain("## Project workflow");
+    expect(out).toContain(WORKFLOW_BODY);
+    // Header still emitted.
+    expect(out).toContain("Issue: OP-1 — Demo issue");
+    expect(out).toContain("Note: /Users/me/vault/Projects/demo/ISSUES/OP-1.md");
   });
 
-  it("legacy explicit (workflowMode='legacy'): byte-identical to the implicit default", async () => {
+  it("OP-208 cutover: explicit workflowMode='legacy' is now byte-identical to the implicit default (gate is dead in buildPrompt)", async () => {
+    // The `workflowMode` arg no longer gates buildPrompt's behaviour; it's
+    // kept on `BuildPromptArgs` only because `launchAgentModal` still uses it
+    // for UI panel affordances. Confirming the implicit and 'legacy'-explicit
+    // outputs are byte-identical guards against accidentally re-introducing
+    // the gate.
     const app = fakeApp(legacyWorkflowFiles());
     const implicit = await buildPrompt(app, fakeStore(), {
       entry: entry(),
@@ -439,10 +446,12 @@ describe("buildPrompt — OP-198 (2a)", () => {
     expect(out).toContain("Ask @you for review.");
   });
 
-  it("modules mode falls back to legacy block when WORKFLOW.md is missing", async () => {
-    // No WORKFLOW.md on disk — composer returns null. Caller falls through
-    // to the legacy `## Project workflow` block, which itself emits nothing
-    // because there's no file to inline. Net: no workflow section at all.
+  it("no WORKFLOW.md on disk → composer returns null → no workflow section emitted", async () => {
+    // Pre-OP-208 this test described "modules mode falls back to legacy block
+    // when WORKFLOW.md is missing" — the legacy fallback also emitted nothing
+    // because there was no file to inline. Post-cutover the fallback is gone;
+    // the composer's null return means "no WORKFLOW.md", and the section is
+    // simply suppressed. Net behaviour is unchanged: no workflow section.
     const app = fakeApp([]);
     const out = await buildPrompt(app, fakeStore(), {
       entry: entry(),

--- a/plugins/op-obsidian/src/promptBuild.test.ts
+++ b/plugins/op-obsidian/src/promptBuild.test.ts
@@ -368,6 +368,34 @@ describe("buildPrompt — OP-198 (2a) / OP-208 (8a, cutover)", () => {
     expect(explicit).toBe(implicit);
   });
 
+  it("OP-208 cutover: shape-4 WORKFLOW.md (type: <other>) synthesises body instead of being dropped", async () => {
+    // Pre-OP-208, the legacy inline blob read WORKFLOW.md verbatim via
+    // stripFrontmatter — `type: project` (shape 4) would have been read and
+    // its body inlined. Post-cutover the legacy blob is gone, so a shape-4
+    // file that previously got content inlined would silently lose it.
+    // Fix: workflowFile.ts now synthesises shape 4 like shapes 1/2/3/5 so
+    // the body is preserved (with a warning diagnostic to signal the author
+    // should fix the type field).
+    const shape4Body = "# Workflow\n\nDo the thing.";
+    const app = fakeApp([
+      {
+        path: "Projects/demo/WORKFLOW.md",
+        raw: `---\ntype: note\n---\n${shape4Body}\n`,
+        frontmatter: { type: "note" },
+      },
+    ]);
+    const out = await buildPrompt(app, fakeStore(), {
+      entry: entry(),
+      profile: profile(),
+      injection: injection(),
+      vaultBasePath: "/Users/me/vault",
+      mode: "work",
+    });
+    expect(out).toContain("## Project workflow");
+    expect(out).toContain(shape4Body);
+    expect(out).toContain("Issue: OP-1 — Demo issue");
+  });
+
   it("modules mode: composer output replaces the legacy 'From Projects/.../WORKFLOW.md' blob", async () => {
     const app = fakeApp([
       // Modern WORKFLOW.md frontmatter (OP-196 schema).

--- a/plugins/op-obsidian/src/promptBuild.ts
+++ b/plugins/op-obsidian/src/promptBuild.ts
@@ -16,19 +16,22 @@ export interface BuildPromptArgs {
   injection: InjectionSettings;
   vaultBasePath?: string;
   mode?: AgentLaunchMode;
-  /** OP-198 (2a): selects the workflow-injection engine. `'modules'` calls
-   *  `loadAndComposeWorkflow`; `'legacy'` (default) inlines
-   *  `Projects/<slug>/WORKFLOW.md` verbatim. */
+  /** OP-198 (2a): selects the workflow-injection engine. OP-208 (8a, cutover)
+   *  removed the legacy code path from `buildPrompt`, so this field is no
+   *  longer consulted here — both modes route through `composeWorkflowSection`
+   *  (whose own legacy-fallback ladder handles vanilla `WORKFLOW.md`). The
+   *  field is kept on `BuildPromptArgs` because callers (notably
+   *  `launchAgentModal`) still gate UI panel affordances on it. */
   workflowMode?: WorkflowMode;
   /** OP-198 (2a): vault-wide user vars threaded into the composer's Global
-   *  precedence layer. Unused when `workflowMode === 'legacy'`. */
+   *  precedence layer. Always consulted post-OP-208 cutover. */
   workflowVars?: Record<string, string>;
   /** OP-204 (3d): per-launch user-var overrides threaded into the composer's
    *  Launch precedence layer (level 4 — wins over Module / Global / Project).
    *  Sourced from the launch modal's "Workflow variables" panel, the URI
    *  parser's `var.<name>=<value>` keys, and the auto-advance carry-through
-   *  (`fm.launch_vars`). Empty/absent maps cleanly omit the layer. Unused
-   *  when `workflowMode === 'legacy'`. */
+   *  (`fm.launch_vars`). Empty/absent maps cleanly omit the layer. Always
+   *  consulted post-OP-208 cutover. */
   launchVars?: Record<string, string>;
   /** OP-198 (2a) — extended in OP-199 (2b): name of the workflow step to
    *  compose for this launch. Defaults to `'kickoff'`. OP-199 wires
@@ -74,45 +77,18 @@ export async function buildPrompt(
   parts.push(renderSkillTrigger(profile, entry.id));
 
   if (injection.includeWorkflow && entry.project) {
-    const workflowMode: WorkflowMode = args.workflowMode ?? "legacy";
-    let composedSection: string | null = null;
-
-    if (workflowMode === "modules") {
-      // OP-198 (2a) / OP-199 (2b): swap the legacy inline blob for OP-197's
-      // composer. `composeWorkflowSection` returns:
-      //   - null  → no WORKFLOW.md, fall through to legacy below
-      //   - ""    → WORKFLOW.md exists but step was empty, suppress
-      //   - text  → splice the composed section
-      composedSection = await composeWorkflowSection(app, args);
-    }
-
-    if (composedSection !== null) {
-      // Composer ran: '' means WORKFLOW.md exists but the step had no output
-      // (e.g. `modules: []`). Don't push anything — the user opted into
-      // modules mode so silently injecting the legacy inline blob would be
-      // wrong. Non-empty: splice into the prompt as-is.
-      if (composedSection) parts.push(composedSection);
-    } else {
-      // Legacy path — kept byte-identical (OP-198 acceptance criterion).
-      const workflowPath = `Projects/${entry.project}/WORKFLOW.md`;
-      const wf = app.vault.getAbstractFileByPath(workflowPath);
-      if (wf instanceof TFile) {
-        const raw = await app.vault.read(wf);
-        const body = stripFrontmatter(raw).trim();
-        if (body) {
-          const cap = Math.max(0, injection.maxWorkflowChars | 0);
-          if (cap === 0 || body.length > cap) {
-            // Over the inline cap (or inlining disabled): point at the file
-            // rather than burn kickoff context.
-            parts.push(
-              `## Project workflow\n\nSee ${workflowPath} for this project's SDLC policy. Read it before touching the repo.`,
-            );
-          } else {
-            parts.push(`## Project workflow\n\nFrom ${workflowPath}:\n\n${body}`);
-          }
-        }
-      }
-    }
+    // OP-208 (8a, cutover): the modular composer is now the only path. Its
+    // legacy-fallback ladder (`workflowFile.ts` shapes 1/2/3/5) wraps vanilla
+    // WORKFLOW.md into a synthetic kickoff step, so projects without a
+    // schema-conformant workflow file still get their body inlined.
+    // `composeWorkflowSection` returns:
+    //   - null   → no WORKFLOW.md on disk; emit nothing
+    //   - ""     → WORKFLOW.md exists but the step composed to empty
+    //              (`modules: []` or every module rendered to whitespace);
+    //              explicit-suppress contract from OP-198 — emit nothing
+    //   - text   → splice into the prompt as-is
+    const composedSection = await composeWorkflowSection(app, args);
+    if (composedSection) parts.push(composedSection);
   }
 
   const header: string[] = [];

--- a/plugins/op-obsidian/src/promptBuild.ts
+++ b/plugins/op-obsidian/src/promptBuild.ts
@@ -206,8 +206,8 @@ export async function composeWorkflowSection(
     ctx,
   });
 
-  // `null` means WORKFLOW.md was not found — signal the caller to fall
-  // back to the legacy inline blob.
+  // `null` means WORKFLOW.md was not found on disk — the workflow section
+  // is omitted entirely (there is no legacy inline blob post-OP-208 cutover).
   if (!composed) return null;
 
   // OP-199 (2b) lenient fallback: requested step missing entirely → retry

--- a/plugins/op-obsidian/src/settings.test.ts
+++ b/plugins/op-obsidian/src/settings.test.ts
@@ -251,26 +251,30 @@ describe("mergeSettings", () => {
     expect(mergeSettings({ projectOrder: ["  baz  "] }).projectOrder).toEqual(["baz"]);
   });
 
-  it("OP-198: workflowMode defaults to 'legacy' on fresh install", () => {
-    expect(DEFAULT_SETTINGS.workflowMode).toBe("legacy");
-    expect(mergeSettings({}).workflowMode).toBe("legacy");
-    expect(mergeSettings(null).workflowMode).toBe("legacy");
+  it("OP-208 (8a, cutover): workflowMode default flipped to 'modules' on fresh install", () => {
+    expect(DEFAULT_SETTINGS.workflowMode).toBe("modules");
+    expect(mergeSettings({}).workflowMode).toBe("modules");
+    expect(mergeSettings(null).workflowMode).toBe("modules");
   });
 
-  it("OP-198: workflowMode accepts 'legacy' / 'modules'; rejects unknown literals and non-strings", () => {
-    expect(mergeSettings({ workflowMode: "modules" }).workflowMode).toBe("modules");
+  it("OP-208 (8a, cutover): existing data.json with workflowMode === 'legacy' is preserved (no auto-flip)", () => {
+    // Migration semantics from OP-208 scope: users who explicitly opted into
+    // 'legacy' (or installed before the field existed and later wrote 'legacy')
+    // KEEP that value. The default flip only affects blobs with no
+    // workflowMode field at all.
     expect(mergeSettings({ workflowMode: "legacy" }).workflowMode).toBe("legacy");
-    // Unknown literal — falls back to default.
+    expect(mergeSettings({ workflowMode: "modules" }).workflowMode).toBe("modules");
+    // Unknown literal — falls back to (post-cutover) default.
     expect(
       mergeSettings({ workflowMode: "experimental" as unknown as "legacy" }).workflowMode,
-    ).toBe("legacy");
+    ).toBe("modules");
     // Non-string — falls back to default.
     expect(
       mergeSettings({ workflowMode: 1 as unknown as "legacy" }).workflowMode,
-    ).toBe("legacy");
+    ).toBe("modules");
     expect(
       mergeSettings({ workflowMode: null as unknown as "legacy" }).workflowMode,
-    ).toBe("legacy");
+    ).toBe("modules");
   });
 
   it("OP-198: workflowVars defaults to {} on fresh install; not shared with DEFAULT_SETTINGS", () => {
@@ -324,15 +328,18 @@ describe("mergeSettings", () => {
     ).toEqual({ "a.b": "v1", "x/y": "v2" });
   });
 
-  it("OP-198: existing user upgrading from a version pre-workflowMode loads cleanly with defaults", () => {
+  it("OP-198: existing user upgrading from a version pre-workflowMode picks up the post-cutover default", () => {
     // Simulates a real data.json blob captured before OP-198 — no
-    // workflowMode / workflowVars keys at all. Both must default cleanly.
+    // workflowMode / workflowVars keys at all. After the OP-208 cutover the
+    // default is 'modules', so absent-field blobs flip to modules on next
+    // load (the composer's legacy-fallback ladder still handles vanilla
+    // WORKFLOW.md transparently).
     const out = mergeSettings({
       defaultAgent: "claude",
       injection: { maxBodyChars: 8000 },
       workingDirs: { foo: "/code/foo" },
     });
-    expect(out.workflowMode).toBe("legacy");
+    expect(out.workflowMode).toBe("modules");
     expect(out.workflowVars).toEqual({});
   });
 

--- a/plugins/op-obsidian/src/settings.test.ts
+++ b/plugins/op-obsidian/src/settings.test.ts
@@ -268,12 +268,23 @@ describe("mergeSettings", () => {
     expect(
       mergeSettings({ workflowMode: "experimental" as unknown as "legacy" }).workflowMode,
     ).toBe("modules");
+    // Empty string — typeof check passes, but WORKFLOW_MODES.has("") is false → default.
+    expect(
+      mergeSettings({ workflowMode: "" as unknown as "legacy" }).workflowMode,
+    ).toBe("modules");
     // Non-string — falls back to default.
     expect(
       mergeSettings({ workflowMode: 1 as unknown as "legacy" }).workflowMode,
     ).toBe("modules");
     expect(
       mergeSettings({ workflowMode: null as unknown as "legacy" }).workflowMode,
+    ).toBe("modules");
+    // Arrays / objects fail the typeof guard before WORKFLOW_MODES.has — no coercion possible.
+    expect(
+      mergeSettings({ workflowMode: ["legacy"] as unknown as "legacy" }).workflowMode,
+    ).toBe("modules");
+    expect(
+      mergeSettings({ workflowMode: { valueOf: () => "legacy" } as unknown as "legacy" }).workflowMode,
     ).toBe("modules");
   });
 

--- a/plugins/op-obsidian/src/settings.ts
+++ b/plugins/op-obsidian/src/settings.ts
@@ -891,20 +891,15 @@ export class OpSettingsTab extends PluginSettingTab {
         }),
       );
 
-    new Setting(containerEl)
-      .setName("Workflow inline cap (chars)")
-      .setDesc(
-        "If WORKFLOW.md exceeds this size, the prompt surfaces only the path with a 'read this first' hint instead of inlining. 0 disables inlining (path-only).",
-      )
-      .addText((t) =>
-        t.setValue(String(s.injection.maxWorkflowChars)).onChange(async (v) => {
-          const n = parseInt(v, 10);
-          if (Number.isFinite(n) && n >= 0) {
-            s.injection.maxWorkflowChars = n;
-            await this.plugin.saveSettings();
-          }
-        }),
-      );
+    // OP-208 (8a, cutover): the "Workflow inline cap (chars)" row was retired
+    // here. The legacy WORKFLOW.md inline path in `promptBuild.ts` was removed
+    // at the same cutover; `injection.maxWorkflowChars` is still honored by
+    // the modular composer (`composeWorkflowPure.ts`) as a soft size budget
+    // (info-severity `size-budget` diagnostic on overrun) and by the editor
+    // validator. The Workflows top-level group from OP-201 surfaces those
+    // diagnostics, so an editable text-input row here would be redundant —
+    // and confusing, since the new default of 50000 is generous enough that
+    // most users never hit the budget.
 
     const preambleSetting = new Setting(containerEl)
       .setName("Extra preamble")

--- a/plugins/op-obsidian/src/settingsPure.ts
+++ b/plugins/op-obsidian/src/settingsPure.ts
@@ -136,8 +136,13 @@ export interface OpSettings {
   // command, when wired) to re-trigger.
   firstRunCompleted: boolean;
   /** OP-198 (2a): switch between the legacy `WORKFLOW.md` inline-blob path
-   *  and the OP-197 modular composer at kickoff. Defaults to `'legacy'` so
-   *  upgrading users see byte-identical prompts until they opt in. */
+   *  and the OP-197 modular composer at kickoff. OP-208 (8a, cutover) flipped
+   *  the default to `'modules'`; the legacy code path in `promptBuild.ts`
+   *  was removed at the same time, so this field now only gates UI affordances
+   *  in `launchAgentModal` (panels that prompt the user for module-only inputs
+   *  show a "modules disabled" notice when this is `'legacy'`). The composer's
+   *  own legacy-fallback ladder (`workflowFile.ts`, shapes 1/2/3/5) handles
+   *  vanilla `WORKFLOW.md` transparently regardless of this flag. */
   workflowMode: WorkflowMode;
   /** OP-198 (2a): vault-wide user vars threaded into the composer's
    *  Global precedence layer (OP-197 §"Precedence"). Per-project values live
@@ -212,7 +217,7 @@ export const DEFAULT_SETTINGS: OpSettings = {
   projectOrder: [],
   recent: [],
   firstRunCompleted: false,
-  workflowMode: "legacy",
+  workflowMode: "modules",
   workflowVars: {},
   previewAutoExpandDismissed: false,
 };

--- a/plugins/op-obsidian/src/workflowFile.fixtures.test.ts
+++ b/plugins/op-obsidian/src/workflowFile.fixtures.test.ts
@@ -66,20 +66,21 @@ describe("legacy fallback fixtures", () => {
     expect(c.body).toBe(stripWorkflowFrontmatter(raw));
   });
 
-  it("(4) 4-wrong-type.md classifies as legacy-4 — caller drops with schema-mismatch", () => {
+  it("(4) 4-wrong-type.md classifies as legacy-4 — synthesises body with warning (OP-208 cutover fix)", () => {
     const raw = readFixture("4-wrong-type.md");
     const c = classifyLegacy(raw, { type: "project", project: "demo-project" });
     expect(c.shape).toBe("legacy-4");
-    // synthesizeLegacyWorkflow refuses to handle this shape — caller must
-    // emit a schema-mismatch and return null instead. We assert the refusal.
-    expect(() =>
-      synthesizeLegacyWorkflow({
-        path: "Projects/demo/WORKFLOW.md",
-        project: "demo",
-        body: c.body,
-        shape: c.shape,
-      }),
-    ).toThrow(/not synthesisable/);
+    // OP-208 cutover fix: synthesizeLegacyWorkflow now accepts legacy-4 so that
+    // pre-cutover WORKFLOW.md files with wrong `type:` don't silently lose their
+    // body content. The IO layer emits a warning diagnostic instead of dropping.
+    const wf = synthesizeLegacyWorkflow({
+      path: "Projects/demo/WORKFLOW.md",
+      project: "demo",
+      body: c.body,
+      shape: c.shape,
+    });
+    expect(wf.source.isLegacy).toBe(true);
+    expect(wf.steps[0].legacyKickoffBody).toBe(c.body);
   });
 
   it("(5) 5-null-frontmatter.md classifies as legacy-5", () => {

--- a/plugins/op-obsidian/src/workflowFile.test.ts
+++ b/plugins/op-obsidian/src/workflowFile.test.ts
@@ -172,7 +172,12 @@ describe("loadWorkflowFile — legacy fallback shapes", () => {
     expect(r.workflow!.steps[0].legacyKickoffBody).toBe("# Body\ntext\n");
   });
 
-  it("(4) type: <other> → legacy-4 drop with schema-mismatch diagnostic", async () => {
+  it("(4) type: <other> → legacy-4 synthesises body with warning diagnostic (OP-208 cutover fix)", async () => {
+    // Pre-OP-208 the legacy inline blob in buildPrompt read WORKFLOW.md
+    // verbatim regardless of frontmatter. The new shape-4 handler synthesises
+    // from the body (like shapes 1/2/3/5) so users whose WORKFLOW.md carries
+    // `type: <other>` from a metadata plugin don't silently lose their
+    // workflow content after the cutover.
     const raw = "---\ntype: project\n---\nbody\n";
     const app = fakeApp([
       {
@@ -182,8 +187,11 @@ describe("loadWorkflowFile — legacy fallback shapes", () => {
       },
     ]);
     const r = await loadWorkflowFile(app, "demo");
-    expect(r.workflow).toBeNull();
+    expect(r.workflow).not.toBeNull();
+    expect(r.workflow!.source.isLegacy).toBe(true);
+    expect(r.workflow!.steps[0].legacyKickoffBody).toBe("body\n");
     expect(r.diagnostics[0].code).toBe("schema-mismatch");
+    expect(r.diagnostics[0].severity).toBe("warning");
     expect((r.diagnostics[0].extra as Record<string, unknown>).actual).toBe("project");
   });
 

--- a/plugins/op-obsidian/src/workflowFile.ts
+++ b/plugins/op-obsidian/src/workflowFile.ts
@@ -150,18 +150,33 @@ async function loadAtPath(app: App, args: LoadAtPathArgs): Promise<LoadWorkflowR
     return { workflow, diagnostics: [legacyShapeDiagnostic(args.path, classification.shape)] };
   }
 
-  // Legacy 4 — wrong type. Drop the file with a schema-mismatch diagnostic.
+  // Legacy 4 — type field is set but isn't "workflow". Pre-OP-198 users may
+  // have `type: <other>` (e.g. `type: note`) in their WORKFLOW.md from another
+  // Obsidian plugin's metadata system. Post-OP-208 there is no legacy inline
+  // blob to fall back to, so dropping the file silently would cause these users
+  // to lose all workflow content after the cutover. Synthesise from the body
+  // (same as shapes 1/2/3/5) and emit a warning so they know to fix the type
+  // field, without breaking their kickoff prompt in the meantime.
   if (classification.shape === "legacy-4") {
     const actualType = (fmInput && typeof fmInput === "object" && !Array.isArray(fmInput))
       ? (fmInput as Record<string, unknown>).type
       : undefined;
+    const workflow = synthesizeLegacyWorkflow({
+      path: args.path,
+      project: args.project,
+      body: classification.body,
+      shape: classification.shape,
+    });
     return {
-      workflow: null,
+      workflow,
       diagnostics: [
         {
           code: "schema-mismatch",
-          severity: "error",
-          message: `${args.path}: type must be "workflow", got "${String(actualType)}".`,
+          severity: "warning",
+          message:
+            `${args.path}: type must be "workflow", got "${String(actualType)}". ` +
+            `Body wrapped into a synthetic kickoff step (legacy compatibility — OP-208 cutover). ` +
+            `Set \`type: workflow\` (and add \`steps:\`) to silence this warning.`,
           extra: { path: args.path, field: "type", expected: "workflow", actual: String(actualType) },
         },
       ],

--- a/plugins/op-obsidian/src/workflowFilePure.test.ts
+++ b/plugins/op-obsidian/src/workflowFilePure.test.ts
@@ -324,20 +324,22 @@ describe("synthesizeLegacyWorkflow", () => {
     expect(wf.extendsPath).toBeNull();
   });
 
-  it("works for shapes 1, 2, 3, 5", () => {
-    for (const shape of ["legacy-1", "legacy-2", "legacy-3", "legacy-5"] as const) {
+  it("works for shapes 1, 2, 3, 4, 5", () => {
+    for (const shape of ["legacy-1", "legacy-2", "legacy-3", "legacy-4", "legacy-5"] as const) {
       const wf = synthesizeLegacyWorkflow({ path: PATH, project: PROJECT, body: "x", shape });
       expect(wf.steps[0].legacyKickoffBody).toBe("x");
     }
   });
 
-  it("throws for non-synthesisable shapes (defensive)", () => {
+  it("throws only for 'modern' (defensive)", () => {
     expect(() =>
       synthesizeLegacyWorkflow({ path: PATH, project: PROJECT, body: "x", shape: "modern" }),
     ).toThrow();
+    // legacy-4 no longer throws: OP-208 shape-4 cutover fix — body is
+    // synthesised so pre-cutover users don't silently lose workflow content.
     expect(() =>
       synthesizeLegacyWorkflow({ path: PATH, project: PROJECT, body: "x", shape: "legacy-4" }),
-    ).toThrow();
+    ).not.toThrow();
   });
 });
 

--- a/plugins/op-obsidian/src/workflowFilePure.ts
+++ b/plugins/op-obsidian/src/workflowFilePure.ts
@@ -686,14 +686,17 @@ export function classifyLegacy(
 }
 
 /**
- * Synthesise a `WorkflowFile` for legacy shapes 1, 2, 3, 5. The synthesised
+ * Synthesise a `WorkflowFile` for legacy shapes 1, 2, 3, 4, 5. The synthesised
  * workflow has one step (`step: "kickoff", modules: []`) carrying the
  * entire body verbatim in `legacyKickoffBody`. Defaults are empty arrays /
  * `kind: "all"` with no values — the launch overrides will fill them.
  *
  * Caller (IO layer) must guarantee `shape` is one of `legacy-1`, `legacy-2`,
- * `legacy-3`, `legacy-5` — `legacy-4` (wrong type) should produce a
- * `schema-mismatch` diagnostic and `null` workflow instead.
+ * `legacy-3`, `legacy-4`, `legacy-5`. Shape `legacy-4` (wrong `type:` field)
+ * synthesises from the body with a `warning`-severity diagnostic so that
+ * pre-OP-208 WORKFLOW.md files that incidentally carry `type: <other>` (e.g.
+ * from a metadata-management plugin) do not lose their workflow content after
+ * the OP-208 cutover.
  */
 export function synthesizeLegacyWorkflow(args: {
   path: string;
@@ -702,13 +705,13 @@ export function synthesizeLegacyWorkflow(args: {
   shape: LegacyShape;
 }): WorkflowFile {
   const { path, project, body, shape } = args;
-  if (shape === "modern" || shape === "legacy-4") {
-    // Defensive: callers should never reach this path with a non-synthesisable
-    // shape. Surface the misuse loudly rather than silently producing a
-    // workflow that hides the underlying schema problem.
+  if (shape === "modern") {
+    // Defensive: callers should never reach this path with a modern shape.
+    // Surface the misuse loudly rather than silently producing a workflow that
+    // hides the underlying schema problem.
     throw new Error(
-      `synthesizeLegacyWorkflow: shape ${shape} is not synthesisable — ` +
-        `callers must route modern through parseWorkflowFile and legacy-4 through schema-mismatch.`,
+      `synthesizeLegacyWorkflow: shape "modern" is not synthesisable — ` +
+        `callers must route modern files through parseWorkflowFile.`,
     );
   }
   const step: WorkflowStep = {

--- a/plugins/op/.claude-plugin/plugin.json
+++ b/plugins/op/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "op",
   "description": "Obsidian Projects workflow — schema, slash commands, and agent skill for running a Jira-lite issue tracker inside an Obsidian vault.",
-  "version": "0.76.0",
+  "version": "0.77.0",
   "author": {
     "name": "Eugene Archibald"
   },


### PR DESCRIPTION
## Summary

- **Default flip:** `DEFAULT_SETTINGS.workflowMode` is now `'modules'`. `mergeSettings` preserves explicitly-saved `'legacy'` values; absent-field blobs pick up the new default.
- **Legacy promptBuild blob removed:** the workflow injection branch in `buildPrompt` no longer reads `WORKFLOW.md` verbatim under a `From <path>:` preamble. Both modes route through `composeWorkflowSection`, whose own legacy-fallback ladder (`workflowFile.ts` shapes 1/2/3/5) wraps vanilla `WORKFLOW.md` into a synthetic kickoff step. The `workflowMode` arg-driven gate inside `buildPrompt` is gone (the `main.ts` evaluator gate too).
- **Settings cap row retired:** the `Workflow inline cap (chars)` row in the Injection collapsible is deleted (replaced by the Workflows top-level group from OP-201). The `maxWorkflowChars` field stays on `OpSettings` because the composer / editor validator still honor it as a soft size budget.

## Migration semantics

| Saved data.json | Loaded `workflowMode` | Behavior |
| --- | --- | --- |
| Field absent | `"modules"` (new default) | Modules engine; vanilla `WORKFLOW.md` handled by legacy-fallback ladder |
| `"legacy"` (explicit) | `"legacy"` (preserved) | Modules engine still runs in `promptBuild` (legacy code path removed); `launchAgentModal` still shows "modules disabled" notices — those gates are out of scope here (belong to OP-209's docs/agent-facing pass) |
| `"modules"` | `"modules"` (preserved) | Unchanged |

Stored-`'legacy'` users functionally use the modules engine after this PR. The legacy-fallback ladder preserves their user-visible kickoff content for vanilla `WORKFLOW.md`.

## Test plan

- [x] `npm test` — 1530/1530 vitest cases pass (one pre-existing 0-test suite failure in `iTermPrefs.test.ts` from a Vitest-4 / `obsidian` package resolution quirk, unrelated to this PR — confirmed by running the same test against `main`).
- [x] Settings test additions: `DEFAULT_SETTINGS.workflowMode === "modules"`; `mergeSettings({ workflowMode: "legacy" })` preserves `"legacy"`; absent-field blob → `"modules"`.
- [x] promptBuild test rewrite: vanilla `WORKFLOW.md` routes through the legacy-fallback ladder; explicit `workflowMode: "legacy"` is now byte-identical to the implicit default (gate is dead in `buildPrompt`).
- [x] Smoke test against `OP-Test` vault: plugin loads at v0.77.0; live `workflowMode === "modules"`; "Workflow inline cap (chars)" row absent from the Injection collapsible; "Include project workflow" toggle still present; `dev:console` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)