### PR TITLE
OP-220: shared slugify util + {{slug}} plugin var + real template tokens in quickstart

### DIFF
--- a/docs/workflow-modules/02-quickstart.md
+++ b/docs/workflow-modules/02-quickstart.md
@@ -101,14 +101,21 @@ order: 10
 ---
 
 Always create a feature branch off `main` before making changes. Branch
-names use `<issue-id>-<slug>`. Push commits to that branch only —
-never directly to `main`.
+names use `{{id}}-{{slug}}`. Push commits to that branch only — never
+directly to `main`.
 ```
 
 That's it: three lines of body, six lines of frontmatter. The filename
 basename (`branching.md`) must match the `id:` field
 (`id: branching`) — a mismatch is a `malformed-frontmatter` diagnostic
 and the module is silently dropped.
+
+`{{id}}` and `{{slug}}` are always-on plugin vars: `{{id}}` is the
+issue's canonical id (e.g. `OP-194`); `{{slug}}` is a kebab-cased,
+40-char-capped slug derived from the issue's `title:`. Together they
+produce a branch suggestion the agent can use verbatim. The full
+registry — and the precedence rules for user-declared vars — lives in
+[05-variables-and-templating.md](./05-variables-and-templating.md).
 
 ## 4. See it in the launch preview (60 seconds)
 
@@ -118,22 +125,30 @@ the command palette (⌘P). The launch modal opens.
 Below the **Cancel** / **Launch** buttons, find the **▶ Composed prompt
 preview** disclosure. Click it to expand.
 
-You should see the body of `branching.md` rendered as the kickoff prompt:
+You should see the body of `branching.md` rendered as the kickoff prompt
+**with `{{id}}` and `{{slug}}` substituted** for your current issue. For
+an issue like `OP-194` titled "Add module variables", that renders as:
 
 ```
-▼ Composed prompt preview        187 chars · 1 module · 0 diagnostics
+▼ Composed prompt preview        ~190 chars · 1 module · 0 diagnostics
 
 Always create a feature branch off `main` before making changes. Branch
-names use `<issue-id>-<slug>`. Push commits to that branch only —
-never directly to `main`.
+names use `OP-194-add-module-variables`. Push commits to that branch
+only — never directly to `main`.
 ```
 
 The header line on the right of the disclosure tells you how many
-characters of prompt the composer produced (`187 chars`), how many
-modules contributed (`1 module`), and how many diagnostics fired
-(`0 diagnostics` in the happy path). If the module count is `0 modules`,
-scroll back through this walkthrough — most likely your workflow file's
-`steps:` list doesn't mention `branching` in any kickoff step.
+characters of prompt the composer produced (the count varies with the
+issue's title — this example renders ~190 chars), how many modules
+contributed (`1 module`), and how many diagnostics fired (`0 diagnostics`
+in the happy path). If the module count is `0 modules`, scroll back
+through this walkthrough — most likely your workflow file's `steps:`
+list doesn't mention `branching` in any kickoff step.
+
+If you instead see the literal text `{{id}}-{{slug}}` in the rendered
+preview, the launch context isn't supplying the issue — open the
+launch modal from an issue note (not a project root) so the composer
+has an `IssueEntry` to read `title:` from.
 
 **Click Cancel.** You don't need to launch the agent to verify the
 plumbing.

--- a/docs/workflow-modules/05-variables-and-templating.md
+++ b/docs/workflow-modules/05-variables-and-templating.md
@@ -38,6 +38,7 @@ generated reference docs) reads from there.
 | :--- | :--- | :--- | :--- |
 | **Issue identity** | `{{id}}` | The issue's canonical id from frontmatter. | `OP-212` |
 |  | `{{title}}` | The issue's title. | `10b: Authoring tutorials with checked-in examples` |
+|  | `{{slug}}` | Branch-safe kebab slug derived from `title` (lowercased, capped at 40 chars on a `-` boundary, leading `NN[a-z]?:` task-prefix stripped). Pair with `{{id}}` for branch suggestions. | `authoring-tutorials-with-checked-in` |
 |  | `{{project}}` | The project slug the issue belongs to. | `obsidian-projects` |
 |  | `{{status}}` | Lifecycle status. | `in-progress` |
 |  | `{{priority}}` | Priority — undefined when not set. | `med` |

--- a/docs/workflow-modules/reference/plugin-vars.md
+++ b/docs/workflow-modules/reference/plugin-vars.md
@@ -47,6 +47,7 @@ The issue id is {{id}} — branch is {{branch}}, today is {{today}}.
 | `{{project}}` | `obsidian-projects` | The project slug the issue belongs to. |
 | `{{status}}` | `in-progress` | The issue's lifecycle status (open, in-progress, blocked, resolved, wontfix). |
 | `{{priority}}` | `high` | The issue's priority (low, med, high) — undefined if not set. |
+| `{{slug}}` | `add-slug-plugin-var-extract-shared` | Branch-safe kebab-cased slug derived from `title` (lowercase, capped at 40 chars on a `-` boundary, leading `NN[a-z]?:` task-prefix stripped) — undefined if `title` collapses to empty. |
 | `{{parent}}` | `OP-184` | The parent issue id from frontmatter, or `(none — this is a top-level issue)` when no parent is set. |
 | `{{pr_url}}` | `https://github.com/earchibald/obsidian-projects/pull/232` | The pull-request URL once the issue has one — undefined before the PR opens. |
 | `{{github_issue}}` | `https://github.com/earchibald/obsidian-projects/issues/232` | The mirrored GitHub issue URL when the issue is GH-linked — undefined when local-only. |

--- a/plugins/op-obsidian/manifest.json
+++ b/plugins/op-obsidian/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "op-obsidian",
   "name": "Obsidian Projects (op)",
-  "version": "0.79.0",
+  "version": "0.80.0",
   "minAppVersion": "1.5.0",
   "description": "Jira-lite issue tracker for Obsidian vaults — deterministic commands backing the op workflow.",
   "author": "Eugene Archibald",

--- a/plugins/op-obsidian/package.json
+++ b/plugins/op-obsidian/package.json
@@ -1,6 +1,6 @@
 {
   "name": "op-obsidian",
-  "version": "0.79.0",
+  "version": "0.80.0",
   "description": "Obsidian plugin that owns the deterministic half of the op workflow.",
   "main": "main.js",
   "scripts": {

--- a/plugins/op-obsidian/src/listVarsPure.test.ts
+++ b/plugins/op-obsidian/src/listVarsPure.test.ts
@@ -110,6 +110,7 @@ describe("buildListVarsPayload — golden snapshot", () => {
       "project",
       "status",
       "priority",
+      "slug",
       "parent",
       "pr_url",
       "github_issue",

--- a/plugins/op-obsidian/src/pluginVarRegistry.test.ts
+++ b/plugins/op-obsidian/src/pluginVarRegistry.test.ts
@@ -130,6 +130,16 @@ describe("PLUGIN_VAR_REGISTRY", () => {
       expect(PLUGIN_VAR_REGISTRY.slug.compute(ctx)).toBeUndefined();
     });
 
+    it("returns undefined for a whitespace-only title (spaces collapse to empty slug)", () => {
+      const ctx = { ...FIXTURE_CTX, title: "   " };
+      expect(PLUGIN_VAR_REGISTRY.slug.compute(ctx)).toBeUndefined();
+    });
+
+    it("returns undefined for an empty-string title", () => {
+      const ctx = { ...FIXTURE_CTX, title: "" };
+      expect(PLUGIN_VAR_REGISTRY.slug.compute(ctx)).toBeUndefined();
+    });
+
     it("returns undefined when title is missing from a Partial ctx", () => {
       // Mirrors the existing `parent`-slot-absent test: undefined vs. empty has
       // a meaning here. Caller didn't supply the field at all.

--- a/plugins/op-obsidian/src/pluginVarRegistry.test.ts
+++ b/plugins/op-obsidian/src/pluginVarRegistry.test.ts
@@ -49,6 +49,7 @@ describe("PLUGIN_VAR_REGISTRY", () => {
     const required = [
       "id",
       "title",
+      "slug",
       "project",
       "status",
       "priority",
@@ -109,6 +110,45 @@ describe("PLUGIN_VAR_REGISTRY", () => {
     }
   });
 
+  describe("{{slug}} (derived from title)", () => {
+    it("renders the fixture title as a kebab-cased branch tail", () => {
+      // Fixture title: "Generic {{var}} renderer + context builder"
+      expect(PLUGIN_VAR_REGISTRY.slug.compute(FIXTURE_CTX)).toBe(
+        "generic-var-renderer-context-builder",
+      );
+    });
+
+    it("strips a leading `NNb:` task prefix from the title", () => {
+      const ctx = { ...FIXTURE_CTX, title: "10b: Authoring tutorials with checked-in examples" };
+      expect(PLUGIN_VAR_REGISTRY.slug.compute(ctx)).toBe("authoring-tutorials-with-checked-in");
+    });
+
+    it("returns undefined when title collapses to empty (soft-fail contract)", () => {
+      // All-punctuation title -> empty slug -> registry returns undefined so the
+      // renderer leaves `{{slug}}` verbatim and fires a `missing-var` diagnostic.
+      const ctx = { ...FIXTURE_CTX, title: "???" };
+      expect(PLUGIN_VAR_REGISTRY.slug.compute(ctx)).toBeUndefined();
+    });
+
+    it("returns undefined when title is missing from a Partial ctx", () => {
+      // Mirrors the existing `parent`-slot-absent test: undefined vs. empty has
+      // a meaning here. Caller didn't supply the field at all.
+      expect(PLUGIN_VAR_REGISTRY.slug.compute({})).toBeUndefined();
+    });
+
+    it("caps long titles at 40 chars and truncates at the last `-` boundary", () => {
+      const ctx = {
+        ...FIXTURE_CTX,
+        title: "Add slug plugin var and extract shared slugify util and other goodies",
+      };
+      const out = PLUGIN_VAR_REGISTRY.slug.compute(ctx);
+      expect(out).toBeDefined();
+      expect(out!.length).toBeLessThanOrEqual(40);
+      expect(out!.endsWith("-")).toBe(false);
+      expect(out!.startsWith("add-slug-plugin-var")).toBe(true);
+    });
+  });
+
   describe("parent sentinel", () => {
     it("returns the literal parent id when present", () => {
       expect(PLUGIN_VAR_REGISTRY.parent.compute({ ...FIXTURE_CTX, parent: "OP-184" })).toBe("OP-184");
@@ -165,6 +205,7 @@ describe("PLUGIN_VAR_REGISTRY", () => {
     it.each([
       "id",
       "title",
+      "slug",
       "project",
       "status",
       "vault_path",

--- a/plugins/op-obsidian/src/pluginVarRegistry.ts
+++ b/plugins/op-obsidian/src/pluginVarRegistry.ts
@@ -1,4 +1,5 @@
 import type { AgentProfile } from "./agentProfiles";
+import { slugify } from "./slug";
 import type { IssueEntry } from "./types";
 
 // Always-on plugin vars surfaced to workflow-module templates. This file is
@@ -115,6 +116,19 @@ export const PLUGIN_VAR_REGISTRY: Readonly<Record<string, PluginVar>> = Object.f
     description: "The issue's priority (low, med, high) — undefined if not set.",
     example: "high",
     compute: (ctx) => ctx.priority,
+  },
+  slug: {
+    name: "slug",
+    description:
+      "Branch-safe kebab-cased slug derived from `title` (lowercase, capped at 40 chars on a `-` boundary, leading `NN[a-z]?:` task-prefix stripped) — undefined if `title` collapses to empty.",
+    example: "add-slug-plugin-var-extract-shared",
+    compute: (ctx) => {
+      if (ctx.title === undefined) return undefined;
+      return (
+        slugify(ctx.title, { caseFold: true, maxLen: 40, stripLeadingTaskPrefix: true }) ||
+        undefined
+      );
+    },
   },
 
   // Issue links

--- a/plugins/op-obsidian/src/slug.test.ts
+++ b/plugins/op-obsidian/src/slug.test.ts
@@ -1,0 +1,153 @@
+import { describe, expect, it } from "vitest";
+import { slugify } from "./slug";
+
+describe("slugify", () => {
+  describe("defaults (case-preserving, kebab-only, no cap, no fallback)", () => {
+    it("passes a kebab-safe ASCII string through unchanged", () => {
+      expect(slugify("OP-37")).toBe("OP-37");
+    });
+
+    it("replaces tmux-unsafe punctuation with dashes and collapses runs", () => {
+      expect(slugify("OP.37:1 x")).toBe("OP-37-1-x");
+    });
+
+    it("returns empty string when input collapses to nothing and no fallback set", () => {
+      expect(slugify("...")).toBe("");
+    });
+
+    it("returns empty string for empty input", () => {
+      expect(slugify("")).toBe("");
+    });
+
+    it("trims leading and trailing dashes after collapse", () => {
+      expect(slugify("---hello---world---")).toBe("hello-world");
+    });
+
+    it("treats `_` as a separator by default (no allowUnderscore)", () => {
+      expect(slugify("foo_bar")).toBe("foo-bar");
+    });
+  });
+
+  describe("fallback option", () => {
+    it("returns the fallback when input collapses to empty", () => {
+      expect(slugify("...", { fallback: "agent" })).toBe("agent");
+    });
+
+    it("ignores the fallback when input produces a real slug", () => {
+      expect(slugify("OP-37", { fallback: "agent" })).toBe("OP-37");
+    });
+  });
+
+  describe("allowUnderscore option", () => {
+    it("preserves underscores when allowUnderscore=true", () => {
+      expect(slugify("foo_bar", { allowUnderscore: true })).toBe("foo_bar");
+    });
+
+    it("matches the legacy tmuxWindowName behavior — underscore + case preserved, fallback agent", () => {
+      expect(slugify("OP.37:1 x", { allowUnderscore: true, fallback: "agent" })).toBe("OP-37-1-x");
+      expect(slugify("op:workflow:my-project", { allowUnderscore: true, fallback: "agent" }))
+        .toBe("op-workflow-my-project");
+      expect(slugify("...", { allowUnderscore: true, fallback: "agent" })).toBe("agent");
+    });
+  });
+
+  describe("caseFold option", () => {
+    it("lower-cases ASCII when caseFold=true", () => {
+      expect(slugify("Hello-World", { caseFold: true })).toBe("hello-world");
+    });
+
+    it("treats unicode letters as separators after lowercasing", () => {
+      // `é → -` because `[a-z]` is ASCII-only after lowercasing.
+      expect(slugify("café résumé", { caseFold: true })).toBe("caf-r-sum");
+    });
+
+    it("preserves case when caseFold is false (default)", () => {
+      expect(slugify("Hello-World")).toBe("Hello-World");
+    });
+
+    it("combined with allowUnderscore preserves underscore + lowercase", () => {
+      expect(slugify("Hello_World", { caseFold: true, allowUnderscore: true })).toBe("hello_world");
+    });
+  });
+
+  describe("maxLen option", () => {
+    it("does not truncate when output is at or under the cap", () => {
+      expect(slugify("alphabet-soup", { maxLen: 13 })).toBe("alphabet-soup");
+      expect(slugify("alphabet-soup", { maxLen: 50 })).toBe("alphabet-soup");
+    });
+
+    it("truncates at the last `-` boundary inside the cap when one exists", () => {
+      expect(slugify("alphabet-soup-rocks", { maxLen: 14 })).toBe("alphabet-soup");
+    });
+
+    it("truncates flat when no `-` exists inside the cap", () => {
+      expect(slugify("alphabetsoup", { maxLen: 6 })).toBe("alphab");
+    });
+
+    it("re-trims trailing `-` after dash-boundary truncation", () => {
+      // truncated slice has a trailing `-`; the last-dash branch removes it.
+      // truncated="alphabet-" lastDash=8 -> sliced="alphabet"
+      expect(slugify("alphabet-soup", { maxLen: 9 })).toBe("alphabet");
+    });
+
+    it("very long input is capped and lands on a `-` boundary", () => {
+      const long = "Add slug plugin var and extract shared slugify util and other goodies";
+      const out = slugify(long, { caseFold: true, maxLen: 40 });
+      expect(out.length).toBeLessThanOrEqual(40);
+      expect(out.endsWith("-")).toBe(false);
+      // Sanity: starts with the real prefix, not a clipped word
+      expect(out.startsWith("add-slug-plugin-var")).toBe(true);
+    });
+  });
+
+  describe("stripLeadingTaskPrefix option", () => {
+    it("strips a leading `NNb:` prefix when on", () => {
+      expect(slugify("10b: Authoring tutorials", { caseFold: true, stripLeadingTaskPrefix: true }))
+        .toBe("authoring-tutorials");
+    });
+
+    it("strips a leading `NN:` prefix when on", () => {
+      expect(slugify("10: Authoring tutorials", { caseFold: true, stripLeadingTaskPrefix: true }))
+        .toBe("authoring-tutorials");
+    });
+
+    it("leaves the prefix as part of the slug when off", () => {
+      expect(slugify("10b: Authoring tutorials", { caseFold: true }))
+        .toBe("10b-authoring-tutorials");
+    });
+
+    it("only strips when the prefix is followed by a colon", () => {
+      // No colon after the leading number -> normal slugify.
+      expect(slugify("10b Authoring tutorials", { caseFold: true, stripLeadingTaskPrefix: true }))
+        .toBe("10b-authoring-tutorials");
+    });
+
+    it("does not strip an issue-id prefix like OP-220", () => {
+      // No leading digits-colon, so the prefix stays.
+      expect(slugify("OP-220 Title", { caseFold: true, stripLeadingTaskPrefix: true }))
+        .toBe("op-220-title");
+    });
+
+    it("tolerates leading whitespace before the prefix", () => {
+      expect(slugify("  3: Hello", { caseFold: true, stripLeadingTaskPrefix: true })).toBe("hello");
+    });
+  });
+
+  describe("plugin-var registry preset (caseFold + maxLen=40 + stripLeadingTaskPrefix)", () => {
+    const PRESET = { caseFold: true, maxLen: 40, stripLeadingTaskPrefix: true } as const;
+
+    it("renders a typical issue title into a kebab branch tail", () => {
+      expect(slugify("Add {{slug}} plugin var + extract shared slugify util", PRESET))
+        .toBe("add-slug-plugin-var-extract-shared");
+    });
+
+    it("returns empty string for an all-punctuation title (registry chains `|| undefined`)", () => {
+      expect(slugify("???", PRESET)).toBe("");
+    });
+
+    it("strips a numeric-letter task prefix and keeps the body", () => {
+      expect(slugify("10b: Authoring tutorials with checked-in examples", PRESET))
+        .toBe("authoring-tutorials-with-checked-in");
+    });
+  });
+});

--- a/plugins/op-obsidian/src/slug.test.ts
+++ b/plugins/op-obsidian/src/slug.test.ts
@@ -90,6 +90,18 @@ describe("slugify", () => {
       expect(slugify("alphabet-soup", { maxLen: 9 })).toBe("alphabet");
     });
 
+    it("cap = 0 collapses any non-empty input to empty (fallback fires if set)", () => {
+      expect(slugify("hello", { maxLen: 0 })).toBe("");
+      expect(slugify("hello", { maxLen: 0, fallback: "x" })).toBe("x");
+    });
+
+    it("cap = 1 flat-truncates to the first character (no dash in a 1-char slice)", () => {
+      expect(slugify("hello", { maxLen: 1 })).toBe("h");
+      // A post-collapse string starting with a letter can't start with `-`, so
+      // the flat-truncation path is always taken at cap=1.
+      expect(slugify("a-b-c", { maxLen: 1 })).toBe("a");
+    });
+
     it("very long input is capped and lands on a `-` boundary", () => {
       const long = "Add slug plugin var and extract shared slugify util and other goodies";
       const out = slugify(long, { caseFold: true, maxLen: 40 });
@@ -130,6 +142,36 @@ describe("slugify", () => {
 
     it("tolerates leading whitespace before the prefix", () => {
       expect(slugify("  3: Hello", { caseFold: true, stripLeadingTaskPrefix: true })).toBe("hello");
+    });
+
+    it("does NOT strip a leading `: hello` that has no digits before the colon", () => {
+      // Regex requires \d+ at start; a bare colon prefix does not match.
+      // The colon is slugified away normally, so the result is the same as
+      // without stripping — but the important contract is that the regex
+      // didn't fire on a non-digit-prefixed colon.
+      expect(slugify(": hello", { caseFold: true, stripLeadingTaskPrefix: true })).toBe("hello");
+      expect(slugify(": hello", { caseFold: true, stripLeadingTaskPrefix: false })).toBe("hello");
+    });
+
+    it("does NOT strip `1.5: x` — a dot between the digit and colon is not in the pattern", () => {
+      // `\d+[a-z]?\s*:` cannot match `1.5:` because after `1` the next char
+      // is `.` (not a letter or `:`) so the optional `[a-z]?` skips it and
+      // `\s*:` requires `:` immediately — but `.` is there instead.
+      expect(slugify("1.5: x", { caseFold: true, stripLeadingTaskPrefix: true })).toBe("1-5-x");
+    });
+
+    it("strips only the first `NN:` segment from a multi-colon title", () => {
+      // The regex is anchored (^) and has no `g` flag — one application only.
+      // `1: 2: 3` → strip `1: ` → `2: 3` → slug `2-3`.
+      expect(slugify("1: 2: 3", { caseFold: true, stripLeadingTaskPrefix: true })).toBe("2-3");
+      // Verify without stripping produces the full slug.
+      expect(slugify("1: 2: 3", { caseFold: true, stripLeadingTaskPrefix: false })).toBe("1-2-3");
+    });
+
+    it("strips an oversized numeric-only prefix like `1234567890b:`", () => {
+      // The regex matches any run of digits (\d+) regardless of length, so
+      // very large task numbers are still stripped — intentional.
+      expect(slugify("1234567890b: long", { caseFold: true, stripLeadingTaskPrefix: true })).toBe("long");
     });
   });
 

--- a/plugins/op-obsidian/src/slug.test.ts
+++ b/plugins/op-obsidian/src/slug.test.ts
@@ -168,7 +168,7 @@ describe("slugify", () => {
       expect(slugify("1: 2: 3", { caseFold: true, stripLeadingTaskPrefix: false })).toBe("1-2-3");
     });
 
-    it("strips an oversized numeric-only prefix like `1234567890b:`", () => {
+    it("strips an oversized numeric-letter prefix like `1234567890b:`", () => {
       // The regex matches any run of digits (\d+) regardless of length, so
       // very large task numbers are still stripped — intentional.
       expect(slugify("1234567890b: long", { caseFold: true, stripLeadingTaskPrefix: true })).toBe("long");

--- a/plugins/op-obsidian/src/slug.ts
+++ b/plugins/op-obsidian/src/slug.ts
@@ -1,0 +1,54 @@
+// Shared slugify util — single source of truth for "non-alphanum runs → `-`,
+// collapse, trim". Two presets in the codebase consume it today:
+//
+//   * tmux window naming (`tmuxWindowName`) — case-preserving, allows `_`,
+//     no length cap, fallback `"agent"`.
+//   * `{{slug}}` plugin var (PLUGIN_VAR_REGISTRY) — case-folded, kebab-only,
+//     length-capped at 40, optional task-prefix stripping.
+//
+// Defaults are conservative: case-preserving, kebab-only, no cap, no fallback.
+// Each preset opts into the behavior it needs. Extracted in OP-220.
+
+export interface SlugifyOpts {
+  /** Lower-case the output. When set, the post-fold char class is `[^a-z0-9(_)-]+`. */
+  caseFold?: boolean;
+  /** Permit `_` to survive into the output (otherwise `_` is a word boundary like any other punct). */
+  allowUnderscore?: boolean;
+  /** Hard cap on output length. Truncates at the last `-` boundary inside the cap when one exists; otherwise truncates flat. */
+  maxLen?: number;
+  /** Strip a leading `NN[a-z]?:` task-prefix (e.g. `10b:`, `1:`) before slugifying. */
+  stripLeadingTaskPrefix?: boolean;
+  /** Returned when the input collapses to empty after slugification. Default `""`. */
+  fallback?: string;
+}
+
+export function slugify(input: string, opts: SlugifyOpts = {}): string {
+  const {
+    caseFold = false,
+    allowUnderscore = false,
+    maxLen,
+    stripLeadingTaskPrefix = false,
+    fallback = "",
+  } = opts;
+
+  let s = input ?? "";
+  if (stripLeadingTaskPrefix) {
+    s = s.replace(/^\s*\d+[a-z]?\s*:\s*/i, "");
+  }
+  if (caseFold) s = s.toLowerCase();
+
+  const alpha = caseFold ? "a-z" : "A-Za-z";
+  const underscore = allowUnderscore ? "_" : "";
+  const charClass = new RegExp(`[^${alpha}0-9${underscore}-]+`, "g");
+
+  s = s.replace(charClass, "-").replace(/-+/g, "-").replace(/^-+|-+$/g, "");
+
+  if (maxLen != null && s.length > maxLen) {
+    let truncated = s.slice(0, maxLen);
+    const lastDash = truncated.lastIndexOf("-");
+    if (lastDash > 0) truncated = truncated.slice(0, lastDash);
+    s = truncated.replace(/^-+|-+$/g, "");
+  }
+
+  return s || fallback;
+}

--- a/plugins/op-obsidian/src/terminalLaunch.test.ts
+++ b/plugins/op-obsidian/src/terminalLaunch.test.ts
@@ -68,6 +68,46 @@ describe("tmuxWindowName for entry-less launches", () => {
   });
 });
 
+describe("tmuxWindowName migration regression (old inline chain vs slugify preset)", () => {
+  // The original implementation was an inline regex chain:
+  //   issueId.replace(/[^A-Za-z0-9_-]+/g, "-").replace(/-+/g, "-").replace(/^-|-$/g, "") || "agent"
+  // Verify that every stress input produces the exact same output after
+  // migrating to slugify(issueId, { allowUnderscore: true, fallback: "agent" }).
+
+  it("single dash → 'agent' (fallback fires)", () => {
+    expect(tmuxWindowName("-")).toBe("agent");
+  });
+
+  it("multiple consecutive separators are collapsed, then trimmed → fallback", () => {
+    expect(tmuxWindowName("---")).toBe("agent");
+  });
+
+  it("mixed-case, digits, underscore, and dash are preserved unchanged", () => {
+    expect(tmuxWindowName("ABC_123-def")).toBe("ABC_123-def");
+  });
+
+  it("embedded `.` → `-`", () => {
+    expect(tmuxWindowName("OP.37")).toBe("OP-37");
+  });
+
+  it("embedded `+` → `-`", () => {
+    expect(tmuxWindowName("a+b")).toBe("a-b");
+  });
+
+  it("leading dashes are trimmed", () => {
+    expect(tmuxWindowName("---hello")).toBe("hello");
+  });
+
+  it("trailing dashes are trimmed", () => {
+    expect(tmuxWindowName("hello---")).toBe("hello");
+  });
+
+  it("very long input passes through without truncation (no maxLen in this preset)", () => {
+    const long = "a".repeat(200);
+    expect(tmuxWindowName(long)).toBe(long);
+  });
+});
+
 describe("buildITermAttachCommand", () => {
   it("uses the supplied tmux binary and shell-quotes both args", () => {
     const out = buildITermAttachCommand("/opt/homebrew/bin/tmux", "op-agents");

--- a/plugins/op-obsidian/src/terminalLaunch.ts
+++ b/plugins/op-obsidian/src/terminalLaunch.ts
@@ -5,6 +5,7 @@ import * as path from "path";
 import { promisify } from "util";
 
 import { activeWindowId, createTab, createWindow } from "./iterm/driver";
+import { slugify } from "./slug";
 
 const pExecFile = promisify(execFile);
 
@@ -316,13 +317,11 @@ export function buildITermAttachCommand(tmuxBinary: string, session: string): st
 // Sanitize arbitrary text into a tmux-safe window name. tmux uses `:`
 // as the session:window separator in target specs, so we map it (and
 // anything other than alnum/dash/underscore) to a dash, collapse runs,
-// and trim. Falls back to "agent" for empty input.
+// and trim. Falls back to "agent" for empty input. Case is preserved
+// because users grep tmux windows by issue id (`OP-220`), which is
+// upper-case by convention.
 export function tmuxWindowName(issueId: string): string {
-  const safe = issueId
-    .replace(/[^A-Za-z0-9_-]+/g, "-")
-    .replace(/-+/g, "-")
-    .replace(/^-|-$/g, "");
-  return safe || "agent";
+  return slugify(issueId, { allowUnderscore: true, fallback: "agent" });
 }
 
 function shSingleQuote(s: string): string {

--- a/plugins/op/.claude-plugin/plugin.json
+++ b/plugins/op/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "op",
   "description": "Obsidian Projects workflow — schema, slash commands, and agent skill for running a Jira-lite issue tracker inside an Obsidian vault.",
-  "version": "0.79.0",
+  "version": "0.80.0",
   "author": {
     "name": "Eugene Archibald"
   },


### PR DESCRIPTION
## Summary

- Extract `plugins/op-obsidian/src/slug.ts` exporting `slugify(input, opts)` with caseFold / allowUnderscore / maxLen / stripLeadingTaskPrefix / fallback knobs. Migrate `tmuxWindowName` onto it as a thin preset; existing `terminalLaunch.test.ts` cases pass byte-identical (regression contract).
- Add `{{slug}}` to `PLUGIN_VAR_REGISTRY` (Issue identity group). Derived from `title` with `{ caseFold: true, maxLen: 40, stripLeadingTaskPrefix: true }`; chains `|| undefined` so empty titles preserve the existing `missing-var` soft-fail.
- Switch the workflow-modules quickstart `branching.md` example from `<issue-id>-<slug>` prose to real `{{id}}-{{slug}}` tokens; update §4 launch-preview block accordingly. Add `{{slug}}` row to `05-variables-and-templating.md` Issue identity table.

## Open design questions (deferred)

- **Co-resolution with `{{branch}}` once the worktree exists.** Proposed default: re-derive from title (deterministic, pre-worktree-safe). Alternative: parse the branch and infer the slug from it. Not decided here — `{{slug}}` is title-derived; `{{branch}}` retains its existing pre-worktree-undefined semantics.
- **Numeric/lettered task-prefix stripping (`NN[a-z]?:`).** Implemented as opt-in via `stripLeadingTaskPrefix: true` and only triggered for the `{{slug}}` registry entry. Regex `/^\s*\d+[a-z]?\s*:\s*/i` matches `10:`, `10b:`, `1A:` with optional whitespace. Doesn't strip issue-id prefixes (`OP-220 Title`) since they have no colon.
- **Worktree branch construction.** Currently produces `worktree-{{id}}` (no descriptive tail). Whether to include `{{slug}}` there — making branches like `worktree-OP-220-add-slug-plugin-var-extract-shared` — is deferred to a follow-up. Flagged here but not implemented.

## Test plan

- [x] `npx vitest run` — full op-obsidian suite green (1595/1595).
- [x] New `slug.test.ts` covers empty / all-punctuation / unicode / length-cap (with last-`-`-boundary truncation) / leading task-prefix on+off / `allowUnderscore` on+off / `caseFold` on+off / fallback / the registry preset.
- [x] Existing `terminalLaunch.test.ts:15-67` passes unchanged through the migration (regression contract).
- [x] `pluginVarRegistry.test.ts` extended with `{{slug}}` cases — fixture title resolution, prefix stripping, soft-fail contract, length-cap behavior.
- [x] `listVarsPure.test.ts` golden snapshot updated for the new entry order.
- [x] Smoke: `obsidian vault=OP-Test op-list-vars project=demo issue=DM-1` (against op-obsidian@0.80.0) — title "probe chip" → `slug = "probe-chip"`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)