### PR TITLE
OP-179: iTerm tab title — append [Parent: <PARENT-ID>] suffix when issue has a parent

### DIFF
--- a/plugins/op-obsidian/manifest.json
+++ b/plugins/op-obsidian/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "op-obsidian",
   "name": "Obsidian Projects (op)",
-  "version": "0.78.0",
+  "version": "0.78.1",
   "minAppVersion": "1.5.0",
   "description": "Jira-lite issue tracker for Obsidian vaults — deterministic commands backing the op workflow.",
   "author": "Eugene Archibald",

--- a/plugins/op-obsidian/manifest.json
+++ b/plugins/op-obsidian/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "op-obsidian",
   "name": "Obsidian Projects (op)",
-  "version": "0.77.1",
+  "version": "0.78.0",
   "minAppVersion": "1.5.0",
   "description": "Jira-lite issue tracker for Obsidian vaults — deterministic commands backing the op workflow.",
   "author": "Eugene Archibald",

--- a/plugins/op-obsidian/package.json
+++ b/plugins/op-obsidian/package.json
@@ -1,6 +1,6 @@
 {
   "name": "op-obsidian",
-  "version": "0.77.1",
+  "version": "0.78.0",
   "description": "Obsidian plugin that owns the deterministic half of the op workflow.",
   "main": "main.js",
   "scripts": {

--- a/plugins/op-obsidian/package.json
+++ b/plugins/op-obsidian/package.json
@@ -1,6 +1,6 @@
 {
   "name": "op-obsidian",
-  "version": "0.78.0",
+  "version": "0.78.1",
   "description": "Obsidian plugin that owns the deterministic half of the op workflow.",
   "main": "main.js",
   "scripts": {

--- a/plugins/op-obsidian/src/issueStore.ts
+++ b/plugins/op-obsidian/src/issueStore.ts
@@ -175,6 +175,7 @@ export class IssueStore extends Component {
       githubIssue: str(fm.github_issue),
       agent: str(fm.agent),
       title: str(fm.title) ?? file.basename,
+      parent: str(fm.parent),
       resolvedFolder: inResolved,
     };
   }

--- a/plugins/op-obsidian/src/openAgent.ts
+++ b/plugins/op-obsidian/src/openAgent.ts
@@ -270,6 +270,12 @@ export async function openAgent(
     tmuxBinary: settings.tmuxBinary,
     issueId: args.entry.id,
     issueTitle: args.entry.title,
+    // OP-179: append ` [Parent: <PARENT-ID>]` to the iTerm tab/window/session
+    // label when this issue has a parent. Sourced from the parsed entry; if
+    // the entry's `parent` is missing (legacy issue not yet re-indexed), fall
+    // back to a fresh metadata-cache read so newly-set parents take effect on
+    // the next launch without an editor round-trip.
+    parentId: args.entry.parent ?? readParentId(app, args.entry.path) ?? undefined,
     agentId,
     backgroundLaunch: settings.backgroundLaunch,
     orchestrator: {

--- a/plugins/op-obsidian/src/orchestrator.test.ts
+++ b/plugins/op-obsidian/src/orchestrator.test.ts
@@ -4,6 +4,7 @@ import {
   buildViewScript,
   firstEmptyCell,
   labelWithId,
+  labelWithParent,
   pruneDeadSessionSlots,
 } from "./orchestrator";
 import type { RegistryData, WindowState } from "./layout/registry";
@@ -277,5 +278,84 @@ describe("labelWithId", () => {
 
   it("returns the title as-is when it equals the issueId", () => {
     expect(labelWithId("OP-177", "OP-177")).toBe("OP-177");
+  });
+});
+
+describe("labelWithParent", () => {
+  it("appends ` [Parent: <PARENT-ID>]` to the label when parentId is set", () => {
+    expect(labelWithParent("OP-179 add parent suffix", "OP-149")).toBe(
+      "OP-179 add parent suffix [Parent: OP-149]",
+    );
+  });
+
+  it("returns the label unchanged when parentId is undefined", () => {
+    expect(labelWithParent("OP-179 add parent suffix", undefined)).toBe(
+      "OP-179 add parent suffix",
+    );
+  });
+
+  it("returns the label unchanged when parentId is empty", () => {
+    expect(labelWithParent("OP-179 add parent suffix", "")).toBe(
+      "OP-179 add parent suffix",
+    );
+  });
+
+  it("composes cleanly with labelWithId for the bare-id fallback case", () => {
+    // Title-less launch: labelWithId(id, undefined) returns the bare id, then
+    // labelWithParent appends the suffix.
+    expect(labelWithParent(labelWithId("OP-179", undefined), "OP-149")).toBe(
+      "OP-179 [Parent: OP-149]",
+    );
+  });
+});
+
+describe("buildViewScript with parentId", () => {
+  const baseArgs = {
+    tmuxBinary: "/opt/homebrew/bin/tmux",
+    tmuxSession: "op-agents-1",
+    tmuxWindow: "OP-179",
+    issueId: "OP-179",
+    issueTitle: "iTerm tab title: append parent suffix",
+  };
+
+  it("appends `[Parent: <PARENT-ID>]` to the OSC 1 (tab/icon) payload when parentId is set", () => {
+    const out = buildViewScript({ ...baseArgs, parentId: "OP-149" });
+    expect(out).toContain(
+      `printf '\\033]1;%s\\007' 'OP-179 iTerm tab title: append parent suffix [Parent: OP-149]'`,
+    );
+  });
+
+  it("appends `[Parent: <PARENT-ID>]` to the OSC 2 (window title) payload when parentId is set", () => {
+    const out = buildViewScript({ ...baseArgs, parentId: "OP-149" });
+    expect(out).toContain(
+      `printf '\\033]2;%s\\007' 'OP-179 iTerm tab title: append parent suffix [Parent: OP-149]'`,
+    );
+  });
+
+  it("omits the parent suffix when parentId is undefined (no breaking change for non-child issues)", () => {
+    const out = buildViewScript(baseArgs);
+    expect(out).toContain(
+      `printf '\\033]1;%s\\007' 'OP-179 iTerm tab title: append parent suffix'`,
+    );
+    expect(out).not.toContain("[Parent:");
+  });
+
+  it("omits the parent suffix when parentId is empty", () => {
+    const out = buildViewScript({ ...baseArgs, parentId: "" });
+    expect(out).not.toContain("[Parent:");
+  });
+
+  it("strips control characters from parentId before the suffix is composed", () => {
+    const out = buildViewScript({ ...baseArgs, parentId: "OP\x1b-149\x07" });
+    expect(out).toContain(
+      `printf '\\033]2;%s\\007' 'OP-179 iTerm tab title: append parent suffix [Parent: OP-149]'`,
+    );
+  });
+
+  it("appends the parent suffix even with the bare-id fallback (no title)", () => {
+    const { issueTitle, ...rest } = baseArgs;
+    const out = buildViewScript({ ...rest, parentId: "OP-149" });
+    expect(out).toContain(`printf '\\033]1;%s\\007' 'OP-179 [Parent: OP-149]'`);
+    expect(out).toContain(`printf '\\033]2;%s\\007' 'OP-179 [Parent: OP-149]'`);
   });
 });

--- a/plugins/op-obsidian/src/orchestrator.test.ts
+++ b/plugins/op-obsidian/src/orchestrator.test.ts
@@ -307,6 +307,31 @@ describe("labelWithParent", () => {
       "OP-179 [Parent: OP-149]",
     );
   });
+
+  it("returns the label unchanged when parentId is whitespace-only", () => {
+    // `str()` accepts "   " (length > 0) but `labelWithParent` trims it,
+    // consistent with `readParentId`'s `raw.trim().length > 0` guard.
+    expect(labelWithParent("OP-179 add parent suffix", "   ")).toBe(
+      "OP-179 add parent suffix",
+    );
+  });
+
+  it("trims surrounding whitespace from parentId before appending", () => {
+    // Leading/trailing whitespace on the parentId value is stripped.
+    expect(labelWithParent("OP-179 add parent suffix", "  OP-149  ")).toBe(
+      "OP-179 add parent suffix [Parent: OP-149]",
+    );
+  });
+
+  it("appends the suffix when parentId equals the issueId (self-link; upstream op-set-link rejects this)", () => {
+    // `labelWithParent` has no self-link awareness — that guard lives in
+    // `validateLinkArgs` which throws "Cannot link issue to itself: …" before
+    // the parent can be persisted.  This test documents the pass-through for
+    // completeness (a manually-edited frontmatter could still reach here).
+    expect(labelWithParent("OP-179 title", "OP-179")).toBe(
+      "OP-179 title [Parent: OP-179]",
+    );
+  });
 });
 
 describe("buildViewScript with parentId", () => {
@@ -357,5 +382,32 @@ describe("buildViewScript with parentId", () => {
     const out = buildViewScript({ ...rest, parentId: "OP-149" });
     expect(out).toContain(`printf '\\033]1;%s\\007' 'OP-179 [Parent: OP-149]'`);
     expect(out).toContain(`printf '\\033]2;%s\\007' 'OP-179 [Parent: OP-149]'`);
+  });
+
+  it("handles tmux-special char `:` in parentId via shSingleQuote escaping", () => {
+    // `:` is the tmux session:window separator but is safe inside single quotes.
+    const out = buildViewScript({ ...baseArgs, parentId: "OP:149" });
+    expect(out).toContain(`[Parent: OP:149]`);
+    // The whole label is enclosed in single quotes; `:` needs no escaping.
+    expect(out).toContain(`printf '\\033]1;%s\\007' 'OP-179 iTerm tab title: append parent suffix [Parent: OP:149]'`);
+  });
+
+  it("handles single quote in parentId via shSingleQuote escaping", () => {
+    // `shSingleQuote` replaces ' with '\'' so injected single quotes are escaped.
+    const out = buildViewScript({ ...baseArgs, parentId: "OP'149" });
+    // The label string is single-quote-escaped; the parentId apostrophe gets '\''
+    expect(out).toContain(`[Parent: OP'\\''149]`);
+    // No raw unescaped ' adjacent to the %s argument
+    expect(out).not.toMatch(/printf '\\033]1;%s\\007' '[^']*OP'149/);
+  });
+
+  it("OP-178 hook coexists in the same script when parentId is set", () => {
+    // The window-unlinked hook uses tmuxWindow (not the label), so the parent
+    // suffix has no effect on the hook predicate — both OSC payload and hook
+    // must appear together.
+    const out = buildViewScript({ ...baseArgs, parentId: "OP-149" });
+    expect(out).toContain(`[Parent: OP-149]`);
+    expect(out).toContain(`#{==:#{hook_window_name},OP-179}`);
+    expect(out).toContain(`kill-session -t =view-OP-179`);
   });
 });

--- a/plugins/op-obsidian/src/orchestrator.ts
+++ b/plugins/op-obsidian/src/orchestrator.ts
@@ -41,6 +41,12 @@ export interface OrchestrateArgs {
   // basename (e.g. "OP-94 iterm window title shows …"). Falls back to
   // issueId when empty.
   issueTitle?: string;
+  // OP-179: parent issue id (e.g. "OP-149"). When set, all visible labels
+  // (OSC 1 tab name, OSC 2 window title, iTerm session-name slot) carry a
+  // trailing ` [Parent: <PARENT-ID>]` so a child issue's pane is visibly
+  // tagged with its umbrella. Empty/missing → no suffix (no breaking change
+  // for non-child issues; OP-177's exact label shape).
+  parentId?: string;
   agentId: string;
   cwd: string;
   binary: string;
@@ -85,7 +91,10 @@ export async function orchestrateLaunch(
   // Re-launching an existing issue: if the session still exists in iTerm,
   // just select it. Otherwise fall through to fresh assignment — the user
   // likely closed the pane, and the issueId → session mapping is stale.
-  const sessionTitle = labelWithId(args.issueId, args.issueTitle);
+  const sessionTitle = labelWithParent(
+    labelWithId(oscSafe(args.issueId), args.issueTitle !== undefined ? oscSafe(args.issueTitle) : undefined),
+    args.parentId !== undefined ? oscSafe(args.parentId) : undefined,
+  );
   const existing = reg.surfaces[args.issueId];
   if (existing && (await sessionExists(existing.sessionId))) {
     await selectSession(existing.sessionId);
@@ -282,6 +291,7 @@ async function writeViewScript({ args, tmuxSession, tmuxWindow }: ViewArgs): Pro
     tmuxWindow,
     issueId: args.issueId,
     issueTitle: args.issueTitle,
+    parentId: args.parentId,
   });
   await fs.writeFile(viewPath, script, { mode: 0o755 });
   return viewPath;
@@ -293,6 +303,9 @@ interface BuildViewArgs {
   tmuxWindow: string;
   issueId: string;
   issueTitle?: string;
+  // OP-179: when set, the OSC 1/2 payloads get a ` [Parent: <PARENT-ID>]`
+  // suffix. `oscSafe` is applied before the suffix is composed.
+  parentId?: string;
 }
 
 // OP-172: emit BOTH OSC 1 (icon/tab name) and OSC 2 (window title) before
@@ -313,12 +326,17 @@ interface BuildViewArgs {
 // `oscSafe` is applied to id and title *before* `labelWithId` so the dedup
 // check operates on stripped values — a control char injected between the
 // id and its separator cannot bypass the guard.
+//
+// OP-179: when `parentId` is set, append ` [Parent: <PARENT-ID>]` after the
+// id+title prefix via `labelWithParent`. Empty/missing parent keeps OP-177's
+// exact label shape — non-child issues are unchanged.
 export function buildViewScript({
   tmuxBinary,
   tmuxSession,
   tmuxWindow,
   issueId,
   issueTitle,
+  parentId,
 }: BuildViewArgs): string {
   const tmux = shSingleQuote(tmuxBinary);
   const groupSessName = `view-${issueId}`;
@@ -330,7 +348,10 @@ export function buildViewScript({
   // control char injected between the id and its separator (e.g. "OP-177\x07
   // title") cannot bypass `labelWithId`'s prefix guard.  The result is
   // already OSC-safe — no second pass needed.
-  const label = labelWithId(oscSafe(issueId), issueTitle !== undefined ? oscSafe(issueTitle) : undefined);
+  const label = labelWithParent(
+    labelWithId(oscSafe(issueId), issueTitle !== undefined ? oscSafe(issueTitle) : undefined),
+    parentId !== undefined ? oscSafe(parentId) : undefined,
+  );
   const tabName = shSingleQuote(label);
   const windowTitle = shSingleQuote(label);
   // OP-178: the per-pane grouped session shares its window list with the
@@ -480,6 +501,16 @@ export function labelWithId(issueId: string, issueTitle?: string): string {
   // Match id followed by any non-word char (space, colon, dash…) OR end-of-string.
   if (new RegExp(`^${escapedId}(?:\\W|$)`).test(issueTitle)) return issueTitle;
   return `${issueId} ${issueTitle}`;
+}
+
+// OP-179: append ` [Parent: <PARENT-ID>]` to an already-composed label when
+// the issue has a parent. Returns `label` unchanged when `parentId` is
+// undefined or empty (so non-child issues keep OP-177's exact label shape).
+// Caller is expected to pass an `oscSafe`-stripped parentId — the suffix is
+// rendered verbatim into the OSC 1/2 payload.
+export function labelWithParent(label: string, parentId?: string): string {
+  if (!parentId || parentId.length === 0) return label;
+  return `${label} [Parent: ${parentId}]`;
 }
 
 // iTerm's `create window with default profile command "..."` takes a bash

--- a/plugins/op-obsidian/src/orchestrator.ts
+++ b/plugins/op-obsidian/src/orchestrator.ts
@@ -505,12 +505,15 @@ export function labelWithId(issueId: string, issueTitle?: string): string {
 
 // OP-179: append ` [Parent: <PARENT-ID>]` to an already-composed label when
 // the issue has a parent. Returns `label` unchanged when `parentId` is
-// undefined or empty (so non-child issues keep OP-177's exact label shape).
-// Caller is expected to pass an `oscSafe`-stripped parentId — the suffix is
-// rendered verbatim into the OSC 1/2 payload.
+// undefined, empty, or whitespace-only (matching `readParentId`'s
+// `raw.trim().length > 0` guard so a `parent:` field that is all spaces
+// doesn't produce a `[Parent:    ]` suffix). Caller is expected to pass an
+// `oscSafe`-stripped parentId — the trimmed value is rendered verbatim into
+// the OSC 1/2 payload.
 export function labelWithParent(label: string, parentId?: string): string {
-  if (!parentId || parentId.length === 0) return label;
-  return `${label} [Parent: ${parentId}]`;
+  const trimmed = parentId?.trim();
+  if (!trimmed) return label;
+  return `${label} [Parent: ${trimmed}]`;
 }
 
 // iTerm's `create window with default profile command "..."` takes a bash

--- a/plugins/op-obsidian/src/terminalLaunch.ts
+++ b/plugins/op-obsidian/src/terminalLaunch.ts
@@ -36,6 +36,10 @@ export interface LaunchArgs {
   // Human-readable title forwarded to the orchestrator for the iTerm
   // session/pane title (e.g. the issue note's file basename).
   issueTitle?: string;
+  // OP-179: parent issue id forwarded to the orchestrator. When set, the
+  // iTerm tab/window/session label gets a ` [Parent: <PARENT-ID>]` suffix so
+  // a child issue's pane is visibly tagged with its umbrella.
+  parentId?: string;
   agentId: string;
   // Override the tmux window name (sanitized to tmux-safe chars). Used by
   // entry-less launches that have no `issueId` — the workflow editor
@@ -91,6 +95,7 @@ export async function launchInTerminal(args: LaunchArgs): Promise<LaunchResult> 
       {
         issueId: args.issueId,
         issueTitle: args.issueTitle,
+        parentId: args.parentId,
         agentId: args.agentId,
         cwd: args.cwd,
         binary: args.binary,

--- a/plugins/op-obsidian/src/types.ts
+++ b/plugins/op-obsidian/src/types.ts
@@ -17,6 +17,7 @@ export interface IssueEntry {
   githubIssue?: string;
   agent?: string;
   title: string;
+  parent?: string;
   resolvedFolder: boolean;
 }
 

--- a/plugins/op/.claude-plugin/plugin.json
+++ b/plugins/op/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "op",
   "description": "Obsidian Projects workflow — schema, slash commands, and agent skill for running a Jira-lite issue tracker inside an Obsidian vault.",
-  "version": "0.77.1",
+  "version": "0.78.0",
   "author": {
     "name": "Eugene Archibald"
   },

--- a/plugins/op/.claude-plugin/plugin.json
+++ b/plugins/op/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "op",
   "description": "Obsidian Projects workflow — schema, slash commands, and agent skill for running a Jira-lite issue tracker inside an Obsidian vault.",
-  "version": "0.78.0",
+  "version": "0.78.1",
   "author": {
     "name": "Eugene Archibald"
   },


### PR DESCRIPTION
## Summary
- Surface `parent:` on `IssueEntry` (parser + type), plumb `parentId` through `openAgent` → `LaunchArgs` → `OrchestrateArgs` → `BuildViewArgs`.
- New `labelWithParent(label, parentId)` helper in `orchestrator.ts` appends ` [Parent: <PARENT-ID>]` to the OSC 1 / OSC 2 / `setSessionName` payloads when set; `oscSafe` is applied to the parent id alongside the id/title.
- 10 new vitest cases (`labelWithParent` + `buildViewScript` parent coverage). Full suite green: 1541 / 1541.
- UI affordance reuses the existing canonical writer `op-set-link issue=<id> relation=parent target=<PARENT>`. Palette command and settings field are follow-ups.
- Builds on OP-177's id-prefix work; no behavior change for non-child issues.

## Test plan
- [x] `npx vitest run` in `plugins/op-obsidian/`
- [x] `node scripts/bump-version.mjs` → 0.78.0 (minor — additive `parent:` surfacing)
- [x] `node scripts/dev-sync.mjs` to OP-Test, plugin reload OK
- [x] OP-Test smoke: `IssueEntry.parent` flips through `processFrontMatter` round-trip; deployed `main.js` contains the `[Parent: ${o}]` literal and the `parentId` path through `orchestrateLaunch`; console clear

🤖 Generated with [Claude Code](https://claude.com/claude-code)