### PR TITLE
OP-214: 10d — sharing + migration guides

### DIFF
--- a/docs/workflow-modules/migration/from-agent-flows.md
+++ b/docs/workflow-modules/migration/from-agent-flows.md
@@ -1,0 +1,372 @@
+# Migrate Agent Flows
+
+If you've been using op long enough to have issues with `flow:` and
+`complexity:` in their frontmatter, this guide is for you. The auto-advance
+machinery — the bit that picks the next agent stage to launch when an agent's
+`SessionEnd` hook fires — was rewritten in OP-188. The user-facing contract
+didn't change, but the engine underneath did, and the migration story is
+worth knowing if you're authoring custom workflows or wondering why your
+pre-existing `flow: planning` issues still walk cleanly.
+
+The short version:
+
+- **What changed**: `flowOrchestrator.ts` no longer carries a hardcoded
+  transition matrix. It walks the project's loaded `WorkflowFile.steps`
+  list. Step transitions follow the order *you* declare in
+  `Projects/<slug>/WORKFLOW.md`.
+- **What stayed the same**: per-issue `flow:` / `complexity:` frontmatter,
+  the `flow.autoAdvance` setting, level-4 launch override carry-forward,
+  and the historical evaluate-fast-path semantics for `simple` complexity.
+- **What handles old data**: a permanent legacy → canonical alias map
+  (`LEGACY_FLOW_ALIAS`) plus a separate legacy-fallback path that runs
+  the original hardcoded matrix verbatim when no schema-1 workflow file
+  is present.
+
+You don't need to do anything to your existing issues. The migration is
+content-preserving and the alias map is permanent.
+
+## What changed (the engine)
+
+Before OP-188, `flowOrchestrator.ts` carried the SDLC sequence in code:
+
+```ts
+// pre-OP-188 (sketch)
+function flowAdvanceDecision({ flow, complexity, exitStatus }) {
+  if (exitStatus !== "clean") return null;
+  switch (flow) {
+    case "evaluate":
+      if (complexity === "simple")  return { nextFlow: "implementation" };
+      if (complexity === "complex") return { nextFlow: "planning" };
+      return null;
+    case "planning":       return { nextFlow: "implementation" };
+    case "implementation": return { nextFlow: "review" };
+    case "review":         return { nextFlow: "finalization" };
+    case "finalization":
+    case "done":
+    case null:             return null;
+  }
+}
+```
+
+The matrix was source-of-truth: changing the order required code changes,
+and there was no way to insert a custom step between, say, `review` and
+`finalization` without forking the plugin.
+
+After OP-188, the function takes a loaded workflow file as input and walks
+its `steps:` list:
+
+```ts
+// post-OP-188 (sketch — see flowOrchestrator.ts:flowAdvanceDecision)
+function flowAdvanceDecision({ workflow, flow, complexity, exitStatus }) {
+  if (exitStatus !== "clean") return null;
+  if (flow === null) return null;
+  if (workflow === null || workflow.source.isLegacy) {
+    return legacyFlowAdvanceDecision({ flow, complexity, exitStatus });
+  }
+  const current = aliasResolve(flow);            // legacy → canonical
+  const i = findStepIndex(workflow.steps, current);
+  if (i === -1) return null;
+  if (current === "evaluate") {
+    if (complexity === "simple")  return skipPlanStep(workflow.steps, i);
+    if (complexity === "complex") return advanceOne(workflow.steps, i);
+    return null;
+  }
+  return advanceOne(workflow.steps, i);
+}
+```
+
+Two consequences worth highlighting:
+
+1. **Custom steps work without code changes.** Insert a new step between
+   `review` and `finalize` in your workflow file's `steps:` list and
+   auto-advance picks it up. The walker is entirely workflow-file driven.
+2. **Step-not-in-workflow returns `null` (no advancement)**, not an
+   exception. If your issue's current `flow:` value doesn't appear in the
+   project's `steps:` list, the orchestrator quietly stops and waits for
+   you. Visible as a no-op auto-advance in the response payload; never
+   surfaces as a hard error.
+
+The complexity branch at `evaluate` is preserved verbatim: `simple`
+fast-paths past the `plan` step (skipping every adjacent step that aliases
+to `plan`); `complex` advances by one. Same fast-path the hardcoded matrix
+ever shipped.
+
+## What stayed the same (the user-facing surface)
+
+If you've been using op for a while, none of this changed:
+
+- **`flow:` and `complexity:` frontmatter on issues.** The fields work the
+  same way: `flow:` carries the issue's current step id;
+  `complexity:` carries `simple` or `complex` for the evaluate-step
+  branching. Writing them via `obsidian op-set-flow issue=<id>
+  flow=<step>` (or via the URI handler) still works exactly as before.
+- **`autoAdvance` setting.** The plugin's per-vault
+  `settings.flow.autoAdvance` boolean still gates whether SessionEnd hooks
+  trigger an auto-advance launch. Off → SessionEnd is a no-op; on → the
+  plugin invokes `flowAdvanceDecision` and launches the next stage's
+  agent if the function returns a non-null result.
+- **Level-4 launch overrides.** When an agent was launched with
+  `var.<name>=<value>` overrides (the "this single run" layer of the
+  precedence chain), those overrides carry forward across the auto-advance
+  chain via `carriedLaunchVars`. The advance call site in
+  `main.ts:advanceFlowAndLaunch` runs `loadWorkflowFile` *before* invoking
+  the decision function, but the carry-forward path is downstream of the
+  decision and didn't change.
+- **The evaluate fast-path.** `complexity: simple` skips `plan` and lands
+  the issue at `implement`. `complexity: complex` advances by one to
+  `plan`. Missing complexity at `evaluate` returns `null` so the walker
+  awaits a user decision. Same semantics — same call sites still rely on
+  it.
+- **Abnormal exits don't auto-advance.** `exitStatus !== "clean"` → return
+  `null`. Crashed agents, user-cancelled launches, hook failures all stop
+  the chain. No silent re-launch.
+
+In short: if you write or read `flow:` / `complexity:` from anywhere — a
+script, a custom hook, a manual frontmatter edit — your code keeps working.
+
+## How legacy `flow:` enum values keep working
+
+Pre-OP-188 issues had a closed-enum `flow:` value:
+
+| Pre-OP-188 (closed enum) | Post-OP-188 (canonical step id) |
+| :--- | :--- |
+| `evaluate` | `evaluate` (unchanged) |
+| `planning` | `plan` |
+| `implementation` | `implement` |
+| `review` | `review` (unchanged) |
+| `finalization` | `finalize` |
+| `done` | `done` (terminal sentinel) |
+
+The mapping lives as `LEGACY_FLOW_ALIAS` in `flowOrchestrator.ts` and is
+**permanent** — there's no plan to retire it. Old in-flight issues with
+`flow: planning` walk cleanly forever; you don't need to back-fill the
+canonical step id into existing frontmatter.
+
+```ts
+// flowOrchestrator.ts:LEGACY_FLOW_ALIAS (frozen at module load)
+export const LEGACY_FLOW_ALIAS = Object.freeze({
+  evaluate: "evaluate",
+  planning: "plan",
+  plan: "plan",
+  implementation: "implement",
+  implement: "implement",
+  review: "review",
+  finalization: "finalize",
+  finalize: "finalize",
+  done: "done",
+});
+```
+
+The alias map is applied **symmetrically** in two places:
+
+1. **The issue's `flow:` value.** When the orchestrator reads the issue's
+   current step from frontmatter, it alias-resolves the value before
+   looking it up in the workflow's `steps:` list. So `flow: planning` in a
+   pre-OP-188 issue resolves to canonical `plan` and finds the matching
+   slot.
+2. **Step ids in the workflow file.** When the orchestrator walks
+   `workflow.steps[*].step`, it alias-resolves each id. So a custom
+   workflow that still uses `step: planning` in its `steps:` list walks
+   the same way as one that uses canonical `step: plan`.
+
+Symmetric application means every combination of "issue uses legacy id +
+workflow uses canonical id" / "issue uses canonical id + workflow uses
+legacy id" / "both legacy" / "both canonical" lands at the same step. New
+writes (auto-advance, scaffolds, the canonical settings) always emit
+canonical ids; the legacy ids are accepted on read forever.
+
+### What about custom step ids?
+
+The map only covers the historical 6-value enum. Step ids you invent —
+`triage`, `qa-handoff`, `release-bake` — pass through `aliasResolve` as
+`null` (unrecognized). The walker handles that case: a `null` from
+`aliasResolve` on the *current* step returns `null` from the decision
+function (no advancement). On a *workflow-file step id*, the walker still
+matches the literal id, so workflows using custom step ids still walk —
+they just can't claim canonical-mode behavior at the launch surface.
+
+This is why `setFlow` loosened from a closed enum to a free-form non-empty
+string at the same time: writing `obsidian op-set-flow issue=OP-42
+flow=triage` succeeds, the auto-advance walker finds `triage` in your
+custom workflow, and the next step launches normally. The walker enforces
+"is this step in the workflow," not the writer.
+
+## How the legacy fallback path keeps pre-modules projects working
+
+If a project hasn't migrated its `WORKFLOW.md` to schema-1, OP-188 ships
+that case behind a fallback:
+
+```ts
+// flowOrchestrator.ts:flowAdvanceDecision
+if (workflow === null || workflow.source.isLegacy) {
+  return legacyFlowAdvanceDecision({ flow, complexity, exitStatus });
+}
+```
+
+`legacyFlowAdvanceDecision` is the byte-for-byte original hardcoded matrix
+from before OP-188. It's exported alongside the new walker so the migration
+story is "the OLD function still exists, called only when needed." Two
+trigger conditions:
+
+- **`workflow === null`**: the project has no `WORKFLOW.md` at all, or its
+  `WORKFLOW.md` failed to parse (an unrecoverable `error`-severity
+  diagnostic). Auto-advance falls back to the historical sequence.
+- **`workflow.source.isLegacy === true`**: the loader synthesized a
+  legacy workflow via the six-shape fallback ladder (see
+  [`from-workflow-md.md`](./from-workflow-md.md) for the full ladder).
+  These files have one synthesized `kickoff` step that carries the entire
+  legacy body verbatim; the synthesized `steps:` list isn't navigable, so
+  the orchestrator routes through the old matrix instead.
+
+Either way, pre-modules projects keep auto-advancing through the
+historical `evaluate → plan → implement → review → finalize` sequence
+even after upgrading to a post-OP-188 op-obsidian. **You don't lose
+auto-advance by keeping a legacy WORKFLOW.md** — the modules schema is
+fully opt-in.
+
+The fallback path uses canonical ids in its output regardless of input
+shape — `flow: planning` (legacy enum) advances to `flow: implement`
+(canonical), not `flow: implementation`. New writes always emit the
+canonical id; the alias map exists to accept old values on read.
+
+## What the new default workflow ships
+
+Projects scaffolded post-OP-188 get a self-contained schema-1 `WORKFLOW.md`
+seeded by `scaffoldProject`:
+
+```yaml
+---
+project: <your-slug>
+type: workflow
+schema: 1
+default_agent: claude
+default_model: opus
+steps:
+  - step: evaluate
+    modules: []
+  - step: plan
+    modules: []
+  - step: implement
+    modules: []
+  - step: review
+    modules: []
+  - step: finalize
+    modules: []
+---
+```
+
+Empty `modules:` lists for now — the scaffold doesn't presume which
+modules you want to compose. The five-step sequence matches the historical
+matrix exactly, so a fresh-scaffolded project's auto-advance behavior is
+identical to a pre-OP-188 project's. Add modules to each step's list as
+your project's rules emerge; share them across projects via
+[`share-modules.md`](../sharing/share-modules.md) once you have a few you
+like.
+
+The seed is *self-contained*, not `extends:`-based, on purpose: there's no
+auto-installed global default to depend on. If you want a global, author
+`Projects/_op-workflow.md` yourself and switch the per-project file to
+`extends: Projects/_op-workflow.md` afterwards. Both shapes work; the
+self-contained shape is just the simplest starting point.
+
+## Migration recipe
+
+For most users this is a no-op — you don't need to touch existing data.
+But if you want to clean up:
+
+### Issues with legacy `flow:` enum values
+
+Don't bother. The alias map is permanent and the read-side resolution is
+zero-cost. Touching frontmatter on dozens of in-flight issues is more risk
+than it's worth.
+
+If you do want to back-fill the canonical id on a single issue
+(say, because the workflow editor UI shows you the literal value and
+you'd rather see `plan` than `planning`), edit the issue note's
+frontmatter directly:
+
+```diff
+- flow: planning
++ flow: plan
+```
+
+…or run the CLI:
+
+```bash
+obsidian op-set-flow issue=OP-42 flow=plan
+```
+
+The auto-advance walker doesn't care which form is on disk.
+
+### Projects still on a legacy WORKFLOW.md
+
+The fallback keeps you working. When you're ready to migrate the workflow
+file itself, follow [`from-workflow-md.md`](./from-workflow-md.md) — that
+covers the schema-1 frontmatter contract, the module decomposition pattern,
+and the legacy fallback ladder.
+
+The migration is independent of what your existing in-flight issues have
+in their `flow:` field. Once the workflow file is schema-1, the engine
+walks it via the new path; pre-existing issues with `flow: planning`
+still resolve cleanly through the alias map.
+
+### Custom step ids you've added
+
+If you've been writing custom step ids via `op-set-flow flow=<custom>`
+since OP-188, your workflow file's `steps:` list needs to carry that id
+literally — there's no alias for it, since the alias map is closed to the
+historical enum. Add a step record:
+
+```yaml
+steps:
+  - step: triage
+    modules: [<modules for the triage step>]
+  - step: kickoff
+    modules: [...]
+  ...
+```
+
+Step ids are free-form strings — same trim/non-empty rule as the issue's
+`flow:` field. Pick names that read well in launch logs.
+
+## Behavioral differences worth knowing
+
+A few edge cases changed shape between the hardcoded matrix and the new
+walker. None should affect normal use, but worth flagging:
+
+- **Step missing from the workflow.** Pre-OP-188 the matrix only knew the
+  closed enum, so this case was impossible. Post-OP-188 the walker reports
+  no-advancement (`null`) when an issue's current step isn't found in the
+  workflow's `steps:` list. Visible as a quiet "auto-advance stalled" in
+  the response payload.
+- **Workflow with extra steps between `evaluate` and `plan`.** The
+  evaluate-step `simple` fast-path scans forward from
+  `evaluateIndex + 1` and returns the first step whose canonical id is
+  not `plan`. So if you've inserted `triage` between `evaluate` and
+  `plan`, `simple` complexity skips `plan` *and* lands at `triage`'s
+  next sibling — not at `triage` itself. Tweak the order or scope if
+  you want triage to run on every issue, simple or complex.
+- **Embedded newlines in `flow:`.** `validateFlow` rejects step ids with
+  embedded `\r\n` characters across all three entry points (`setFlow`,
+  the URI handler, the CLI parser). This was an OP-188 adversarial-review
+  catch and lands in the same release.
+- **`done` is terminal.** Issues with `flow: done` never advance — same
+  as before. The alias map carries `done: "done"` for completeness.
+
+## Where to next
+
+- [`from-workflow-md.md`](./from-workflow-md.md) — the migration story for
+  the workflow file itself: legacy `WORKFLOW.md` blob → schema-1 +
+  modules. Required reading if you want to take advantage of per-step
+  injection.
+- [`share-modules.md`](../sharing/share-modules.md) — once your modules
+  exist as files, the `op-export-module` / `op-import-module` flow makes
+  them shareable across vaults.
+- [`workflow-file-schema.md`](../../specs/workflow-file-schema.md) — the
+  full workflow-file contract, including the legacy fallback ladder
+  reference and the model registry.
+- [`flowOrchestrator.ts`](https://github.com/earchibald/obsidian-projects/blob/main/plugins/op-obsidian/src/flowOrchestrator.ts)
+  — the engine source, including the canonical `LEGACY_FLOW_ALIAS` map
+  and the `legacyFlowAdvanceDecision` fallback. The frozen alias map is
+  the source of truth for what legacy values resolve to what canonical
+  ids.

--- a/docs/workflow-modules/migration/from-agent-flows.md
+++ b/docs/workflow-modules/migration/from-agent-flows.md
@@ -342,10 +342,16 @@ walker. None should affect normal use, but worth flagging:
 - **Workflow with extra steps between `evaluate` and `plan`.** The
   evaluate-step `simple` fast-path scans forward from
   `evaluateIndex + 1` and returns the first step whose canonical id is
-  not `plan`. So if you've inserted `triage` between `evaluate` and
-  `plan`, `simple` complexity skips `plan` *and* lands at `triage`'s
-  next sibling — not at `triage` itself. Tweak the order or scope if
-  you want triage to run on every issue, simple or complex.
+  not `plan`. Critically: if the first non-`plan` step is a *custom*
+  step id (one not in `LEGACY_FLOW_ALIAS`), `aliasResolve` returns
+  `null` and `outputFor(null)` returns `null` — so the fast-path
+  **stalls** (returns `null`, no auto-advance). The loop only skips
+  steps that alias to canonical `plan`; custom step ids stop the scan
+  immediately. Concretely: if you've inserted `triage` between
+  `evaluate` and `plan`, `simple` complexity stalls rather than
+  skipping past `triage`. Put custom steps *after* `implement` (not
+  between `evaluate` and `plan`) if you want them to be reachable
+  through the simple-complexity fast-path.
 - **Embedded newlines in `flow:`.** `validateFlow` rejects step ids with
   embedded `\r\n` characters across all three entry points (`setFlow`,
   the URI handler, the CLI parser). This was an OP-188 adversarial-review

--- a/docs/workflow-modules/migration/from-workflow-md.md
+++ b/docs/workflow-modules/migration/from-workflow-md.md
@@ -1,0 +1,482 @@
+# Migrate from a Legacy WORKFLOW.md
+
+The classic op layout was a single `Projects/<slug>/WORKFLOW.md` per project —
+a long markdown blob that the agent received verbatim at kickoff. It worked
+fine, but every agent launch carried every rule, even rules that only applied
+later in the lifecycle, and there was no clean way to share rules across
+projects.
+
+The modules schema replaces the monolith with composable pieces: small named
+markdown files under `Projects/_op-modules/` (global) or
+`Projects/<slug>/MODULES/` (per-project), wired together by a per-project
+schema-1 `WORKFLOW.md` that lists which modules each step composes from.
+
+You don't have to migrate today. **The loader supports legacy WORKFLOW.md
+files indefinitely** via a six-shape fallback ladder — your agents keep
+auto-advancing on the rules you already wrote. This guide walks the actual
+migration this project went through (OP-189) so you have a concrete shape to
+copy, and documents the fallback ladder so you know what'll happen if you
+keep your existing file as-is.
+
+## Why migrate
+
+Three things you get with the new schema:
+
+1. **Per-step injection.** A rule scoped to `review` only reaches the agent
+   when a review-mode session launches. A `kickoff` agent doesn't carry the
+   release-day rules; a `finalize` agent doesn't carry the planning rules.
+   Lower context, sharper signal.
+2. **Cross-project reuse.** A rule that's genuinely vault-wide (branching
+   discipline, commit cadence, "don't mock the database") lands once in
+   `Projects/_op-modules/` and every project that mentions it in its
+   `steps:` list picks it up. No copy-paste drift between project WORKFLOW
+   blobs.
+3. **Shadow without forking.** A project that wants a stricter version of a
+   global rule drops a same-id file under its own `MODULES/` folder. The
+   global is shadowed silently; the per-project copy reaches the agent. No
+   inheritance gymnastics, no "extends-with-overrides" vocabulary — same id
+   wins, project beats global.
+
+You also get cleaner reviews — diffs to a 10-line module are auditable in a
+way diffs to a 200-line `WORKFLOW.md` blob aren't — and the import/export
+flow described in [`share-modules.md`](../sharing/share-modules.md) only
+works on individual modules, so migrating unblocks sharing.
+
+## The migration this project did, in full
+
+This repo's own `WORKFLOW.md` was a long monolithic SDLC doc. OP-189 split it
+into 9 modules behind a schema-1 workflow file. The shape is general — most
+projects' WORKFLOW.md files have the same kinds of rules, just in different
+prose — so it's a useful template.
+
+### Before
+
+`Projects/obsidian-projects/WORKFLOW.md`, condensed to the section headings:
+
+```markdown
+# obsidian-projects — workflow
+
+## Branching
+Always work in an isolated worktree. No exceptions, including one-line tweaks…
+
+## Tmux experimentation: never target shared op sessions
+When developing anything that touches the orchestrator… do not run kill-session
+against op-agents-* prefixes. This is what caused OP-180: an agent…
+
+## Version bump cadence
+Every issue that ships code bumps the project's version files in lockstep…
+
+## Commit-to-issue mapping
+After each commit, run `op-append-commit issue=<id> sha=<sha7> subject=<msg>`…
+
+## PR requirement
+PRs are required to merge to main. Title format: `<ISSUE>: <subject>`. Pull
+after merge — `gh pr merge --squash --delete-branch` doesn't fast-forward…
+
+## Adversarial AI review before merge
+Request adversarial Copilot review on the PR before squash-merging. Bypass
+criteria: docs-only PRs, version-bump-only commits, …
+
+## Releases (op-obsidian)
+op-obsidian releases auto-publish from main via .github/workflows/op-obsidian-release.yml…
+
+## GitHub issue close on resolve
+When closeGithubIssueOnResolve is on, op-resolve runs `gh issue close` on the
+issue's github_issue: URL atomically. The setting lives at
+settings.github.closeGithubIssueOnResolve — NOT the top level (the => {} misread).
+
+## Parent-issue orchestration
+For umbrella tickets: dispatch each child to its own tmux window under
+session `op-agents`, name windows by issue id, poll `tmux capture-pane`…
+```
+
+Every section was always loaded — including the parent-orchestration rule
+on every solo-issue agent that didn't have a parent at all, and the
+adversarial-review rule on a kickoff-only evaluator that wasn't going to
+merge anything.
+
+### After
+
+The same content, decomposed into 9 module files plus a schema-1
+`WORKFLOW.md` that lists which modules each step composes from.
+
+**6 cross-cutting modules at `Projects/_op-modules/`** (global; any project
+can reuse them):
+
+```
+Projects/_op-modules/
+├── branching.md              (scope: kickoff, order: 10)
+├── tmux-safety.md            (scope: kickoff, order: 20)
+├── version-cadence.md        (scope: kickoff, order: 30)
+├── commit-mapping.md         (scope: kickoff, order: 40)
+├── pr-required.md            (scope: kickoff, order: 50)
+└── adversarial-review.md     (scope: review,  order: 10)
+```
+
+**3 per-project modules at `Projects/obsidian-projects/MODULES/`**
+(obsidian-projects-specific behavior other projects don't need):
+
+```
+Projects/obsidian-projects/MODULES/
+├── parent-orchestration.md           (scope: kickoff,  order: 60, project: obsidian-projects)
+├── github-issue-close-on-resolve.md  (scope: finalize, order: 20, project: obsidian-projects)
+└── releases.md                       (scope: finalize, order: 30, project: obsidian-projects)
+```
+
+**The new `Projects/obsidian-projects/WORKFLOW.md`:**
+
+```yaml
+---
+project: obsidian-projects
+type: workflow
+schema: 1
+default_agent: claude
+default_model: opus
+updated: 2026-04-26
+steps:
+  - step: kickoff
+    modules: [branching, tmux-safety, version-cadence, commit-mapping, pr-required, parent-orchestration]
+  - step: evaluate
+    modules: []
+  - step: plan
+    modules: []
+  - step: implement
+    modules: []
+  - step: review
+    modules: [adversarial-review]
+  - step: finalize
+    modules: [github-issue-close-on-resolve, releases]
+---
+
+# obsidian-projects — workflow
+
+This workflow composes per-step modules from `Projects/_op-modules/` (global)
+and `Projects/obsidian-projects/MODULES/` (per-project) into the SDLC ruleset
+that used to live as monolithic prose in this file.
+```
+
+Each step's `modules:` list is just an ordered list of ids — the loader walks
+each module file, buckets by `scope:`, sorts by `order:`, and stitches the
+bodies into the prompt for the matching step. `kickoff` agents now carry six
+rules; `review` agents carry one (`adversarial-review`); `finalize` agents
+carry two (`github-issue-close-on-resolve`, `releases`). Solo-issue
+evaluators no longer carry the umbrella-orchestration rules they don't need.
+
+### One module's full before/after
+
+The most concrete view is the level of a single rule. Take this repo's
+tmux-safety rule — the one with the OP-180 incident lore. In the legacy
+`WORKFLOW.md` it was a section under `## Tmux experimentation`. After
+migration it lives at `Projects/_op-modules/tmux-safety.md`:
+
+```markdown
+---
+id: tmux-safety
+title: Tmux safety — never target shared op sessions
+type: workflow-module
+scope: kickoff
+order: 20
+vars:
+  - { name: protected_session_prefixes, default: "op-agents-,view-",
+      description: "Comma-separated list of tmux session-name prefixes that
+      must never receive destructive commands — these host live agent state." }
+  - experiment_session_pattern=op-experiment-$$
+---
+
+When developing or debugging anything that touches the orchestrator,
+terminal launch, or tmux integration … do not run `tmux kill-session`,
+`tmux kill-window`, `tmux kill-server`, or any other destructive tmux
+command against a target whose name starts with any of
+`{{vars.protected_session_prefixes}}`.
+
+This is what caused **OP-180**: an agent developing OP-178 was experimenting
+with raw tmux commands as it worked, ran a `kill-session` against an
+op-agents target, and took down both its own window and the sibling agent…
+
+[full body preserved verbatim]
+
+[…]
+```
+
+Two things landed in the new shape:
+
+1. **The `vars:` block.** The two values that were repo-specific in the
+   legacy prose (`op-agents-,view-` for the protected prefixes; the
+   experiment-session pattern) became declared variables. Other projects
+   override them in their own `STATUS.md` `vars:` block without forking the
+   module body.
+2. **Body fidelity.** The OP-180 incident story stays — it's the canonical
+   "why this rule exists" lore. Stripping it would weaken the rule. The
+   migration is content-preserving by default; you generalize over time as
+   you find which rules are genuinely portable.
+
+The other 8 modules followed the same template: lift the rule from the
+legacy section, declare any project-specific values as `vars:` with sensible
+defaults, preserve the prose verbatim, set `scope:` to the lifecycle phase
+the rule actually applies to.
+
+### Scope-tag rationale
+
+- **`kickoff`** — branching, tmux-safety, version-cadence, commit-mapping,
+  pr-required, parent-orchestration. Every session-starting agent needs
+  these. The rule "always work in a worktree" is useless if it only
+  reaches the agent at review time.
+- **`review`** — adversarial-review. Only the merging agent needs to know
+  the bypass criteria for the Copilot review gate; the kickoff prompt
+  shouldn't carry those rules.
+- **`finalize`** — github-issue-close-on-resolve, releases. The op-resolve
+  agent needs the release-flow rules; nobody else does.
+- **`evaluate` / `plan` / `implement`** — empty for now. Phase-specific
+  guidance lives in the per-mode skill prompts, and adding modules at
+  these scopes would duplicate without adding signal. Future cross-cutting
+  rules can land here without needing a schema change.
+
+### What didn't change
+
+The path stays at `Projects/<slug>/WORKFLOW.md` — there's no rename. The
+loader detects the schema by reading `type:` and `schema:` from frontmatter,
+not by filename. Nothing else in your project's setup needs to move; the
+issue notes, scaffold base, STATUS.md, and `Projects/_scratch/` all behave
+exactly as before.
+
+## Step-by-step migration recipe
+
+A version of the OP-189 plan, generalized for any project. Allow yourself
+two sessions: one to author the modules, one to verify the composed prompt
+matches what you had before.
+
+### 1. List the rules in your current WORKFLOW.md
+
+For each `## ` section in your existing `Projects/<slug>/WORKFLOW.md`:
+
+- What's the rule, in one sentence?
+- Is it cross-cutting (every project of yours wants it) or per-project?
+- Which lifecycle phase does it apply to (`kickoff` / `evaluate` / `plan`
+  / `implement` / `review` / `finalize`, or a custom step)?
+- Are there project-specific values that other projects would override
+  (commands, paths, prefixes, branch names)?
+
+Write the list down. The migration is mostly bookkeeping; the categorization
+is the actual work.
+
+### 2. Create the module files
+
+For each rule, create a markdown file under one of:
+
+- `Projects/_op-modules/<id>.md` if cross-cutting.
+- `Projects/<slug>/MODULES/<id>.md` if project-specific (set
+  `project: <slug>` in the frontmatter).
+
+The frontmatter contract is small — see
+[`workflow-module-schema.md`](../../specs/workflow-module-schema.md) for the
+full reference, but the minimum is:
+
+```yaml
+---
+id: <kebab-case-id>             # must match the filename basename
+title: <human-readable title>
+type: workflow-module           # required literal
+scope: kickoff                   # the step you want this rule injected at
+order: 10                        # sort key within the scope (lower first)
+vars:                            # optional: declared variables
+  - some_var=default
+---
+```
+
+The body is the rule prose, lifted verbatim from your legacy WORKFLOW.md
+section. Use `{{vars.some_var}}` anywhere a project-specific value should
+be substitutable.
+
+The filename basename must match the `id:` field. A mismatch surfaces as a
+`malformed-frontmatter` diagnostic and the module is silently dropped from
+composition — easy to miss until you check the launch preview's diagnostic
+count.
+
+### 3. Rewrite WORKFLOW.md as a schema-1 file
+
+Replace the legacy prose at `Projects/<slug>/WORKFLOW.md` with the new
+shape:
+
+```yaml
+---
+project: <your-slug>
+type: workflow
+schema: 1
+default_agent: claude
+default_model: opus
+updated: <today>
+steps:
+  - step: kickoff
+    modules: [<list every kickoff-scoped module by id>]
+  - step: evaluate
+    modules: []
+  - step: plan
+    modules: []
+  - step: implement
+    modules: []
+  - step: review
+    modules: [<list every review-scoped module by id>]
+  - step: finalize
+    modules: [<list every finalize-scoped module by id>]
+---
+
+# <project name> — workflow
+
+<short prose explainer pointing at the module split>
+```
+
+The body is opaque commentary; the loader only reads frontmatter. A
+one-paragraph description of how the modules compose makes future you (or a
+new collaborator) much faster on the next migration.
+
+If you'd rather keep a global default workflow that several projects share,
+author it once at `Projects/_op-workflow.md` and have each per-project
+`WORKFLOW.md` pull it in via `extends: Projects/_op-workflow.md`. The
+[2-quickstart](../02-quickstart.md) walks the `extends:` shape end-to-end.
+
+### 4. Verify the composed prompt
+
+Open any issue in the migrated project and run **op: open agent**. Expand
+the **Composed prompt preview** disclosure. The composed kickoff prompt
+should be the concatenation of every module body listed in your
+`steps[step=kickoff].modules:` array, in `order:` order, with `{{vars.*}}`
+references substituted by their bindings.
+
+Walk the legacy WORKFLOW.md section-by-section and confirm each rule lands
+in the composed preview at the right scope. The rule *substance* should be
+identical to the legacy file's content; the *delivery* should be sharpened
+(right rule at the right phase). If a rule is missing, either:
+
+- The module's `id:` doesn't match the filename basename (silent drop —
+  check the diagnostic count in the preview).
+- The module's `scope:` doesn't match any step in WORKFLOW.md (loaded but
+  never injected — also surfaces as a diagnostic).
+- The module is named in `WORKFLOW.md` `steps[*].modules` but doesn't
+  exist on disk (preview reports "module not found").
+
+The **Composed prompt preview** disclosure is the canonical "did the
+migration work?" surface — much faster than launching a real agent.
+
+### 5. Don't bump anything
+
+Vault content changes don't bump op-obsidian's version. The migration is
+markdown, not code. The OP-189 issue commit history was empty for the
+same reason — no PR, no version bump, no release.
+
+If your project does have version-bump cadence rules (i.e. you're using
+`version-cadence.md` from `_op-modules/`), the migration itself doesn't
+trigger them — those rules apply to the project the workflow belongs to,
+not to the workflow file's own state.
+
+## The legacy fallback ladder
+
+You can keep your existing `WORKFLOW.md` as-is forever. The loader applies
+a six-shape fallback ladder before declaring a file unparseable. Each shape
+maps to one of: "synthesize a one-step legacy workflow from the body" or
+"drop the file with a diagnostic." Here's the full table — the same one
+that lives in [`workflow-file-schema.md`](../../specs/workflow-file-schema.md)
+under "Legacy WORKFLOW.md fallback ladder":
+
+| # | Trigger | Result | Diagnostic |
+| :-- | :-- | :-- | :-- |
+| 1 | No frontmatter fence at all. The file starts with content, not `---`. | Synthesized workflow with one step `{ step: "kickoff", modules: [], legacyKickoffBody: <entire body> }`. `isLegacy: true`. | `schema-mismatch` warning ("running in legacy compatibility mode") |
+| 2 | Frontmatter fence present, no `type:` field. | Same as (1). Body extracted post-fence. | `schema-mismatch` warning |
+| 3 | `type: workflow` but no `steps:` field. | Same as (1). Often appears mid-migration when you've started the rewrite but haven't finished. | `schema-mismatch` warning |
+| 4 | `type: <not workflow>` (i.e. set by a metadata-management plugin to something else). | Synthesized from the body the same way as (1) so pre-OP-208 files don't lose their content; the file is *not* dropped. | `schema-mismatch` warning. (Pre-OP-208 behavior was an `error` and dropped the file; OP-208 softened it after real-world cases turned up.) |
+| 5 | Frontmatter parses to `null` (e.g., empty fence `---\n---`, or `~`). | Same as (1). | `schema-mismatch` warning |
+| 6 | Body contains inline `---` HRs after the frontmatter fence. | **Modern parsing** — the fence detector runs against the first `\n---` only. The body's HR lines aren't mistaken for a frontmatter close. | None — this is the happy path; the test fixture exists to lock the regression. |
+
+Shapes 1, 2, 3, 5 all synthesize the same shape: a one-step workflow whose
+single `kickoff` step carries the entire body verbatim as
+`legacyKickoffBody`. The composer renders the body at kickoff; nothing is
+injected at later steps because no later steps exist in the synthesized
+workflow.
+
+Shape 4 is the surprise. It used to be a hard error (the file was dropped),
+and pre-OP-208 projects whose `WORKFLOW.md` had `type:` set to something
+else by a metadata-management plugin would silently lose their workflow
+content. OP-208 softened it: shape 4 now synthesizes the same way as shapes
+1–3, with a `warning`-severity diagnostic so users see "running in legacy
+compatibility mode" rather than "your file vanished."
+
+Shape 6 is the only case in the table that doesn't enter the synthesizer at
+all — it's a perfectly modern workflow whose body happens to contain
+horizontal-rule markdown (`---` lines). The fence detection runs against
+only the first `\n---` after the opening fence, so HR lines lower in the
+body are not mistaken for a closing fence. The fixture exists to lock the
+regression: a future refactor that swaps `indexOf("\n---", 3)` for greedy
+match would silently break shape-6 files.
+
+### How the auto-advance walker handles legacy
+
+The flow walker (the bit that decides what step to launch next when an
+agent's SessionEnd hook fires) routes legacy-synthesized workflows through
+a separate fallback path:
+
+```ts
+// flowOrchestrator.ts:flowAdvanceDecision
+if (workflow === null || workflow.source.isLegacy) {
+  return legacyFlowAdvanceDecision({ flow, complexity, exitStatus });
+}
+// …otherwise walk workflow.steps using LEGACY_FLOW_ALIAS to resolve
+// pre-OP-188 enum values…
+```
+
+`legacyFlowAdvanceDecision` is the byte-for-byte-original hardcoded matrix
+from before the OP-188 refactor. Pre-modules projects keep auto-advancing
+through the historical `evaluate → plan → implement → review → finalize`
+sequence even with no schema-1 workflow file — the modules schema is fully
+opt-in.
+
+For the full story on what changed at the auto-advance layer, see
+[`from-agent-flows.md`](./from-agent-flows.md).
+
+## Common pitfalls
+
+**"My module body shows up but variables aren't substituted."** The body
+references `{{vars.<name>}}` but the variable isn't bound at any layer of
+the precedence chain — Module-default doesn't fire automatically; it's the
+prompt pre-fill, not an automatic write. Either:
+
+- Add a default in the module's `vars:` declaration: `some_var=default`.
+  This binds it as the module-default and the substitution succeeds.
+- Bind it at a higher layer (`STATUS.md vars:` for per-project, the
+  `workflowVars` settings block for global, or via the launch modal for
+  one-off launches).
+
+**"The composed preview shows a module count of `0`."** Almost always one
+of these:
+
+- The module's filename basename doesn't match its `id:` field.
+- The module's `scope:` doesn't appear in any of the workflow's `steps:`
+  ids.
+- The workflow file isn't loading — open the developer console and look
+  for `[op-obsidian]` warnings (`schema-mismatch`, `bad-model`,
+  `malformed-frontmatter`).
+
+**"My legacy WORKFLOW.md still works but the agent feels noisier."** It is
+noisier. The synthesized legacy shape carries the entire body at kickoff;
+none of the per-step injection wins reach the agent until you migrate. Per-
+step injection is the main reason to migrate, not just an aesthetic.
+
+**"I migrated but the auto-advance broke."** Step ids in the workflow are
+matched against the issue's `flow:` value via the `LEGACY_FLOW_ALIAS` map
+([`from-agent-flows.md`](./from-agent-flows.md) covers it in detail). If
+your existing in-flight issues have `flow: planning`/`implementation`/
+`finalization`, they alias to canonical step ids `plan`/`implement`/
+`finalize` automatically — those are the step ids your new workflow file
+should use.
+
+## Where to next
+
+- [`from-agent-flows.md`](./from-agent-flows.md) — the migration story for
+  the auto-advance layer: what changed at the flow walker, what didn't,
+  and how legacy `flow:` enum values keep working forever.
+- [`share-modules.md`](../sharing/share-modules.md) — once your modules
+  exist as files, the `op-export-module` / `op-import-module` flow makes
+  them shareable across vaults.
+- [`workflow-module-schema.md`](../../specs/workflow-module-schema.md) —
+  the full module-file contract.
+- [`workflow-file-schema.md`](../../specs/workflow-file-schema.md) — the
+  full workflow-file contract, including the canonical legacy-fallback
+  ladder reference.

--- a/docs/workflow-modules/sharing/share-modules.md
+++ b/docs/workflow-modules/sharing/share-modules.md
@@ -133,8 +133,12 @@ Now the interesting part. Run the import in Agent-Vault:
 obsidian vault=Agent-Vault op-import-module path=release-checklist.md
 ```
 
-Because `release-checklist.md` has no `project:` field, the importer derives
-`scope: global` and lands the file at `Projects/_op-modules/release-checklist.md`.
+No `--scope` flag was passed, so the importer defaults to `scope: global` and
+lands the file at `Projects/_op-modules/release-checklist.md`. (The default is
+always `global` when `--scope` is omitted from the CLI/URI call, regardless of
+whether the module's frontmatter carries a `project:` field. Pass
+`scope=project project=<slug>` explicitly to land it per-project.)
+
 The body's only `{{vars.<name>}}` reference is `release_command`, and the
 loader walks the four-layer precedence chain looking for a binding:
 

--- a/docs/workflow-modules/sharing/share-modules.md
+++ b/docs/workflow-modules/sharing/share-modules.md
@@ -1,0 +1,351 @@
+# Share Modules Across Vaults
+
+Workflow modules are plain markdown files. They round-trip through git, sync,
+copy-paste, and any other mechanism that moves text between machines. The op
+plugin ships three thin wrappers — `op-export-module`, `op-import-module`, and
+`op-undo-last-import` — that handle the awkward bits of cross-vault sharing:
+bundling per-project modules together, prompting for missing variable values,
+backing up files we're about to overwrite, and giving you a one-step undo when
+you change your mind.
+
+This walkthrough takes you through one full hand-off: a module authored in
+**OP-Test** (this repo's clean-room test vault) → exported → imported into
+**Agent-Vault** (the daily-driver vault). It's the same flow you'd use to share
+a module with a teammate, between two of your own machines, or to keep a global
+default in sync across vaults you maintain.
+
+If you haven't read the [conceptual overview](../01-overview.md) yet, the
+four-layer precedence chain (Module / Global / Project / Launch) is the model
+the import-time variable prompt is built on; skim it first if `{{vars.<name>}}`
+references and per-project shadowing don't already feel familiar.
+
+## What the three commands do
+
+All three are available as palette commands, URI handlers, and CLI verbs.
+
+| Command | What it does |
+| :--- | :--- |
+| `op-export-module` | Writes one module (`id=<id>`) or every module visible to a project (`project=<slug>`) into `Projects/_op-export/`. Single-module exports land at `_op-export/<id>.md`; bundle exports land under `_op-export/<slug>/<id>.md`. |
+| `op-import-module` | Reads a module file from a vault path or absolute filesystem path, picks where it lands (global vs per-project), prompts for any `{{vars.<name>}}` references missing at higher precedence, and writes a transaction record to `Projects/_op-import-history/<ts>.json`. |
+| `op-undo-last-import` | Reverses the most recent import: trashes the imported module file(s), restores any backed-up originals, prunes only the variables that import added (preserving any that already existed). One-step undo only — older transactions are not stacked. |
+
+Modules live as plain `.md` files; the export step is a convenience wrapper
+that re-serializes the module through the same writer the plugin uses
+internally, so a malformed source surfaces a clear diagnostic at export time
+rather than silently passing through.
+
+## Step 1 — Author a module in OP-Test
+
+Pick something concrete enough to be worth sharing. For this walkthrough we'll
+use a `release-checklist` module: a short kickoff-scoped checklist the agent
+should run through before tagging a release. We give it one variable —
+`release_command` — so the same module body works in any project that
+uses it.
+
+`Projects/_op-modules/release-checklist.md` (in OP-Test):
+
+```markdown
+---
+id: release-checklist
+title: Release checklist
+type: workflow-module
+scope: kickoff
+order: 50
+vars:
+  - { name: release_command, default: "node scripts/release.mjs", description: "Command this project uses to cut a release." }
+---
+
+Before tagging a release, run through:
+
+1. `git status` is clean.
+2. CHANGELOG entry exists for the new version.
+3. `{{vars.release_command}}` runs green locally.
+4. The PR that bumped the version has been merged into the default branch.
+```
+
+The frontmatter declares one variable (`release_command`) with an inline
+default and a one-line description. The body uses `{{vars.release_command}}` —
+this is the reference the import flow scans for to decide what to prompt for.
+
+Quick sanity check that OP-Test sees the module:
+
+```bash
+obsidian vault=OP-Test op-list-modules | grep release-checklist
+# → release-checklist (kickoff, order 50) — Projects/_op-modules/release-checklist.md
+```
+
+## Step 2 — Export it from OP-Test
+
+Single-module export, simplest form:
+
+```bash
+obsidian vault=OP-Test op-export-module id=release-checklist
+```
+
+The command writes `Projects/_op-export/release-checklist.md` and prints a
+one-line summary. The full payload (file paths, byte count) lives at
+`Projects/_scratch/op-last-response.md` — the canonical place to read
+structured output from any op verb.
+
+The exported file is byte-equivalent to the source (frontmatter + body
+preserved verbatim, including the `vars:` declarations). You can open it,
+diff it against the original, and round-trip it through git unchanged.
+
+If you wanted to export *every* module visible to a project — the project's
+own `MODULES/` plus any global modules tagged with `project: <slug>` — pass
+`project=<slug>` instead and you'll get a folder bundle:
+
+```bash
+obsidian vault=OP-Test op-export-module project=demo
+# → Projects/_op-export/demo/<id>.md (one file per module)
+```
+
+For a single-module hand-off between vaults, stick with `id=`.
+
+## Step 3 — Move the file to Agent-Vault
+
+Modules are markdown. Anything that moves text between vaults works:
+
+- **Copy** the `.md` file out of OP-Test's `_op-export/` folder and drop it
+  anywhere in Agent-Vault — even outside the vault folder is fine; the
+  importer accepts absolute paths.
+- **Sync** through git, iCloud, Dropbox, etc.
+- **Paste** the file content into a new note inside Agent-Vault.
+
+For this walkthrough, copy the file directly into Agent-Vault's vault root:
+
+```bash
+cp ~/Documents/OP-Test/OP-Test/Projects/_op-export/release-checklist.md \
+   ~/work/Agent-Vault/release-checklist.md
+```
+
+The importer doesn't care that the file lives at the vault root rather than
+under `Projects/_op-modules/` — that decision is the import step's job, not
+the file's. The default landing path is derived from the module's frontmatter
+`project:` field (present → per-project, absent → global), and you can
+override it with `scope=`.
+
+## Step 4 — Import into Agent-Vault (with the variable prompt)
+
+Now the interesting part. Run the import in Agent-Vault:
+
+```bash
+obsidian vault=Agent-Vault op-import-module path=release-checklist.md
+```
+
+Because `release-checklist.md` has no `project:` field, the importer derives
+`scope: global` and lands the file at `Projects/_op-modules/release-checklist.md`.
+The body's only `{{vars.<name>}}` reference is `release_command`, and the
+loader walks the four-layer precedence chain looking for a binding:
+
+1. **Launch overrides** — n/a for headless imports.
+2. **Project** — n/a for a global import.
+3. **Global** (`settings.workflowVars`) — checked.
+4. **Module-default** — the `release_command=node scripts/release.mjs`
+   declaration in the module's own `vars:` block.
+
+Layers 1–3 don't have a binding, so the import needs an answer before it
+can land. The palette command opens a single-prompt modal per missing var,
+pre-filled with the module's inline default:
+
+```
+┌────────────────────────────────────────────────────────────────────┐
+│  Import: release-checklist                                         │
+│                                                                    │
+│  Missing variable: release_command                                 │
+│  Command this project uses to cut a release.                       │
+│                                                                    │
+│  Value:  [node scripts/release.mjs                              ]  │
+│                                                                    │
+│  [ Skip import ]                              [ Continue ]         │
+└────────────────────────────────────────────────────────────────────┘
+```
+
+The pre-fill is exactly the `default:` value from the module's `vars:`
+declaration — that's the contract: "module-supplied `name=VALUE` is the
+prompt pre-fill, not an automatic write." You can accept the default by
+clicking **Continue**, or edit it first if Agent-Vault uses a different
+release command (say `gh release create`).
+
+For headless invocations (CLI / URI), the same flow surfaces as a
+structured response. Run the CLI without an answer and you'll get:
+
+```
+ok: false
+status: needs-input
+needsInput.vars[0]: { name: "release_command", prefill: "node scripts/release.mjs", hasModuleDefault: true, description: "Command this project uses to cut a release." }
+```
+
+Re-dispatch with the answer pre-filled:
+
+```bash
+obsidian vault=Agent-Vault op-import-module \
+  path=release-checklist.md \
+  var.release_command="gh release create"
+```
+
+You can pack multiple var answers into a single packed `vars=` argument too:
+`vars="release_command=gh release create\nother_var=…"` (newline- or
+comma-separated). The packed and per-key forms both exist for parity with
+OP-204's variable contract.
+
+## Step 5 — What the import produced
+
+The import writes three things:
+
+1. **The module file** at the chosen target — for our walkthrough,
+   `Projects/_op-modules/release-checklist.md` in Agent-Vault. Frontmatter and
+   body match the exported file exactly; the `project:` field, if any, is
+   rewritten to whatever scope you picked.
+2. **The variable answer** — for a global import, `settings.workflowVars.release_command`
+   is set to your answer (or the default if you accepted the pre-fill). For
+   `scope=project` imports, the answer lands in the project's `STATUS.md`
+   `vars:` map via `fileManager.processFrontMatter`, so it sits alongside any
+   other per-project variables.
+3. **The transaction record** at `Projects/_op-import-history/<YYYYMMDD-HHmmss-mmm>.json`:
+
+    ```json
+    {
+      "version": 1,
+      "timestamp": "2026-04-26T12:34:56.789Z",
+      "command": "op-import-module",
+      "modulesLanded": [
+        {
+          "sourcePath": "/Users/.../Agent-Vault/release-checklist.md",
+          "targetPath": "Projects/_op-modules/release-checklist.md",
+          "scopeKind": "global",
+          "overwrote": false
+        }
+      ],
+      "varsWritten": [
+        { "name": "release_command", "value": "gh release create",
+          "scopeKind": "global", "preexisting": false }
+      ]
+    }
+    ```
+
+   `preexisting: false` marks variables that this import added; rows with
+   `preexisting: true` (i.e. a value already lived at higher precedence) are
+   recorded for traceability but the undo step skips them.
+
+If the import overwrote an existing module file at `targetPath`, the
+record also carries `backupPath` — the location of the pre-import contents,
+copied to `Projects/_op-import-history/<ts>.bak/<vault-relative-path>`. Undo
+restores from that location.
+
+## Step 6 — Verify the round-trip
+
+The exported file is byte-equivalent to the source. After the import lands,
+diff the imported copy against OP-Test's original:
+
+```bash
+diff ~/Documents/OP-Test/OP-Test/Projects/_op-modules/release-checklist.md \
+     ~/work/Agent-Vault/Projects/_op-modules/release-checklist.md
+# → empty (no diff)
+```
+
+Empty diff means the round-trip is faithful — the byte-equivalence is the
+contract. (For per-project modules with `project:` rewriting, the only
+expected diff is the rewritten `project:` value.)
+
+You can also confirm the agent will pick the module up. Open any issue in
+Agent-Vault, run **op: open agent**, and expand the **Composed prompt
+preview** disclosure. The body of `release-checklist.md` should appear in the
+kickoff section, with `{{vars.release_command}}` substituted with `gh release
+create` (the value you supplied at import time).
+
+## Undoing an import
+
+Changed your mind? `op-undo-last-import` reverses the most recent import:
+
+```bash
+obsidian vault=Agent-Vault op-undo-last-import
+```
+
+It walks the latest transaction record (lex-sorted filenames pick the most
+recent), then:
+
+1. **Trashes** every module file at the recorded `targetPath`.
+2. **Restores** any backed-up originals from `<ts>.bak/`.
+3. **Prunes** only variables that this transaction added (the
+   `preexisting: false` rows). Variables that pre-existed at any scope —
+   marked `preexisting: true` in the record — stay untouched.
+4. **Trashes** the transaction record + its `.bak/` directory so a second
+   undo is a clean no-op.
+
+It's a one-step undo, not a stack: running it twice in a row gives you a
+structured `status: "no-history"` response on the second call (not an error).
+
+If you imported a v2 of a module that overwrote a v1, undo restores v1 from
+the backup *and* respects any variable v1 already supplied — the v2 import
+would have recorded that variable as `preexisting: true` because v1 had
+already supplied a binding. Undo doesn't accidentally strip the v1 value.
+
+## OP-Test → Agent-Vault hand-off, end-to-end
+
+A typical "I tested this in OP-Test, now I want it in my real vault" flow,
+all in one block:
+
+```bash
+# 1. Author + verify in OP-Test (this repo's clean-room vault).
+obsidian vault=OP-Test op-list-modules | grep release-checklist
+
+# 2. Export from OP-Test.
+obsidian vault=OP-Test op-export-module id=release-checklist
+
+# 3. Carry the file across.
+cp ~/Documents/OP-Test/OP-Test/Projects/_op-export/release-checklist.md \
+   ~/work/Agent-Vault/Projects/_op-export/release-checklist.md
+
+# 4. Import into Agent-Vault. Headless form — supply the var answer up front.
+obsidian vault=Agent-Vault op-import-module \
+  path=Projects/_op-export/release-checklist.md \
+  var.release_command="gh release create"
+
+# 5. Verify the file landed and the var is bound.
+obsidian vault=Agent-Vault op-list-vars | grep release_command
+# → release_command (global) = gh release create
+
+# 6. (Optional) Undo if you change your mind.
+obsidian vault=Agent-Vault op-undo-last-import
+```
+
+The same pattern works for any pair of vaults you control, between machines,
+or for sharing a module with a teammate via a gist or PR — the export file is
+just a markdown file.
+
+## Caveats and good habits
+
+- **One concept per module.** Two `kickoff`-scoped modules are easier to
+  reason about at the receiving vault than one module that does five things.
+  Per-scope intra-collision checks catch *variable* collisions; they don't
+  catch prose ones. Smaller modules also undo cleanly: a v2 overwrite of a
+  small module is a smaller blast radius.
+- **Keep `vars:` declarations close to their use.** When the importing vault
+  sees the prompt, the inline default and description from the module's own
+  frontmatter are the only context the user has — make them count. A
+  `description:` field on the variable declaration shows up directly in the
+  prompt modal.
+- **Don't move modules by hand to bypass the import flow.** It works (modules
+  are markdown), but you skip the missing-var bootstrap, the transaction
+  record, and the one-step undo. The wrappers exist to give those for free.
+- **Per-project imports rewrite `project:`.** When you import a module at
+  `scope=project project=<slug>`, the importer rewrites the file's
+  frontmatter `project:` to the chosen slug. The transaction record carries
+  both the original and rewritten values so undo restores the original
+  frontmatter.
+- **Concurrent imports are single-shot.** Filenames use millisecond
+  precision, so back-to-back imports don't collide. There's no lockfile —
+  treat the import flow as serial within a vault.
+
+## Where to next
+
+- [`from-workflow-md.md`](../migration/from-workflow-md.md) — the migration
+  story for projects that still have a legacy `WORKFLOW.md` blob to
+  decompose into modules before they're worth sharing.
+- [`from-agent-flows.md`](../migration/from-agent-flows.md) — the migration
+  story for agent-flow auto-advance: what changes, what doesn't, and how
+  legacy `flow:` enum values keep working forever via the alias map.
+- [`workflow-module-schema.md`](../../specs/workflow-module-schema.md) —
+  the full module-file contract, including the `vars:` declaration shapes
+  the import prompt reads.


### PR DESCRIPTION
## Summary

Authors the three workflow-modules guides under `docs/workflow-modules/`, completing scope item 10d of the OP-193 docs umbrella:

- **`sharing/share-modules.md`** — `op-export-module` / `op-import-module` / `op-undo-last-import` walkthrough with a `release-checklist` example, the `{{vars.<name>}}` import-time prompt showing module-supplied `name=VALUE` pre-fills, the transaction-record + one-step undo flow, and an explicit OP-Test → Agent-Vault hand-off block.
- **`migration/from-workflow-md.md`** — real before/after pulled from this project's own OP-189 migration (legacy monolithic `WORKFLOW.md` → 9 modules + schema-1 workflow file) plus the full six-shape legacy fallback ladder (incl. OP-208's softening of shape 4 from `error` to `warning`).
- **`migration/from-agent-flows.md`** — what changed at the OP-188 `flowOrchestrator` layer vs. what stayed (per-issue `flow:` / `complexity:` frontmatter, `autoAdvance` setting, level-4 launch override carry-forward, evaluate fast-path), with `LEGACY_FLOW_ALIAS` reproduced verbatim and the legacy fallback trigger conditions called out.

Reflects shipped behavior verbatim — every CLI shape, payload field, alias-map row, and fallback trigger was cross-referenced against `cliHandlers.ts`, `main.ts`, `flowOrchestrator.ts`, `workflowFilePure.ts`, and the resolved-issue Summary sections of OP-187 / OP-188 / OP-189 before being committed to prose.

Pure docs; no plugin code touched, no version bump. Closes #252.

## Test plan

- [ ] Read each new doc top-to-bottom; confirm code blocks compile, frontmatter samples are syntactically valid YAML, and cross-links resolve.
- [ ] Spot-check the `from-workflow-md.md` legacy-fallback ladder against `workflowFilePure.ts:classifyLegacy` (six shapes; shape-4 softening; shape-6 fence-detection regression-lock).
- [ ] Spot-check the `from-agent-flows.md` `LEGACY_FLOW_ALIAS` block against `flowOrchestrator.ts` (frozen object literal, symmetric application, closed enum).
- [ ] Spot-check `share-modules.md` CLI flags against `cliHandlers.ts:parseExportModuleParams` / `parseImportModuleParams` (id/project, path/scope/project, var.<name>= and packed vars=).

🤖 Generated with [Claude Code](https://claude.com/claude-code)