### PR TITLE
OP-221 followup: ship the resolve race fix + heal pass that PR #285 lost

### DIFF
--- a/plugins/op-obsidian/manifest.json
+++ b/plugins/op-obsidian/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "op-obsidian",
   "name": "Obsidian Projects (op)",
-  "version": "0.78.2",
+  "version": "0.78.3",
   "minAppVersion": "1.5.0",
   "description": "Jira-lite issue tracker for Obsidian vaults — deterministic commands backing the op workflow.",
   "author": "Eugene Archibald",

--- a/plugins/op-obsidian/manifest.json
+++ b/plugins/op-obsidian/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "op-obsidian",
   "name": "Obsidian Projects (op)",
-  "version": "0.78.5",
+  "version": "0.78.6",
   "minAppVersion": "1.5.0",
   "description": "Jira-lite issue tracker for Obsidian vaults — deterministic commands backing the op workflow.",
   "author": "Eugene Archibald",

--- a/plugins/op-obsidian/manifest.json
+++ b/plugins/op-obsidian/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "op-obsidian",
   "name": "Obsidian Projects (op)",
-  "version": "0.78.3",
+  "version": "0.78.4",
   "minAppVersion": "1.5.0",
   "description": "Jira-lite issue tracker for Obsidian vaults — deterministic commands backing the op workflow.",
   "author": "Eugene Archibald",

--- a/plugins/op-obsidian/manifest.json
+++ b/plugins/op-obsidian/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "op-obsidian",
   "name": "Obsidian Projects (op)",
-  "version": "0.78.4",
+  "version": "0.78.5",
   "minAppVersion": "1.5.0",
   "description": "Jira-lite issue tracker for Obsidian vaults — deterministic commands backing the op workflow.",
   "author": "Eugene Archibald",

--- a/plugins/op-obsidian/package.json
+++ b/plugins/op-obsidian/package.json
@@ -1,6 +1,6 @@
 {
   "name": "op-obsidian",
-  "version": "0.78.5",
+  "version": "0.78.6",
   "description": "Obsidian plugin that owns the deterministic half of the op workflow.",
   "main": "main.js",
   "scripts": {

--- a/plugins/op-obsidian/package.json
+++ b/plugins/op-obsidian/package.json
@@ -1,6 +1,6 @@
 {
   "name": "op-obsidian",
-  "version": "0.78.3",
+  "version": "0.78.4",
   "description": "Obsidian plugin that owns the deterministic half of the op workflow.",
   "main": "main.js",
   "scripts": {

--- a/plugins/op-obsidian/package.json
+++ b/plugins/op-obsidian/package.json
@@ -1,6 +1,6 @@
 {
   "name": "op-obsidian",
-  "version": "0.78.2",
+  "version": "0.78.3",
   "description": "Obsidian plugin that owns the deterministic half of the op workflow.",
   "main": "main.js",
   "scripts": {

--- a/plugins/op-obsidian/package.json
+++ b/plugins/op-obsidian/package.json
@@ -1,6 +1,6 @@
 {
   "name": "op-obsidian",
-  "version": "0.78.4",
+  "version": "0.78.5",
   "description": "Obsidian plugin that owns the deterministic half of the op workflow.",
   "main": "main.js",
   "scripts": {

--- a/plugins/op-obsidian/src/healStaleResolvedStatus.test.ts
+++ b/plugins/op-obsidian/src/healStaleResolvedStatus.test.ts
@@ -144,7 +144,7 @@ describe("healStaleResolvedStatus", () => {
     expect(file.fm.custom_field).toBe("keep me");
   });
 
-  it("does NOT invent a `resolved:` date when missing — leaves it absent", async () => {
+  it("backfills `resolved:` to today when missing (catch-path scenario)", async () => {
     const drift = entry({
       id: "OP-198",
       path: "Projects/p/RESOLVED ISSUES/OP-198.md",
@@ -161,7 +161,27 @@ describe("healStaleResolvedStatus", () => {
     await healStaleResolvedStatus(app, store);
 
     expect(file.fm.status).toBe("resolved");
-    expect("resolved" in file.fm).toBe(false);
+    expect(file.fm.resolved).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+  });
+
+  it("preserves an existing `resolved:` date — does not overwrite", async () => {
+    const drift = entry({
+      id: "OP-199",
+      path: "Projects/p/RESOLVED ISSUES/OP-199.md",
+      status: "in-progress" as IssueStatus,
+      resolvedFolder: true,
+    });
+    const file: FakeFile = {
+      path: drift.path,
+      fm: { id: "OP-199", status: "in-progress", resolved: "2025-01-15" },
+    };
+    const app = makeApp([file]);
+    const store = makeStore([drift]);
+
+    await healStaleResolvedStatus(app, store);
+
+    expect(file.fm.status).toBe("resolved");
+    expect(file.fm.resolved).toBe("2025-01-15");
   });
 
   it("treats resolvedFolder + wontfix as terminal — no rewrite", async () => {

--- a/plugins/op-obsidian/src/healStaleResolvedStatus.test.ts
+++ b/plugins/op-obsidian/src/healStaleResolvedStatus.test.ts
@@ -111,6 +111,59 @@ describe("healStaleResolvedStatus", () => {
     expect(liveFile.fm.status).toBe("in-progress");
   });
 
+  it("strips zombie agent / agent_session / launch_vars while healing status", async () => {
+    const drift = entry({
+      id: "OP-197",
+      path: "Projects/p/RESOLVED ISSUES/OP-197.md",
+      status: "in-progress" as IssueStatus,
+      resolvedFolder: true,
+    });
+    const file: FakeFile = {
+      path: drift.path,
+      fm: {
+        id: "OP-197",
+        status: "in-progress",
+        resolved: "2026-04-26",
+        agent: "claude",
+        agent_session: "tmux:abc",
+        launch_vars: { x: 1 },
+        // Anything else (custom user fields) must survive untouched.
+        custom_field: "keep me",
+      },
+    };
+    const app = makeApp([file]);
+    const store = makeStore([drift]);
+
+    await healStaleResolvedStatus(app, store);
+
+    expect(file.fm.status).toBe("resolved");
+    expect(file.fm.resolved).toBe("2026-04-26");
+    expect(file.fm.agent).toBeUndefined();
+    expect(file.fm.agent_session).toBeUndefined();
+    expect(file.fm.launch_vars).toBeUndefined();
+    expect(file.fm.custom_field).toBe("keep me");
+  });
+
+  it("does NOT invent a `resolved:` date when missing — leaves it absent", async () => {
+    const drift = entry({
+      id: "OP-198",
+      path: "Projects/p/RESOLVED ISSUES/OP-198.md",
+      status: "in-progress" as IssueStatus,
+      resolvedFolder: true,
+    });
+    const file: FakeFile = {
+      path: drift.path,
+      fm: { id: "OP-198", status: "in-progress" },
+    };
+    const app = makeApp([file]);
+    const store = makeStore([drift]);
+
+    await healStaleResolvedStatus(app, store);
+
+    expect(file.fm.status).toBe("resolved");
+    expect("resolved" in file.fm).toBe(false);
+  });
+
   it("treats resolvedFolder + wontfix as terminal — no rewrite", async () => {
     const wf = entry({
       id: "OP-300",

--- a/plugins/op-obsidian/src/healStaleResolvedStatus.test.ts
+++ b/plugins/op-obsidian/src/healStaleResolvedStatus.test.ts
@@ -1,0 +1,185 @@
+import { describe, it, expect, vi } from "vitest";
+
+const { FakeTFile } = vi.hoisted(() => {
+  class FakeTFile {
+    path: string;
+    constructor(path: string) {
+      this.path = path;
+    }
+  }
+  return { FakeTFile };
+});
+
+vi.mock("obsidian", () => ({
+  TFile: FakeTFile,
+  App: class {},
+}));
+
+import { healStaleResolvedStatus } from "./healStaleResolvedStatus";
+import type { IssueEntry, IssueStatus } from "./types";
+
+function entry(over: Partial<IssueEntry>): IssueEntry {
+  return {
+    path: "x.md",
+    type: "issue",
+    id: "OP-1",
+    project: "p",
+    status: "in-progress",
+    title: "t",
+    resolvedFolder: false,
+    ...over,
+  };
+}
+
+function makeStore(issues: IssueEntry[]) {
+  return { issues: () => issues } as any;
+}
+
+interface FakeFile {
+  path: string;
+  fm: Record<string, any>;
+  shouldThrow?: boolean;
+}
+
+function makeApp(files: FakeFile[]) {
+  const tfiles = new Map<string, any>(
+    files.map((f) => {
+      const tf = Object.assign(new FakeTFile(f.path), f);
+      return [f.path, tf];
+    }),
+  );
+  return {
+    vault: {
+      getAbstractFileByPath: (p: string) => tfiles.get(p) ?? null,
+    },
+    fileManager: {
+      processFrontMatter: async (file: any, fn: (fm: Record<string, any>) => void) => {
+        if (file.shouldThrow) throw new Error("simulated write failure");
+        fn(file.fm);
+      },
+    },
+  } as any;
+}
+
+describe("healStaleResolvedStatus", () => {
+  it("rewrites status to resolved for resolvedFolder rows whose status is non-terminal", async () => {
+    const drift = entry({
+      id: "OP-197",
+      path: "Projects/p/RESOLVED ISSUES/OP-197.md",
+      status: "in-progress" as IssueStatus,
+      resolvedFolder: true,
+    });
+    const ok = entry({
+      id: "OP-200",
+      path: "Projects/p/RESOLVED ISSUES/OP-200.md",
+      status: "resolved" as IssueStatus,
+      resolvedFolder: true,
+    });
+    const live = entry({
+      id: "OP-201",
+      path: "Projects/p/ISSUES/OP-201.md",
+      status: "in-progress" as IssueStatus,
+      resolvedFolder: false,
+    });
+    const driftFile: FakeFile = {
+      path: drift.path,
+      fm: { id: "OP-197", status: "in-progress", resolved: "2026-04-26" },
+    };
+    const okFile: FakeFile = {
+      path: ok.path,
+      fm: { id: "OP-200", status: "resolved", resolved: "2026-04-26" },
+    };
+    const liveFile: FakeFile = {
+      path: live.path,
+      fm: { id: "OP-201", status: "in-progress" },
+    };
+    const app = makeApp([driftFile, okFile, liveFile]);
+    const store = makeStore([drift, ok, live]);
+
+    const result = await healStaleResolvedStatus(app, store);
+
+    expect(result.scanned).toBe(3);
+    expect(result.fixed.map((f) => f.path)).toEqual([drift.path]);
+    expect(result.fixed[0]?.from).toBe("in-progress");
+    expect(result.errors).toEqual([]);
+    // Drift file is rewritten in place — `resolved:` and `id:` preserved.
+    expect(driftFile.fm.status).toBe("resolved");
+    expect(driftFile.fm.resolved).toBe("2026-04-26");
+    expect(driftFile.fm.id).toBe("OP-197");
+    // Healthy files untouched.
+    expect(okFile.fm.status).toBe("resolved");
+    expect(liveFile.fm.status).toBe("in-progress");
+  });
+
+  it("treats resolvedFolder + wontfix as terminal — no rewrite", async () => {
+    const wf = entry({
+      id: "OP-300",
+      path: "Projects/p/RESOLVED ISSUES/OP-300.md",
+      status: "wontfix" as IssueStatus,
+      resolvedFolder: true,
+    });
+    const file: FakeFile = { path: wf.path, fm: { id: "OP-300", status: "wontfix" } };
+    const app = makeApp([file]);
+    const store = makeStore([wf]);
+
+    const result = await healStaleResolvedStatus(app, store);
+
+    expect(result.fixed).toEqual([]);
+    expect(file.fm.status).toBe("wontfix");
+  });
+
+  it("captures errors per-file without aborting the pass", async () => {
+    const okDrift = entry({
+      id: "OP-1",
+      path: "Projects/p/RESOLVED ISSUES/OP-1.md",
+      status: "in-progress" as IssueStatus,
+      resolvedFolder: true,
+    });
+    const failDrift = entry({
+      id: "OP-2",
+      path: "Projects/p/RESOLVED ISSUES/OP-2.md",
+      status: "in-progress" as IssueStatus,
+      resolvedFolder: true,
+    });
+    const missingDrift = entry({
+      id: "OP-3",
+      path: "Projects/p/RESOLVED ISSUES/OP-3.md",
+      status: "in-progress" as IssueStatus,
+      resolvedFolder: true,
+    });
+    const okFile: FakeFile = { path: okDrift.path, fm: { status: "in-progress" } };
+    const failFile: FakeFile = {
+      path: failDrift.path,
+      fm: { status: "in-progress" },
+      shouldThrow: true,
+    };
+    // missingDrift's file is intentionally not registered — getAbstractFileByPath returns null.
+    const app = makeApp([okFile, failFile]);
+    const store = makeStore([okDrift, failDrift, missingDrift]);
+
+    const result = await healStaleResolvedStatus(app, store);
+
+    expect(result.fixed.map((f) => f.path)).toEqual([okDrift.path]);
+    expect(result.errors.map((e) => e.path).sort()).toEqual(
+      [failDrift.path, missingDrift.path].sort(),
+    );
+    expect(okFile.fm.status).toBe("resolved");
+    expect(failFile.fm.status).toBe("in-progress");
+  });
+
+  it("is a no-op when no drift exists", async () => {
+    const all = entry({
+      id: "OP-1",
+      path: "Projects/p/ISSUES/OP-1.md",
+      status: "open" as IssueStatus,
+      resolvedFolder: false,
+    });
+    const app = makeApp([{ path: all.path, fm: { status: "open" } }]);
+    const store = makeStore([all]);
+
+    const result = await healStaleResolvedStatus(app, store);
+    expect(result.scanned).toBe(1);
+    expect(result.fixed).toEqual([]);
+    expect(result.errors).toEqual([]);
+  });
+});

--- a/plugins/op-obsidian/src/healStaleResolvedStatus.test.ts
+++ b/plugins/op-obsidian/src/healStaleResolvedStatus.test.ts
@@ -39,12 +39,16 @@ interface FakeFile {
   path: string;
   fm: Record<string, any>;
   shouldThrow?: boolean;
+  /** Optional mtime (epoch ms) — used by the heal pass to backfill `resolved:`. */
+  mtime?: number;
 }
 
 function makeApp(files: FakeFile[]) {
   const tfiles = new Map<string, any>(
     files.map((f) => {
-      const tf = Object.assign(new FakeTFile(f.path), f);
+      const tf = Object.assign(new FakeTFile(f.path), f, {
+        stat: { mtime: f.mtime ?? 0 },
+      });
       return [f.path, tf];
     }),
   );
@@ -111,7 +115,7 @@ describe("healStaleResolvedStatus", () => {
     expect(liveFile.fm.status).toBe("in-progress");
   });
 
-  it("strips zombie agent / agent_session / launch_vars while healing status", async () => {
+  it("strips launch_vars but PRESERVES agent / agent_session (live-agent safety)", async () => {
     const drift = entry({
       id: "OP-197",
       path: "Projects/p/RESOLVED ISSUES/OP-197.md",
@@ -138,22 +142,47 @@ describe("healStaleResolvedStatus", () => {
 
     expect(file.fm.status).toBe("resolved");
     expect(file.fm.resolved).toBe("2026-04-26");
-    expect(file.fm.agent).toBeUndefined();
-    expect(file.fm.agent_session).toBeUndefined();
+    // Agent metadata preserved — heal does not orphan a possibly-live agent.
+    expect(file.fm.agent).toBe("claude");
+    expect(file.fm.agent_session).toBe("tmux:abc");
+    // launch_vars (pure settings — no live process) is safely cleared.
     expect(file.fm.launch_vars).toBeUndefined();
     expect(file.fm.custom_field).toBe("keep me");
   });
 
-  it("backfills `resolved:` to today when missing (catch-path scenario)", async () => {
+  it("backfills `resolved:` from file.stat.mtime when missing", async () => {
     const drift = entry({
       id: "OP-198",
       path: "Projects/p/RESOLVED ISSUES/OP-198.md",
       status: "in-progress" as IssueStatus,
       resolvedFolder: true,
     });
+    const mtime = Date.UTC(2026, 0, 15, 12, 0, 0); // 2026-01-15
     const file: FakeFile = {
       path: drift.path,
       fm: { id: "OP-198", status: "in-progress" },
+      mtime,
+    };
+    const app = makeApp([file]);
+    const store = makeStore([drift]);
+
+    await healStaleResolvedStatus(app, store);
+
+    expect(file.fm.status).toBe("resolved");
+    expect(file.fm.resolved).toBe("2026-01-15");
+  });
+
+  it("falls back to today's date when mtime is unavailable", async () => {
+    const drift = entry({
+      id: "OP-199",
+      path: "Projects/p/RESOLVED ISSUES/OP-199.md",
+      status: "in-progress" as IssueStatus,
+      resolvedFolder: true,
+    });
+    const file: FakeFile = {
+      path: drift.path,
+      fm: { id: "OP-199", status: "in-progress" },
+      mtime: 0, // unavailable
     };
     const app = makeApp([file]);
     const store = makeStore([drift]);

--- a/plugins/op-obsidian/src/healStaleResolvedStatus.ts
+++ b/plugins/op-obsidian/src/healStaleResolvedStatus.ts
@@ -36,25 +36,27 @@ export async function healStaleResolvedStatus(
       errors.push({ path: e.path, error: "file not found in vault" });
       continue;
     }
+    // Backfill `resolved:` with the file's mtime when the field is missing
+    // (catch-path scenario in `runResolve`: rename succeeded but the
+    // frontmatter write threw, so neither `status:` nor `resolved:` was
+    // ever applied). mtime ≈ rename time on the moved file, which is the
+    // closest proxy to the original resolve moment. Falls back to today
+    // if stat is unavailable.
+    const fallbackResolved = isoDate(file.stat?.mtime) ?? today();
+    // `launch_vars:` is pure settings — no live process attached — so
+    // clearing it is safe and matches `runResolve`'s cleanup.
+    // We deliberately do NOT touch `agent:` / `agent_session:` here:
+    // copilot review #4 — a long-running agent attached to a drifted
+    // file would be orphaned by an unconditional clear. The OP-156 §5
+    // keep-alive logic in `runResolve` and the sidebar In flight tab
+    // already handle agent+resolvedFolder cases correctly; users can
+    // detach a stale agent via the existing command.
     try {
       await app.fileManager.processFrontMatter(file, (fm) => {
         fm.status = "resolved";
-        // Mirror runResolve's frontmatter cleanup: a drifted file may also
-        // carry zombie `agent:` / `agent_session:` / `launch_vars:` entries
-        // that the original resolve flow would have removed but that the
-        // race left in place. Clearing them here keeps the healed file in
-        // a state indistinguishable from a clean resolve.
-        delete fm.agent;
-        delete fm.agent_session;
         delete fm.launch_vars;
-        // Gemini review #2 (2nd pass): if `resolved:` is missing too
-        // (resolve.ts catch-path scenario where processFrontMatter threw
-        // before either field was written), set today as a best-effort
-        // fallback. It may be off by hours/days from the actual rename
-        // time, but a missing date breaks downstream sort/filter/query
-        // semantics; today's date is recoverable, absence is not.
         if (typeof fm.resolved !== "string" || fm.resolved.length === 0) {
-          fm.resolved = new Date().toISOString().slice(0, 10);
+          fm.resolved = fallbackResolved;
         }
       });
       fixed.push({ path: e.path, from: e.status });
@@ -63,4 +65,13 @@ export async function healStaleResolvedStatus(
     }
   }
   return { scanned: issues.length, fixed, errors };
+}
+
+function today(): string {
+  return new Date().toISOString().slice(0, 10);
+}
+
+function isoDate(epochMs: number | undefined): string | undefined {
+  if (typeof epochMs !== "number" || !Number.isFinite(epochMs) || epochMs <= 0) return undefined;
+  return new Date(epochMs).toISOString().slice(0, 10);
 }

--- a/plugins/op-obsidian/src/healStaleResolvedStatus.ts
+++ b/plugins/op-obsidian/src/healStaleResolvedStatus.ts
@@ -1,0 +1,49 @@
+import { App, TFile } from "obsidian";
+import type { IssueStore } from "./issueStore";
+import type { IssueStatus } from "./types";
+
+const TERMINAL: ReadonlySet<IssueStatus> = new Set<IssueStatus>(["resolved", "wontfix"]);
+
+export interface HealResult {
+  scanned: number;
+  fixed: { path: string; from: IssueStatus }[];
+  errors: { path: string; error: string }[];
+}
+
+/**
+ * OP-221: scan all issues; for any whose file lives in `RESOLVED ISSUES/`
+ * but whose `status:` frontmatter is non-terminal, rewrite
+ * `status: resolved`.
+ *
+ * Fixes the data-drift state observed in the wild on OP-197 (file moved to
+ * RESOLVED ISSUES/, `resolved:` written, but `status:` left as `in-progress`)
+ * caused by a race between `processFrontMatter` and `renameFile` in the
+ * pre-OP-221 ordering of `runResolve`. The race itself is fixed in
+ * `resolve.ts` (rename → write); this pass cleans up legacy drift on first
+ * load. Idempotent — re-running on a clean vault is a no-op.
+ */
+export async function healStaleResolvedStatus(
+  app: App,
+  store: IssueStore,
+): Promise<HealResult> {
+  const issues = store.issues();
+  const drift = issues.filter((e) => e.resolvedFolder && !TERMINAL.has(e.status));
+  const fixed: HealResult["fixed"] = [];
+  const errors: HealResult["errors"] = [];
+  for (const e of drift) {
+    const file = app.vault.getAbstractFileByPath(e.path);
+    if (!(file instanceof TFile)) {
+      errors.push({ path: e.path, error: "file not found in vault" });
+      continue;
+    }
+    try {
+      await app.fileManager.processFrontMatter(file, (fm) => {
+        fm.status = "resolved";
+      });
+      fixed.push({ path: e.path, from: e.status });
+    } catch (err: any) {
+      errors.push({ path: e.path, error: err?.message ?? String(err) });
+    }
+  }
+  return { scanned: issues.length, fixed, errors };
+}

--- a/plugins/op-obsidian/src/healStaleResolvedStatus.ts
+++ b/plugins/op-obsidian/src/healStaleResolvedStatus.ts
@@ -43,11 +43,19 @@ export async function healStaleResolvedStatus(
         // carry zombie `agent:` / `agent_session:` / `launch_vars:` entries
         // that the original resolve flow would have removed but that the
         // race left in place. Clearing them here keeps the healed file in
-        // a state indistinguishable from a clean resolve. We do NOT touch
-        // `resolved:` — if it's missing, we can't infer a correct date.
+        // a state indistinguishable from a clean resolve.
         delete fm.agent;
         delete fm.agent_session;
         delete fm.launch_vars;
+        // Gemini review #2 (2nd pass): if `resolved:` is missing too
+        // (resolve.ts catch-path scenario where processFrontMatter threw
+        // before either field was written), set today as a best-effort
+        // fallback. It may be off by hours/days from the actual rename
+        // time, but a missing date breaks downstream sort/filter/query
+        // semantics; today's date is recoverable, absence is not.
+        if (typeof fm.resolved !== "string" || fm.resolved.length === 0) {
+          fm.resolved = new Date().toISOString().slice(0, 10);
+        }
       });
       fixed.push({ path: e.path, from: e.status });
     } catch (err: any) {

--- a/plugins/op-obsidian/src/healStaleResolvedStatus.ts
+++ b/plugins/op-obsidian/src/healStaleResolvedStatus.ts
@@ -39,6 +39,15 @@ export async function healStaleResolvedStatus(
     try {
       await app.fileManager.processFrontMatter(file, (fm) => {
         fm.status = "resolved";
+        // Mirror runResolve's frontmatter cleanup: a drifted file may also
+        // carry zombie `agent:` / `agent_session:` / `launch_vars:` entries
+        // that the original resolve flow would have removed but that the
+        // race left in place. Clearing them here keeps the healed file in
+        // a state indistinguishable from a clean resolve. We do NOT touch
+        // `resolved:` — if it's missing, we can't infer a correct date.
+        delete fm.agent;
+        delete fm.agent_session;
+        delete fm.launch_vars;
       });
       fixed.push({ path: e.path, from: e.status });
     } catch (err: any) {

--- a/plugins/op-obsidian/src/main.ts
+++ b/plugins/op-obsidian/src/main.ts
@@ -61,6 +61,7 @@ import { resolveRepoPath } from "./repoPath";
 import { writeUriResponse, type UriResponsePayload } from "./uriResponse";
 import { normalizeUriParams, collectRepeated, parseLaunchVarsFromUri } from "./uriParams";
 import { runResolve, type ResolveArgs } from "./resolve";
+import { healStaleResolvedStatus } from "./healStaleResolvedStatus";
 import { shouldAutoResolve } from "./autoResolveOnStatusChange";
 import {
   findIssueById as findIssueByIdPure,
@@ -399,6 +400,26 @@ export default class OpPlugin extends Plugin {
       ).catch((err) => {
         console.error("[op-obsidian] first-run readme scaffold failed", err);
       });
+      // OP-221: clean up legacy data drift where a pre-OP-221 `runResolve`
+      // race left an issue in `RESOLVED ISSUES/` with a non-terminal
+      // `status:`. Idempotent — no-op on a clean vault. The fix in
+      // `resolve.ts` (rename → write) prevents new drift; this pass heals
+      // the historical state.
+      void healStaleResolvedStatus(this.app, this.store)
+        .then((res) => {
+          if (res.fixed.length > 0) {
+            console.info(
+              `[op-obsidian] healed ${res.fixed.length} stale-status issue(s) in RESOLVED ISSUES/`,
+              res.fixed,
+            );
+          }
+          if (res.errors.length > 0) {
+            console.warn("[op-obsidian] healStaleResolvedStatus errors", res.errors);
+          }
+        })
+        .catch((err) => {
+          console.error("[op-obsidian] healStaleResolvedStatus threw", err);
+        });
     });
 
     // OP-151 (§2) + OP-162 (§11): note-level decoration infra. The

--- a/plugins/op-obsidian/src/main.ts
+++ b/plugins/op-obsidian/src/main.ts
@@ -406,16 +406,16 @@ export default class OpPlugin extends Plugin {
       // `resolve.ts` (rename → write) prevents new drift; this pass heals
       // historical state.
       //
-      // Gemini review #1 (2nd pass): `metadataCache.on("resolved")` fires
-      // *each time* a batch of pending parse work completes — including
-      // partial batches mid-load on a large vault. Single-firing on the
-      // first event would race the IssueStore's hydration. Debounce
-      // instead: reset a 750ms quiet-window timer on every `resolved`
-      // event; only fire once the cache has been quiet for that long.
-      // The single-fire latch ensures subsequent per-edit `resolved`
-      // events after the heal don't re-trigger it. The 4s hard ceiling
-      // guarantees forward progress on a vault that never quiets (e.g.,
-      // open with a sync engine continuously touching files).
+      // `metadataCache.on("resolved")` fires *each time* a batch of pending
+      // parse work completes — including partial batches mid-load on a
+      // large vault. Single-firing on the first event would race the
+      // IssueStore's hydration. Debounce instead: reset a 750ms
+      // quiet-window timer on every `resolved` event; only fire once the
+      // cache has been quiet for that long. The single-fire latch ensures
+      // subsequent per-edit `resolved` events after the heal don't
+      // re-trigger it. The 4s hard ceiling guarantees forward progress on
+      // a vault that never quiets (e.g., open with a sync engine
+      // continuously touching files).
       let healFired = false;
       let healDebounce: number | undefined;
       const HEAL_QUIET_MS = 750;
@@ -2505,11 +2505,11 @@ export default class OpPlugin extends Plugin {
           : [],
       });
 
-      // OP-221 (gemini review #3, 2nd pass): when `processFrontMatter`
-      // failed after the rename succeeded, the file is moved but its
-      // status/resolved frontmatter wasn't written. Warn the user so they
-      // know the heal pass will reconcile it on next reload — silently
-      // returning success would mask the inconsistency.
+      // OP-221: when `processFrontMatter` failed after the rename
+      // succeeded, the file is moved but its status/resolved frontmatter
+      // wasn't written. Warn the user so they know the heal pass will
+      // reconcile it on next reload — silently returning success would
+      // mask the inconsistency.
       if (result.frontmatterWriteError && result.issueId) {
         notify(
           `op: ${result.issueId} resolved (file moved) but frontmatter write failed — will heal on next reload`,

--- a/plugins/op-obsidian/src/main.ts
+++ b/plugins/op-obsidian/src/main.ts
@@ -404,22 +404,40 @@ export default class OpPlugin extends Plugin {
       // race left an issue in `RESOLVED ISSUES/` with a non-terminal
       // `status:`. Idempotent — no-op on a clean vault. The fix in
       // `resolve.ts` (rename → write) prevents new drift; this pass heals
-      // the historical state.
-      void healStaleResolvedStatus(this.app, this.store)
-        .then((res) => {
-          if (res.fixed.length > 0) {
-            console.info(
-              `[op-obsidian] healed ${res.fixed.length} stale-status issue(s) in RESOLVED ISSUES/`,
-              res.fixed,
-            );
-          }
-          if (res.errors.length > 0) {
-            console.warn("[op-obsidian] healStaleResolvedStatus errors", res.errors);
-          }
-        })
-        .catch((err) => {
-          console.error("[op-obsidian] healStaleResolvedStatus threw", err);
-        });
+      // historical state. Gemini review #1: the IssueStore rebuilds inside
+      // its own onLayoutReady callback (synchronous iteration over
+      // metadataCache), so we must run AFTER the store has hydrated AND
+      // after the metadata cache has finished its initial resolve — bind
+      // the trigger to `metadataCache.on("resolved")` and gate it with a
+      // single-fire flag so subsequent `resolved` events (fired on every
+      // file edit) don't re-run the pass.
+      let healFired = false;
+      const fireHeal = () => {
+        if (healFired) return;
+        healFired = true;
+        void healStaleResolvedStatus(this.app, this.store)
+          .then((res) => {
+            if (res.fixed.length > 0) {
+              console.info(
+                `[op-obsidian] healed ${res.fixed.length} stale-status issue(s) in RESOLVED ISSUES/`,
+                res.fixed,
+              );
+            }
+            if (res.errors.length > 0) {
+              console.warn("[op-obsidian] healStaleResolvedStatus errors", res.errors);
+            }
+          })
+          .catch((err) => {
+            console.error("[op-obsidian] healStaleResolvedStatus threw", err);
+          });
+      };
+      // Run on the next `metadataCache.resolved` event, OR after a
+      // generous fallback timer if the cache is already settled and
+      // won't fire again on this load (avoids hanging the heal forever
+      // on a vault with no pending parse work).
+      const ref = this.app.metadataCache.on("resolved", fireHeal);
+      this.registerEvent(ref);
+      window.setTimeout(fireHeal, 1500);
     });
 
     // OP-151 (§2) + OP-162 (§11): note-level decoration infra. The

--- a/plugins/op-obsidian/src/main.ts
+++ b/plugins/op-obsidian/src/main.ts
@@ -404,17 +404,30 @@ export default class OpPlugin extends Plugin {
       // race left an issue in `RESOLVED ISSUES/` with a non-terminal
       // `status:`. Idempotent — no-op on a clean vault. The fix in
       // `resolve.ts` (rename → write) prevents new drift; this pass heals
-      // historical state. Gemini review #1: the IssueStore rebuilds inside
-      // its own onLayoutReady callback (synchronous iteration over
-      // metadataCache), so we must run AFTER the store has hydrated AND
-      // after the metadata cache has finished its initial resolve — bind
-      // the trigger to `metadataCache.on("resolved")` and gate it with a
-      // single-fire flag so subsequent `resolved` events (fired on every
-      // file edit) don't re-run the pass.
+      // historical state.
+      //
+      // Gemini review #1 (2nd pass): `metadataCache.on("resolved")` fires
+      // *each time* a batch of pending parse work completes — including
+      // partial batches mid-load on a large vault. Single-firing on the
+      // first event would race the IssueStore's hydration. Debounce
+      // instead: reset a 750ms quiet-window timer on every `resolved`
+      // event; only fire once the cache has been quiet for that long.
+      // The single-fire latch ensures subsequent per-edit `resolved`
+      // events after the heal don't re-trigger it. The 4s hard ceiling
+      // guarantees forward progress on a vault that never quiets (e.g.,
+      // open with a sync engine continuously touching files).
       let healFired = false;
+      let healDebounce: number | undefined;
+      const HEAL_QUIET_MS = 750;
+      const HEAL_HARD_CEILING_MS = 4000;
       const fireHeal = () => {
         if (healFired) return;
         healFired = true;
+        if (healDebounce !== undefined) window.clearTimeout(healDebounce);
+        // Reading from the live store is correct here: the store hydrates
+        // synchronously inside its own onLayoutReady callback (registered
+        // before this one), so by the time the debounce window settles
+        // the store reflects the on-disk vault state.
         void healStaleResolvedStatus(this.app, this.store)
           .then((res) => {
             if (res.fixed.length > 0) {
@@ -431,13 +444,20 @@ export default class OpPlugin extends Plugin {
             console.error("[op-obsidian] healStaleResolvedStatus threw", err);
           });
       };
-      // Run on the next `metadataCache.resolved` event, OR after a
-      // generous fallback timer if the cache is already settled and
-      // won't fire again on this load (avoids hanging the heal forever
-      // on a vault with no pending parse work).
-      const ref = this.app.metadataCache.on("resolved", fireHeal);
+      const armDebounce = () => {
+        if (healFired) return;
+        if (healDebounce !== undefined) window.clearTimeout(healDebounce);
+        healDebounce = window.setTimeout(fireHeal, HEAL_QUIET_MS);
+      };
+      const ref = this.app.metadataCache.on("resolved", armDebounce);
       this.registerEvent(ref);
-      window.setTimeout(fireHeal, 1500);
+      // Arm immediately too — if the cache is already settled at
+      // onLayoutReady (small vault), no further `resolved` events fire
+      // and the debounce alone would never trip.
+      armDebounce();
+      // Hard ceiling: even if `resolved` keeps firing (busy vault, sync
+      // engine churn), heal at this point so we make forward progress.
+      window.setTimeout(fireHeal, HEAL_HARD_CEILING_MS);
     });
 
     // OP-151 (§2) + OP-162 (§11): note-level decoration infra. The
@@ -2484,6 +2504,22 @@ export default class OpPlugin extends Plugin {
             ]
           : [],
       });
+
+      // OP-221 (gemini review #3, 2nd pass): when `processFrontMatter`
+      // failed after the rename succeeded, the file is moved but its
+      // status/resolved frontmatter wasn't written. Warn the user so they
+      // know the heal pass will reconcile it on next reload — silently
+      // returning success would mask the inconsistency.
+      if (result.frontmatterWriteError && result.issueId) {
+        notify(
+          `op: ${result.issueId} resolved (file moved) but frontmatter write failed — will heal on next reload`,
+        );
+        console.warn(
+          "[op-obsidian] resolve frontmatterWriteError",
+          result.issueId,
+          result.frontmatterWriteError,
+        );
+      }
 
       // §5: surface a second, actionable Notice when `agent:` survived the
       // resolve (live tmux window) or when tmux was unreachable. [Open agent]

--- a/plugins/op-obsidian/src/resolve.test.ts
+++ b/plugins/op-obsidian/src/resolve.test.ts
@@ -217,3 +217,65 @@ describe("runResolve — agent-badge persistence (OP-156 §5)", () => {
     expect(recorded.renamedTo).toBe("Projects/demo/RESOLVED ISSUES/OP-1 t.md");
   });
 });
+
+// OP-221 (gemini review #2): if processFrontMatter throws AFTER the rename
+// has already moved the file, the function must still trash linked tasks
+// and return — leaving the moved file in a stale-status state that the
+// startup heal pass will reconcile on the next plugin load.
+describe("runResolve — graceful failure when frontmatter write throws", () => {
+  it("still trashes linked tasks when processFrontMatter throws after rename", async () => {
+    const e = issue();
+    const file = new FakeTFile(e.path);
+    const taskTrashed: string[] = [];
+
+    const taskFile = new FakeTFile("Projects/demo/TASKS/OP-1.1 work.md");
+    const store: any = {
+      byPath: (p: string) => (p === e.path ? e : undefined),
+      tasks: () => [
+        {
+          path: taskFile.path,
+          type: "task",
+          id: "OP-1.1",
+          project: "demo",
+          status: "in-progress",
+          issueLink: "OP-1",
+          title: "OP-1.1 work",
+        },
+      ],
+      issues: () => [e],
+    };
+
+    const consoleErr = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    const app: any = {
+      vault: {
+        getAbstractFileByPath: (p: string) =>
+          p === e.path ? file : p === taskFile.path ? taskFile : null,
+        adapter: { exists: async () => true },
+        createFolder: async () => {},
+        trash: async (f: any) => {
+          taskTrashed.push(f.path);
+        },
+      },
+      fileManager: {
+        processFrontMatter: async () => {
+          throw new Error("simulated yaml parse failure");
+        },
+        renameFile: async () => {},
+      },
+    };
+
+    const res = await runResolve(app, store, { path: e.path, confirmed: true });
+
+    expect(res.ok).toBe(true);
+    expect(res.movedTo).toBe("Projects/demo/RESOLVED ISSUES/OP-1 t.md");
+    expect(res.trashed).toEqual([taskFile.path]);
+    expect(taskTrashed).toEqual([taskFile.path]);
+    expect(consoleErr).toHaveBeenCalledWith(
+      expect.stringContaining("processFrontMatter failed after rename"),
+      "Projects/demo/RESOLVED ISSUES/OP-1 t.md",
+      expect.stringContaining("simulated yaml parse failure"),
+    );
+    consoleErr.mockRestore();
+  });
+});

--- a/plugins/op-obsidian/src/resolve.test.ts
+++ b/plugins/op-obsidian/src/resolve.test.ts
@@ -271,11 +271,21 @@ describe("runResolve — graceful failure when frontmatter write throws", () => 
     expect(res.movedTo).toBe("Projects/demo/RESOLVED ISSUES/OP-1 t.md");
     expect(res.trashed).toEqual([taskFile.path]);
     expect(taskTrashed).toEqual([taskFile.path]);
+    // OP-221 (gemini #3, 2nd pass): partial-failure must be visible to caller.
+    expect(res.frontmatterWriteError).toContain("simulated yaml parse failure");
     expect(consoleErr).toHaveBeenCalledWith(
       expect.stringContaining("processFrontMatter failed after rename"),
       "Projects/demo/RESOLVED ISSUES/OP-1 t.md",
       expect.stringContaining("simulated yaml parse failure"),
     );
     consoleErr.mockRestore();
+  });
+
+  it("leaves frontmatterWriteError undefined on a clean resolve", async () => {
+    const e = issue();
+    const { store, app } = makeFakes(e, { status: "in-progress" });
+    const res = await runResolve(app, store, { path: e.path, confirmed: true });
+    expect(res.ok).toBe(true);
+    expect(res.frontmatterWriteError).toBeUndefined();
   });
 });

--- a/plugins/op-obsidian/src/resolve.ts
+++ b/plugins/op-obsidian/src/resolve.ts
@@ -58,6 +58,15 @@ export interface ResolveResult {
    * ran (no agent set on the issue, or the legacy no-probe path).
    */
   agentProbeOk?: boolean;
+  /**
+   * OP-221 (gemini review #3, 2nd pass): when `processFrontMatter` throws
+   * AFTER the rename has already moved the file, runResolve catches the
+   * error, continues with task trashing + gh-close, and surfaces the
+   * failure here so the caller can warn the user. The startup heal pass
+   * (`healStaleResolvedStatus`) reconciles the moved file's stale status
+   * + missing `resolved:` on next plugin load.
+   */
+  frontmatterWriteError?: string;
 }
 
 export async function runResolve(
@@ -201,6 +210,7 @@ export async function runResolve(
     githubCloseError,
     agentKept,
     agentProbeOk,
+    frontmatterWriteError: frontmatterWriteFailed,
   };
 }
 

--- a/plugins/op-obsidian/src/resolve.ts
+++ b/plugins/op-obsidian/src/resolve.ts
@@ -126,6 +126,23 @@ export async function runResolve(
   }
 
   const today = new Date().toISOString().slice(0, 10);
+
+  // OP-221: rename FIRST, then write frontmatter on the moved file. The
+  // previous order (processFrontMatter then renameFile) opened a window
+  // where the rename could drop the status update — when the issue file
+  // had an open editor view with a dirty buffer (or any pending writer
+  // racing with us), Obsidian's rename machinery could re-flush the
+  // stale buffer to the new path, reverting the status write but leaving
+  // `resolved:` intact (the OP-197 drift state). Doing the write AFTER
+  // the rename means our processFrontMatter is unconditionally the last
+  // word on the moved file's frontmatter.
+  //
+  // Safe wrt event handlers: the auto-resolve guard short-circuits on
+  // `entry.resolvedFolder` (autoResolveOnStatusChange.ts L31), and the
+  // gh-close listener is idempotent. `inFlightResolvePaths` still tracks
+  // the source path for belt-and-suspenders.
+  await app.fileManager.renameFile(file, targetPath);
+
   await app.fileManager.processFrontMatter(file, (fm) => {
     fm.status = targetStatus;
     fm.resolved = today;
@@ -137,8 +154,6 @@ export async function runResolve(
     // not inherit stale Launch overrides from its previous lifecycle.
     delete fm.launch_vars;
   });
-
-  await app.fileManager.renameFile(file, targetPath);
 
   const trashed: string[] = [];
   for (const t of tasks) {

--- a/plugins/op-obsidian/src/resolve.ts
+++ b/plugins/op-obsidian/src/resolve.ts
@@ -59,12 +59,12 @@ export interface ResolveResult {
    */
   agentProbeOk?: boolean;
   /**
-   * OP-221 (gemini review #3, 2nd pass): when `processFrontMatter` throws
-   * AFTER the rename has already moved the file, runResolve catches the
-   * error, continues with task trashing + gh-close, and surfaces the
-   * failure here so the caller can warn the user. The startup heal pass
-   * (`healStaleResolvedStatus`) reconciles the moved file's stale status
-   * + missing `resolved:` on next plugin load.
+   * OP-221: when `processFrontMatter` throws AFTER the rename has already
+   * moved the file, runResolve catches the error, continues with task
+   * trashing + gh-close, and surfaces the failure here so the caller can
+   * warn the user. The startup heal pass (`healStaleResolvedStatus`)
+   * reconciles the moved file's stale status + missing `resolved:` on
+   * next plugin load.
    */
   frontmatterWriteError?: string;
 }
@@ -152,11 +152,11 @@ export async function runResolve(
   // the source path for belt-and-suspenders.
   await app.fileManager.renameFile(file, targetPath);
 
-  // OP-221 follow-up (gemini review #2): if processFrontMatter throws
-  // (malformed YAML, sync-engine lock), we MUST still trash linked tasks
-  // and run the gh-close hook. Swallowing here is intentional — the heal
-  // pass on next plugin load (`healStaleResolvedStatus`) will catch any
-  // file that ended up moved with stale status.
+  // OP-221: if processFrontMatter throws (malformed YAML, sync-engine
+  // lock), we MUST still trash linked tasks and run the gh-close hook.
+  // Swallowing here is intentional — the heal pass on next plugin load
+  // (`healStaleResolvedStatus`) will catch any file that ended up moved
+  // with stale status.
   let frontmatterWriteFailed: string | undefined;
   try {
     await app.fileManager.processFrontMatter(file, (fm) => {

--- a/plugins/op-obsidian/src/resolve.ts
+++ b/plugins/op-obsidian/src/resolve.ts
@@ -143,17 +143,32 @@ export async function runResolve(
   // the source path for belt-and-suspenders.
   await app.fileManager.renameFile(file, targetPath);
 
-  await app.fileManager.processFrontMatter(file, (fm) => {
-    fm.status = targetStatus;
-    fm.resolved = today;
-    if (!agentKept) {
-      delete fm.agent;
-      delete fm.agent_session;
-    }
-    // OP-204 (3d): clear `launch_vars:` so a re-opened resolved issue does
-    // not inherit stale Launch overrides from its previous lifecycle.
-    delete fm.launch_vars;
-  });
+  // OP-221 follow-up (gemini review #2): if processFrontMatter throws
+  // (malformed YAML, sync-engine lock), we MUST still trash linked tasks
+  // and run the gh-close hook. Swallowing here is intentional — the heal
+  // pass on next plugin load (`healStaleResolvedStatus`) will catch any
+  // file that ended up moved with stale status.
+  let frontmatterWriteFailed: string | undefined;
+  try {
+    await app.fileManager.processFrontMatter(file, (fm) => {
+      fm.status = targetStatus;
+      fm.resolved = today;
+      if (!agentKept) {
+        delete fm.agent;
+        delete fm.agent_session;
+      }
+      // OP-204 (3d): clear `launch_vars:` so a re-opened resolved issue does
+      // not inherit stale Launch overrides from its previous lifecycle.
+      delete fm.launch_vars;
+    });
+  } catch (err: any) {
+    frontmatterWriteFailed = err?.message ?? String(err);
+    console.error(
+      "[op-obsidian] resolve: processFrontMatter failed after rename — heal pass will reconcile on next load",
+      targetPath,
+      frontmatterWriteFailed,
+    );
+  }
 
   const trashed: string[] = [];
   for (const t of tasks) {

--- a/plugins/op/.claude-plugin/plugin.json
+++ b/plugins/op/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "op",
   "description": "Obsidian Projects workflow — schema, slash commands, and agent skill for running a Jira-lite issue tracker inside an Obsidian vault.",
-  "version": "0.78.2",
+  "version": "0.78.3",
   "author": {
     "name": "Eugene Archibald"
   },

--- a/plugins/op/.claude-plugin/plugin.json
+++ b/plugins/op/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "op",
   "description": "Obsidian Projects workflow — schema, slash commands, and agent skill for running a Jira-lite issue tracker inside an Obsidian vault.",
-  "version": "0.78.4",
+  "version": "0.78.5",
   "author": {
     "name": "Eugene Archibald"
   },

--- a/plugins/op/.claude-plugin/plugin.json
+++ b/plugins/op/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "op",
   "description": "Obsidian Projects workflow — schema, slash commands, and agent skill for running a Jira-lite issue tracker inside an Obsidian vault.",
-  "version": "0.78.5",
+  "version": "0.78.6",
   "author": {
     "name": "Eugene Archibald"
   },

--- a/plugins/op/.claude-plugin/plugin.json
+++ b/plugins/op/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "op",
   "description": "Obsidian Projects workflow — schema, slash commands, and agent skill for running a Jira-lite issue tracker inside an Obsidian vault.",
-  "version": "0.78.3",
+  "version": "0.78.4",
   "author": {
     "name": "Eugene Archibald"
   },


### PR DESCRIPTION
## Summary

PR #285 was supposed to ship the OP-221 fix in 5 commits (sidebar filter + resolve race + heal pass + 2 review rounds). Only commit 1 (sidebar filter) made it into main — `git push` didn't propagate the subsequent 4 commits to the PR branch before the merge, so the actual root-cause fix never landed.

This PR cherry-picks the 4 lost commits onto a fresh branch and re-ships them. No new code — these are the exact commits as reviewed (gemini ×2, copilot ×2, final verdict "Ship as-is").

## What's included

- 989c772 — fix resolve race (rename → write) + heal pass module
- 9aa6278 — gemini round 1 fixes (debounce trigger, try/catch, cleanup)
- 267053b — gemini round 2 fixes (per-batch debounce, mtime/date backfill, partial-failure visibility)
- 325228a — copilot fixes (preserve agent, mtime backfill, comment hygiene)

## Test plan

- [x] 1561/1561 tests pass
- [x] `dev-sync` to OP-Test (heal pass smoke verified earlier — DM-2 drift auto-corrected with agent preserved)

🤖 Generated with [Claude Code](https://claude.com/claude-code)