### PR TITLE
OP-240: embed dashboard installer assets

### DIFF
--- a/docs/specs/OP-217-agent-dashboard.md
+++ b/docs/specs/OP-217-agent-dashboard.md
@@ -57,7 +57,7 @@ The iTerm2 control protocol is exposed exclusively through the official `iterm2`
 The daemon is **opt-in.** First-time setup is initiated by the user running `op-dashboard` (palette or URI). If neither the iTerm browser plugin nor the daemon is detected, the plugin opens a Setup modal that:
 
 1. Detects whether `iTermBrowserPlugin` is installed; if not, links to `brew install --cask itermbrowserplugin` with a copy-to-clipboard button.
-2. Detects whether `op-dashboard.py` exists in `~/Library/ApplicationSupport/iTerm2/Scripts/AutoLaunch/`; if not, offers an "Install daemon" button that copies the bundled script (shipped under `plugins/op-obsidian/dashboard/op-dashboard.py`) into that folder and prompts the user to restart iTerm2.
+2. Detects whether `op-dashboard.py` exists in `~/Library/ApplicationSupport/iTerm2/Scripts/AutoLaunch/`; if not, offers an "Install daemon" button that installs the bundled daemon payload plus `client/index.html` into that folder and prompts the user to restart iTerm2.
 3. Detects whether the daemon is running on its configured port; if not, instructs the user to restart iTerm2 (or to run the daemon manually for one session via the `Run` menu in iTerm Scripts).
 
 We never silently drop a Python file into the user's iTerm Scripts folder.

--- a/plugins/op-obsidian/dashboard/README.md
+++ b/plugins/op-obsidian/dashboard/README.md
@@ -5,9 +5,9 @@ and a localhost web server. Powers the agent dashboard described in
 [`docs/specs/OP-217-agent-dashboard.md`](../../../docs/specs/OP-217-agent-dashboard.md).
 
 This directory ships the daemon source. The plugin's Setup modal (OP-232)
-copies `op-dashboard.py` into
+installs `op-dashboard.py` plus its sibling `client/index.html` into
 `~/Library/Application Support/iTerm2/Scripts/AutoLaunch/` — never silently;
-the user is always prompted before the file lands. iTerm2 starts the daemon
+the user is always prompted before the files land. iTerm2 starts the daemon
 on launch and on every restart.
 
 ## Runtime requirements
@@ -34,6 +34,7 @@ missing.
 | Path | Purpose |
 |---|---|
 | `~/Library/Application Support/iTerm2/Scripts/AutoLaunch/op-dashboard.py` | The daemon itself (copied here by OP-232). |
+| `~/Library/Application Support/iTerm2/Scripts/AutoLaunch/client/index.html` | The dashboard SPA served by the daemon at `/`. |
 | `~/Library/Application Support/iTerm2/Scripts/AutoLaunch/op-dashboard.token` | Auth token, regenerated on startup, mode 0600. |
 | `~/Library/Application Support/iTerm2/Scripts/AutoLaunch/op-dashboard.config.json` | Optional config. Currently honors `vault_data_paths: [...]` for `data.json` discovery. |
 | `~/Library/Logs/op-dashboard.log` | Rotating log (1 MB × 3 backups). |

--- a/plugins/op-obsidian/esbuild.config.mjs
+++ b/plugins/op-obsidian/esbuild.config.mjs
@@ -31,7 +31,7 @@ const context = await esbuild.context({
   outfile: "main.js",
   platform: "node",
   minify: prod,
-  loader: { ".md": "text" },
+  loader: { ".md": "text", ".html": "text", ".py": "text" },
 });
 
 if (prod) {

--- a/plugins/op-obsidian/manifest.json
+++ b/plugins/op-obsidian/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "op-obsidian",
   "name": "Obsidian Projects (op)",
-  "version": "0.85.2",
+  "version": "0.85.3",
   "minAppVersion": "1.5.0",
   "description": "Jira-lite issue tracker for Obsidian vaults — deterministic commands backing the op workflow.",
   "author": "Eugene Archibald",

--- a/plugins/op-obsidian/package.json
+++ b/plugins/op-obsidian/package.json
@@ -1,6 +1,6 @@
 {
   "name": "op-obsidian",
-  "version": "0.85.2",
+  "version": "0.85.3",
   "description": "Obsidian plugin that owns the deterministic half of the op workflow.",
   "main": "main.js",
   "scripts": {

--- a/plugins/op-obsidian/src/dashboardBundledAssets.ts
+++ b/plugins/op-obsidian/src/dashboardBundledAssets.ts
@@ -1,0 +1,14 @@
+import daemonSource from "../dashboard/op-dashboard.py";
+import clientIndexHtml from "../dashboard/client/index.html";
+
+export interface BundledDashboardAssets {
+  sourceLabel: string;
+  daemonContent: string;
+  clientContent: string;
+}
+
+export const BUNDLED_DASHBOARD_ASSETS: BundledDashboardAssets = {
+  sourceLabel: "Embedded in the plugin bundle (`dashboard/op-dashboard.py` + `dashboard/client/index.html`)",
+  daemonContent: daemonSource,
+  clientContent: clientIndexHtml,
+};

--- a/plugins/op-obsidian/src/dashboardInstall.test.ts
+++ b/plugins/op-obsidian/src/dashboardInstall.test.ts
@@ -7,7 +7,6 @@ import {
 import { tmpdir } from "node:os";
 import * as path from "node:path";
 import {
-  bundledDaemonSource,
   formatUptime,
   getDashboardLogPath,
   probeDaemonStatus,
@@ -18,18 +17,6 @@ describe("getDashboardLogPath", () => {
   it("derives the macOS Library/Logs path from a home dir", () => {
     expect(getDashboardLogPath("/home/me")).toBe(
       "/home/me/Library/Logs/op-dashboard.log",
-    );
-  });
-});
-
-describe("bundledDaemonSource", () => {
-  it("joins the plugin dir with dashboard/op-dashboard.py", () => {
-    const src = bundledDaemonSource({
-      pluginDir: ".obsidian/plugins/op-obsidian",
-      vaultBasePath: "/tmp/vault",
-    });
-    expect(src).toBe(
-      "/tmp/vault/.obsidian/plugins/op-obsidian/dashboard/op-dashboard.py",
     );
   });
 });

--- a/plugins/op-obsidian/src/dashboardInstall.ts
+++ b/plugins/op-obsidian/src/dashboardInstall.ts
@@ -31,20 +31,6 @@ export interface PluginPaths {
   vaultBasePath: string;
 }
 
-/** Pure: resolve where the bundled daemon script lives at runtime. The
- * plugin's `manifest.dir` + adapter base path point at the installed plugin
- * folder; the daemon source ships under `dashboard/op-dashboard.py` next
- * to `main.js`. (`dev-sync.mjs` and the BRAT release artifacts must include
- * the `dashboard/` folder for this path to resolve to a real file.) */
-export function bundledDaemonSource(paths: PluginPaths): string {
-  return path.join(
-    paths.vaultBasePath,
-    paths.pluginDir,
-    "dashboard",
-    "op-dashboard.py",
-  );
-}
-
 /** Pure: format an uptime in seconds as "1h 23m 04s" / "23m 04s" / "04s".
  * Used by the daemon-status badge. */
 export function formatUptime(seconds: number): string {

--- a/plugins/op-obsidian/src/dashboardSetupModal.test.ts
+++ b/plugins/op-obsidian/src/dashboardSetupModal.test.ts
@@ -1,0 +1,71 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { mkdtempSync, readFileSync, rmSync, statSync } from "node:fs";
+import { tmpdir } from "node:os";
+import * as path from "node:path";
+
+vi.mock("obsidian", () => ({
+  App: class {},
+  Modal: class {},
+  Notice: class {},
+  Setting: class {
+    addButton(cb: (button: { setButtonText: () => unknown; setCta: () => unknown; onClick: () => unknown }) => unknown) {
+      cb({
+        setButtonText: () => this,
+        setCta: () => this,
+        onClick: () => this,
+      });
+      return this;
+    }
+  },
+}));
+
+import { dashboardClientPath, installDaemon } from "./dashboardSetupModal";
+
+describe("dashboardClientPath", () => {
+  it("installs the client next to the daemon under client/index.html", () => {
+    expect(dashboardClientPath("/tmp/AutoLaunch/op-dashboard.py")).toBe(
+      "/tmp/AutoLaunch/client/index.html",
+    );
+  });
+});
+
+describe("installDaemon", () => {
+  let workDir: string;
+
+  afterEach(() => {
+    if (workDir) rmSync(workDir, { recursive: true, force: true });
+  });
+
+  it("writes the daemon and client assets into AutoLaunch layout", () => {
+    workDir = mkdtempSync(path.join(tmpdir(), "op-dashboard-install-"));
+    const daemonPath = path.join(workDir, "Scripts", "AutoLaunch", "op-dashboard.py");
+    const result = installDaemon(
+      {
+        sourceLabel: "embedded",
+        daemonContent: "#!/usr/bin/env python3\nprint('ok')\n",
+        clientContent: "<!doctype html><title>dashboard</title>\n",
+      },
+      daemonPath,
+    );
+
+    expect(result).toEqual({ ok: true });
+    expect(readFileSync(daemonPath, "utf8")).toContain("print('ok')");
+    expect(readFileSync(dashboardClientPath(daemonPath), "utf8")).toContain("<!doctype html>");
+    expect(statSync(daemonPath).mode & 0o777).toBe(0o755);
+  });
+
+  it("fails when the embedded daemon payload is empty", () => {
+    workDir = mkdtempSync(path.join(tmpdir(), "op-dashboard-install-"));
+    const daemonPath = path.join(workDir, "Scripts", "AutoLaunch", "op-dashboard.py");
+    expect(
+      installDaemon(
+        {
+          sourceLabel: "embedded",
+          daemonContent: " \n",
+          clientContent: "<!doctype html>",
+        },
+        daemonPath,
+      ),
+    ).toEqual({ ok: false, reason: "bundled daemon payload is empty" });
+  });
+});

--- a/plugins/op-obsidian/src/dashboardSetupModal.ts
+++ b/plugins/op-obsidian/src/dashboardSetupModal.ts
@@ -1,8 +1,8 @@
 // OP-232: Setup modal for the agent dashboard. Runs the four gates from
 // `dashboardOpen.detectSetupGates`, surfaces each one with actionable copy,
-// and exposes the "Install daemon" button that copies the bundled
-// `op-dashboard.py` (shipped by OP-230) into the user's iTerm AutoLaunch
-// directory.
+// and exposes the "Install daemon" button that writes the bundled
+// `op-dashboard.py` plus `client/index.html` (shipped by OP-230 / OP-231)
+// into the user's iTerm AutoLaunch directory.
 //
 // Never silently writes — Install always opens a confirm sub-modal listing
 // the source path, the destination path, and whether a copy already exists.
@@ -24,16 +24,16 @@ import {
 import * as fs from "fs";
 import * as os from "os";
 import * as path from "path";
+import type { BundledDashboardAssets } from "./dashboardBundledAssets";
 
 export interface DashboardSetupDeps {
   /** Probe used by `detectSetupGates`. Production passes a `requestUrl`-backed
    *  probe with a 1-second AbortController; the modal injects it so the
    *  confirm/cancel UX can be exercised without a real daemon. */
   probeHealthz: (url: string, timeoutMs: number) => Promise<boolean>;
-  /** Source path of the bundled `op-dashboard.py` daemon (typically
-   *  `<vault-config>/.obsidian/plugins/op-obsidian/dashboard/op-dashboard.py`).
-   *  Must exist; the Install button copies it into the AutoLaunch dir. */
-  bundledDaemonPath: string;
+  /** Bundled daemon + client payload embedded in the plugin's main bundle so
+   *  BRAT installs still have the dashboard runtime assets available. */
+  bundledAssets: BundledDashboardAssets;
   /** Optional clipboard writer (`navigator.clipboard.writeText`). Used for
    *  the "Copy" button next to the Homebrew install instruction. */
   copyToClipboard?: (text: string) => Promise<void>;
@@ -140,16 +140,20 @@ export class DashboardSetupModal extends Modal {
         });
       } else {
         gate.createEl("p", {
-          text: "Click Install daemon to copy op-dashboard.py into your iTerm AutoLaunch folder. You’ll always be asked to confirm before the file is written.",
+          text: "Click Install daemon to install op-dashboard.py and its client/index.html sibling into your iTerm AutoLaunch folder. You’ll always be asked to confirm before the files are written.",
         });
       }
       gate.createEl("p", {
         cls: "op-dashboard-setup__path",
-        text: `Source: ${this.deps.bundledDaemonPath}`,
+        text: `Source: ${this.deps.bundledAssets.sourceLabel}`,
       });
       gate.createEl("p", {
         cls: "op-dashboard-setup__path",
         text: `Target: ${paths.daemonPath}`,
+      });
+      gate.createEl("p", {
+        cls: "op-dashboard-setup__path",
+        text: `Also installs: ${dashboardClientPath(paths.daemonPath)}`,
       });
       new Setting(gate).addButton((b) =>
         b
@@ -232,7 +236,7 @@ export class DashboardSetupModal extends Modal {
   private openInstallConfirm(targetPath: string): void {
     new InstallDaemonConfirmModal(
       this.app,
-      this.deps.bundledDaemonPath,
+      this.deps.bundledAssets,
       targetPath,
       () => void this.refresh(),
     ).open();
@@ -242,7 +246,7 @@ export class DashboardSetupModal extends Modal {
 class InstallDaemonConfirmModal extends Modal {
   constructor(
     app: App,
-    private sourcePath: string,
+    private assets: BundledDashboardAssets,
     private targetPath: string,
     private onInstalled: () => void,
   ) {
@@ -264,15 +268,19 @@ class InstallDaemonConfirmModal extends Modal {
     this.contentEl.createEl("p", {
       text: exists
         ? "An op-dashboard.py already exists at the target path. Confirming will overwrite it."
-        : "Confirming will copy the bundled op-dashboard.py into your iTerm AutoLaunch folder.",
+        : "Confirming will install the bundled op-dashboard.py and client/index.html into your iTerm AutoLaunch folder.",
     });
     this.contentEl.createEl("p", {
       cls: "op-dashboard-setup__path",
-      text: `Source: ${this.sourcePath}`,
+      text: `Source: ${this.assets.sourceLabel}`,
     });
     this.contentEl.createEl("p", {
       cls: "op-dashboard-setup__path",
       text: `Target: ${this.targetPath}`,
+    });
+    this.contentEl.createEl("p", {
+      cls: "op-dashboard-setup__path",
+      text: `Also installs: ${dashboardClientPath(this.targetPath)}`,
     });
 
     new Setting(this.contentEl)
@@ -281,10 +289,10 @@ class InstallDaemonConfirmModal extends Modal {
           .setButtonText(exists ? "Reinstall" : "Install")
           .setCta()
           .onClick(() => {
-            const result = installDaemon(this.sourcePath, this.targetPath);
+            const result = installDaemon(this.assets, this.targetPath);
             if (result.ok) {
               new Notice(
-                "op-dashboard.py installed. Restart iTerm2 to start the daemon.",
+                "op-dashboard.py and client/index.html installed. Restart iTerm2 to start the daemon.",
                 /* timeout */ 6000,
               );
               this.close();
@@ -308,15 +316,23 @@ export interface InstallDaemonResult {
 }
 
 /** Pure-ish helper exported for testing. Synchronous because the dest write
- *  is a single file copy and we want the post-write Notice to fire only
+ *  is a small local write and we want the post-write Notice to fire only
  *  after the bytes hit disk. */
-export function installDaemon(sourcePath: string, targetPath: string): InstallDaemonResult {
+export function installDaemon(
+  assets: BundledDashboardAssets,
+  targetPath: string,
+): InstallDaemonResult {
   try {
-    if (!fs.existsSync(sourcePath)) {
-      return { ok: false, reason: `bundled daemon missing at ${sourcePath}` };
+    if (!assets.daemonContent.trim()) {
+      return { ok: false, reason: "bundled daemon payload is empty" };
+    }
+    if (!assets.clientContent.trim()) {
+      return { ok: false, reason: "bundled client payload is empty" };
     }
     fs.mkdirSync(path.dirname(targetPath), { recursive: true });
-    fs.copyFileSync(sourcePath, targetPath);
+    fs.writeFileSync(targetPath, assets.daemonContent, "utf8");
+    fs.mkdirSync(path.dirname(dashboardClientPath(targetPath)), { recursive: true });
+    fs.writeFileSync(dashboardClientPath(targetPath), assets.clientContent, "utf8");
     // Daemon expects executable permission. `iterm2` AutoLaunch runs `python3
     // <script>` so technically the bit isn't required, but setting it
     // matches what users get if they install via `cp` and means manual
@@ -330,6 +346,10 @@ export function installDaemon(sourcePath: string, targetPath: string): InstallDa
   } catch (err) {
     return { ok: false, reason: describeErr(err) };
   }
+}
+
+export function dashboardClientPath(targetPath: string): string {
+  return path.join(path.dirname(targetPath), "client", "index.html");
 }
 
 async function defaultClipboardWriter(text: string): Promise<void> {

--- a/plugins/op-obsidian/src/main.ts
+++ b/plugins/op-obsidian/src/main.ts
@@ -160,6 +160,7 @@ import {
   type SetupGatesWithToken,
 } from "./dashboardOpen";
 import { DashboardSetupModal } from "./dashboardSetupModal";
+import { BUNDLED_DASHBOARD_ASSETS } from "./dashboardBundledAssets";
 import * as os from "os";
 import { existsSync, readFileSync } from "fs";
 import { execFile } from "child_process";
@@ -4882,23 +4883,11 @@ export default class OpPlugin extends Plugin {
   }
 
   private openDashboardSetupModal(gates: SetupGatesWithToken): void {
-    const bundledDaemonPath = this.resolveBundledDashboardDaemonPath();
-    if (!bundledDaemonPath) {
-      // Should never happen — `manifest.dir` is always populated when the
-      // plugin is loaded — but defend against it so the user gets a clear
-      // error rather than a silent open of the modal with a broken Install
-      // button.
-      new Notice(
-        "op: cannot resolve bundled op-dashboard.py path — try restarting Obsidian",
-        6000,
-      );
-      return;
-    }
     new DashboardSetupModal(
       this.app,
       {
         probeHealthz: (url, timeoutMs) => probeDashboardHealthz(url, timeoutMs),
-        bundledDaemonPath,
+        bundledAssets: BUNDLED_DASHBOARD_ASSETS,
         port: this.settings.dashboard.port,
       },
       () => void this.runOpenDashboardCommand(),
@@ -4916,28 +4905,6 @@ export default class OpPlugin extends Plugin {
       return;
     }
     new Notice(`op: dashboard URL ${url}`, 8000);
-  }
-
-  /**
-   * Resolves the absolute path to the bundled `op-dashboard.py` shipped with
-   * this plugin (under `dashboard/op-dashboard.py`). Returns `undefined`
-   * when the manifest's vault-relative dir or the adapter's base path are
-   * unreachable — same surface as `resolveCookieCachePath`.
-   */
-  private resolveBundledDashboardDaemonPath(): string | undefined {
-    const dir = this.manifest.dir;
-    const adapter = this.app.vault.adapter as unknown as {
-      basePath?: string;
-      getBasePath?: () => string;
-    };
-    const base =
-      typeof adapter.basePath === "string"
-        ? adapter.basePath
-        : typeof adapter.getBasePath === "function"
-        ? adapter.getBasePath()
-        : undefined;
-    if (!dir || !base) return undefined;
-    return `${base}/${dir}/dashboard/op-dashboard.py`;
   }
 
   /**

--- a/plugins/op-obsidian/src/settings.ts
+++ b/plugins/op-obsidian/src/settings.ts
@@ -42,7 +42,6 @@ import {
 } from "./dashboardOpen";
 import { installDaemon as installDashboardDaemon } from "./dashboardSetupModal";
 import {
-  bundledDaemonSource,
   formatUptime,
   getDashboardLogPath,
   probeDaemonStatus,
@@ -50,6 +49,7 @@ import {
   revealDashboardLog,
   type DaemonStatus,
 } from "./dashboardInstall";
+import { BUNDLED_DASHBOARD_ASSETS } from "./dashboardBundledAssets";
 import { applyProjectOrder, listProjects } from "./projects";
 import { AGENT_IDS, type AgentId } from "./agentProfiles";
 import type { ITermPlacement } from "./terminalLaunch";
@@ -1832,7 +1832,7 @@ export class OpSettingsTab extends PluginSettingTab {
    * OP-235: Dashboard subsection (per OP-217 §"New settings subsection").
    * Five rows — port, target, daemon-status, token, install. Designed to
    * compose with OP-232's already-landed surface: the "Install daemon"
-   * button calls OP-232's exported `installDaemon(sourcePath, targetPath)`;
+     * button calls OP-232's exported `installDaemon(assets, targetPath)`;
    * the daemon-status row uses a richer `probeDaemonStatus` than the
    * boolean OP-232 healthz probe so the badge can render uptime/version.
    *
@@ -2088,56 +2088,29 @@ export class OpSettingsTab extends PluginSettingTab {
     new Setting(containerEl)
       .setName("Install daemon")
       .setDesc(
-        "Copy the bundled `op-dashboard.py` (shipped by OP-230) into ~/Library/Application Support/iTerm2/Scripts/AutoLaunch/ — same install path as OP-232's Setup modal. Idempotent. Restart iTerm2 after install/upgrade.",
+        "Install the bundled `op-dashboard.py` plus its `client/index.html` sibling into ~/Library/Application Support/iTerm2/Scripts/AutoLaunch/ — same install path as OP-232's Setup modal. Idempotent. Restart iTerm2 after install/upgrade.",
       )
       .addButton((b) =>
         b
           .setButtonText("Install / upgrade")
           .setCta()
           .onClick(async () => {
-            const sourcePath = this.resolveBundledDashboardSource();
-            if (!sourcePath) {
-              notify(
-                "Could not resolve the bundled daemon path — plugin manifest is missing `dir`. Reinstall the plugin and retry.",
-              );
-              return;
-            }
-            const result = installDashboardDaemon(sourcePath, paths.daemonPath);
+            const result = installDashboardDaemon(
+              BUNDLED_DASHBOARD_ASSETS,
+              paths.daemonPath,
+            );
             if (result.ok) {
               notify(
-                `Installed daemon to ${paths.daemonPath}. Restart iTerm2 to launch it.`,
+                `Installed daemon and client assets to ${paths.autoLaunchDir}. Restart iTerm2 to launch it.`,
               );
             } else {
               notify(
-                `Install failed: ${result.reason ?? "unknown error"}. Source: ${sourcePath}.`,
+                `Install failed: ${result.reason ?? "unknown error"}. Source: ${BUNDLED_DASHBOARD_ASSETS.sourceLabel}.`,
               );
             }
             await refreshStatus();
           }),
       );
-  }
-
-  /**
-   * OP-235: resolve the absolute path to the bundled `op-dashboard.py`
-   * shipped under `dashboard/op-dashboard.py` next to `main.js`. Mirrors
-   * the private `resolveBundledDashboardDaemonPath()` already in main.ts —
-   * factored small here rather than promoting the main.ts version to public,
-   * to keep OP-235's diff scoped to the Settings tab.
-   */
-  private resolveBundledDashboardSource(): string | null {
-    const dir = this.plugin.manifest.dir;
-    const adapter = this.app.vault.adapter as unknown as {
-      basePath?: string;
-      getBasePath?: () => string;
-    };
-    const base =
-      typeof adapter.basePath === "string"
-        ? adapter.basePath
-        : typeof adapter.getBasePath === "function"
-        ? adapter.getBasePath()
-        : null;
-    if (!dir || !base) return null;
-    return bundledDaemonSource({ pluginDir: dir, vaultBasePath: base });
   }
 
   private renderDeveloper(containerEl: HTMLElement): void {

--- a/plugins/op/.claude-plugin/plugin.json
+++ b/plugins/op/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "op",
   "description": "Obsidian Projects workflow — schema, slash commands, and agent skill for running a Jira-lite issue tracker inside an Obsidian vault.",
-  "version": "0.85.2",
+  "version": "0.85.3",
   "author": {
     "name": "Eugene Archibald"
   },


### PR DESCRIPTION
## Summary
- embed the dashboard daemon and client assets into the plugin bundle
- install both files into iTerm AutoLaunch instead of reading from the installed plugin folder
- add tests and docs for the BRAT-shaped install path

## Testing
- npm run build
- CI=1 npx vitest run src/dashboardOpen.test.ts src/dashboardInstall.test.ts src/dashboardSetupModal.test.ts
- python3 plugins/op-obsidian/dashboard/test_op_dashboard.py
- node scripts/dev-sync.mjs + OP-Test modal smoke with no plugin dashboard dir
- node scripts/prepare-op-obsidian-release.mjs

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>