### PR TITLE
OP-244: fix orchestrated Copilot launch

### DIFF
--- a/plugins/op-obsidian/manifest.json
+++ b/plugins/op-obsidian/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "op-obsidian",
   "name": "Obsidian Projects (op)",
-  "version": "0.84.2",
+  "version": "0.84.3",
   "minAppVersion": "1.5.0",
   "description": "Jira-lite issue tracker for Obsidian vaults — deterministic commands backing the op workflow.",
   "author": "Eugene Archibald",

--- a/plugins/op-obsidian/package.json
+++ b/plugins/op-obsidian/package.json
@@ -1,6 +1,6 @@
 {
   "name": "op-obsidian",
-  "version": "0.84.2",
+  "version": "0.84.3",
   "description": "Obsidian plugin that owns the deterministic half of the op workflow.",
   "main": "main.js",
   "scripts": {

--- a/plugins/op-obsidian/src/agentProfiles.test.ts
+++ b/plugins/op-obsidian/src/agentProfiles.test.ts
@@ -73,6 +73,21 @@ describe("launchFlagsFor (claude base profile)", () => {
   });
 });
 
+describe("launchFlagsFor (copilot base profile)", () => {
+  const p = BASE_PROFILES.copilot;
+
+  it("uses autopilot + allow-all for implement and work launches", () => {
+    expect(launchFlagsFor(p, "implement")).toEqual(["--autopilot", "--allow-all"]);
+    expect(launchFlagsFor(p, "work")).toEqual(["--autopilot", "--allow-all"]);
+  });
+
+  it("keeps autopilot + allow-all on mode-specific launches too", () => {
+    for (const mode of ["evaluate", "plan", "review", "finalize"] as const) {
+      expect(launchFlagsFor(p, mode)).toEqual(["--autopilot", "--allow-all"]);
+    }
+  });
+});
+
 describe("promptPreambleFor (claude base profile)", () => {
   const p = BASE_PROFILES.claude;
 
@@ -144,6 +159,6 @@ describe("BASE_PROFILES sanity", () => {
   it("only claude ships custom-agent launch flags out of the box", () => {
     expect(BASE_PROFILES.claude.evaluateLaunchFlags.length).toBeGreaterThan(0);
     expect(BASE_PROFILES.gemini.evaluateLaunchFlags).toEqual([]);
-    expect(BASE_PROFILES.copilot.evaluateLaunchFlags).toEqual([]);
+    expect(BASE_PROFILES.copilot.evaluateLaunchFlags).toEqual(["--autopilot", "--allow-all"]);
   });
 });

--- a/plugins/op-obsidian/src/agentProfiles.ts
+++ b/plugins/op-obsidian/src/agentProfiles.ts
@@ -105,6 +105,7 @@ const CLAUDE_FINALIZE_LAUNCH_FLAGS = claudeAgentLaunchFlags(
   CLAUDE_FINALIZE_AGENT_NAME,
   CLAUDE_FINALIZE_AGENT_DEFINITION,
 );
+const COPILOT_LAUNCH_FLAGS = ["--autopilot", "--allow-all"];
 
 /**
  * Modes an agent session can launch in. `"work"` is a deprecated alias for
@@ -229,11 +230,11 @@ export const BASE_PROFILES: Readonly<Record<AgentId, AgentProfile>> = Object.fre
     id: "copilot",
     label: "Copilot CLI",
     binary: "copilot",
-    launchFlags: [],
-    evaluateLaunchFlags: [],
-    planLaunchFlags: [],
-    reviewLaunchFlags: [],
-    finalizeLaunchFlags: [],
+    launchFlags: [...COPILOT_LAUNCH_FLAGS],
+    evaluateLaunchFlags: [...COPILOT_LAUNCH_FLAGS],
+    planLaunchFlags: [...COPILOT_LAUNCH_FLAGS],
+    reviewLaunchFlags: [...COPILOT_LAUNCH_FLAGS],
+    finalizeLaunchFlags: [...COPILOT_LAUNCH_FLAGS],
     promptPreamble: DEFAULT_PREAMBLE,
     evaluatePromptPreamble: DEFAULT_EVALUATE_PREAMBLE,
     planPromptPreamble: DEFAULT_PLAN_PREAMBLE,

--- a/plugins/op-obsidian/src/orchestrator.test.ts
+++ b/plugins/op-obsidian/src/orchestrator.test.ts
@@ -62,6 +62,20 @@ describe("buildAgentInnerScript — OSC 1337 SetUserVar=op_issue (OP-233)", () =
     expect(oscIdx).toBeGreaterThan(0);
     expect(execIdx).toBeGreaterThan(oscIdx);
   });
+
+  it("uses copilot's interactive prompt flag in orchestrated launches", () => {
+    const s = buildAgentInnerScript({
+      args: makeOrchArgs({
+        issueId: "OP-244",
+        agentId: "copilot",
+        binary: "/opt/homebrew/bin/copilot",
+        launchFlags: ["--autopilot", "--allow-all"],
+      }),
+      promptPath: "/tmp/op-agent-xyz/prompt.txt",
+    });
+    expect(s).toContain(`exec '/opt/homebrew/bin/copilot' '--autopilot' '--allow-all' -i "$PROMPT"`);
+    expect(s).not.toContain(`exec '/opt/homebrew/bin/copilot' '--autopilot' '--allow-all' "$PROMPT"`);
+  });
 });
 
 describe("firstEmptyCell", () => {

--- a/plugins/op-obsidian/src/orchestrator.ts
+++ b/plugins/op-obsidian/src/orchestrator.ts
@@ -16,7 +16,7 @@ import {
   setWindowName,
   splitSession,
 } from "./iterm/driver";
-import { buildPrepScript, tmuxWindowName } from "./terminalLaunch";
+import { buildAgentExecCommand, buildPrepScript, tmuxWindowName } from "./terminalLaunch";
 
 const pExecFile = promisify(execFile);
 
@@ -419,9 +419,7 @@ export function buildAgentInnerScript({
   args: OrchestrateArgs;
   promptPath: string;
 }): string {
-  const flagsShell = args.launchFlags.map(shSingleQuote).join(" ");
   const cwdShell = shSingleQuote(args.cwd);
-  const binShell = shSingleQuote(args.binary);
   const promptShell = shSingleQuote(promptPath);
   const issueIdShell = shSingleQuote(args.issueId);
   const agentIdShell = shSingleQuote(args.agentId);
@@ -449,7 +447,15 @@ export function buildAgentInnerScript({
       `exec "$SHELL" -l`,
     );
   } else {
-    lines.push(`PROMPT=$(<${promptShell})`, `exec ${binShell} ${flagsShell} "$PROMPT"`);
+    lines.push(
+      `PROMPT=$(<${promptShell})`,
+      `exec ${buildAgentExecCommand({
+        agentId: args.agentId,
+        binary: args.binary,
+        launchFlags: args.launchFlags,
+        promptRef: '"$PROMPT"',
+      })}`,
+    );
   }
   lines.push("");
   return lines.join("\n");

--- a/plugins/op/.claude-plugin/plugin.json
+++ b/plugins/op/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "op",
   "description": "Obsidian Projects workflow — schema, slash commands, and agent skill for running a Jira-lite issue tracker inside an Obsidian vault.",
-  "version": "0.84.2",
+  "version": "0.84.3",
   "author": {
     "name": "Eugene Archibald"
   },


### PR DESCRIPTION
## Summary
- route orchestrated Copilot launches through the shared agent exec builder so iTerm uses `copilot -i` too
- default Copilot launches to `--autopilot --allow-all` across all launch modes
- add regression coverage for the orchestrator and Copilot profile flags

## Validation
- CI=1 npx vitest run src/terminalLaunch.test.ts
- CI=1 npx vitest run src/orchestrator.test.ts
- CI=1 npx vitest run src/agentProfiles.test.ts
- CI=1 npm test *(known pre-existing failure remains in `src/iTermPrefs.test.ts` resolving `obsidian`)*
- npm run build
- node scripts/dev-sync.mjs
- OP-Test smoke: launched `handleOpOpenAgentUri({id:"TST-1",agent:"copilot",mode:"implement"})`, confirmed generated `agent.command` uses `copilot --autopilot --allow-all -i "$PROMPT"`, and verified tmux pane stays alive with `pane_current_command=copilot`