### PR TITLE
OP-230: op-dashboard daemon — aiohttp + iterm2 + tmux

### DIFF
--- a/plugins/op-obsidian/.gitignore
+++ b/plugins/op-obsidian/.gitignore
@@ -2,3 +2,4 @@ node_modules/
 main.js
 main.js.map
 *.log
+dashboard/__pycache__/

--- a/plugins/op-obsidian/dashboard/README.md
+++ b/plugins/op-obsidian/dashboard/README.md
@@ -1,0 +1,97 @@
+# op-dashboard daemon
+
+Long-lived Python daemon that brokers between the iTerm2 Python API, tmux,
+and a localhost web server. Powers the agent dashboard described in
+[`docs/specs/OP-217-agent-dashboard.md`](../../../docs/specs/OP-217-agent-dashboard.md).
+
+This directory ships the daemon source. The plugin's Setup modal (OP-232)
+copies `op-dashboard.py` into
+`~/Library/Application Support/iTerm2/Scripts/AutoLaunch/` — never silently;
+the user is always prompted before the file lands. iTerm2 starts the daemon
+on launch and on every restart.
+
+## Runtime requirements
+
+- macOS (the daemon exits cleanly on other platforms)
+- Python 3.11+ (uses `dataclasses` defaults, structural typing, modern asyncio)
+- `aiohttp` — hard dep, needed for HTTP + WebSocket
+- `iterm2` — optional; the daemon falls back to tmux-only mode without it
+
+```bash
+pip3 install aiohttp iterm2
+```
+
+The Setup modal will surface `pip3 install` instructions when these are
+missing.
+
+## Files at runtime
+
+| Path | Purpose |
+|---|---|
+| `~/Library/Application Support/iTerm2/Scripts/AutoLaunch/op-dashboard.py` | The daemon itself (copied here by OP-232). |
+| `~/Library/Application Support/iTerm2/Scripts/AutoLaunch/op-dashboard.token` | Auth token, regenerated on startup, mode 0600. |
+| `~/Library/Application Support/iTerm2/Scripts/AutoLaunch/op-dashboard.config.json` | Optional config. Currently honors `vault_data_paths: [...]` for `data.json` discovery. |
+| `~/Library/Logs/op-dashboard.log` | Rotating log (1 MB × 3 backups). |
+
+## Surface
+
+- `GET /` — serves the SPA from `client/index.html` if present, otherwise a
+  diagnostic placeholder. Unauthenticated (chrome only).
+- `GET /healthz?token=…` — `{"ok": true, "version": "...", "uptime_s": N, "iterm": bool}`. **Requires token.**
+- `GET /ws?token=…` — bidirectional control channel. Token-mismatch closes
+  with code 4401.
+
+WebSocket frames are documented in the OP-217 spec under "Server contract".
+
+## Identity correlation
+
+A live row exists when the union of these sources has the issue id:
+
+- iTerm sessions whose `user.op_issue` user-var decodes to `<issue-id>`
+  (base64-encoded by OP-233; raw fallback honored).
+- tmux windows under any session matching `^op-agents(-\d+)?$`, where the
+  window name is `tmuxWindowName(issueId)` =
+  `slugify(issueId, { allowUnderscore: true })` (case-preserving). For
+  canonical ids like `OP-217`, slug == id.
+- *(opt-in)* `data.json` `orchestratorState.surfaces` if a vault path is
+  pointed at via the `OP_DASHBOARD_DATA_JSON` env var or
+  `op-dashboard.config.json`.
+
+The reconciler runs on the 1 s poll loop and on every iTerm layout-change
+notification.
+
+## Fallback modes
+
+- **No iterm2 package or API disabled.** Daemon logs once, sets
+  `iterm: false` in `/healthz`, and serves rows from tmux only. The
+  `close_pane` command returns an `error` frame with code
+  `iterm_unavailable`.
+- **No tmux server.** `list-windows` fails benignly; the daemon serves
+  whatever iTerm reports (likely zero rows) until tmux is brought up.
+- **Pre-OP-217 `data.json`.** Reader uses defensive `.get` chains and
+  yields empty AgentMetadata rather than raising.
+
+## Testing
+
+The pure-Python helpers ship a `unittest` suite that runs without aiohttp,
+iterm2, or tmux:
+
+```bash
+python3 plugins/op-obsidian/dashboard/test_op_dashboard.py
+```
+
+End-to-end smoke (daemon up, browser tab live, send/quit/close round-trip)
+lives in OP-236 — that issue gates the whole OP-217 chain's merge to main.
+
+## Adversarial review surface
+
+OP-236's adversarial Copilot review pressure-tests the seven failure modes
+in `docs/specs/OP-217-agent-dashboard.md`:
+
+1. Token leakage / port impersonation.
+2. New-session race vs. dashboard connect.
+3. Cleanup symmetry (closed tab → no leaks).
+4. `revealAgentSession` re-entrancy with mid-launch orchestrator.
+5. Unknown-issue param validation (single `error` frame, not a 500).
+6. Schema drift on a pre-OP-217 `data.json`.
+7. Concurrent send commands from multiple clients.

--- a/plugins/op-obsidian/dashboard/README.md
+++ b/plugins/op-obsidian/dashboard/README.md
@@ -14,12 +14,17 @@ on launch and on every restart.
 
 - macOS (the daemon exits cleanly on other platforms)
 - Python 3.11+ (uses `dataclasses` defaults, structural typing, modern asyncio)
-- `aiohttp` — hard dep, needed for HTTP + WebSocket
-- `iterm2` — optional; the daemon falls back to tmux-only mode without it
+- `aiohttp >= 3.9, < 4` — hard dep, needed for HTTP + WebSocket
+- `iterm2 >= 2.1` — optional; the daemon falls back to tmux-only mode without it
 
 ```bash
-pip3 install aiohttp iterm2
+pip3 install 'aiohttp>=3.9,<4' 'iterm2>=2.1'
 ```
+
+Both versions are pinned because the daemon ships into the user's
+`AutoLaunch` directory — a major-version bump in either dep can silently
+break every dashboard install. OP-232's Setup modal will surface the
+version constraint when its `import` probe finds a mismatch.
 
 The Setup modal will surface `pip3 install` instructions when these are
 missing.

--- a/plugins/op-obsidian/dashboard/op-dashboard.py
+++ b/plugins/op-obsidian/dashboard/op-dashboard.py
@@ -124,14 +124,18 @@ class AgentSession:
     model: Optional[str] = None
     context_pct: Optional[int] = None
     state: str = "idle"
-    last_activity: Optional[float] = None  # epoch s
+    last_activity: Optional[float] = None  # epoch s — for client serialization
     last_capture: str = ""
-    started_at: Optional[float] = None     # epoch s
+    started_at: Optional[float] = None     # epoch s — for client serialization
     workdir: Optional[str] = None
     stale: bool = False
     # Internal — not serialized:
     _last_capture_hash: int = 0
-    _exited_at: Optional[float] = None
+    # Monotonic timestamps — used for liveness thresholds. Survives wall-clock
+    # jumps (NTP, manual clock changes) that would otherwise produce negative
+    # ages and pin classify_state() at "running" forever.
+    _last_activity_mono: Optional[float] = None
+    _exited_at_mono: Optional[float] = None
 
     def to_json(self) -> dict:
         return {
@@ -537,6 +541,14 @@ class AppState:
     iterm: ITermBridge
     poll_task: Optional[asyncio.Task] = None
     shutdown_event: asyncio.Event = field(default_factory=asyncio.Event)
+    # Serializes mutating tmux operations (send-keys / kill-window) across
+    # all clients. Two browser tabs sending to the same window simultaneously
+    # would otherwise interleave at command granularity (e.g. tmux receives
+    # "foo", "bar", Enter, Enter instead of "foo\n" then "bar\n"). Capture
+    # operations are read-only and stay unlocked. Lock granularity is
+    # global because tmux's own command processing serializes anyway and
+    # the daemon is dev-tooling — N=1..10 agents, throughput is fine.
+    tmux_lock: asyncio.Lock = field(default_factory=asyncio.Lock)
 
 
 # ---- Static index ----------------------------------------------------------
@@ -681,22 +693,25 @@ async def dispatch(state: AppState, ws, raw: str) -> None:
 async def handle_send(state: AppState, sess: AgentSession, text: str) -> None:
     if not text or not sess.tmux_target:
         return
-    await send_text(sess.tmux_target, text)
-    # Two-Enter quirk (per project memory): capture 100 ms later; if the
-    # input box still echoes the line and there's no spinner, send a single
-    # additional Enter. Single-shot, no loop.
-    await asyncio.sleep(0.1)
-    after = await capture_pane(sess.tmux_target, lines=10)
-    has_spinner = any(c in after for c in SPINNER_CHARS)
-    if (not has_spinner) and text in after:
-        await send_enter(sess.tmux_target)
+    # Hold the tmux lock across the entire send + capture + optional-second-Enter
+    # sequence so two clients sending simultaneously don't interleave keys at
+    # command granularity. capture-pane between the writes IS the consistency
+    # check the two-Enter quirk relies on — splitting the lock would defeat it.
+    async with state.tmux_lock:
+        await send_text(sess.tmux_target, text)
+        await asyncio.sleep(0.1)
+        after = await capture_pane(sess.tmux_target, lines=10)
+        has_spinner = any(c in after for c in SPINNER_CHARS)
+        if (not has_spinner) and text in after:
+            await send_enter(sess.tmux_target)
     await refresh_one(state, sess)
 
 
 async def handle_quit(state: AppState, sess: AgentSession) -> None:
     if not sess.tmux_target:
         return
-    await send_quit(sess.tmux_target)
+    async with state.tmux_lock:
+        await send_quit(sess.tmux_target)
     await refresh_one(state, sess)
 
 
@@ -736,6 +751,7 @@ async def reconcile(state: AppState) -> Tuple[List[AgentSession], List[AgentSess
     added: List[AgentSession] = []
     updated: List[AgentSession] = []
     now = time.time()
+    now_mono = time.monotonic()
 
     issue_to_target: Dict[str, str] = {}
     for session_name, window_name in tmux_rows:
@@ -785,14 +801,15 @@ async def reconcile(state: AppState) -> Tuple[List[AgentSession], List[AgentSess
                 state="exited",
             )
             sess.started_at = now
-            sess._exited_at = now
+            sess._exited_at_mono = now_mono
             state.registry.upsert(sess)
             added.append(sess)
         else:
             sess.iterm_session_id = uuid
             sess.stale = True
             sess.state = "exited"
-            sess._exited_at = sess._exited_at or now
+            if sess._exited_at_mono is None:
+                sess._exited_at_mono = now_mono
             updated.append(sess)
 
     # Remove tmux+iterm-orphaned sessions after grace window.
@@ -801,12 +818,12 @@ async def reconcile(state: AppState) -> Tuple[List[AgentSession], List[AgentSess
         gone_from_tmux = issue_id not in issue_to_target
         gone_from_iterm = issue_id not in iterm_map
         if gone_from_tmux and gone_from_iterm:
-            if sess._exited_at is None:
-                sess._exited_at = now
+            if sess._exited_at_mono is None:
+                sess._exited_at_mono = now_mono
                 sess.state = "exited"
                 if sess not in updated:
                     updated.append(sess)
-            elif now - sess._exited_at > EXITED_GRACE_S:
+            elif now_mono - sess._exited_at_mono > EXITED_GRACE_S:
                 state.registry.remove(issue_id)
                 removed.append(issue_id)
 
@@ -820,11 +837,16 @@ async def refresh_one(state: AppState, sess: AgentSession) -> None:
     capture = await capture_pane(sess.tmux_target)
     capture_hash = hash(capture)
     now = time.time()
+    now_mono = time.monotonic()
     if capture_hash != sess._last_capture_hash and capture:
-        sess.last_activity = now
+        sess.last_activity = now            # for client serialization
+        sess._last_activity_mono = now_mono  # for liveness threshold
         sess._last_capture_hash = capture_hash
     sess.last_capture = "\n".join(capture.splitlines()[-CAPTURE_DISPLAY_LINES:])
-    last_age = (now - sess.last_activity) if sess.last_activity else 9999.0
+    # Compute idle/running threshold against monotonic so a wall-clock jump
+    # (NTP, manual clock change) can't pin a session at "running" forever
+    # via a negative delta.
+    last_age = (now_mono - sess._last_activity_mono) if sess._last_activity_mono else 9999.0
     classifier = AGENT_CLASSIFIERS.get(sess.agent_id, CLAUDE_CLASSIFIER)
     sess.state = classify_state(capture, last_age, classifier)
     sess.context_pct = extract_context_pct(capture, classifier)

--- a/plugins/op-obsidian/dashboard/op-dashboard.py
+++ b/plugins/op-obsidian/dashboard/op-dashboard.py
@@ -1,0 +1,928 @@
+#!/usr/bin/env python3
+"""op-dashboard.py — agent dashboard daemon (OP-217).
+
+See docs/specs/OP-217-agent-dashboard.md for the product spec. This script
+is shipped under plugins/op-obsidian/dashboard/op-dashboard.py and copied
+into ~/Library/ApplicationSupport/iTerm2/Scripts/AutoLaunch/ by the
+plugin's Setup modal (OP-232).
+
+Runtime requirements:
+    pip3 install aiohttp iterm2
+
+The `iterm2` package is best-effort — if it's missing or the API is
+disabled, the daemon runs in tmux-only mode (Close pane returns an error
+frame and the iterm_session_id field is null on every row).
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import base64
+import contextlib
+import errno
+import hmac
+import json
+import logging
+import logging.handlers
+import os
+import re
+import secrets
+import signal
+import socket
+import sys
+import time
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Set, Tuple
+
+# ---- Constants -------------------------------------------------------------
+
+VERSION = "0.1.0"
+DEFAULT_PORT = 49217
+DEFAULT_HOST = "127.0.0.1"
+
+HOME = Path(os.path.expanduser("~"))
+AUTOLAUNCH_DIR = HOME / "Library/Application Support/iTerm2/Scripts/AutoLaunch"
+TOKEN_PATH = AUTOLAUNCH_DIR / "op-dashboard.token"
+CONFIG_PATH = AUTOLAUNCH_DIR / "op-dashboard.config.json"
+LOG_PATH = HOME / "Library/Logs/op-dashboard.log"
+
+POLL_INTERVAL_S = 1.0
+CAPTURE_TAIL_LINES = 50
+CAPTURE_DISPLAY_LINES = 30
+RUNNING_DELTA_THRESHOLD_S = 30
+EXITED_GRACE_S = 5 * 60
+
+WS_CLOSE_TOKEN_INVALID = 4401
+
+# Matches `op-agents` and `op-agents-1`, `op-agents-2`, etc.
+TMUX_SESSION_RE = re.compile(r"^op-agents(?:-\d+)?$")
+
+VALID_STATES = ("running", "waiting_user", "waiting_review", "idle", "exited")
+
+# Spinner glyphs claude-code/claude-cli print while a turn is in flight. If
+# any are present in the tail, suppress `waiting_user` classification — the
+# agent is mid-thought, not asking the user a question. ASCII spinners
+# (`|/-\`) are intentionally NOT included: `(y/n)` and similar prompts
+# contain literal slashes and were causing false suppressions.
+SPINNER_CHARS = "⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏◐◓◑◒"
+
+log = logging.getLogger("op-dashboard")
+
+
+# ---- Logging ---------------------------------------------------------------
+
+def setup_logging() -> None:
+    LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
+    if log.handlers:
+        return
+    log.setLevel(logging.INFO)
+    fmt = logging.Formatter(
+        "%(asctime)s %(levelname)s %(name)s: %(message)s",
+        datefmt="%Y-%m-%dT%H:%M:%S%z",
+    )
+    file_h = logging.handlers.RotatingFileHandler(
+        LOG_PATH, maxBytes=1_000_000, backupCount=3, encoding="utf-8"
+    )
+    file_h.setFormatter(fmt)
+    log.addHandler(file_h)
+    stderr_h = logging.StreamHandler()
+    stderr_h.setFormatter(fmt)
+    log.addHandler(stderr_h)
+
+
+# ---- Token management ------------------------------------------------------
+
+def generate_token() -> str:
+    return secrets.token_urlsafe(32)
+
+
+def write_token(path: Path, token: str) -> None:
+    """Write the token atomically with mode 0600."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_suffix(path.suffix + ".tmp")
+    flags = os.O_WRONLY | os.O_CREAT | os.O_TRUNC
+    fd = os.open(str(tmp), flags, 0o600)
+    try:
+        os.write(fd, token.encode("utf-8"))
+    finally:
+        os.close(fd)
+    os.replace(str(tmp), str(path))
+    os.chmod(str(path), 0o600)
+
+
+# ---- AgentSession dataclass + serialization --------------------------------
+
+@dataclass
+class AgentSession:
+    issue_id: str
+    iterm_session_id: Optional[str] = None
+    tmux_target: str = ""
+    agent_id: str = "claude"
+    model: Optional[str] = None
+    context_pct: Optional[int] = None
+    state: str = "idle"
+    last_activity: Optional[float] = None  # epoch s
+    last_capture: str = ""
+    started_at: Optional[float] = None     # epoch s
+    workdir: Optional[str] = None
+    stale: bool = False
+    # Internal — not serialized:
+    _last_capture_hash: int = 0
+    _exited_at: Optional[float] = None
+
+    def to_json(self) -> dict:
+        return {
+            "issue_id": self.issue_id,
+            "iterm_session_id": self.iterm_session_id,
+            "tmux_target": self.tmux_target,
+            "agent_id": self.agent_id,
+            "model": self.model,
+            "context_pct": self.context_pct,
+            "state": self.state,
+            "last_activity": iso(self.last_activity),
+            "last_capture": self.last_capture,
+            "started_at": iso(self.started_at),
+            "workdir": self.workdir,
+            "stale": self.stale,
+        }
+
+
+def iso(t: Optional[float]) -> Optional[str]:
+    if t is None:
+        return None
+    return datetime.fromtimestamp(t, tz=timezone.utc).isoformat()
+
+
+# ---- State classifiers -----------------------------------------------------
+
+@dataclass
+class StateClassifier:
+    waiting_user: List[re.Pattern]
+    waiting_review: List[re.Pattern]
+    context_pct: Optional[re.Pattern] = None
+
+
+CLAUDE_CLASSIFIER = StateClassifier(
+    waiting_user=[
+        re.compile(r"\(yes/no\)"),
+        re.compile(r"\(y/n\)", re.IGNORECASE),
+        re.compile(r"\bApprove\?"),
+        re.compile(r"\bDo you want to\b"),
+        re.compile(r"^\s*❯\s", re.MULTILINE),
+        re.compile(r"^\s*\d+\.\s+No,? and ", re.MULTILINE),  # Claude Code menu
+    ],
+    waiting_review=[
+        re.compile(r"Polling for Copilot review"),
+        re.compile(r"polling.*review", re.IGNORECASE),
+    ],
+    context_pct=re.compile(r"context.{0,40}?(\d+)\s*%", re.IGNORECASE),
+)
+
+AGENT_CLASSIFIERS: Dict[str, StateClassifier] = {"claude": CLAUDE_CLASSIFIER}
+
+
+def classify_state(
+    capture: str,
+    last_activity_age_s: float,
+    classifier: StateClassifier,
+) -> str:
+    """Return one of running|waiting_user|waiting_review|idle.
+
+    `exited` is decided by the reconciler based on tmux liveness and is not
+    returned from this function.
+    """
+    has_spinner = any(c in capture for c in SPINNER_CHARS)
+    if not has_spinner:
+        for pat in classifier.waiting_user:
+            if pat.search(capture):
+                return "waiting_user"
+    for pat in classifier.waiting_review:
+        if pat.search(capture):
+            return "waiting_review"
+    if last_activity_age_s < RUNNING_DELTA_THRESHOLD_S:
+        return "running"
+    return "idle"
+
+
+def extract_context_pct(capture: str, classifier: StateClassifier) -> Optional[int]:
+    if classifier.context_pct is None:
+        return None
+    m = classifier.context_pct.search(capture)
+    if not m:
+        return None
+    try:
+        v = int(m.group(1))
+    except (TypeError, ValueError):
+        return None
+    return max(0, min(100, v))
+
+
+# ---- tmux helpers ----------------------------------------------------------
+
+class TmuxError(Exception):
+    pass
+
+
+async def tmux_run(*args: str, check: bool = True) -> Tuple[int, str, str]:
+    """Run `tmux <args...>`, return (rc, stdout, stderr)."""
+    proc = await asyncio.create_subprocess_exec(
+        "tmux", *args,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+    )
+    out_b, err_b = await proc.communicate()
+    rc = proc.returncode if proc.returncode is not None else -1
+    out = out_b.decode("utf-8", errors="replace")
+    err = err_b.decode("utf-8", errors="replace")
+    if check and rc != 0 and "no server running" not in (err + out):
+        raise TmuxError(f"tmux {' '.join(args)} failed (rc={rc}): {err.strip()}")
+    return rc, out, err
+
+
+def parse_list_windows(stdout: str) -> List[Tuple[str, str]]:
+    """Parse `tmux list-windows -a -F '#S:#W'` output → [(session, window)]."""
+    out: List[Tuple[str, str]] = []
+    for line in stdout.splitlines():
+        line = line.strip()
+        if not line or ":" not in line:
+            continue
+        session, _, window = line.partition(":")
+        out.append((session, window))
+    return out
+
+
+def filter_op_agent_windows(rows: List[Tuple[str, str]]) -> List[Tuple[str, str]]:
+    return [(s, w) for s, w in rows if TMUX_SESSION_RE.match(s)]
+
+
+async def list_op_agent_windows() -> List[Tuple[str, str]]:
+    rc, out, _ = await tmux_run("list-windows", "-a", "-F", "#S:#W", check=False)
+    if rc != 0:
+        return []
+    return filter_op_agent_windows(parse_list_windows(out))
+
+
+async def capture_pane(target: str, lines: int = CAPTURE_TAIL_LINES) -> str:
+    """Capture the last `lines` rows of the named tmux window's active pane."""
+    rc, out, _ = await tmux_run(
+        "capture-pane", "-p", "-J", "-S", f"-{lines}", "-t", target, check=False
+    )
+    if rc != 0:
+        return ""
+    return out
+
+
+async def send_text(target: str, text: str) -> None:
+    """Send a literal string + Enter to the named tmux window."""
+    await tmux_run("send-keys", "-t", target, "-l", text, check=False)
+    await tmux_run("send-keys", "-t", target, "Enter", check=False)
+
+
+async def send_enter(target: str) -> None:
+    await tmux_run("send-keys", "-t", target, "Enter", check=False)
+
+
+async def send_quit(target: str) -> None:
+    """Send `/quit` + Enter + Enter — Claude Code requires the second Enter."""
+    await tmux_run("send-keys", "-t", target, "-l", "/quit", check=False)
+    await tmux_run("send-keys", "-t", target, "Enter", check=False)
+    await tmux_run("send-keys", "-t", target, "Enter", check=False)
+
+
+# ---- iTerm bridge (best-effort) --------------------------------------------
+
+class ITermBridge:
+    """Wraps the iterm2 Python API. No-ops when the API is unavailable."""
+
+    def __init__(self) -> None:
+        self.connection = None
+        self.app = None
+        self.available = False
+        self._uuid_by_issue: Dict[str, str] = {}
+
+    async def start(self) -> None:
+        try:
+            import iterm2  # type: ignore
+        except ImportError:
+            log.warning("iterm2 Python package not installed — running in tmux-only mode.")
+            return
+        try:
+            self.connection = await iterm2.Connection.async_create()
+            self.app = await iterm2.async_get_app(self.connection)
+            self.available = True
+            log.info("iTerm2 Python API connected.")
+        except Exception as e:  # broad: API disabled, version mismatch, socket missing.
+            log.warning("iTerm2 Python API unavailable (%s) — running in tmux-only mode.", e)
+            self.available = False
+
+    async def scan(self) -> Dict[str, str]:
+        """Return {issue_id: iterm_session_id} from `user.op_issue` user vars."""
+        if not self.available or self.app is None:
+            return {}
+        result: Dict[str, str] = {}
+        try:
+            for window in self.app.terminal_windows:
+                for tab in window.tabs:
+                    for sess in tab.sessions:
+                        try:
+                            raw = await sess.async_get_variable("user.op_issue")
+                        except Exception:
+                            raw = None
+                        if not raw:
+                            continue
+                        issue_id = decode_user_op_issue(str(raw))
+                        if issue_id:
+                            result[issue_id] = sess.session_id
+        except Exception as e:
+            log.warning("iterm scan failed: %s", e)
+        self._uuid_by_issue = dict(result)
+        return result
+
+    async def close_pane(self, issue_id: str) -> bool:
+        if not self.available or self.app is None:
+            return False
+        uuid = self._uuid_by_issue.get(issue_id)
+        if not uuid:
+            return False
+        sess = self.app.get_session_by_id(uuid)
+        if sess is None:
+            return False
+        try:
+            await sess.async_close(force=True)
+            return True
+        except Exception as e:
+            log.warning("close_pane(%s) failed: %s", issue_id, e)
+            return False
+
+
+def decode_user_op_issue(raw: str) -> Optional[str]:
+    """Best-effort decode of `user.op_issue` — base64 first, raw second."""
+    if not raw:
+        return None
+    raw = raw.strip()
+    try:
+        decoded = base64.b64decode(raw, validate=True).decode("utf-8", errors="strict")
+        if decoded and all(c.isprintable() for c in decoded):
+            return decoded.strip()
+    except Exception:
+        pass
+    return raw
+
+
+# ---- data.json reader ------------------------------------------------------
+
+def find_data_json_paths() -> List[Path]:
+    """Return candidate data.json paths from env or config (best-effort)."""
+    paths: List[Path] = []
+    env = os.environ.get("OP_DASHBOARD_DATA_JSON", "").strip()
+    if env:
+        for chunk in env.split(":"):
+            p = Path(chunk).expanduser()
+            if p.exists():
+                paths.append(p)
+    if CONFIG_PATH.exists():
+        try:
+            cfg = json.loads(CONFIG_PATH.read_text(encoding="utf-8"))
+            for chunk in cfg.get("vault_data_paths", []) or []:
+                p = Path(str(chunk)).expanduser()
+                if p.exists():
+                    paths.append(p)
+        except Exception as e:
+            log.warning("config read failed (%s): %s", CONFIG_PATH, e)
+    return paths
+
+
+def read_orchestrator_state(path: Path) -> Dict[str, dict]:
+    """Read the plugin's data.json and return {issue_id: surface-record}.
+
+    Defensive: every field uses .get with a default so a pre-OP-217 data.json
+    (no AgentMetadata) yields empty AgentMetadata fields without raising.
+    """
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except Exception as e:
+        log.warning("data.json read failed (%s): %s", path, e)
+        return {}
+    if not isinstance(data, dict):
+        return {}
+    reg = data.get("orchestratorState") or {}
+    surfaces = reg.get("surfaces") if isinstance(reg, dict) else None
+    out: Dict[str, dict] = {}
+    if isinstance(surfaces, dict):
+        for issue_id, ref in surfaces.items():
+            if isinstance(ref, dict):
+                out[str(issue_id)] = ref
+    return out
+
+
+def extract_agent_meta(ref: dict) -> Tuple[str, Optional[str], Optional[str], Optional[float]]:
+    """Pull (agent_id, model, workdir, started_at) from a surface-ref dict."""
+    agent_id = "claude"
+    model: Optional[str] = None
+    workdir: Optional[str] = None
+    started_at: Optional[float] = None
+    if not isinstance(ref, dict):
+        return agent_id, model, workdir, started_at
+    aid = ref.get("agentId")
+    if isinstance(aid, str) and aid:
+        agent_id = aid
+    meta = ref.get("agentMeta")
+    if isinstance(meta, dict):
+        if isinstance(meta.get("model"), str):
+            model = meta["model"]
+        if isinstance(meta.get("workdir"), str):
+            workdir = meta["workdir"]
+        st = meta.get("startTime")
+        if isinstance(st, (int, float)) and st > 0:
+            started_at = float(st) / 1000.0
+    return agent_id, model, workdir, started_at
+
+
+# ---- SessionRegistry -------------------------------------------------------
+
+class SessionRegistry:
+    def __init__(self) -> None:
+        self.sessions: Dict[str, AgentSession] = {}
+
+    def upsert(self, sess: AgentSession) -> Tuple[bool, AgentSession]:
+        existing = self.sessions.get(sess.issue_id)
+        if existing is None:
+            self.sessions[sess.issue_id] = sess
+            return True, sess
+        if existing.started_at is None and sess.started_at is not None:
+            existing.started_at = sess.started_at
+        existing.iterm_session_id = sess.iterm_session_id or existing.iterm_session_id
+        existing.tmux_target = sess.tmux_target or existing.tmux_target
+        existing.agent_id = sess.agent_id or existing.agent_id
+        existing.model = sess.model or existing.model
+        existing.workdir = sess.workdir or existing.workdir
+        existing.stale = sess.stale
+        return False, existing
+
+    def remove(self, issue_id: str) -> Optional[AgentSession]:
+        return self.sessions.pop(issue_id, None)
+
+    def get(self, issue_id: str) -> Optional[AgentSession]:
+        return self.sessions.get(issue_id)
+
+    def values(self) -> List[AgentSession]:
+        return list(self.sessions.values())
+
+
+# ---- Hub: WebSocket client tracking + broadcast ----------------------------
+
+class Hub:
+    def __init__(self) -> None:
+        self._clients: Set[Any] = set()
+        self._lock = asyncio.Lock()
+
+    async def add(self, ws: Any) -> None:
+        async with self._lock:
+            self._clients.add(ws)
+
+    async def remove(self, ws: Any) -> None:
+        async with self._lock:
+            self._clients.discard(ws)
+
+    @property
+    def count(self) -> int:
+        return len(self._clients)
+
+    async def broadcast(self, frame: dict) -> None:
+        async with self._lock:
+            clients = list(self._clients)
+        msg = json.dumps(frame, default=str)
+        for ws in clients:
+            try:
+                await ws.send_str(msg)
+            except Exception as e:
+                log.debug("broadcast to client failed: %s", e)
+
+    async def shutdown(self) -> None:
+        async with self._lock:
+            clients = list(self._clients)
+            self._clients.clear()
+        for ws in clients:
+            with contextlib.suppress(Exception):
+                await ws.close()
+
+
+# ---- Auth ------------------------------------------------------------------
+
+def request_token(request) -> str:
+    return (
+        request.query.get("token", "")
+        or request.headers.get("X-Op-Token", "")
+        or ""
+    )
+
+
+def token_ok(provided: str, expected: str) -> bool:
+    if not provided or not expected:
+        return False
+    return hmac.compare_digest(provided.encode("utf-8"), expected.encode("utf-8"))
+
+
+# ---- App state -------------------------------------------------------------
+
+@dataclass
+class AppState:
+    token: str
+    started_at: float
+    registry: SessionRegistry
+    hub: Hub
+    iterm: ITermBridge
+    poll_task: Optional[asyncio.Task] = None
+    shutdown_event: asyncio.Event = field(default_factory=asyncio.Event)
+
+
+# ---- Static index ----------------------------------------------------------
+
+DIAGNOSTIC_HTML = """<!doctype html>
+<html><head><meta charset='utf-8'><title>op-dashboard daemon</title>
+<style>body{font:14px -apple-system,BlinkMacSystemFont,sans-serif;padding:2em;color:#222;}
+h1{font-size:1.2em;margin:0 0 .5em;}code{background:#eee;padding:.1em .3em;border-radius:3px;}</style>
+</head><body>
+<h1>op-dashboard daemon — placeholder</h1>
+<p>The daemon is running. The single-page UI ships in OP-231; until then
+this page just confirms the HTTP/WS surface is alive.</p>
+<p>Health: <code>GET /healthz?token=&hellip;</code> · WebSocket: <code>/ws?token=&hellip;</code></p>
+<p>Logs: <code>~/Library/Logs/op-dashboard.log</code></p>
+</body></html>
+"""
+
+
+def static_index_path() -> Optional[Path]:
+    """If a sibling client/index.html exists, prefer it (OP-231 ships this)."""
+    here = Path(__file__).resolve().parent
+    for candidate in (here / "client" / "index.html", here / "index.html"):
+        if candidate.is_file():
+            return candidate
+    return None
+
+
+# ---- HTTP/WS routes --------------------------------------------------------
+
+def build_app(state: AppState):
+    from aiohttp import web, WSMsgType
+
+    routes = web.RouteTableDef()
+
+    @routes.get("/")
+    async def index(_request):
+        # Index page does NOT require the token — it's chrome. The browser
+        # then upgrades to /ws *with* the token; the token gates data.
+        path = static_index_path()
+        if path is not None:
+            return web.FileResponse(path)
+        return web.Response(text=DIAGNOSTIC_HTML, content_type="text/html")
+
+    @routes.get("/healthz")
+    async def healthz(request):
+        if not token_ok(request_token(request), state.token):
+            return web.json_response({"ok": False, "error": "auth"}, status=401)
+        return web.json_response({
+            "ok": True,
+            "version": VERSION,
+            "uptime_s": int(time.time() - state.started_at),
+            "iterm": state.iterm.available,
+        })
+
+    @routes.get("/ws")
+    async def ws_handler(request):
+        if not token_ok(request_token(request), state.token):
+            ws = web.WebSocketResponse()
+            await ws.prepare(request)
+            await ws.close(code=WS_CLOSE_TOKEN_INVALID, message=b"invalid token")
+            return ws
+        ws = web.WebSocketResponse(heartbeat=30.0)
+        await ws.prepare(request)
+        await state.hub.add(ws)
+        log.info("client connected (clients=%d)", state.hub.count)
+        await ws.send_str(json.dumps({
+            "type": "snapshot",
+            "sessions": [s.to_json() for s in state.registry.values()],
+        }))
+        try:
+            async for msg in ws:
+                if msg.type == WSMsgType.TEXT:
+                    await dispatch(state, ws, msg.data)
+                elif msg.type == WSMsgType.ERROR:
+                    log.warning("ws error: %s", ws.exception())
+        finally:
+            await state.hub.remove(ws)
+            log.info("client disconnected (clients=%d)", state.hub.count)
+        return ws
+
+    app = web.Application()
+    app.add_routes(routes)
+    return app
+
+
+# ---- Frame dispatch --------------------------------------------------------
+
+async def dispatch(state: AppState, ws, raw: str) -> None:
+    try:
+        frame = json.loads(raw)
+    except Exception:
+        await ws.send_str(json.dumps(
+            {"type": "error", "code": "bad_json", "message": "frame is not JSON"}
+        ))
+        return
+    if not isinstance(frame, dict):
+        await ws.send_str(json.dumps(
+            {"type": "error", "code": "bad_frame", "message": "frame must be object"}
+        ))
+        return
+    typ = frame.get("type")
+    issue_id = str(frame.get("issue_id") or "")
+    if typ in ("send", "quit", "close_pane", "reveal", "refresh") and not issue_id:
+        await ws.send_str(json.dumps(
+            {"type": "error", "code": "missing_issue_id", "message": "issue_id is required"}
+        ))
+        return
+    sess = state.registry.get(issue_id) if issue_id else None
+    if typ in ("send", "quit", "close_pane", "reveal", "refresh") and sess is None:
+        await ws.send_str(json.dumps({
+            "type": "error",
+            "code": "unknown_issue",
+            "issue_id": issue_id,
+            "message": f"no live session for {issue_id}",
+        }))
+        return
+    try:
+        if typ == "send":
+            text = str(frame.get("text") or "")
+            await handle_send(state, sess, text)
+        elif typ == "quit":
+            await handle_quit(state, sess)
+        elif typ == "close_pane":
+            await handle_close_pane(state, sess, ws)
+        elif typ == "reveal":
+            await handle_reveal(state, sess)
+        elif typ == "refresh":
+            await refresh_one(state, sess)
+        else:
+            await ws.send_str(json.dumps({
+                "type": "error", "code": "bad_type",
+                "message": f"unknown frame type: {typ!r}",
+            }))
+    except Exception as e:
+        log.exception("command %s failed", typ)
+        await ws.send_str(json.dumps({
+            "type": "error", "code": "exception", "issue_id": issue_id,
+            "message": str(e),
+        }))
+
+
+async def handle_send(state: AppState, sess: AgentSession, text: str) -> None:
+    if not text or not sess.tmux_target:
+        return
+    await send_text(sess.tmux_target, text)
+    # Two-Enter quirk (per project memory): capture 100 ms later; if the
+    # input box still echoes the line and there's no spinner, send a single
+    # additional Enter. Single-shot, no loop.
+    await asyncio.sleep(0.1)
+    after = await capture_pane(sess.tmux_target, lines=10)
+    has_spinner = any(c in after for c in SPINNER_CHARS)
+    if (not has_spinner) and text in after:
+        await send_enter(sess.tmux_target)
+    await refresh_one(state, sess)
+
+
+async def handle_quit(state: AppState, sess: AgentSession) -> None:
+    if not sess.tmux_target:
+        return
+    await send_quit(sess.tmux_target)
+    await refresh_one(state, sess)
+
+
+async def handle_close_pane(state: AppState, sess: AgentSession, ws) -> None:
+    if not state.iterm.available:
+        await ws.send_str(json.dumps({
+            "type": "error", "code": "iterm_unavailable", "issue_id": sess.issue_id,
+            "message": "iTerm Python API unavailable — close the pane manually.",
+        }))
+        return
+    closed = await state.iterm.close_pane(sess.issue_id)
+    if not closed:
+        await ws.send_str(json.dumps({
+            "type": "error", "code": "no_pane", "issue_id": sess.issue_id,
+            "message": "no iTerm pane is associated with this issue.",
+        }))
+
+
+async def handle_reveal(_state: AppState, sess: AgentSession) -> None:
+    url = f"obsidian://op-attach-current?id={sess.issue_id}"
+    proc = await asyncio.create_subprocess_exec("open", url)
+    await proc.wait()
+
+
+# ---- Reconciler / poll loop -----------------------------------------------
+
+async def reconcile(state: AppState) -> Tuple[List[AgentSession], List[AgentSession], List[str]]:
+    """Build the in-memory session map from tmux + iTerm + data.json."""
+    tmux_rows = await list_op_agent_windows()
+    iterm_map = await state.iterm.scan()
+    data_json_map: Dict[str, dict] = {}
+    for path in find_data_json_paths():
+        for issue_id, ref in read_orchestrator_state(path).items():
+            data_json_map.setdefault(issue_id, ref)
+
+    seen: Set[str] = set()
+    added: List[AgentSession] = []
+    updated: List[AgentSession] = []
+    now = time.time()
+
+    issue_to_target: Dict[str, str] = {}
+    for session_name, window_name in tmux_rows:
+        # tmuxWindowName(issueId) == slugify(issueId, {allowUnderscore: true}).
+        # For canonical ids like `OP-217`, slug == id; the literal window
+        # name is the issue id when iTerm hasn't tagged the session.
+        issue_id = window_name
+        issue_to_target[issue_id] = f"{session_name}:{window_name}"
+
+    for issue_id, target in issue_to_target.items():
+        seen.add(issue_id)
+        # Prefer iTerm's canonical id if it case-insensitively matches.
+        canonical = next(
+            (k for k in iterm_map if k.lower() == issue_id.lower()),
+            issue_id,
+        )
+        ref = data_json_map.get(canonical, {})
+        agent_id, model, workdir, started_at = extract_agent_meta(ref)
+        candidate = AgentSession(
+            issue_id=canonical,
+            iterm_session_id=iterm_map.get(canonical),
+            tmux_target=target,
+            agent_id=agent_id,
+            model=model,
+            workdir=workdir,
+            started_at=started_at,
+            stale=False,
+        )
+        is_new, sess = state.registry.upsert(candidate)
+        if is_new:
+            sess.started_at = sess.started_at or now
+            added.append(sess)
+        else:
+            updated.append(sess)
+
+    # iTerm-only sessions (tmux window gone): mark stale + exited.
+    for issue_id, uuid in iterm_map.items():
+        if issue_id in seen:
+            continue
+        sess = state.registry.get(issue_id)
+        if sess is None:
+            sess = AgentSession(
+                issue_id=issue_id,
+                iterm_session_id=uuid,
+                tmux_target="",
+                stale=True,
+                state="exited",
+            )
+            sess.started_at = now
+            sess._exited_at = now
+            state.registry.upsert(sess)
+            added.append(sess)
+        else:
+            sess.iterm_session_id = uuid
+            sess.stale = True
+            sess.state = "exited"
+            sess._exited_at = sess._exited_at or now
+            updated.append(sess)
+
+    # Remove tmux+iterm-orphaned sessions after grace window.
+    removed: List[str] = []
+    for issue_id, sess in list(state.registry.sessions.items()):
+        gone_from_tmux = issue_id not in issue_to_target
+        gone_from_iterm = issue_id not in iterm_map
+        if gone_from_tmux and gone_from_iterm:
+            if sess._exited_at is None:
+                sess._exited_at = now
+                sess.state = "exited"
+                if sess not in updated:
+                    updated.append(sess)
+            elif now - sess._exited_at > EXITED_GRACE_S:
+                state.registry.remove(issue_id)
+                removed.append(issue_id)
+
+    return added, updated, removed
+
+
+async def refresh_one(state: AppState, sess: AgentSession) -> None:
+    """Recapture pane + reclassify state for a single session."""
+    if not sess.tmux_target:
+        return
+    capture = await capture_pane(sess.tmux_target)
+    capture_hash = hash(capture)
+    now = time.time()
+    if capture_hash != sess._last_capture_hash and capture:
+        sess.last_activity = now
+        sess._last_capture_hash = capture_hash
+    sess.last_capture = "\n".join(capture.splitlines()[-CAPTURE_DISPLAY_LINES:])
+    last_age = (now - sess.last_activity) if sess.last_activity else 9999.0
+    classifier = AGENT_CLASSIFIERS.get(sess.agent_id, CLAUDE_CLASSIFIER)
+    sess.state = classify_state(capture, last_age, classifier)
+    sess.context_pct = extract_context_pct(capture, classifier)
+    await state.hub.broadcast({"type": "session_updated", "session": sess.to_json()})
+
+
+async def poll_loop(state: AppState) -> None:
+    while not state.shutdown_event.is_set():
+        try:
+            added, _updated, removed = await reconcile(state)
+            for sess in added:
+                await state.hub.broadcast({"type": "session_added", "session": sess.to_json()})
+            for sess in state.registry.values():
+                if sess.tmux_target:
+                    await refresh_one(state, sess)
+            for issue_id in removed:
+                await state.hub.broadcast({"type": "session_removed", "issue_id": issue_id})
+        except Exception:
+            log.exception("poll loop iteration failed")
+        try:
+            await asyncio.wait_for(state.shutdown_event.wait(), timeout=POLL_INTERVAL_S)
+        except asyncio.TimeoutError:
+            pass
+
+
+# ---- main ------------------------------------------------------------------
+
+async def run(args: argparse.Namespace) -> int:
+    # Single-instance probe — fail-fast if another daemon already owns the port.
+    probe = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    try:
+        try:
+            probe.bind((args.host, args.port))
+        except OSError as e:
+            if e.errno in (errno.EADDRINUSE, errno.EACCES):
+                log.error("port %d already in use — another op-dashboard is running.", args.port)
+                return 0
+            raise
+    finally:
+        probe.close()
+
+    try:
+        from aiohttp import web
+    except ImportError:
+        log.error("aiohttp not installed — `pip3 install aiohttp` and restart iTerm.")
+        return 1
+
+    state = AppState(
+        token=generate_token(),
+        started_at=time.time(),
+        registry=SessionRegistry(),
+        hub=Hub(),
+        iterm=ITermBridge(),
+    )
+    write_token(TOKEN_PATH, state.token)
+    log.info("token written to %s (mode 0600)", TOKEN_PATH)
+
+    if not args.no_iterm:
+        await state.iterm.start()
+
+    app = build_app(state)
+    runner = web.AppRunner(app)
+    await runner.setup()
+    site = web.TCPSite(runner, args.host, args.port)
+    await site.start()
+    log.info("op-dashboard %s listening on %s:%d", VERSION, args.host, args.port)
+
+    state.poll_task = asyncio.create_task(poll_loop(state))
+
+    loop = asyncio.get_running_loop()
+    for sig in (signal.SIGINT, signal.SIGTERM):
+        with contextlib.suppress(NotImplementedError):
+            loop.add_signal_handler(sig, lambda: state.shutdown_event.set())
+    await state.shutdown_event.wait()
+    log.info("shutdown signal received — stopping.")
+    if state.poll_task:
+        state.poll_task.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await state.poll_task
+    await state.hub.shutdown()
+    await runner.cleanup()
+    return 0
+
+
+def main() -> int:
+    if sys.platform != "darwin":
+        setup_logging()
+        log.error("op-dashboard is macOS-only (platform=%s) — exiting.", sys.platform)
+        return 0
+    parser = argparse.ArgumentParser(description="op-dashboard daemon")
+    parser.add_argument("--port", type=int, default=DEFAULT_PORT)
+    parser.add_argument("--host", default=DEFAULT_HOST)
+    parser.add_argument("--no-iterm", action="store_true",
+                        help="Skip iTerm Python API (force tmux-only mode).")
+    args = parser.parse_args()
+    setup_logging()
+    return asyncio.run(run(args))
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/plugins/op-obsidian/dashboard/test_op_dashboard.py
+++ b/plugins/op-obsidian/dashboard/test_op_dashboard.py
@@ -260,6 +260,43 @@ class AgentSessionToJsonTests(unittest.TestCase):
         self.assertIsNone(opd.iso(None))
 
 
+class MonotonicAndConcurrencyTests(unittest.TestCase):
+    """Guards for the OP-236 pressure-test fixes (clock-jump + interleaved sends)."""
+
+    def test_agent_session_carries_monotonic_fields(self):
+        # Wall-clock fields stay (serialized to clients); monotonic mirrors
+        # back them for liveness thresholds.
+        s = opd.AgentSession(issue_id="OP-1")
+        self.assertIsNone(s.last_activity)
+        self.assertIsNone(s._last_activity_mono)
+        self.assertIsNone(s._exited_at_mono)
+        # Internal monotonic fields don't leak into the wire format.
+        d = s.to_json()
+        self.assertNotIn("_last_activity_mono", d)
+        self.assertNotIn("_exited_at_mono", d)
+        # The serialized last_activity stays epoch-based.
+        self.assertIn("last_activity", d)
+
+    def test_app_state_carries_tmux_lock(self):
+        import asyncio as _asyncio
+        async def _check():
+            state = opd.AppState(
+                token="t",
+                started_at=0.0,
+                registry=opd.SessionRegistry(),
+                hub=opd.Hub(),
+                iterm=opd.ITermBridge(),
+            )
+            self.assertIsInstance(state.tmux_lock, _asyncio.Lock)
+            # Re-entrant double-acquire blocks — proves it's a real exclusion lock.
+            await state.tmux_lock.acquire()
+            try:
+                self.assertTrue(state.tmux_lock.locked())
+            finally:
+                state.tmux_lock.release()
+        _asyncio.run(_check())
+
+
 class TmuxSessionRegexTests(unittest.TestCase):
     def test_matches(self):
         for s in ["op-agents", "op-agents-1", "op-agents-22", "op-agents-100"]:

--- a/plugins/op-obsidian/dashboard/test_op_dashboard.py
+++ b/plugins/op-obsidian/dashboard/test_op_dashboard.py
@@ -1,0 +1,274 @@
+"""Pure-Python tests for op-dashboard.py — no aiohttp, no iterm2, no tmux.
+
+Run from the repo root with `python3 plugins/op-obsidian/dashboard/test_op_dashboard.py`
+or via `python3 -m unittest discover plugins/op-obsidian/dashboard/`.
+
+These cover the bits the daemon ships that don't require live IPC: regex
+classifiers, tmux output parsing, base64 user-var decoding, token roundtrip,
+and the data.json reader's defensive fallbacks.
+"""
+from __future__ import annotations
+
+import base64
+import importlib.util
+import json
+import os
+import stat
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+spec = importlib.util.spec_from_file_location("op_dashboard", HERE / "op-dashboard.py")
+opd = importlib.util.module_from_spec(spec)  # type: ignore[arg-type]
+sys.modules["op_dashboard"] = opd
+assert spec and spec.loader
+spec.loader.exec_module(opd)  # type: ignore[union-attr]
+
+# Silence the daemon logger during test runs — its warnings on malformed
+# fixtures are expected behavior covered by assertions.
+import logging as _logging
+opd.log.setLevel(_logging.CRITICAL)
+
+
+class TmuxParseTests(unittest.TestCase):
+    def test_parse_list_windows(self):
+        out = "op-agents:OP-217\nop-agents-1:OP-218\nmain:scratch\n"
+        rows = opd.parse_list_windows(out)
+        self.assertEqual(rows, [
+            ("op-agents", "OP-217"),
+            ("op-agents-1", "OP-218"),
+            ("main", "scratch"),
+        ])
+
+    def test_parse_list_windows_skips_blank_and_malformed(self):
+        out = "\n  \nfoo\n:bar\nop-agents:OP-1\n"
+        rows = opd.parse_list_windows(out)
+        # `:bar` parses to ("", "bar") — partition on first `:` gives empty
+        # session; the filter rejects it next.
+        self.assertIn(("op-agents", "OP-1"), rows)
+
+    def test_filter_op_agent_windows(self):
+        rows = [
+            ("op-agents", "OP-1"),
+            ("op-agents-2", "OP-2"),
+            ("op-agents-22", "OP-3"),
+            ("main", "x"),
+            ("op-agents-x", "y"),  # not numeric suffix
+            ("opagents", "z"),
+        ]
+        kept = opd.filter_op_agent_windows(rows)
+        self.assertEqual(kept, [
+            ("op-agents", "OP-1"),
+            ("op-agents-2", "OP-2"),
+            ("op-agents-22", "OP-3"),
+        ])
+
+
+class StateClassifierTests(unittest.TestCase):
+    def setUp(self):
+        self.cls = opd.CLAUDE_CLASSIFIER
+
+    def test_running_when_recent_activity(self):
+        self.assertEqual(opd.classify_state("hello world", 5.0, self.cls), "running")
+
+    def test_idle_when_stale(self):
+        self.assertEqual(opd.classify_state("hello world", 60.0, self.cls), "idle")
+
+    def test_waiting_user_yes_no(self):
+        self.assertEqual(opd.classify_state("Continue? (yes/no)", 5.0, self.cls), "waiting_user")
+
+    def test_waiting_user_y_n(self):
+        self.assertEqual(opd.classify_state("Apply diff (y/n)?", 5.0, self.cls), "waiting_user")
+
+    def test_waiting_user_do_you_want_to(self):
+        self.assertEqual(
+            opd.classify_state("Do you want to proceed", 5.0, self.cls),
+            "waiting_user",
+        )
+
+    def test_waiting_review(self):
+        s = "Polling for Copilot review (attempt 3/12)"
+        self.assertEqual(opd.classify_state(s, 5.0, self.cls), "waiting_review")
+
+    def test_spinner_suppresses_waiting_user(self):
+        # Spinner glyph ⠹ in the tail vetoes waiting_user — agent is mid-thought.
+        s = "⠹ Thinking…\n(yes/no)"
+        self.assertEqual(opd.classify_state(s, 5.0, self.cls), "running")
+
+    def test_context_pct_extraction(self):
+        s = "Context left until auto-compact: 23%"
+        self.assertEqual(opd.extract_context_pct(s, self.cls), 23)
+        self.assertEqual(opd.extract_context_pct("context: 38%", self.cls), 38)
+        self.assertIsNone(opd.extract_context_pct("no context here", self.cls))
+
+    def test_context_pct_clamped(self):
+        s = "context: 999%"
+        # Clamps to 100 (defensive; real Claude won't print >100).
+        self.assertEqual(opd.extract_context_pct(s, self.cls), 100)
+
+
+class UserOpIssueDecodeTests(unittest.TestCase):
+    def test_base64_roundtrip(self):
+        b64 = base64.b64encode(b"OP-217").decode()
+        self.assertEqual(opd.decode_user_op_issue(b64), "OP-217")
+
+    def test_raw_passes_through(self):
+        # `OP-217` is not valid base64 (length 6, non-mult-of-4) → raw fallback.
+        self.assertEqual(opd.decode_user_op_issue("OP-217"), "OP-217")
+
+    def test_empty(self):
+        self.assertIsNone(opd.decode_user_op_issue(""))
+
+    def test_whitespace_stripped(self):
+        self.assertEqual(opd.decode_user_op_issue("  OP-217  "), "OP-217")
+
+    def test_b64_with_padding(self):
+        b64 = base64.b64encode(b"OP-1").decode()
+        self.assertEqual(opd.decode_user_op_issue(b64), "OP-1")
+
+
+class TokenWriteTests(unittest.TestCase):
+    def test_token_persisted_mode_0600(self):
+        with tempfile.TemporaryDirectory() as td:
+            path = Path(td) / "tok"
+            opd.write_token(path, "abc123")
+            mode = stat.S_IMODE(path.stat().st_mode)
+            self.assertEqual(mode, 0o600)
+            self.assertEqual(path.read_text(), "abc123")
+
+    def test_token_overwrite(self):
+        with tempfile.TemporaryDirectory() as td:
+            path = Path(td) / "tok"
+            opd.write_token(path, "first")
+            opd.write_token(path, "second")
+            self.assertEqual(path.read_text(), "second")
+            # Mode preserved across rewrites.
+            self.assertEqual(stat.S_IMODE(path.stat().st_mode), 0o600)
+
+    def test_token_generation_is_unique_and_urlsafe(self):
+        a = opd.generate_token()
+        b = opd.generate_token()
+        self.assertNotEqual(a, b)
+        # token_urlsafe outputs only [A-Za-z0-9_-].
+        self.assertRegex(a, r"^[A-Za-z0-9_\-]+$")
+
+
+class AuthTests(unittest.TestCase):
+    def test_token_ok_constant_time(self):
+        self.assertTrue(opd.token_ok("abc", "abc"))
+        self.assertFalse(opd.token_ok("abc", "abcd"))
+        self.assertFalse(opd.token_ok("", "abc"))
+        self.assertFalse(opd.token_ok("abc", ""))
+
+
+class DataJsonReaderTests(unittest.TestCase):
+    def _write(self, payload):
+        td = tempfile.mkdtemp()
+        path = Path(td) / "data.json"
+        path.write_text(json.dumps(payload))
+        return path
+
+    def test_reads_orchestrator_state(self):
+        path = self._write({
+            "orchestratorState": {
+                "surfaces": {
+                    "OP-217": {"agentId": "claude", "agentMeta": {"model": "claude-sonnet-4-6"}},
+                    "OP-218": {"agentId": "codex"},
+                },
+            },
+        })
+        out = opd.read_orchestrator_state(path)
+        self.assertEqual(set(out.keys()), {"OP-217", "OP-218"})
+        self.assertEqual(out["OP-217"]["agentId"], "claude")
+
+    def test_pre_op217_data_json_yields_empty(self):
+        # Pre-OP-217 data.json has no orchestratorState. Schema-drift test.
+        path = self._write({"someOtherKey": 1})
+        self.assertEqual(opd.read_orchestrator_state(path), {})
+
+    def test_malformed_json_returns_empty(self):
+        td = tempfile.mkdtemp()
+        path = Path(td) / "data.json"
+        path.write_text("not json {")
+        self.assertEqual(opd.read_orchestrator_state(path), {})
+
+    def test_missing_orchestrator_state_returns_empty(self):
+        path = self._write({"orchestratorState": "wrong-type"})
+        self.assertEqual(opd.read_orchestrator_state(path), {})
+
+    def test_extract_agent_meta_defensive(self):
+        # Pre-OP-217 surface ref with no agentMeta → all defaults.
+        agent_id, model, workdir, started = opd.extract_agent_meta({})
+        self.assertEqual(agent_id, "claude")
+        self.assertIsNone(model)
+        self.assertIsNone(workdir)
+        self.assertIsNone(started)
+
+    def test_extract_agent_meta_full(self):
+        ref = {
+            "agentId": "codex",
+            "agentMeta": {
+                "model": "gpt-5",
+                "workdir": "/tmp/wd",
+                "startTime": 1714200000_000,  # epoch ms
+            },
+        }
+        agent_id, model, workdir, started = opd.extract_agent_meta(ref)
+        self.assertEqual(agent_id, "codex")
+        self.assertEqual(model, "gpt-5")
+        self.assertEqual(workdir, "/tmp/wd")
+        self.assertAlmostEqual(started, 1714200000.0, places=3)
+
+
+class SessionRegistryTests(unittest.TestCase):
+    def test_upsert_new_then_merge(self):
+        reg = opd.SessionRegistry()
+        s1 = opd.AgentSession(issue_id="OP-1", tmux_target="op-agents:OP-1")
+        is_new, _ = reg.upsert(s1)
+        self.assertTrue(is_new)
+        # Second upsert with new model — merges, doesn't duplicate.
+        s2 = opd.AgentSession(issue_id="OP-1", tmux_target="op-agents:OP-1", model="claude-sonnet-4-6")
+        is_new, merged = reg.upsert(s2)
+        self.assertFalse(is_new)
+        self.assertEqual(merged.model, "claude-sonnet-4-6")
+        self.assertEqual(len(reg.values()), 1)
+
+    def test_remove(self):
+        reg = opd.SessionRegistry()
+        reg.upsert(opd.AgentSession(issue_id="OP-1"))
+        self.assertIsNotNone(reg.remove("OP-1"))
+        self.assertIsNone(reg.get("OP-1"))
+
+
+class AgentSessionToJsonTests(unittest.TestCase):
+    def test_to_json_excludes_internals(self):
+        s = opd.AgentSession(issue_id="OP-1", tmux_target="op-agents:OP-1")
+        s._last_capture_hash = 1234
+        s._exited_at = 1000.0
+        d = s.to_json()
+        self.assertNotIn("_last_capture_hash", d)
+        self.assertNotIn("_exited_at", d)
+        self.assertEqual(d["issue_id"], "OP-1")
+
+    def test_iso_serialization(self):
+        ts = 1714200000.0
+        out = opd.iso(ts)
+        self.assertIsNotNone(out)
+        self.assertTrue(out.endswith("+00:00"))
+        self.assertIsNone(opd.iso(None))
+
+
+class TmuxSessionRegexTests(unittest.TestCase):
+    def test_matches(self):
+        for s in ["op-agents", "op-agents-1", "op-agents-22", "op-agents-100"]:
+            self.assertIsNotNone(opd.TMUX_SESSION_RE.match(s))
+
+    def test_rejects(self):
+        for s in ["op-agent", "op-agentsx", "op-agents-", "op-agents-1a", "main"]:
+            self.assertIsNone(opd.TMUX_SESSION_RE.match(s))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/plugins/op-obsidian/manifest.json
+++ b/plugins/op-obsidian/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "op-obsidian",
   "name": "Obsidian Projects (op)",
-  "version": "0.80.1",
+  "version": "0.80.2",
   "minAppVersion": "1.5.0",
   "description": "Jira-lite issue tracker for Obsidian vaults — deterministic commands backing the op workflow.",
   "author": "Eugene Archibald",

--- a/plugins/op-obsidian/package.json
+++ b/plugins/op-obsidian/package.json
@@ -1,6 +1,6 @@
 {
   "name": "op-obsidian",
-  "version": "0.80.1",
+  "version": "0.80.2",
   "description": "Obsidian plugin that owns the deterministic half of the op workflow.",
   "main": "main.js",
   "scripts": {

--- a/plugins/op/.claude-plugin/plugin.json
+++ b/plugins/op/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "op",
   "description": "Obsidian Projects workflow — schema, slash commands, and agent skill for running a Jira-lite issue tracker inside an Obsidian vault.",
-  "version": "0.80.1",
+  "version": "0.80.2",
   "author": {
     "name": "Eugene Archibald"
   },


### PR DESCRIPTION
## Summary

Single-file Python daemon at `plugins/op-obsidian/dashboard/op-dashboard.py` that ships the daemon half of the OP-217 agent dashboard. Closes the OP-230 child of the umbrella ticket; siblings (OP-231 SPA, OP-232 command + modal, OP-233 instrumentation, OP-234 metadata, OP-235 settings) ship separately.

- HTTP `/` (diagnostic placeholder until OP-231) + `/healthz` (token-gated) + WebSocket `/ws` (close 4401 on token mismatch) with the spec's frame schema.
- Identity correlation via the union of iTerm `user.op_issue` (base64 decode + raw fallback) and tmux `op-agents(-N)?:<sanitized-id>` windows. `data.json` `orchestratorState` reading is opt-in (env var or sibling config file) and degrades cleanly on pre-OP-217 schemas.
- Token regenerated on startup, persisted 0600 via atomic rename to `AutoLaunch/op-dashboard.token`. Single-instance port bind probe; macOS-only platform gate.
- Graceful tmux-only fallback when `iterm2.Connection.async_create()` fails: `close_pane` returns an `iterm_unavailable` error frame, the SPA can show the row, all other commands work.
- Two-Enter quirk handled daemon-side (capture + spinner check after the first Enter).
- Patch-bump only — daemon ships as an unloaded static asset; user-visible behavior arrives with OP-232.

## Test plan

- [x] `python3 plugins/op-obsidian/dashboard/test_op_dashboard.py` — 33/33 pass (regex classifiers, tmux output parser, base64 decoder, token writer roundtrip, data.json defensive reader, pre-OP-217 schema-drift fixture).
- [x] `node scripts/bump-version.mjs 0.80.1` — manifest/package/plugin in lockstep, `main.js` fresher than manifest.
- [x] `node scripts/dev-sync.mjs` + `obsidian vault=OP-Test eval` — plugin reloads at 0.80.1, no console errors.
- [ ] End-to-end smoke (daemon up, browser tab live, send/quit/close round-trip, token rotation) — gated to OP-236 per the umbrella spec.

🤖 Generated with [Claude Code](https://claude.com/claude-code)