### PR TITLE
OP-234: SurfaceRef.agent — launch-time AgentMetadata for OP-230 dashboard

### DIFF
--- a/plugins/op-obsidian/manifest.json
+++ b/plugins/op-obsidian/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "op-obsidian",
   "name": "Obsidian Projects (op)",
-  "version": "0.80.2",
+  "version": "0.81.0",
   "minAppVersion": "1.5.0",
   "description": "Jira-lite issue tracker for Obsidian vaults — deterministic commands backing the op workflow.",
   "author": "Eugene Archibald",

--- a/plugins/op-obsidian/package.json
+++ b/plugins/op-obsidian/package.json
@@ -1,6 +1,6 @@
 {
   "name": "op-obsidian",
-  "version": "0.80.2",
+  "version": "0.81.0",
   "description": "Obsidian plugin that owns the deterministic half of the op workflow.",
   "main": "main.js",
   "scripts": {

--- a/plugins/op-obsidian/src/layout/registry.test.ts
+++ b/plugins/op-obsidian/src/layout/registry.test.ts
@@ -203,4 +203,32 @@ describe("registry — AgentMetadata (OP-234)", () => {
     const out = mergeRegistry(malformed);
     expect(out.surfaces["OP-8"].agent).toBeUndefined();
   });
+
+  it("drops the agent block when contextWindowSize is NaN or Infinity", () => {
+    const malformed = {
+      surfaces: {
+        "OP-9": {
+          sessionId: "s9",
+          windowId: "w1",
+          cellIndex: 0,
+          layoutId: "2x2",
+          tmuxWindow: "OP-9",
+          agent: { startTime: 1, contextWindowSize: NaN },
+        },
+        "OP-10": {
+          sessionId: "s10",
+          windowId: "w1",
+          cellIndex: 1,
+          layoutId: "2x2",
+          tmuxWindow: "OP-10",
+          agent: { startTime: 2, contextWindowSize: Infinity },
+        },
+      },
+      windows: {},
+      windowOrder: [],
+    };
+    const out = mergeRegistry(malformed);
+    expect(out.surfaces["OP-9"].agent).toBeUndefined();
+    expect(out.surfaces["OP-10"].agent).toBeUndefined();
+  });
 });

--- a/plugins/op-obsidian/src/layout/registry.test.ts
+++ b/plugins/op-obsidian/src/layout/registry.test.ts
@@ -88,3 +88,119 @@ describe("registry", () => {
     expect(roundTrip.windowOrder).toEqual(["w1"]);
   });
 });
+
+// OP-234: AgentMetadata is the launch-time payload the OP-230 dashboard
+// daemon reads from data.json on first connect. Round-tripping has to keep
+// pre-OP-217 surfaces (no `agent` block) valid — schema-drift guard.
+describe("registry — AgentMetadata (OP-234)", () => {
+  it("round-trips an agent block with all fields populated", () => {
+    const r = emptyRegistry();
+    addWindow(r, win("w1"));
+    assignSurface(r, "OP-1", {
+      sessionId: "s0",
+      windowId: "w1",
+      cellIndex: 0,
+      layoutId: "2x2",
+      tmuxWindow: "OP-1",
+      agent: {
+        model: "claude-sonnet-4-6",
+        contextWindowSize: 200_000,
+        startTime: 1735000000000,
+        workdir: "/Users/me/Projects/op",
+      },
+    });
+    const out = mergeRegistry(JSON.parse(JSON.stringify(r)));
+    expect(out.surfaces["OP-1"].agent).toEqual({
+      model: "claude-sonnet-4-6",
+      contextWindowSize: 200_000,
+      startTime: 1735000000000,
+      workdir: "/Users/me/Projects/op",
+    });
+  });
+
+  it("round-trips a minimal agent block (only startTime)", () => {
+    const r = emptyRegistry();
+    addWindow(r, win("w1"));
+    assignSurface(r, "OP-2", {
+      sessionId: "s1",
+      windowId: "w1",
+      cellIndex: 0,
+      layoutId: "2x2",
+      tmuxWindow: "OP-2",
+      agent: { startTime: 1735000000000 },
+    });
+    const out = mergeRegistry(JSON.parse(JSON.stringify(r)));
+    expect(out.surfaces["OP-2"].agent).toEqual({ startTime: 1735000000000 });
+  });
+
+  it("preserves pre-OP-217 surfaces with no agent block (schema-drift guard)", () => {
+    // Simulate a data.json snapshot written before OP-234 shipped — surfaces
+    // have no `agent` field at all. mergeRegistry must keep the row, not
+    // synthesize an empty AgentMetadata.
+    const legacy = {
+      surfaces: {
+        "OP-99": {
+          sessionId: "s9",
+          windowId: "w1",
+          cellIndex: 0,
+          layoutId: "2x2",
+          tmuxWindow: "OP-99",
+        },
+      },
+      windows: {
+        w1: {
+          windowId: "w1",
+          layoutId: "2x2",
+          sessionIds: ["s9", undefined, undefined, undefined],
+          tmuxSession: "op-agents-w1",
+        },
+      },
+      windowOrder: ["w1"],
+    };
+    const out = mergeRegistry(legacy);
+    expect(out.surfaces["OP-99"].sessionId).toBe("s9");
+    expect(out.surfaces["OP-99"].agent).toBeUndefined();
+  });
+
+  it("drops a malformed agent block but keeps the surface", () => {
+    // A surface-id mapping is the dashboard's primary key — losing it because
+    // someone wrote nonsense into `agent` would break far more than it would
+    // protect. Strip the `agent` block, keep the surface.
+    const malformed = {
+      surfaces: {
+        "OP-7": {
+          sessionId: "s7",
+          windowId: "w1",
+          cellIndex: 0,
+          layoutId: "2x2",
+          tmuxWindow: "OP-7",
+          agent: { startTime: "not-a-number", model: 42 },
+        },
+      },
+      windows: {},
+      windowOrder: [],
+    };
+    const out = mergeRegistry(malformed);
+    expect(out.surfaces["OP-7"].sessionId).toBe("s7");
+    expect(out.surfaces["OP-7"].agent).toBeUndefined();
+  });
+
+  it("drops the agent block when individual optional fields are wrong-typed", () => {
+    const malformed = {
+      surfaces: {
+        "OP-8": {
+          sessionId: "s8",
+          windowId: "w1",
+          cellIndex: 0,
+          layoutId: "2x2",
+          tmuxWindow: "OP-8",
+          agent: { startTime: 1, model: "ok", contextWindowSize: "200000" },
+        },
+      },
+      windows: {},
+      windowOrder: [],
+    };
+    const out = mergeRegistry(malformed);
+    expect(out.surfaces["OP-8"].agent).toBeUndefined();
+  });
+});

--- a/plugins/op-obsidian/src/layout/registry.ts
+++ b/plugins/op-obsidian/src/layout/registry.ts
@@ -122,7 +122,7 @@ function isAgentMetadata(v: unknown): v is AgentMetadata {
   const a = v as AgentMetadata;
   if (typeof a.startTime !== "number" || !Number.isFinite(a.startTime)) return false;
   if (a.model !== undefined && typeof a.model !== "string") return false;
-  if (a.contextWindowSize !== undefined && typeof a.contextWindowSize !== "number") return false;
+  if (a.contextWindowSize !== undefined && (typeof a.contextWindowSize !== "number" || !Number.isFinite(a.contextWindowSize))) return false;
   if (a.workdir !== undefined && typeof a.workdir !== "string") return false;
   return true;
 }

--- a/plugins/op-obsidian/src/layout/registry.ts
+++ b/plugins/op-obsidian/src/layout/registry.ts
@@ -7,6 +7,29 @@ import type { LayoutId } from "./layouts";
 // Windows themselves are also tracked so the orchestrator can detect overflow
 // (all cells in the active window are occupied → spin a new window).
 
+// OP-234: launch-time metadata about the agent occupying a surface. Persisted
+// alongside the surface so the OP-230 dashboard daemon can pull a snapshot on
+// first connect without re-deriving it from scrollback. All fields except
+// `startTime` are optional — pre-OP-217 `data.json` predates this block, so
+// the daemon must tolerate `undefined` and degrade to `ctx —` / `model —`.
+export interface AgentMetadata {
+  // Canonical model id at launch (e.g. "claude-sonnet-4-6"). Sourced from
+  // the resolver's chosen model when the workflow file pinned one; undefined
+  // when the launch fell back to the agent CLI's default.
+  model?: string;
+  // Total token budget for `model` (e.g. 200_000 for Claude 4.x). Looked up
+  // from `modelRegistry.contextWindowFor` — undefined when the model is
+  // unknown or when no model was resolved.
+  contextWindowSize?: number;
+  // Epoch ms when the surface was assigned. The reattach path preserves the
+  // prior value rather than resetting to "now" — the agent process didn't
+  // actually restart.
+  startTime: number;
+  // Absolute path the agent's shell cd'd into. Mirrors the orchestrator's
+  // `args.cwd`.
+  workdir?: string;
+}
+
 export interface SurfaceRef {
   // iTerm session id (UUID string) of the agent's pane. Authoritative —
   // windowId/cellIndex are cache that may become stale if the user rearranges
@@ -20,6 +43,9 @@ export interface SurfaceRef {
   layoutId: LayoutId;
   // tmux window name the session is attached to (issueId-based).
   tmuxWindow: string;
+  // OP-234: launch-time agent metadata. Optional so pre-OP-217 surfaces in
+  // an existing data.json keep validating.
+  agent?: AgentMetadata;
 }
 
 export interface WindowState {
@@ -53,7 +79,16 @@ export function mergeRegistry(loaded: unknown): RegistryData {
   const l = loaded as Partial<RegistryData>;
   if (l.surfaces && typeof l.surfaces === "object") {
     for (const [k, v] of Object.entries(l.surfaces)) {
-      if (isSurface(v)) base.surfaces[k] = v;
+      if (isSurface(v)) {
+        // OP-234: drop `agent` entirely when its shape is wrong rather than
+        // discarding the whole surface — a malformed metadata block must not
+        // break the issue→pane mapping the dashboard depends on.
+        const sanitized: SurfaceRef = { ...v };
+        if (sanitized.agent !== undefined && !isAgentMetadata(sanitized.agent)) {
+          delete sanitized.agent;
+        }
+        base.surfaces[k] = sanitized;
+      }
     }
   }
   if (l.windows && typeof l.windows === "object") {
@@ -77,6 +112,19 @@ function isSurface(v: unknown): v is SurfaceRef {
     typeof s.layoutId === "string" &&
     typeof s.tmuxWindow === "string"
   );
+}
+
+// OP-234: structural check for the optional `agent` block on a SurfaceRef.
+// `startTime` is the only required field — model / contextWindowSize / workdir
+// are all nullable per the spec ("ctx — / model —" rendering on absence).
+function isAgentMetadata(v: unknown): v is AgentMetadata {
+  if (!v || typeof v !== "object") return false;
+  const a = v as AgentMetadata;
+  if (typeof a.startTime !== "number" || !Number.isFinite(a.startTime)) return false;
+  if (a.model !== undefined && typeof a.model !== "string") return false;
+  if (a.contextWindowSize !== undefined && typeof a.contextWindowSize !== "number") return false;
+  if (a.workdir !== undefined && typeof a.workdir !== "string") return false;
+  return true;
 }
 
 function isWindowState(v: unknown): v is WindowState {

--- a/plugins/op-obsidian/src/modelRegistry.test.ts
+++ b/plugins/op-obsidian/src/modelRegistry.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from "vitest";
 import {
   MODEL_REGISTRY,
+  contextWindowFor,
   isKnownAgent,
   knownAgents,
   validateModelName,
@@ -169,6 +170,38 @@ describe("validateModelName — input hygiene", () => {
     const r = validateModelName("claude", "ultra", "<defaults>");
     if (r.ok) throw new Error("expected failure");
     expect(r.bad.stepId).toBe("<defaults>");
+  });
+});
+
+describe("contextWindowFor", () => {
+  it("returns 200K for Claude 4.x family canonical ids", () => {
+    expect(contextWindowFor("claude-opus-4-7")).toBe(200_000);
+    expect(contextWindowFor("claude-sonnet-4-6")).toBe(200_000);
+    expect(contextWindowFor("claude-haiku-4-5-20251001")).toBe(200_000);
+  });
+
+  it("returns 1M for Gemini 2.x", () => {
+    expect(contextWindowFor("gemini-2.5-pro")).toBe(1_000_000);
+    expect(contextWindowFor("gemini-2.5-flash")).toBe(1_000_000);
+  });
+
+  it("returns the documented budget for OpenAI/Copilot models", () => {
+    expect(contextWindowFor("gpt-5")).toBe(400_000);
+    expect(contextWindowFor("gpt-4.1")).toBe(1_000_000);
+  });
+
+  it("returns undefined for unknown ids and empty input", () => {
+    expect(contextWindowFor("claude-opus-9-9")).toBeUndefined();
+    expect(contextWindowFor(undefined)).toBeUndefined();
+    expect(contextWindowFor("")).toBeUndefined();
+  });
+
+  it("does NOT resolve aliases — caller must pass canonical ids", () => {
+    // The orchestrator hands `resolved.canonicalModel` here; bare aliases
+    // like "opus" are a contract violation and return undefined rather than
+    // silently resolving. validateModelName is the alias-aware entry point.
+    expect(contextWindowFor("opus")).toBeUndefined();
+    expect(contextWindowFor("sonnet")).toBeUndefined();
   });
 });
 

--- a/plugins/op-obsidian/src/modelRegistry.ts
+++ b/plugins/op-obsidian/src/modelRegistry.ts
@@ -201,6 +201,46 @@ export function isKnownAgent(agent: string): boolean {
   );
 }
 
+// OP-234: per-canonical-model context-window budgets in tokens. Used by the
+// orchestrator to populate `SurfaceRef.agent.contextWindowSize` so the OP-230
+// dashboard daemon can render `ctx <pct>%` without re-deriving the budget from
+// scrollback. Unknown ids return `undefined` — the daemon degrades to `ctx —`
+// per the OP-217 spec, so silence is preferred over guessing.
+//
+// Sources: Anthropic / Google / GitHub model docs at the time of writing.
+// Adding a new pinned id: add it to `MODEL_CONTEXT_WINDOWS` *and* to the
+// agent's `versioned` set above.
+const MODEL_CONTEXT_WINDOWS: Record<string, number> = {
+  // Claude 4.x family — all 200K input window.
+  "claude-opus-4-7": 200_000,
+  "claude-opus-4-6": 200_000,
+  "claude-opus-4-5": 200_000,
+  "claude-sonnet-4-6": 200_000,
+  "claude-sonnet-4-5": 200_000,
+  "claude-haiku-4-5": 200_000,
+  "claude-haiku-4-5-20251001": 200_000,
+  // Gemini 2.x — 1M-token context for Pro / Flash; 2.0 Pro/Flash same budget.
+  "gemini-2.5-pro": 1_000_000,
+  "gemini-2.5-flash": 1_000_000,
+  "gemini-2.0-pro": 1_000_000,
+  "gemini-2.0-flash": 1_000_000,
+  // OpenAI / Copilot — GPT-5 ships a 400K window; GPT-4.1 ships 1M.
+  "gpt-5": 400_000,
+  "gpt-4.1": 1_000_000,
+};
+
+/**
+ * Look up the context-window size (in tokens) for a canonical model id. Pass
+ * the resolver's `canonicalModel` here — aliases are not accepted because the
+ * registry only carries pinned ids. Returns `undefined` for unknown / missing
+ * ids so the OP-234 metadata block can record `contextWindowSize: undefined`
+ * and the dashboard renders `ctx —` per OP-217 §UI.
+ */
+export function contextWindowFor(canonicalId: string | undefined): number | undefined {
+  if (!canonicalId) return undefined;
+  return MODEL_CONTEXT_WINDOWS[canonicalId];
+}
+
 /**
  * Test-only invariant check: every alias must resolve to a known versioned id
  * for the same agent. Exported so the test suite can assert it; not used at

--- a/plugins/op-obsidian/src/openAgent.ts
+++ b/plugins/op-obsidian/src/openAgent.ts
@@ -33,7 +33,7 @@ import {
   openRecoveryDialog,
   type RecoveryDialogOutcome,
 } from "./recoveryDialog";
-import { validateModelName } from "./modelRegistry";
+import { contextWindowFor, validateModelName } from "./modelRegistry";
 
 /** Arguments accepted by {@link openAgent}. */
 export interface OpenAgentArgs {
@@ -278,6 +278,13 @@ export async function openAgent(
     parentId: args.entry.parent ?? readParentId(app, args.entry.path) ?? undefined,
     agentId,
     backgroundLaunch: settings.backgroundLaunch,
+    // OP-234: forward the resolver's canonical model + its registry-known
+    // context-window budget into the orchestrator so the new SurfaceRef.agent
+    // block records them on launch. Both stay undefined when the launch
+    // bypassed the resolver (agentOverride / forcePick / alwaysPick) — the
+    // dashboard renders `model —` / `ctx —` per OP-217 §UI.
+    model: resolved?.canonicalModel,
+    contextWindowSize: contextWindowFor(resolved?.canonicalModel),
     orchestrator: {
       settings,
       registry: {

--- a/plugins/op-obsidian/src/orchestrator.ts
+++ b/plugins/op-obsidian/src/orchestrator.ts
@@ -5,7 +5,7 @@ import * as path from "path";
 import { promisify } from "util";
 
 import { LAYOUTS, type LayoutId } from "./layout/layouts";
-import type { RegistryData, SurfaceRef, WindowState } from "./layout/registry";
+import type { AgentMetadata, RegistryData, SurfaceRef, WindowState } from "./layout/registry";
 import { activeWindow, addWindow, assignSurface } from "./layout/registry";
 import type { OpSettings } from "./settingsPure";
 import {
@@ -63,6 +63,13 @@ export interface OrchestrateArgs {
   // (growth into an existing window) does not need additional treatment —
   // `splitSession` does not call ActivateRequest in the first place.
   backgroundLaunch?: boolean;
+  // OP-234: launch-time agent metadata persisted into `SurfaceRef.agent` so
+  // the OP-230 dashboard daemon can pull a snapshot without re-deriving from
+  // scrollback. Both are optional — undefined when no model was resolved
+  // (fallback to the agent CLI's default) or the id is unknown to the
+  // model registry's context-window table.
+  model?: string;
+  contextWindowSize?: number;
 }
 
 export interface OrchestrateResult {
@@ -191,6 +198,7 @@ export async function orchestrateLaunch(
       cellIndex: nextCellIndex,
       layoutId: win.layoutId,
       tmuxWindow: windowName,
+      agent: makeAgentMetadata(args),
     };
     assignSurface(reg, args.issueId, ref);
     await registry.save(reg);
@@ -238,6 +246,7 @@ export async function orchestrateLaunch(
     cellIndex: 0,
     layoutId: ceiling,
     tmuxWindow: windowName,
+    agent: makeAgentMetadata(args),
   };
   assignSurface(reg, args.issueId, ref);
   await registry.save(reg);
@@ -491,6 +500,18 @@ export function firstEmptyCell(
     if (!sessionIds[i]) return i;
   }
   return -1;
+}
+
+// OP-234: assemble the launch-time AgentMetadata block. Only invoked on the
+// fresh-launch paths (split / new-window) — the reattach branch leaves the
+// existing surface's metadata intact because the agent process didn't restart.
+function makeAgentMetadata(args: OrchestrateArgs): AgentMetadata {
+  return {
+    model: args.model,
+    contextWindowSize: args.contextWindowSize,
+    startTime: Date.now(),
+    workdir: args.cwd,
+  };
 }
 
 function pruneWindow(reg: RegistryData, windowId: string): void {

--- a/plugins/op-obsidian/src/terminalLaunch.ts
+++ b/plugins/op-obsidian/src/terminalLaunch.ts
@@ -63,6 +63,12 @@ export interface LaunchArgs {
   // skips the `ActivateRequest`. No effect on Terminal.app — Terminal has
   // no equivalent non-activating launch path. Defaults to false.
   backgroundLaunch?: boolean;
+  // OP-234: forwarded into `OrchestrateArgs` so the orchestrator can record
+  // them on the new `SurfaceRef.agent` block. Only consumed on the
+  // orchestrator path (iTerm + orchestrator.enabled); the legacy tmux -CC
+  // attach path doesn't track per-agent metadata.
+  model?: string;
+  contextWindowSize?: number;
 }
 
 export interface LaunchResult {
@@ -106,6 +112,8 @@ export async function launchInTerminal(args: LaunchArgs): Promise<LaunchResult> 
         tmuxBinary: args.tmuxBinary,
         baseTmuxSession: SHARED_TMUX_SESSION,
         backgroundLaunch: args.backgroundLaunch,
+        model: args.model,
+        contextWindowSize: args.contextWindowSize,
       },
       args.orchestrator.settings,
       args.orchestrator.registry,

--- a/plugins/op/.claude-plugin/plugin.json
+++ b/plugins/op/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "op",
   "description": "Obsidian Projects workflow — schema, slash commands, and agent skill for running a Jira-lite issue tracker inside an Obsidian vault.",
-  "version": "0.80.2",
+  "version": "0.81.0",
   "author": {
     "name": "Eugene Archibald"
   },


### PR DESCRIPTION
## Summary

Persist launch-time `AgentMetadata { model?, contextWindowSize?, startTime, workdir? }` on each `SurfaceRef` (Wave 1 of the OP-217 dashboard rollout). The OP-230 daemon will read this snapshot from `data.json` on first connect rather than re-deriving from scrollback.

- `layout/registry.ts` — `AgentMetadata` interface + optional `agent?` on `SurfaceRef`. `mergeRegistry` validates the agent block leniently (`startTime` required, everything else optional and shape-checked); a malformed block is dropped but the surface (the dashboard's primary key) survives.
- `orchestrator.ts` — forward `model` / `contextWindowSize` via `OrchestrateArgs`; populate `SurfaceRef.agent` on the two fresh-launch paths only. The reattach branch leaves the prior block intact (the agent process didn't restart).
- `terminalLaunch.ts` / `openAgent.ts` — thread `resolved?.canonicalModel` + `modelRegistry.contextWindowFor()` from the resolver through to the orchestrator.
- `modelRegistry.ts` — new `contextWindowFor(canonicalId)` helper with the per-canonical-model token budgets (200K Claude 4.x, 1M Gemini, 400K GPT-5, 1M GPT-4.1). Aliases are rejected — `validateModelName` is the alias-aware entry point.

Schema-drift guard verified: a `data.json` written before this PR (no `agent` field) round-trips cleanly with `agent === undefined`, and a malformed `agent` block is stripped without losing the surface row.

Parent: OP-217.

## Test plan

- [x] `npx vitest run` — 1571/1571 pass; new coverage in `layout/registry.test.ts` (round-trip, minimal block, pre-OP-217 compat, malformed-drop) and `modelRegistry.test.ts` (`contextWindowFor` happy path + unknown ids + aliases-rejected).
- [x] `npx tsc --noEmit` — no new errors (the 8 reported errors all pre-exist on `main`; verified by stash + re-run).
- [x] `node scripts/bump-version.mjs minor` — 0.80.0 → 0.81.0 (additive surface).
- [x] `node scripts/dev-sync.mjs` — synced to OP-Test, plugin reload clean.
- [x] OP-Test live round-trip: synthetic `SurfaceRef` with full `agent` block written via `saveSettings`, then re-read from `loadData()` — fields persisted verbatim. Console clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)