### PR TITLE
OP-244: fix Copilot agent launch

### DIFF
--- a/plugins/op-obsidian/manifest.json
+++ b/plugins/op-obsidian/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "op-obsidian",
   "name": "Obsidian Projects (op)",
-  "version": "0.84.0",
+  "version": "0.84.1",
   "minAppVersion": "1.5.0",
   "description": "Jira-lite issue tracker for Obsidian vaults — deterministic commands backing the op workflow.",
   "author": "Eugene Archibald",

--- a/plugins/op-obsidian/package.json
+++ b/plugins/op-obsidian/package.json
@@ -1,6 +1,6 @@
 {
   "name": "op-obsidian",
-  "version": "0.84.0",
+  "version": "0.84.1",
   "description": "Obsidian plugin that owns the deterministic half of the op workflow.",
   "main": "main.js",
   "scripts": {

--- a/plugins/op-obsidian/src/terminalLaunch.test.ts
+++ b/plugins/op-obsidian/src/terminalLaunch.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from "vitest";
 import {
   SHARED_TMUX_SESSION,
+  buildAgentExecCommand,
   buildITermAttachCommand,
   buildInnerScript,
   buildPrepScript,
@@ -193,5 +194,34 @@ describe("buildITermAttachCommand", () => {
   it("escapes embedded single quotes in the binary path", () => {
     const out = buildITermAttachCommand("/path/with'quote/tmux", "op-agents");
     expect(out).toBe(`'/path/with'\\''quote/tmux' -CC attach -t 'op-agents'`);
+  });
+});
+
+describe("buildAgentExecCommand", () => {
+  it("passes the prompt positionally for claude-style CLIs", () => {
+    expect(buildAgentExecCommand({
+      agentId: "claude",
+      binary: "claude",
+      launchFlags: ["--permission-mode", "auto"],
+      promptRef: '"$PROMPT"',
+    })).toBe("'claude' '--permission-mode' 'auto' \"$PROMPT\"");
+  });
+
+  it("uses copilot's interactive prompt flag", () => {
+    expect(buildAgentExecCommand({
+      agentId: "copilot",
+      binary: "copilot",
+      launchFlags: ["--model", "gpt-5"],
+      promptRef: '"$PROMPT"',
+    })).toBe("'copilot' '--model' 'gpt-5' -i \"$PROMPT\"");
+  });
+
+  it("omits prompt wiring in debug launches", () => {
+    expect(buildAgentExecCommand({
+      agentId: "copilot",
+      binary: "copilot",
+      launchFlags: [],
+      promptRef: "",
+    })).toBe("'copilot'");
   });
 });

--- a/plugins/op-obsidian/src/terminalLaunch.ts
+++ b/plugins/op-obsidian/src/terminalLaunch.ts
@@ -77,6 +77,13 @@ export interface LaunchResult {
   tmuxWindow: string;
 }
 
+interface BuildAgentExecCommandArgs {
+  agentId: string;
+  binary: string;
+  launchFlags: string[];
+  promptRef: string;
+}
+
 export async function launchInTerminal(args: LaunchArgs): Promise<LaunchResult> {
   if (process.platform !== "darwin") {
     throw new Error(`op: terminal launch currently supports macOS only (platform=${process.platform})`);
@@ -257,9 +264,7 @@ interface InnerScriptArgs {
 // binary. Pure string-building — no fs — so it's exercised by unit tests
 // without touching disk.
 export function buildInnerScript({ args, promptPath }: InnerScriptArgs): string {
-  const flagsShell = args.launchFlags.map(shSingleQuote).join(" ");
   const cwdShell = shSingleQuote(args.cwd);
-  const binShell = shSingleQuote(args.binary);
   const promptShell = shSingleQuote(promptPath);
   const agentIdShell = shSingleQuote(args.agentId);
 
@@ -299,12 +304,22 @@ export function buildInnerScript({ args, promptPath }: InnerScriptArgs): string 
     // while a human drives the session.
     innerLines.push(
       `echo "[op] debug agent launch — no prompt (issue=${args.issueId ?? "<none>"} agent=${args.agentId})"`,
-      `exec ${binShell} ${flagsShell}`,
+      `exec ${buildAgentExecCommand({
+        agentId: args.agentId,
+        binary: args.binary,
+        launchFlags: args.launchFlags,
+        promptRef: "",
+      })}`,
     );
   } else {
     innerLines.push(
       `PROMPT=$(<${promptShell})`,
-      `exec ${binShell} ${flagsShell} "$PROMPT"`,
+      `exec ${buildAgentExecCommand({
+        agentId: args.agentId,
+        binary: args.binary,
+        launchFlags: args.launchFlags,
+        promptRef: '"$PROMPT"',
+      })}`,
     );
   }
   innerLines.push("");
@@ -346,6 +361,26 @@ export function buildPrepScript({ tmuxBinary, session, windowName, innerPath }: 
 // a session name with shell metacharacters are still safe.
 export function buildITermAttachCommand(tmuxBinary: string, session: string): string {
   return `${shSingleQuote(tmuxBinary)} -CC attach -t ${shSingleQuote(session)}`;
+}
+
+export function buildAgentExecCommand({
+  agentId,
+  binary,
+  launchFlags,
+  promptRef,
+}: BuildAgentExecCommandArgs): string {
+  const parts = [
+    shSingleQuote(binary),
+    ...launchFlags.map(shSingleQuote),
+  ];
+  if (promptRef) {
+    if (agentId === "copilot") {
+      parts.push("-i", promptRef);
+    } else {
+      parts.push(promptRef);
+    }
+  }
+  return parts.join(" ");
 }
 
 // Sanitize arbitrary text into a tmux-safe window name. tmux uses `:`

--- a/plugins/op/.claude-plugin/plugin.json
+++ b/plugins/op/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "op",
   "description": "Obsidian Projects workflow — schema, slash commands, and agent skill for running a Jira-lite issue tracker inside an Obsidian vault.",
-  "version": "0.84.0",
+  "version": "0.84.1",
   "author": {
     "name": "Eugene Archibald"
   },


### PR DESCRIPTION
## Summary
- use a Copilot-specific interactive launch command instead of passing the prompt positionally
- add terminal launch coverage for Copilot prompt wiring
- bump the plugin release version to 0.84.1

## Validation
- npm run build
- npx vitest run src/terminalLaunch.test.ts src/terminalLaunch.backgroundLaunch.test.ts
- OP-Test smoke: op-open-agent -> copilot for TST-1