### PR TITLE
OP-221: In flight tab respects resolvedFolder over stale status

### DIFF
--- a/plugins/op-obsidian/manifest.json
+++ b/plugins/op-obsidian/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "op-obsidian",
   "name": "Obsidian Projects (op)",
-  "version": "0.78.1",
+  "version": "0.78.2",
   "minAppVersion": "1.5.0",
   "description": "Jira-lite issue tracker for Obsidian vaults — deterministic commands backing the op workflow.",
   "author": "Eugene Archibald",

--- a/plugins/op-obsidian/package.json
+++ b/plugins/op-obsidian/package.json
@@ -1,6 +1,6 @@
 {
   "name": "op-obsidian",
-  "version": "0.78.1",
+  "version": "0.78.2",
   "description": "Obsidian plugin that owns the deterministic half of the op workflow.",
   "main": "main.js",
   "scripts": {

--- a/plugins/op-obsidian/src/sidebarView.test.ts
+++ b/plugins/op-obsidian/src/sidebarView.test.ts
@@ -203,6 +203,65 @@ describe("pickIssuesForTab", () => {
     } as any);
     expect(out.map((e) => e.id)).toEqual(["OP-6", "OP-5", "OP-4"]);
   });
+
+  // OP-221: an issue that lives in RESOLVED ISSUES/ but whose `status:`
+  // frontmatter never flipped to a terminal value (the OP-197 data state)
+  // must not appear in the In flight tab — the folder is the source of
+  // truth, not the status field.
+  describe("OP-221: resolvedFolder beats stale status", () => {
+    const driftNoAgent = entry({
+      id: "OP-197",
+      status: "in-progress",
+      resolvedFolder: true,
+      resolved: "2026-04-26",
+    });
+    const driftAliveAgent = entry({
+      id: "OP-198",
+      status: "in-progress",
+      resolvedFolder: true,
+      agent: "claude",
+      resolved: "2026-04-26",
+    });
+    const driftDeadAgent = entry({
+      id: "OP-199",
+      status: "in-progress",
+      resolvedFolder: true,
+      agent: "claude",
+      resolved: "2026-04-26",
+    });
+
+    it("hides folder-resolved rows in In flight even when status is stale and no agent", () => {
+      const out = pickIssuesForTab([inProg, driftNoAgent], "in-flight" as any, {
+        liveTmuxWindows: new Set<string>(),
+        recentResolvedLimit: 20,
+      } as any);
+      expect(out.map((e) => e.id).sort()).toEqual(["OP-2"]);
+    });
+
+    it("keeps folder-resolved rows with stale status when their tmux window is live (OP-156 §5)", () => {
+      const out = pickIssuesForTab([inProg, driftAliveAgent, driftDeadAgent], "in-flight" as any, {
+        liveTmuxWindows: new Set(["OP-198"]),
+        recentResolvedLimit: 20,
+      } as any);
+      expect(out.map((e) => e.id).sort()).toEqual(["OP-198", "OP-2"]);
+    });
+
+    it("keeps folder-resolved rows with stale status when probe is unknown", () => {
+      const out = pickIssuesForTab([driftAliveAgent], "in-flight" as any, {
+        liveTmuxWindows: undefined,
+        recentResolvedLimit: 20,
+      } as any);
+      expect(out.map((e) => e.id)).toEqual(["OP-198"]);
+    });
+
+    it("includes folder-resolved rows with stale status in the Resolved tab (folder is source of truth)", () => {
+      const out = pickIssuesForTab([driftNoAgent], "resolved" as any, {
+        liveTmuxWindows: new Set<string>(),
+        recentResolvedLimit: 20,
+      } as any);
+      expect(out.map((e) => e.id)).toEqual(["OP-197"]);
+    });
+  });
 });
 
 describe("shouldShowProjectChip", () => {

--- a/plugins/op-obsidian/src/sidebarView.ts
+++ b/plugins/op-obsidian/src/sidebarView.ts
@@ -962,6 +962,10 @@ function isResolved(e: IssueEntry): boolean {
  *                   tmux window is still live (per OP-156 §5). Unknown-tmux
  *                   (`undefined`/`null`) does not hide rows — same rule as
  *                   {@link OpSidebarView.isAgentBadgeStale}.
+ *                   The folder-resolved check runs BEFORE the status check so a
+ *                   row that lives in `RESOLVED ISSUES/` but still carries a
+ *                   non-terminal `status:` (data drift like OP-197) is treated
+ *                   as resolved — the folder is the source of truth here.
  *  - `resolved`   → resolved/wontfix, sorted by resolved-date desc, sliced to
  *                   `opts.recentResolvedLimit`.
  */
@@ -976,12 +980,13 @@ export function pickIssuesForTab(
   if (tab === "in-flight") {
     return issues
       .filter((e) => {
-        if (e.status === "in-progress" || e.status === "blocked") return true;
-        if (!e.agent) return false;
         if (isResolved(e)) {
+          if (!e.agent) return false;
           if (!opts.liveTmuxWindows) return true;
           return opts.liveTmuxWindows.has(tmuxWindowName(e.id));
         }
+        if (e.status === "in-progress" || e.status === "blocked") return true;
+        if (!e.agent) return false;
         return true;
       })
       .sort(byId);

--- a/plugins/op/.claude-plugin/plugin.json
+++ b/plugins/op/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "op",
   "description": "Obsidian Projects workflow — schema, slash commands, and agent skill for running a Jira-lite issue tracker inside an Obsidian vault.",
-  "version": "0.78.1",
+  "version": "0.78.2",
   "author": {
     "name": "Eugene Archibald"
   },


### PR DESCRIPTION
## Summary

- Reorder `pickIssuesForTab`'s in-flight branch so `isResolved(e)` short-circuits before the `e.status` check. Issues whose file lives in `RESOLVED ISSUES/` no longer leak into the In flight tab when their `status:` frontmatter never flipped to a terminal value (the OP-197 data state).
- The folder remains the source of truth for resolution state in the UI; the OP-156 §5 keep-alive logic (agent set + live tmux → keep showing) is preserved on the new short-circuit path.
- Three test fixtures cover the new data-drift cases: no agent → hidden, alive agent → kept, unknown tmux probe → kept.

Reproduced in user's vault: OP-197 lives in \`RESOLVED ISSUES/\` with \`status: in-progress\` and \`resolved: 2026-04-26\`; pre-fix the In flight tab kept showing it. Post-fix the same data state hides correctly. Verified end-to-end in OP-Test.

## Test plan

- [x] `npx vitest run sidebarView.test.ts` — 50/50 pass, 3 new fixtures green
- [x] `npx vitest run` — 1535/1535 pass
- [x] OP-Test smoke: forced `status: in-progress` on a file in \`RESOLVED ISSUES/\`, In flight tab renders \`(none)\` (was the stale row pre-fix)

Closes OP-221.

🤖 Generated with [Claude Code](https://claude.com/claude-code)