### PR TITLE
OP-219: workflowMode dropdown in Settings → Workflows + doc fixes

### DIFF
--- a/docs/workflow-modules/02-quickstart.md
+++ b/docs/workflow-modules/02-quickstart.md
@@ -16,35 +16,33 @@ re-explanation.
   walkthrough below, we'll use a placeholder slug `myproject`).
 - An issue in that project — any open issue will do.
 
-## 1. Switch to modules mode (30 seconds)
+## 1. Confirm modules mode (10 seconds)
 
-`workflowMode` is a per-vault setting. There's no UI toggle yet (one is
-tracked under the OP-186 settings work) — until then, flip it by hand
-in the plugin's `data.json`:
+`workflowMode` is a per-vault setting controlled from **Settings → Obsidian
+Projects (op) → Workflows → Workflow mode**. Two values:
 
-1. Quit Obsidian (or fully disable the op-obsidian plugin) before
-   editing — the running plugin holds a copy of the settings in memory
-   and will overwrite manual edits on the next save.
-2. Open `<your-vault>/.obsidian/plugins/op-obsidian/data.json` in any
-   text editor.
-3. Find the top-level `"workflowMode"` key (it defaults to `"legacy"`).
-   Change its value to `"modules"`. Save.
-4. Re-open the vault (or re-enable the plugin).
+- **Modules (default)** — the launcher composes the prompt from
+  workflow-module files in this vault. This is the post-OP-208 default
+  for fresh installs.
+- **Legacy (inline WORKFLOW.md)** — the launcher inlines the project's
+  `WORKFLOW.md` as opaque prose and ignores any modules you create.
 
-If `workflowMode` is missing entirely, your install pre-dates OP-198 —
-add `"workflowMode": "modules"` as a new top-level entry in the JSON
-object.
+Open the dropdown and confirm it reads **Modules (default)**. If your
+install is older than the OP-208 cutover and the prior value was
+`"legacy"`, the migration preserved it — pick **Modules (default)** now
+to follow this walkthrough. The change is saved immediately; no restart.
 
-Verify with the developer console (Cmd-Option-I in Obsidian, Console
-tab):
+If you'd rather verify from the developer console (Cmd-Option-I in
+Obsidian, Console tab):
 
 ```js
 app.plugins.plugins["op-obsidian"].settings.workflowMode
 // → "modules"
 ```
 
-Until this flip, the launch modal uses the legacy injection blob and
-ignores any module files you create.
+Under Legacy mode the launch modal uses the WORKFLOW.md injection blob
+and ignores any module files you create — you'll see a "Workflow modules
+disabled" callout in the launch preview if you forget to flip it.
 
 ## 2. Author a global workflow file (90 seconds)
 

--- a/docs/workflow-modules/05-settings-reference.md
+++ b/docs/workflow-modules/05-settings-reference.md
@@ -232,18 +232,14 @@ The bold takeaway:
   diagnostic), and the dual surface created confusion. Until then both
   controls coexist; the modules engine ignores this row.
 - **`workflowMode`** is the master toggle — `"legacy"` uses the
-  inline-cap path; `"modules"` uses the OP-201 module engine. There's
-  no UI toggle yet; until OP-186 lands, flip it by editing
-  `<vault>/.obsidian/plugins/op-obsidian/data.json` (see
-  [02-quickstart.md § step 1](./02-quickstart.md#1-switch-to-modules-mode-30-seconds)).
-  After OP-208, the default flips from `"legacy"` to `"modules"` — but
-  vaults that already have `workflowMode: "legacy"` set stay on legacy
-  (the migration treats an explicit value as user opt-in).
-
-If you've never edited `data.json` directly, the safe order is: quit
-Obsidian first (or fully disable op-obsidian) → edit → re-enable. The
-running plugin caches settings in memory and overwrites manual edits on
-its next save.
+  inline-cap path; `"modules"` uses the OP-201 module engine. Surfaced
+  as the **Workflow mode** dropdown at the top of the **Workflows**
+  group (OP-219); the change is saved immediately and the section
+  re-renders so the empty-state copy and launch preview reflect the new
+  mode without a restart. After OP-208, the default for fresh installs
+  flipped from `"legacy"` to `"modules"` — vaults that already have
+  `workflowMode: "legacy"` set stay on legacy (the migration treats an
+  explicit value as user opt-in).
 
 ## Where to next
 

--- a/plugins/op-obsidian/src/settings.ts
+++ b/plugins/op-obsidian/src/settings.ts
@@ -49,6 +49,7 @@ import {
   type SidebarTab,
   type SidebarDensity,
   type OpSettings,
+  type WorkflowMode,
   DEFAULT_SETTINGS,
   mergeSettings,
   matchSettingRow,
@@ -526,6 +527,13 @@ export class OpSettingsTab extends PluginSettingTab {
   // ─── Workflows section renderer (OP-201) ────────────────────────────────
 
   private renderWorkflows(containerEl: HTMLElement): void {
+    // OP-219: workflowMode dropdown — the master toggle gating whether the
+    // module engine drives injection at all. Rendered first so it's visible
+    // before any module-specific UI; on change re-renders the whole section
+    // so the "Workflow modules disabled" callouts in the launch preview /
+    // module list reflect the new mode immediately.
+    this.renderWorkflowModeRow(containerEl);
+
     const result = loadModules(this.app);
     const { modules, diagnostics } = result;
 
@@ -558,6 +566,29 @@ export class OpSettingsTab extends PluginSettingTab {
       "Tokens you can reference in a module body via {{name}}. These are computed per-launch from the issue, the agent profile, and the launch context — they sit at Launch override (the highest precedence). User-declared {{vars.<name>}} are a separate namespace declared in a module's `vars:` block.",
     );
     this.renderAvailableVariables(varsCollapsible.body);
+  }
+
+  private renderWorkflowModeRow(parentEl: HTMLElement): void {
+    const s = this.plugin.settings;
+    const row = new Setting(parentEl)
+      .setName("Workflow mode")
+      .setDesc(
+        "Master toggle for prompt composition. Modules: the launcher composes the prompt from workflow-module files in this vault (post-OP-208 default). Legacy: the launcher inlines the project's WORKFLOW.md as-is and ignores any modules. Existing installs that explicitly set this stay on whatever they had — the OP-208 cutover only flipped the default for installs that never wrote a value.",
+      )
+      .addDropdown((dd) => {
+        dd.addOption("modules", "Modules (default)");
+        dd.addOption("legacy", "Legacy (inline WORKFLOW.md)");
+        dd.setValue(s.workflowMode);
+        dd.onChange(async (value) => {
+          s.workflowMode = value as WorkflowMode;
+          await this.plugin.saveSettings();
+          // Re-render the whole section so the empty-state copy, module
+          // list, and preview disclosures pick up the new mode without a
+          // settings-tab close/reopen.
+          this.rerenderSection("workflows");
+        });
+      });
+    row.settingEl.dataset.opRow = "workflowMode";
   }
 
   private renderWorkflowsEmptyState(parentEl: HTMLElement): void {


### PR DESCRIPTION
## Summary

- Adds a **Workflow mode** dropdown at the top of the Settings → Workflows group, exposing `settings.workflowMode` (`"modules"` ↔ `"legacy"`). The OP-186 umbrella restructured the Settings tab (OP-201 / PR #260) but never wired a UI binding — users have been hand-editing `data.json` since OP-198 introduced the field.
- On change, the row re-renders the Workflows section so the empty-state copy, module list, and launch-preview "modules disabled" callouts reflect the new mode without a restart.
- Docs: `02-quickstart.md` §1 rewritten around the new dropdown (drops the manual `data.json` walkthrough); `05-settings-reference.md` updated to point at the dropdown instead of the OP-186 deferral note.
- Composer / evaluator / launcher untouched — pure UI binding on an existing setting; semver bumped minor (new user-facing control).

## Test plan

- [x] `npm test` in `plugins/op-obsidian/` — 1561 passed (one pre-existing iTermPrefs vitest resolution failure, untouched by this branch).
- [x] DOM probe in OP-Test: dropdown renders under `[data-op-row="workflowMode"]` with the two expected options, defaults to `modules`.
- [x] Set `workflowMode = legacy` via the plugin API, `plugin:reload`, dropdown shows `legacy` — persistence confirmed.
- [x] Dispatch a `change` event on the `<select>` → `data.json` updates on disk.
- [x] No new errors in the Obsidian dev console after rendering the Settings tab.

🤖 Generated with [Claude Code](https://claude.com/claude-code)