### PR TITLE
OP-244: ship Copilot launch hotfix

### DIFF
--- a/plugins/op-obsidian/manifest.json
+++ b/plugins/op-obsidian/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "op-obsidian",
   "name": "Obsidian Projects (op)",
-  "version": "0.84.1",
+  "version": "0.84.2",
   "minAppVersion": "1.5.0",
   "description": "Jira-lite issue tracker for Obsidian vaults — deterministic commands backing the op workflow.",
   "author": "Eugene Archibald",

--- a/plugins/op-obsidian/package.json
+++ b/plugins/op-obsidian/package.json
@@ -1,6 +1,6 @@
 {
   "name": "op-obsidian",
-  "version": "0.84.1",
+  "version": "0.84.2",
   "description": "Obsidian plugin that owns the deterministic half of the op workflow.",
   "main": "main.js",
   "scripts": {

--- a/plugins/op-obsidian/src/terminalLaunch.test.ts
+++ b/plugins/op-obsidian/src/terminalLaunch.test.ts
@@ -178,6 +178,19 @@ describe("buildInnerScript — OSC 1337 SetUserVar=op_issue (OP-233)", () => {
     expect(oscIdx).toBeGreaterThan(0);
     expect(execIdx).toBeGreaterThan(oscIdx);
   });
+
+  it("uses copilot's -i form in the actual generated inner script", () => {
+    const s = buildInnerScript({
+      args: makeArgs({
+        issueId: "OP-244",
+        agentId: "copilot",
+        binary: "/opt/homebrew/bin/copilot",
+      }),
+      promptPath: "/tmp/op-agent-xyz/prompt.txt",
+    });
+    expect(s).toContain(`exec '/opt/homebrew/bin/copilot' -i "$PROMPT"`);
+    expect(s).not.toContain(`exec '/opt/homebrew/bin/copilot'  "$PROMPT"`);
+  });
 });
 
 describe("buildITermAttachCommand", () => {

--- a/plugins/op/.claude-plugin/plugin.json
+++ b/plugins/op/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "op",
   "description": "Obsidian Projects workflow — schema, slash commands, and agent skill for running a Jira-lite issue tracker inside an Obsidian vault.",
-  "version": "0.84.1",
+  "version": "0.84.2",
   "author": {
     "name": "Eugene Archibald"
   },


### PR DESCRIPTION
## Summary
- cut a corrective 0.84.2 release because the 0.84.1 BRAT bundle still launched Copilot with a positional prompt
- add a regression test on the generated inner script for Copilot
- verify the iTerm launch path now emits `copilot -i "$PROMPT"`

## Validation
- npx vitest run src/terminalLaunch.test.ts src/terminalLaunch.backgroundLaunch.test.ts
- OP-Test iTerm smoke: generated `agent.command` uses `copilot -i "$PROMPT"`