### PR TITLE
OP-222: rename op-demo prefix from OPD to DEMO

### DIFF
--- a/docs/specs/OP-149-feel-great-ux-design.md
+++ b/docs/specs/OP-149-feel-great-ux-design.md
@@ -442,7 +442,7 @@ Use `createFragment` builder, set timeout `0` for actionable ones (sticky until 
 
 - A 4-line "what is this" intro.
 - The hotkey preset table from §3, with a working **Apply preset** chip (CM6 widget calling `applyPreset()`).
-- One **Start tour** chip that scaffolds a demo project (`op-demo`, prefix `OPD`) with three pre-seeded issues — the user can `/op:resolve` them as they explore. Removable in one click.
+- One **Start tour** chip that scaffolds a demo project (`op-demo`, prefix `DEMO`) with three pre-seeded issues — the user can `/op:resolve` them as they explore. Removable in one click.
 - A footer link to the GitHub repo.
 
 No modals. The README is the tour. Dismissed by deleting the file (we don't recreate it).

--- a/plugins/op-obsidian/manifest.json
+++ b/plugins/op-obsidian/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "op-obsidian",
   "name": "Obsidian Projects (op)",
-  "version": "0.78.6",
+  "version": "0.78.7",
   "minAppVersion": "1.5.0",
   "description": "Jira-lite issue tracker for Obsidian vaults — deterministic commands backing the op workflow.",
   "author": "Eugene Archibald",

--- a/plugins/op-obsidian/package.json
+++ b/plugins/op-obsidian/package.json
@@ -1,6 +1,6 @@
 {
   "name": "op-obsidian",
-  "version": "0.78.6",
+  "version": "0.78.7",
   "description": "Obsidian plugin that owns the deterministic half of the op workflow.",
   "main": "main.js",
   "scripts": {

--- a/plugins/op-obsidian/src/firstRunReadme.test.ts
+++ b/plugins/op-obsidian/src/firstRunReadme.test.ts
@@ -49,7 +49,7 @@ describe("DEMO_ISSUES", () => {
 
   it("renders an issue note with valid frontmatter", () => {
     const note = buildDemoIssueNote(DEMO_ISSUES[0]);
-    expect(note).toContain("id: OPD-1");
+    expect(note).toContain("id: DEMO-1");
     expect(note).toContain("type: issue");
     expect(note).toContain("status: open");
     expect(note).toContain("project: op-demo");

--- a/plugins/op-obsidian/src/firstRunReadme.ts
+++ b/plugins/op-obsidian/src/firstRunReadme.ts
@@ -19,7 +19,7 @@ import { normalizePath } from "obsidian";
 
 export const README_PATH = "Projects/_op-readme.md";
 export const DEMO_PROJECT_SLUG = "op-demo";
-export const DEMO_PROJECT_PREFIX = "OPD";
+export const DEMO_PROJECT_PREFIX = "DEMO";
 export const DEMO_PROJECT_FOLDER = `Projects/${DEMO_PROJECT_SLUG}`;
 
 /**
@@ -57,7 +57,7 @@ export function buildReadmeBody(): string {
     "",
     "## Try it on a demo project",
     "",
-    "Spin up a throwaway `op-demo` project (prefix `OPD`) with three pre-seeded",
+    "Spin up a throwaway `op-demo` project (prefix `DEMO`) with three pre-seeded",
     "issues so you can practice `/op:resolve` against real data:",
     "",
     "```op-action",
@@ -92,8 +92,8 @@ export function buildDemoStatusBody(): string {
     "# op-demo — practice project",
     "",
     "Three pre-seeded issues live in `ISSUES/`. Practice the resolve flow",
-    "(`/op:resolve` or the sidebar's `r` shortcut) against `OPD-1`/`OPD-2`/",
-    "`OPD-3` — they have no real-world consequence.",
+    "(`/op:resolve` or the sidebar's `r` shortcut) against `DEMO-1`/`DEMO-2`/",
+    "`DEMO-3` — they have no real-world consequence.",
     "",
     "When you're done, tear the whole project down with one click:",
     "",

--- a/plugins/op/.claude-plugin/plugin.json
+++ b/plugins/op/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "op",
   "description": "Obsidian Projects workflow — schema, slash commands, and agent skill for running a Jira-lite issue tracker inside an Obsidian vault.",
-  "version": "0.78.6",
+  "version": "0.78.7",
   "author": {
     "name": "Eugene Archibald"
   },


### PR DESCRIPTION
## Summary

- `op-demo` and `obsidian-plugin-development` both shipped with prefix `OPD`. `obsidian-plugin-development` is the user's real, repo-backed project — `op-demo` is the throwaway scaffold from `firstRunReadme.ts`, so it moves to a new prefix.
- New prefix: `DEMO` (free per the active vault's existing-prefix scan).
- Single source of truth: `DEMO_PROJECT_PREFIX` in `firstRunReadme.ts`. The body strings in the README + STATUS.md and one prose mention in the OP-149 spec are kept in sync. `firstRunReadme.test.ts` updated to assert `id: DEMO-1`.

## Test plan

- [x] `npx vitest run src/firstRunReadme.test.ts` — all firstRunReadme tests pass
- [x] `npm test` — full suite passes (1561 tests; one pre-existing failed-suite in `iTermPrefs.test.ts` unrelated to this change)
- [x] dev-sync to OP-Test, run `op-start-tour` → `Projects/op-demo/` scaffolds with `prefix: DEMO`, files `DEMO-1.md`, `DEMO-2.md`, `DEMO-3.md`, all carrying `id: DEMO-N`
- [x] `op-remove-demo` cleans up

## Notes

- **Out of scope:** migrating already-scaffolded demo issues in user vaults. Demo files are documented as throwaway; the README points at the Remove-demo chip as the teardown gesture. Users on the new build keep their `OPD-*` notes until they Remove + re-Start tour.
- **`CLAUDE.md` mention of `OPD-8`** refers to **obsidian-plugin-development** (the project that keeps `OPD`), so no edit there.

Closes #284.

🤖 Generated with [Claude Code](https://claude.com/claude-code)