### PR TITLE
OP-240: ship dashboard release bundle

### DIFF
--- a/.github/workflows/op-obsidian-release.yml
+++ b/.github/workflows/op-obsidian-release.yml
@@ -72,6 +72,10 @@ jobs:
         working-directory: plugins/op-obsidian
         run: npm run build
 
+      - name: Prepare release bundle
+        if: steps.guard.outputs.skip == 'false'
+        run: node scripts/prepare-op-obsidian-release.mjs
+
       - name: Create and push tag
         if: steps.guard.outputs.skip == 'false'
         env:
@@ -93,4 +97,6 @@ jobs:
             --title "op-obsidian v$VERSION" \
             --generate-notes \
             plugins/op-obsidian/main.js \
-            plugins/op-obsidian/manifest.json
+            plugins/op-obsidian/manifest.json \
+            plugins/op-obsidian/styles.css \
+            plugins/op-obsidian/.release/op-obsidian.zip

--- a/docs/specs/OP-29-community-plugin-submission.md
+++ b/docs/specs/OP-29-community-plugin-submission.md
@@ -14,12 +14,13 @@ Reference: https://docs.obsidian.md/Plugins/Releasing/Submit+your+plugin
 - [ ] `versions.json` — add a row for each `manifest.json` version that bumped `minAppVersion`.
 - [ ] LICENSE — confirm MIT (matches `package.json`).
 - [ ] README.md — top-level install / usage section. Current README needs a community-store-facing rewrite: what it does, screenshots, settings overview, known limitations (macOS-only agent launcher).
-- [ ] `main.js`, `manifest.json`, `styles.css` committed or shipped via GitHub release assets.
+- [ ] `main.js`, `manifest.json`, `styles.css`, and `op-obsidian.zip` committed or shipped via GitHub release assets. The zip must preserve `dashboard/op-dashboard.py` (and its sibling `dashboard/client/index.html`) under the installed plugin root.
 
 ## GitHub release
 
 - [ ] Tag matches `manifest.json` version exactly (no `v` prefix — the reviewer bot is strict).
-- [ ] Release assets: `main.js`, `manifest.json`, `styles.css`.
+- [ ] Release assets: `main.js`, `manifest.json`, `styles.css`, `op-obsidian.zip`.
+- [ ] `op-obsidian.zip` contains `dashboard/op-dashboard.py` and `dashboard/client/index.html` under the `op-obsidian/` root — do not flatten or omit the `dashboard/` subtree.
 - [ ] Release notes summarise user-visible changes.
 
 ## Screenshots (for README + submission PR)

--- a/plugins/op-obsidian/.gitignore
+++ b/plugins/op-obsidian/.gitignore
@@ -1,5 +1,6 @@
 node_modules/
 main.js
 main.js.map
+.release/
 *.log
 dashboard/__pycache__/

--- a/plugins/op-obsidian/README.md
+++ b/plugins/op-obsidian/README.md
@@ -20,7 +20,7 @@ The plugin is the typed, in-vault half of the [`op` workflow](../op/). The paire
 2. `BRAT → Add Beta Plugin with frozen version` → `https://github.com/earchibald/obsidian-projects` → pick the latest `op-obsidian-v*` tag.
 3. Enable **Obsidian Projects (op)** under `Settings → Community plugins`.
 
-BRAT will track the monorepo's `op-obsidian-v*` release tags and pull `main.js` + `manifest.json` automatically.
+BRAT will track the monorepo's `op-obsidian-v*` release tags and pull `main.js`, `manifest.json`, and `styles.css` automatically. The release job also publishes `op-obsidian.zip`, which preserves the runtime `dashboard/` tree for manual installs and release validation.
 
 ### From source
 
@@ -31,7 +31,7 @@ npm install
 npm run build
 ```
 
-Then copy `main.js` and `manifest.json` into `<vault>/.obsidian/plugins/op-obsidian/` and enable the plugin. The repo's `CLAUDE.md` documents the exact reload dance used during development.
+Then copy `main.js`, `manifest.json`, `styles.css`, and the `dashboard/` folder into `<vault>/.obsidian/plugins/op-obsidian/` and enable the plugin. The repo's `CLAUDE.md` documents the exact reload dance used during development.
 
 ## Command reference
 

--- a/plugins/op-obsidian/manifest.json
+++ b/plugins/op-obsidian/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "op-obsidian",
   "name": "Obsidian Projects (op)",
-  "version": "0.85.1",
+  "version": "0.85.2",
   "minAppVersion": "1.5.0",
   "description": "Jira-lite issue tracker for Obsidian vaults — deterministic commands backing the op workflow.",
   "author": "Eugene Archibald",

--- a/plugins/op-obsidian/package.json
+++ b/plugins/op-obsidian/package.json
@@ -1,6 +1,6 @@
 {
   "name": "op-obsidian",
-  "version": "0.85.1",
+  "version": "0.85.2",
   "description": "Obsidian plugin that owns the deterministic half of the op workflow.",
   "main": "main.js",
   "scripts": {

--- a/plugins/op/.claude-plugin/plugin.json
+++ b/plugins/op/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "op",
   "description": "Obsidian Projects workflow — schema, slash commands, and agent skill for running a Jira-lite issue tracker inside an Obsidian vault.",
-  "version": "0.85.1",
+  "version": "0.85.2",
   "author": {
     "name": "Eugene Archibald"
   },

--- a/scripts/prepare-op-obsidian-release.mjs
+++ b/scripts/prepare-op-obsidian-release.mjs
@@ -1,0 +1,87 @@
+#!/usr/bin/env node
+
+import { cpSync, existsSync, mkdirSync, rmSync, statSync } from "node:fs";
+import { spawnSync } from "node:child_process";
+import { dirname, join, relative } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const root = join(here, "..");
+const pluginDir = join(root, "plugins/op-obsidian");
+const releaseDir = join(pluginDir, ".release");
+const bundleDir = join(releaseDir, "op-obsidian");
+const bundleZip = join(releaseDir, "op-obsidian.zip");
+
+const bundleAssets = [
+  "main.js",
+  "manifest.json",
+  "styles.css",
+  "dashboard/op-dashboard.py",
+  "dashboard/client/index.html",
+];
+
+for (const relPath of bundleAssets) {
+  const absPath = join(pluginDir, relPath);
+  if (!existsSync(absPath)) {
+    console.error(`prepare-op-obsidian-release: missing required asset ${relative(root, absPath)}`);
+    process.exit(1);
+  }
+  if (!statSync(absPath).isFile()) {
+    console.error(`prepare-op-obsidian-release: expected file, found non-file at ${relative(root, absPath)}`);
+    process.exit(1);
+  }
+}
+
+rmSync(releaseDir, { recursive: true, force: true });
+mkdirSync(bundleDir, { recursive: true });
+
+for (const relPath of bundleAssets) {
+  const destPath = join(bundleDir, relPath);
+  mkdirSync(dirname(destPath), { recursive: true });
+  cpSync(join(pluginDir, relPath), destPath);
+}
+
+const zip = spawnSync("zip", ["-qr", bundleZip, "op-obsidian"], {
+  cwd: releaseDir,
+  stdio: "inherit",
+});
+if (zip.status !== 0) {
+  process.exit(zip.status ?? 1);
+}
+
+const list = spawnSync(
+  "python3",
+  [
+    "-c",
+    "import sys, zipfile\nwith zipfile.ZipFile(sys.argv[1]) as zf:\n    print('\\n'.join(zf.namelist()))\n",
+    bundleZip,
+  ],
+  {
+    cwd: releaseDir,
+    encoding: "utf8",
+  },
+);
+if (list.status !== 0) {
+  process.stderr.write(list.stderr ?? "");
+  process.exit(list.status ?? 1);
+}
+
+const zipEntries = new Set(
+  list.stdout
+    .split("\n")
+    .map((line) => line.trim())
+    .filter(Boolean),
+);
+
+for (const relPath of bundleAssets) {
+  const zipPath = `op-obsidian/${relPath}`;
+  if (!zipEntries.has(zipPath)) {
+    console.error(`prepare-op-obsidian-release: bundle zip is missing ${zipPath}`);
+    process.exit(1);
+  }
+}
+
+console.log(`prepare-op-obsidian-release: wrote ${relative(root, bundleZip)}`);
+for (const relPath of bundleAssets) {
+  console.log(`  - ${relPath}`);
+}


### PR DESCRIPTION
## Summary
- add a release-bundle prep step that validates and zips the plugin runtime layout
- publish styles.css and op-obsidian.zip as release assets
- document the required dashboard subtree in release prep docs

## Testing
- npm run build
- python3 plugins/op-obsidian/dashboard/test_op_dashboard.py
- node scripts/prepare-op-obsidian-release.mjs
- node scripts/dev-sync.mjs + OP-Test plugin load smoke

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>