### PR TITLE
OP-219 followup: bump op-obsidian to 0.79.0

### DIFF
--- a/plugins/op-obsidian/manifest.json
+++ b/plugins/op-obsidian/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "op-obsidian",
   "name": "Obsidian Projects (op)",
-  "version": "0.78.7",
+  "version": "0.79.0",
   "minAppVersion": "1.5.0",
   "description": "Jira-lite issue tracker for Obsidian vaults — deterministic commands backing the op workflow.",
   "author": "Eugene Archibald",

--- a/plugins/op-obsidian/package.json
+++ b/plugins/op-obsidian/package.json
@@ -1,6 +1,6 @@
 {
   "name": "op-obsidian",
-  "version": "0.78.7",
+  "version": "0.79.0",
   "description": "Obsidian plugin that owns the deterministic half of the op workflow.",
   "main": "main.js",
   "scripts": {

--- a/plugins/op/.claude-plugin/plugin.json
+++ b/plugins/op/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "op",
   "description": "Obsidian Projects workflow — schema, slash commands, and agent skill for running a Jira-lite issue tracker inside an Obsidian vault.",
-  "version": "0.78.7",
+  "version": "0.79.0",
   "author": {
     "name": "Eugene Archibald"
   },


### PR DESCRIPTION
## Summary

- PR #288 squash-merged the OP-219 workflowMode dropdown but lost the version bump during a rebase conflict resolution (`git checkout --ours` on the version files picked the upstream `0.78.7` instead of the rebased branch's `0.79.0`).
- Release CI ran against `ec778ed`, read manifest `0.78.7`, saw the existing `op-obsidian-v0.78.7` tag, and skipped — so the dropdown shipped to `main` without a release.
- This is a pure 3-file version bump (`manifest.json`, `package.json`, `plugin.json`) so the release workflow publishes `op-obsidian-v0.79.0` on merge.

## Test plan

- [x] `bump-version.mjs minor` → 0.79.0 across all three files; build green; main.js fresher than manifest.
- [ ] After merge: `gh release list --limit 3` shows `op-obsidian-v0.79.0` within ~2 min.

🤖 Generated with [Claude Code](https://claude.com/claude-code)