### PR TITLE
OP-233: tag launched agent sessions with user.op_issue

### DIFF
--- a/plugins/op-obsidian/manifest.json
+++ b/plugins/op-obsidian/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "op-obsidian",
   "name": "Obsidian Projects (op)",
-  "version": "0.80.0",
+  "version": "0.80.1",
   "minAppVersion": "1.5.0",
   "description": "Jira-lite issue tracker for Obsidian vaults — deterministic commands backing the op workflow.",
   "author": "Eugene Archibald",

--- a/plugins/op-obsidian/package.json
+++ b/plugins/op-obsidian/package.json
@@ -1,6 +1,6 @@
 {
   "name": "op-obsidian",
-  "version": "0.80.0",
+  "version": "0.80.1",
   "description": "Obsidian plugin that owns the deterministic half of the op workflow.",
   "main": "main.js",
   "scripts": {

--- a/plugins/op-obsidian/src/orchestrator.test.ts
+++ b/plugins/op-obsidian/src/orchestrator.test.ts
@@ -1,11 +1,13 @@
 import { describe, it, expect } from "vitest";
 
 import {
+  buildAgentInnerScript,
   buildViewScript,
   firstEmptyCell,
   labelWithId,
   labelWithParent,
   pruneDeadSessionSlots,
+  type OrchestrateArgs,
 } from "./orchestrator";
 import type { RegistryData, WindowState } from "./layout/registry";
 
@@ -16,6 +18,51 @@ function makeReg(win: WindowState, surfaces: RegistryData["surfaces"] = {}): Reg
     windowOrder: [win.windowId],
   };
 }
+
+function makeOrchArgs(overrides: Partial<OrchestrateArgs> = {}): OrchestrateArgs {
+  return {
+    issueId: "OP-233",
+    agentId: "claude",
+    cwd: "/repo",
+    binary: "/usr/local/bin/claude",
+    launchFlags: [],
+    prompt: "do the thing",
+    tmuxBinary: "/opt/homebrew/bin/tmux",
+    baseTmuxSession: "op-agents",
+    ...overrides,
+  };
+}
+
+describe("buildAgentInnerScript — OSC 1337 SetUserVar=op_issue (OP-233)", () => {
+  it("emits OSC 1337 SetUserVar with base64-encoded issue id between env exports and exec", () => {
+    const s = buildAgentInnerScript({
+      args: makeOrchArgs({ issueId: "OP-233" }),
+      promptPath: "/tmp/op-agent-xyz/prompt.txt",
+    });
+    expect(s).toContain(
+      `printf '\\033]1337;SetUserVar=op_issue=%s\\007' 'T1AtMjMz'`,
+    );
+    const envIdx = s.indexOf("export OP_AGENT_ID=");
+    const oscIdx = s.indexOf("SetUserVar=op_issue");
+    const execIdx = s.indexOf("exec '/usr/local/bin/claude'");
+    expect(oscIdx).toBeGreaterThan(envIdx);
+    expect(execIdx).toBeGreaterThan(oscIdx);
+  });
+
+  it("emits OSC before the debug interactive shell exec too", () => {
+    const s = buildAgentInnerScript({
+      args: makeOrchArgs({ issueId: "TST-5", debug: true }),
+      promptPath: "/tmp/op-agent-xyz/prompt.txt",
+    });
+    expect(s).toContain(
+      `printf '\\033]1337;SetUserVar=op_issue=%s\\007' 'VFNULTU='`,
+    );
+    const oscIdx = s.indexOf("SetUserVar=op_issue");
+    const execIdx = s.indexOf(`exec "$SHELL" -l`);
+    expect(oscIdx).toBeGreaterThan(0);
+    expect(execIdx).toBeGreaterThan(oscIdx);
+  });
+});
 
 describe("firstEmptyCell", () => {
   it("returns the lowest undefined index within the cell count", () => {

--- a/plugins/op-obsidian/src/orchestrator.ts
+++ b/plugins/op-obsidian/src/orchestrator.ts
@@ -385,14 +385,31 @@ export function buildViewScript({
 }
 
 // Agent inner script: same shape as the pre-orchestrator launch path —
-// cd + PATH + env + exec binary with prompt (or interactive shell in debug
-// mode). Factored here so the tmux window runs it when first created.
+// cd + PATH + env + OP-233 iTerm tag + exec binary with prompt (or
+// interactive shell in debug mode). Factored here so the tmux window runs
+// it when first created.
 async function writeAgentInnerScript(args: OrchestrateArgs): Promise<string> {
   const dir = await fs.mkdtemp(path.join(os.tmpdir(), "op-agent-"));
   const innerPath = path.join(dir, "agent.command");
   const promptPath = path.join(dir, "prompt.txt");
   await fs.writeFile(promptPath, args.prompt, { mode: 0o600 });
+  const inner = buildAgentInnerScript({ args, promptPath });
+  await fs.writeFile(innerPath, inner, { mode: 0o755 });
+  return innerPath;
+}
 
+// Pure script-string builder for the orchestrator's per-agent inner script.
+// Exported so the OSC 1337 emit (OP-233) and the env exports can be
+// asserted directly. Mirror to terminalLaunch.ts buildInnerScript — both
+// launch paths must emit identical OSC bytes so OP-230's session-correlation
+// rule is uniform.
+export function buildAgentInnerScript({
+  args,
+  promptPath,
+}: {
+  args: OrchestrateArgs;
+  promptPath: string;
+}): string {
   const flagsShell = args.launchFlags.map(shSingleQuote).join(" ");
   const cwdShell = shSingleQuote(args.cwd);
   const binShell = shSingleQuote(args.binary);
@@ -408,6 +425,14 @@ async function writeAgentInnerScript(args: OrchestrateArgs): Promise<string> {
     `export OP_ISSUE_ID=${issueIdShell}`,
     `export OP_AGENT_ID=${agentIdShell}`,
   ];
+  // OP-233: tag the iTerm session with `user.op_issue` so op-dashboard
+  // (OP-230) can correlate iTerm sessions to op issues. The orchestrator
+  // path always has args.issueId — orchestrator launches are gated on it
+  // upstream (see orchestrateLaunch's caller in terminalLaunch.ts).
+  const b64Issue = Buffer.from(args.issueId, "utf8").toString("base64");
+  lines.push(
+    `printf '\\033]1337;SetUserVar=op_issue=%s\\007' ${shSingleQuote(b64Issue)}`,
+  );
   if (args.debug) {
     lines.push(
       `echo "[op] debug agent launch — interactive shell (issue=${args.issueId} agent=${args.agentId})"`,
@@ -418,8 +443,7 @@ async function writeAgentInnerScript(args: OrchestrateArgs): Promise<string> {
     lines.push(`PROMPT=$(<${promptShell})`, `exec ${binShell} ${flagsShell} "$PROMPT"`);
   }
   lines.push("");
-  await fs.writeFile(innerPath, lines.join("\n"), { mode: 0o755 });
-  return innerPath;
+  return lines.join("\n");
 }
 
 // Probe each tracked session in a window. Clear slots whose iTerm session

--- a/plugins/op-obsidian/src/terminalLaunch.test.ts
+++ b/plugins/op-obsidian/src/terminalLaunch.test.ts
@@ -2,9 +2,25 @@ import { describe, it, expect } from "vitest";
 import {
   SHARED_TMUX_SESSION,
   buildITermAttachCommand,
+  buildInnerScript,
   buildPrepScript,
   tmuxWindowName,
+  type LaunchArgs,
 } from "./terminalLaunch";
+
+function makeArgs(overrides: Partial<LaunchArgs> = {}): LaunchArgs {
+  return {
+    cwd: "/repo",
+    binary: "/usr/local/bin/claude",
+    launchFlags: [],
+    prompt: "do the thing",
+    terminalApp: "iTerm",
+    iTermPlacement: "new-tab",
+    tmuxBinary: "/opt/homebrew/bin/tmux",
+    agentId: "claude",
+    ...overrides,
+  };
+}
 
 describe("SHARED_TMUX_SESSION", () => {
   it("is the fixed session name op-agents", () => {
@@ -105,6 +121,61 @@ describe("tmuxWindowName migration regression (old inline chain vs slugify prese
   it("very long input passes through without truncation (no maxLen in this preset)", () => {
     const long = "a".repeat(200);
     expect(tmuxWindowName(long)).toBe(long);
+  });
+});
+
+describe("buildInnerScript — OSC 1337 SetUserVar=op_issue (OP-233)", () => {
+  it("emits OSC 1337 SetUserVar with base64-encoded issue id when issueId is set", () => {
+    const s = buildInnerScript({
+      args: makeArgs({ issueId: "OP-233" }),
+      promptPath: "/tmp/op-agent-xyz/prompt.txt",
+    });
+    // Buffer.from("OP-233", "utf8").toString("base64") === "T1AtMjMz"
+    expect(s).toContain(
+      `printf '\\033]1337;SetUserVar=op_issue=%s\\007' 'T1AtMjMz'`,
+    );
+  });
+
+  it("encodes a different issue id correctly", () => {
+    const s = buildInnerScript({
+      args: makeArgs({ issueId: "TST-5" }),
+      promptPath: "/tmp/op-agent-xyz/prompt.txt",
+    });
+    // Buffer.from("TST-5", "utf8").toString("base64") === "VFNULTU="
+    expect(s).toContain(
+      `printf '\\033]1337;SetUserVar=op_issue=%s\\007' 'VFNULTU='`,
+    );
+  });
+
+  it("does not emit OSC 1337 when issueId is unset (entry-less launches stay untagged)", () => {
+    const s = buildInnerScript({
+      args: makeArgs({ issueId: undefined, windowName: "op-workflow-foo" }),
+      promptPath: "/tmp/op-agent-xyz/prompt.txt",
+    });
+    expect(s).not.toContain("SetUserVar=op_issue");
+    expect(s).not.toContain("\\033]1337");
+  });
+
+  it("places the OSC emit before exec'ing the agent binary", () => {
+    const s = buildInnerScript({
+      args: makeArgs({ issueId: "OP-233" }),
+      promptPath: "/tmp/op-agent-xyz/prompt.txt",
+    });
+    const oscIdx = s.indexOf("SetUserVar=op_issue");
+    const execIdx = s.indexOf("exec '/usr/local/bin/claude'");
+    expect(oscIdx).toBeGreaterThan(0);
+    expect(execIdx).toBeGreaterThan(oscIdx);
+  });
+
+  it("places the OSC emit before exec in debug mode too", () => {
+    const s = buildInnerScript({
+      args: makeArgs({ issueId: "OP-233", debug: true }),
+      promptPath: "/tmp/op-agent-xyz/prompt.txt",
+    });
+    const oscIdx = s.indexOf("SetUserVar=op_issue");
+    const execIdx = s.indexOf("exec '/usr/local/bin/claude'");
+    expect(oscIdx).toBeGreaterThan(0);
+    expect(execIdx).toBeGreaterThan(oscIdx);
   });
 });
 

--- a/plugins/op-obsidian/src/terminalLaunch.ts
+++ b/plugins/op-obsidian/src/terminalLaunch.ts
@@ -214,48 +214,10 @@ async function writeLaunchScripts({
 
   await fs.writeFile(promptPath, args.prompt, { mode: 0o600 });
 
-  const flagsShell = args.launchFlags.map(shSingleQuote).join(" ");
-  const cwdShell = shSingleQuote(args.cwd);
-  const binShell = shSingleQuote(args.binary);
-  const promptShell = shSingleQuote(promptPath);
   const tmuxShell = shSingleQuote(args.tmuxBinary);
   const sessShell = shSingleQuote(session);
 
-  // Inner: cd + read prompt from side-file (bash 3.2 heredoc-in-$() bug
-  // otherwise, see OP-25) + exec the agent binary.
-  //
-  // Obsidian's launch PATH omits /opt/homebrew/bin and ~/.local/bin, so
-  // `claude`'s statusLine (commonly `npx -y ccstatusline@latest`) silently
-  // fails to resolve in spawned agent windows. Prepend the usual user-shell
-  // dirs so statusline and other CLI tools behave as in a normal terminal.
-  // See OP-41.
-  const agentIdShell = shSingleQuote(args.agentId);
-  const innerLines = [
-    "#!/bin/bash",
-    "set -e",
-    `cd ${cwdShell}`,
-    `export PATH="/opt/homebrew/bin:/usr/local/bin:$HOME/.local/bin:$HOME/bin:$PATH"`,
-  ];
-  if (args.issueId) {
-    innerLines.push(`export OP_ISSUE_ID=${shSingleQuote(args.issueId)}`);
-  }
-  innerLines.push(`export OP_AGENT_ID=${agentIdShell}`);
-  if (args.debug) {
-    // Launch the agent binary interactively with no initial prompt so
-    // the launch flow (PATH, env, tmux window) can be exercised end-to-end
-    // while a human drives the session.
-    innerLines.push(
-      `echo "[op] debug agent launch — no prompt (issue=${args.issueId ?? "<none>"} agent=${args.agentId})"`,
-      `exec ${binShell} ${flagsShell}`,
-    );
-  } else {
-    innerLines.push(
-      `PROMPT=$(<${promptShell})`,
-      `exec ${binShell} ${flagsShell} "$PROMPT"`,
-    );
-  }
-  innerLines.push("");
-  const inner = innerLines.join("\n");
+  const inner = buildInnerScript({ args, promptPath });
   await fs.writeFile(innerPath, inner, { mode: 0o755 });
 
   // Outer (Terminal.app only): ensure session/window exists, then attach.
@@ -275,6 +237,70 @@ async function writeLaunchScripts({
   await fs.writeFile(outerPath, outer, { mode: 0o755 });
 
   return { innerPath, outerPath };
+}
+
+interface InnerScriptArgs {
+  args: LaunchArgs;
+  promptPath: string;
+}
+
+// Build the inner agent script that runs inside the tmux pane: cd, env
+// exports, optional iTerm session-tag emit (OP-233), then exec the agent
+// binary. Pure string-building — no fs — so it's exercised by unit tests
+// without touching disk.
+export function buildInnerScript({ args, promptPath }: InnerScriptArgs): string {
+  const flagsShell = args.launchFlags.map(shSingleQuote).join(" ");
+  const cwdShell = shSingleQuote(args.cwd);
+  const binShell = shSingleQuote(args.binary);
+  const promptShell = shSingleQuote(promptPath);
+  const agentIdShell = shSingleQuote(args.agentId);
+
+  // Inner: cd + read prompt from side-file (bash 3.2 heredoc-in-$() bug
+  // otherwise, see OP-25) + exec the agent binary.
+  //
+  // Obsidian's launch PATH omits /opt/homebrew/bin and ~/.local/bin, so
+  // `claude`'s statusLine (commonly `npx -y ccstatusline@latest`) silently
+  // fails to resolve in spawned agent windows. Prepend the usual user-shell
+  // dirs so statusline and other CLI tools behave as in a normal terminal.
+  // See OP-41.
+  const innerLines = [
+    "#!/bin/bash",
+    "set -e",
+    `cd ${cwdShell}`,
+    `export PATH="/opt/homebrew/bin:/usr/local/bin:$HOME/.local/bin:$HOME/bin:$PATH"`,
+  ];
+  if (args.issueId) {
+    innerLines.push(`export OP_ISSUE_ID=${shSingleQuote(args.issueId)}`);
+  }
+  innerLines.push(`export OP_AGENT_ID=${agentIdShell}`);
+  // OP-233: tag the iTerm session with `user.op_issue` so op-dashboard
+  // (OP-230) can correlate iTerm sessions to op issues. We compute the
+  // base64 at script-build time (Node Buffer) so the runtime script doesn't
+  // depend on `base64` being on PATH and to avoid platform-specific line
+  // wrapping. `\007` (BEL) terminates the OSC; `\033` is ESC. Under tmux
+  // -CC iTerm parses pane bytes directly, so we don't wrap in a tmux
+  // passthrough sequence — that wrap would also need allow-passthrough.
+  // Terminal.app silently ignores OSC 1337, so the emit is harmless there.
+  if (args.issueId) {
+    const b64 = Buffer.from(args.issueId, "utf8").toString("base64");
+    innerLines.push(`printf '\\033]1337;SetUserVar=op_issue=%s\\007' ${shSingleQuote(b64)}`);
+  }
+  if (args.debug) {
+    // Launch the agent binary interactively with no initial prompt so
+    // the launch flow (PATH, env, tmux window) can be exercised end-to-end
+    // while a human drives the session.
+    innerLines.push(
+      `echo "[op] debug agent launch — no prompt (issue=${args.issueId ?? "<none>"} agent=${args.agentId})"`,
+      `exec ${binShell} ${flagsShell}`,
+    );
+  } else {
+    innerLines.push(
+      `PROMPT=$(<${promptShell})`,
+      `exec ${binShell} ${flagsShell} "$PROMPT"`,
+    );
+  }
+  innerLines.push("");
+  return innerLines.join("\n");
 }
 
 interface PrepArgs {

--- a/plugins/op/.claude-plugin/plugin.json
+++ b/plugins/op/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "op",
   "description": "Obsidian Projects workflow — schema, slash commands, and agent skill for running a Jira-lite issue tracker inside an Obsidian vault.",
-  "version": "0.80.0",
+  "version": "0.80.1",
   "author": {
     "name": "Eugene Archibald"
   },


### PR DESCRIPTION
## Summary

- Inner agent script now emits `OSC 1337 SetUserVar=op_issue=<base64-issue-id>` after the env exports and before `exec`'ing the agent binary. iTerm decodes the base64 and stores the issue id as `user.op_issue`, giving op-dashboard (OP-230) the per-session correlation key it needs.
- Base64 is computed at script-build time in Node so the runtime script doesn't depend on `base64` being on PATH and avoids platform-specific `base64` line-wrap behavior.
- Refactored `writeLaunchScripts` to delegate to a new pure `buildInnerScript`, exposed for unit tests so the OSC's presence and placement can be asserted without touching disk.

**Why script-side, not orchestrator-side.** The inner script always runs inside the agent's tmux pane. Its stdout flows through the pane's pty → tmux → iTerm via the `tmux -CC` control channel, so the OSC bytes arrive at iTerm regardless of which placement path took us there. Putting the emit in the orchestrator would only cover the iTerm-orchestrated path and would have to reach into the pane's bytestream.

**Why this beats Claude Code's startup banner.** OSC 1337 is a state-mutation sequence: iTerm processes the bytes as they arrive and stores `user.op_issue` on the session object. Claude Code's banner (alt-screen + clear) doesn't unset session-scoped user variables.

**Entry-less launches stay untagged.** The workflow editor (no `issueId`, just `windowName`) does not emit the OSC, matching OP-230's correlation rule that an iTerm session with no `user.op_issue` is not an op session.

Closes #301.

## Test plan

- [x] `npx vitest run src/terminalLaunch.test.ts` — 5 new OP-233 tests, plus the existing 25 still pass.
- [x] `npx vitest run` — full op-obsidian suite: 1616 pass, 0 fail.
- [x] Built `main.js` contains the printf + OSC bytes (`grep -c "SetUserVar=op_issue"` → 1).
- [x] iTerm e2e probe (`/tmp/op-233-iterm-probe/probe.py`): inject the exact OSC bytes into a fresh iTerm session via `iterm2.async_inject`, then `await sess.async_get_variable("user.op_issue")` returns `"TST-1"` within 2 s. PASS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)