### PR TITLE
OP-245: fix dashboard daemon status

### DIFF
--- a/plugins/op-obsidian/dashboard/op-dashboard.py
+++ b/plugins/op-obsidian/dashboard/op-dashboard.py
@@ -29,6 +29,7 @@ import os
 import re
 import secrets
 import signal
+import shutil
 import socket
 import sys
 import time
@@ -64,6 +65,13 @@ WS_CLOSE_TOKEN_INVALID = 4401
 
 # Matches `op-agents` and `op-agents-1`, `op-agents-2`, etc.
 TMUX_SESSION_RE = re.compile(r"^op-agents(?:-\d+)?$")
+TMUX_CANDIDATE_PATHS = [
+    "/opt/homebrew/bin/tmux",
+    "/usr/local/bin/tmux",
+    "/opt/local/bin/tmux",
+    "/usr/bin/tmux",
+    "/bin/tmux",
+]
 
 VALID_STATES = ("running", "waiting_user", "waiting_review", "idle", "exited")
 
@@ -75,6 +83,7 @@ VALID_STATES = ("running", "waiting_user", "waiting_review", "idle", "exited")
 SPINNER_CHARS = "⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏◐◓◑◒"
 
 log = logging.getLogger("op-dashboard")
+_tmux_missing_warned = False
 
 
 # ---- Logging ---------------------------------------------------------------
@@ -235,13 +244,40 @@ class TmuxError(Exception):
     pass
 
 
+def resolve_tmux_binary(
+    which=shutil.which,
+    exists=lambda p: Path(p).exists(),
+) -> str:
+    explicit = os.environ.get("OP_DASHBOARD_TMUX_BINARY", "").strip()
+    if explicit:
+        return explicit
+    detected = which("tmux")
+    if detected:
+        return detected
+    for candidate in TMUX_CANDIDATE_PATHS:
+        if exists(candidate):
+            return candidate
+    return "tmux"
+
+
 async def tmux_run(*args: str, check: bool = True) -> Tuple[int, str, str]:
     """Run `tmux <args...>`, return (rc, stdout, stderr)."""
-    proc = await asyncio.create_subprocess_exec(
-        "tmux", *args,
-        stdout=asyncio.subprocess.PIPE,
-        stderr=asyncio.subprocess.PIPE,
-    )
+    global _tmux_missing_warned
+    tmux_binary = resolve_tmux_binary()
+    try:
+        proc = await asyncio.create_subprocess_exec(
+            tmux_binary, *args,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+    except FileNotFoundError:
+        err = f"{tmux_binary}: not found"
+        if not _tmux_missing_warned:
+            log.warning("tmux unavailable (%s) — running without tmux data.", err)
+            _tmux_missing_warned = True
+        if check:
+            raise TmuxError(err)
+        return 127, "", err
     out_b, err_b = await proc.communicate()
     rc = proc.returncode if proc.returncode is not None else -1
     out = out_b.decode("utf-8", errors="replace")

--- a/plugins/op-obsidian/dashboard/test_op_dashboard.py
+++ b/plugins/op-obsidian/dashboard/test_op_dashboard.py
@@ -65,6 +65,24 @@ class TmuxParseTests(unittest.TestCase):
             ("op-agents-22", "OP-3"),
         ])
 
+    def test_resolve_tmux_binary_prefers_which(self):
+        self.assertEqual(
+            opd.resolve_tmux_binary(
+                which=lambda _: "/tmp/tmux",
+                exists=lambda _: False,
+            ),
+            "/tmp/tmux",
+        )
+
+    def test_resolve_tmux_binary_falls_back_to_known_paths(self):
+        self.assertEqual(
+            opd.resolve_tmux_binary(
+                which=lambda _: None,
+                exists=lambda p: p == "/opt/homebrew/bin/tmux",
+            ),
+            "/opt/homebrew/bin/tmux",
+        )
+
 
 class StateClassifierTests(unittest.TestCase):
     def setUp(self):

--- a/plugins/op-obsidian/manifest.json
+++ b/plugins/op-obsidian/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "op-obsidian",
   "name": "Obsidian Projects (op)",
-  "version": "0.85.4",
+  "version": "0.85.5",
   "minAppVersion": "1.5.0",
   "description": "Jira-lite issue tracker for Obsidian vaults — deterministic commands backing the op workflow.",
   "author": "Eugene Archibald",

--- a/plugins/op-obsidian/package.json
+++ b/plugins/op-obsidian/package.json
@@ -1,6 +1,6 @@
 {
   "name": "op-obsidian",
-  "version": "0.85.4",
+  "version": "0.85.5",
   "description": "Obsidian plugin that owns the deterministic half of the op workflow.",
   "main": "main.js",
   "scripts": {

--- a/plugins/op-obsidian/src/dashboardInstall.test.ts
+++ b/plugins/op-obsidian/src/dashboardInstall.test.ts
@@ -4,14 +4,21 @@ import {
   rmSync,
   writeFileSync,
 } from "node:fs";
+import { EventEmitter } from "node:events";
+import type { ClientRequest, IncomingMessage } from "node:http";
 import { tmpdir } from "node:os";
 import * as path from "node:path";
+import * as http from "node:http";
 import {
   formatUptime,
   getDashboardLogPath,
   probeDaemonStatus,
   readDashboardToken,
 } from "./dashboardInstall";
+
+vi.mock("node:http", () => ({
+  get: vi.fn(),
+}));
 
 describe("getDashboardLogPath", () => {
   it("derives the macOS Library/Logs path from a home dir", () => {
@@ -73,34 +80,40 @@ describe("readDashboardToken", () => {
 });
 
 describe("probeDaemonStatus", () => {
-  const realFetch = globalThis.fetch;
+  const httpGetMock = vi.mocked(http.get);
 
   afterEach(() => {
-    globalThis.fetch = realFetch;
+    httpGetMock.mockReset();
   });
 
-  it("reports running:false when fetch rejects (daemon offline)", async () => {
-    globalThis.fetch = vi.fn().mockRejectedValue(new Error("ECONNREFUSED")) as unknown as typeof fetch;
+  it("reports running:false when the request errors (daemon offline)", async () => {
+    httpGetMock.mockImplementation(() => {
+      const req = makeRequest();
+      queueMicrotask(() => req.emit("error", new Error("ECONNREFUSED")));
+      return req as ClientRequest;
+    });
     const status = await probeDaemonStatus(49217, "tok");
     expect(status.running).toBe(false);
   });
 
   it("flags authError when the daemon returns 401", async () => {
-    globalThis.fetch = vi.fn().mockResolvedValue({
-      ok: false,
-      status: 401,
-      json: async () => ({}),
-    } as unknown as Response) as unknown as typeof fetch;
+    httpGetMock.mockImplementation((_url, cb) => {
+      const req = makeRequest();
+      queueMicrotask(() => emitResponse(cb, 401, "{}"));
+      return req as ClientRequest;
+    });
     const status = await probeDaemonStatus(49217, "stale-token");
     expect(status).toEqual({ running: true, authError: true });
   });
 
   it("parses the running daemon's healthz payload", async () => {
-    globalThis.fetch = vi.fn().mockResolvedValue({
-      ok: true,
-      status: 200,
-      json: async () => ({ ok: true, version: "0.84.0", uptime_s: 42, iterm: true }),
-    } as unknown as Response) as unknown as typeof fetch;
+    httpGetMock.mockImplementation((_url, cb) => {
+      const req = makeRequest();
+      queueMicrotask(() =>
+        emitResponse(cb, 200, JSON.stringify({ ok: true, version: "0.84.0", uptime_s: 42, iterm: true })),
+      );
+      return req as ClientRequest;
+    });
     const status = await probeDaemonStatus(49217, "good");
     expect(status).toEqual({
       running: true,
@@ -115,36 +128,50 @@ describe("probeDaemonStatus", () => {
   // stale badge. Verify by holding the fetch mock open until the test fires
   // `ext.abort()`, then assert the helper resolved to running:false (the
   // catch path) and that the inner signal saw the abort.
-  it("aborts the in-flight fetch when the external signal fires", async () => {
-    let capturedAborted = false;
-    globalThis.fetch = vi.fn((_url, init?: RequestInit) =>
-      new Promise<Response>((_resolve, reject) => {
-        const sig = init?.signal;
-        sig?.addEventListener("abort", () => {
-          capturedAborted = sig.aborted;
-          reject(new DOMException("aborted", "AbortError"));
-        });
-      }),
-    ) as unknown as typeof fetch;
+  it("aborts the in-flight probe when the external signal fires", async () => {
+    let destroyed = false;
+    httpGetMock.mockImplementation(() => {
+      const req = makeRequest();
+      req.destroy = vi.fn(() => {
+        destroyed = true;
+        return req as ClientRequest;
+      }) as ClientRequest["destroy"];
+      return req as ClientRequest;
+    });
     const ext = new AbortController();
     const probe = probeDaemonStatus(49217, "tok", { signal: ext.signal });
     await new Promise((r) => setTimeout(r, 0));
     ext.abort();
     const status = await probe;
     expect(status).toEqual({ running: false });
-    expect(capturedAborted).toBe(true);
+    expect(destroyed).toBe(true);
   });
 
   it("aborts immediately when the external signal is already aborted", async () => {
     const ext = new AbortController();
     ext.abort();
-    let captured: AbortSignal | undefined;
-    globalThis.fetch = vi.fn(async (_url, init?: RequestInit) => {
-      captured = init?.signal;
-      throw new DOMException("aborted", "AbortError");
-    }) as unknown as typeof fetch;
     const status = await probeDaemonStatus(49217, "tok", { signal: ext.signal });
     expect(status).toEqual({ running: false });
-    expect(captured?.aborted).toBe(true);
+    expect(httpGetMock).not.toHaveBeenCalled();
   });
 });
+
+function makeRequest(): EventEmitter & Pick<ClientRequest, "on" | "setTimeout" | "destroy" | "removeListener"> {
+  const req = new EventEmitter() as EventEmitter &
+    Pick<ClientRequest, "on" | "setTimeout" | "destroy" | "removeListener">;
+  req.setTimeout = vi.fn();
+  req.destroy = vi.fn(() => req as ClientRequest);
+  return req;
+}
+
+function emitResponse(
+  callback: ((res: IncomingMessage) => void) | undefined,
+  status: number,
+  body: string,
+): void {
+  const res = new EventEmitter() as IncomingMessage;
+  res.statusCode = status;
+  callback?.(res);
+  res.emit("data", Buffer.from(body));
+  res.emit("end");
+}

--- a/plugins/op-obsidian/src/dashboardInstall.ts
+++ b/plugins/op-obsidian/src/dashboardInstall.ts
@@ -17,6 +17,7 @@
 
 import { existsSync, readFileSync } from "node:fs";
 import { execFile } from "node:child_process";
+import * as http from "node:http";
 import * as path from "node:path";
 
 /** Pure: where the daemon writes its stderr log per the OP-217 spec. */
@@ -96,27 +97,16 @@ export async function probeDaemonStatus(
   options: ProbeOptions = {},
 ): Promise<DaemonStatus> {
   const { timeoutMs = 1000, signal: external } = options;
-  const ctrl = new AbortController();
-  const t = setTimeout(() => ctrl.abort(), timeoutMs);
-  // Chain external aborts so the fetch is cancelled when the caller closes
-  // its scope (e.g. the Settings tab's hide() handler).
-  const onExternalAbort = () => ctrl.abort();
-  if (external) {
-    if (external.aborted) ctrl.abort();
-    else external.addEventListener("abort", onExternalAbort);
-  }
+  if (external?.aborted) return { running: false };
   try {
-    const url = `http://127.0.0.1:${port}/healthz${
-      token ? `?token=${encodeURIComponent(token)}` : ""
-    }`;
-    const res = await fetch(url, { signal: ctrl.signal });
+    const res = await requestDaemonStatus(port, token, timeoutMs, external);
     if (res.status === 401) {
       return { running: true, authError: true };
     }
-    if (!res.ok) {
+    if (res.status !== 200) {
       return { running: false };
     }
-    const body = (await res.json()) as {
+    const body = (JSON.parse(res.body) ?? {}) as {
       ok?: boolean;
       version?: string;
       uptime_s?: number;
@@ -130,8 +120,68 @@ export async function probeDaemonStatus(
     };
   } catch {
     return { running: false };
-  } finally {
-    clearTimeout(t);
-    if (external) external.removeEventListener("abort", onExternalAbort);
   }
+}
+
+interface DaemonHttpResponse {
+  status: number;
+  body: string;
+}
+
+function requestDaemonStatus(
+  port: number,
+  token: string | null,
+  timeoutMs: number,
+  signal?: AbortSignal,
+): Promise<DaemonHttpResponse> {
+  return new Promise((resolve, reject) => {
+    let settled = false;
+    const req = http.get(
+      `http://127.0.0.1:${port}/healthz${token ? `?token=${encodeURIComponent(token)}` : ""}`,
+      (res) => {
+        const chunks: Buffer[] = [];
+        res.on("data", (chunk) => {
+          chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+        });
+        res.on("end", () => {
+          if (settled) return;
+          settled = true;
+          cleanup();
+          resolve({
+            status: res.statusCode ?? 0,
+            body: Buffer.concat(chunks).toString("utf8"),
+          });
+        });
+      },
+    );
+    const cleanup = () => {
+      req.removeListener("error", onError);
+      req.removeListener("timeout", onTimeout);
+      signal?.removeEventListener("abort", onAbort);
+    };
+    const onError = (err: Error) => {
+      if (settled) return;
+      settled = true;
+      cleanup();
+      reject(err);
+    };
+    const onTimeout = () => {
+      if (settled) return;
+      settled = true;
+      cleanup();
+      req.destroy();
+      reject(new Error("timeout"));
+    };
+    const onAbort = () => {
+      if (settled) return;
+      settled = true;
+      cleanup();
+      req.destroy();
+      reject(new DOMException("aborted", "AbortError"));
+    };
+    req.on("error", onError);
+    req.on("timeout", onTimeout);
+    req.setTimeout(timeoutMs);
+    signal?.addEventListener("abort", onAbort, { once: true });
+  });
 }

--- a/plugins/op-obsidian/src/dashboardSetupModal.test.ts
+++ b/plugins/op-obsidian/src/dashboardSetupModal.test.ts
@@ -119,6 +119,7 @@ describe("dashboardDependencyInstallArgs", () => {
       "-m",
       "pip",
       "install",
+      "--disable-pip-version-check",
       DASHBOARD_AIOHTTP_SPEC,
     ]);
   });

--- a/plugins/op-obsidian/src/dashboardSetupModal.ts
+++ b/plugins/op-obsidian/src/dashboardSetupModal.ts
@@ -330,6 +330,8 @@ export interface InstallDaemonResult {
 export interface DashboardDependencyInstallResult {
   ok: boolean;
   runtimesInstalled: number;
+  runtimePath?: string;
+  alreadySatisfied?: boolean;
   reason?: string;
 }
 
@@ -387,33 +389,54 @@ export function listITermPythonRuntimes(homeDir: string): string[] {
   }
 }
 
+export function preferredITermPythonRuntime(homeDir: string): string | null {
+  const runtimes = listITermPythonRuntimes(homeDir);
+  if (runtimes.length === 0) return null;
+  return [...runtimes].sort(comparePythonRuntimePaths).at(-1) ?? null;
+}
+
 export function dashboardDependencyInstallArgs(): string[] {
-  return ["-m", "pip", "install", DASHBOARD_AIOHTTP_SPEC];
+  return ["-m", "pip", "install", "--disable-pip-version-check", DASHBOARD_AIOHTTP_SPEC];
 }
 
 export async function installDashboardDependencies(
   homeDir: string,
 ): Promise<DashboardDependencyInstallResult> {
-  const runtimes = listITermPythonRuntimes(homeDir);
-  if (runtimes.length === 0) {
+  const runtime = preferredITermPythonRuntime(homeDir);
+  if (!runtime) {
     return {
       ok: false,
       runtimesInstalled: 0,
       reason: "no iTerm bundled Python runtimes were found under ~/Library/Application Support/iTerm2/iterm2env/versions",
     };
   }
-  for (const pythonPath of runtimes) {
-    try {
-      await pExecFile(pythonPath, dashboardDependencyInstallArgs());
-    } catch (err) {
-      return {
-        ok: false,
-        runtimesInstalled: 0,
-        reason: `${pythonPath}: ${describeErr(err)}`,
-      };
-    }
+  try {
+    await pExecFile(runtime, ["-c", "import aiohttp"], { timeout: 5_000 });
+    return {
+      ok: true,
+      runtimesInstalled: 0,
+      runtimePath: runtime,
+      alreadySatisfied: true,
+    };
+  } catch {
+    // Missing aiohttp is the expected bootstrap case — fall through to install.
   }
-  return { ok: true, runtimesInstalled: runtimes.length };
+  try {
+    await pExecFile(runtime, dashboardDependencyInstallArgs(), { timeout: 60_000 });
+    return {
+      ok: true,
+      runtimesInstalled: 1,
+      runtimePath: runtime,
+      alreadySatisfied: false,
+    };
+  } catch (err) {
+    return {
+      ok: false,
+      runtimesInstalled: 0,
+      runtimePath: runtime,
+      reason: `${runtime}: ${describeErr(err)}`,
+    };
+  }
 }
 export function dashboardClientPath(targetPath: string): string {
   return path.join(path.dirname(targetPath), "client", "index.html");
@@ -432,6 +455,24 @@ async function defaultClipboardWriter(text: string): Promise<void> {
 function describeErr(err: unknown): string {
   if (err instanceof Error) return err.message.split("\n")[0];
   return String(err);
+}
+
+function comparePythonRuntimePaths(a: string, b: string): number {
+  const aVersion = versionTuple(path.basename(path.dirname(path.dirname(a))));
+  const bVersion = versionTuple(path.basename(path.dirname(path.dirname(b))));
+  const len = Math.max(aVersion.length, bVersion.length);
+  for (let i = 0; i < len; i++) {
+    const delta = (aVersion[i] ?? 0) - (bVersion[i] ?? 0);
+    if (delta !== 0) return delta;
+  }
+  return a.localeCompare(b);
+}
+
+function versionTuple(raw: string): number[] {
+  return raw
+    .split(".")
+    .map((part) => Number.parseInt(part, 10))
+    .filter((part) => Number.isFinite(part));
 }
 
 // Re-export for callers that only want the AutoLaunch-relative path string.

--- a/plugins/op/.claude-plugin/plugin.json
+++ b/plugins/op/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "op",
   "description": "Obsidian Projects workflow — schema, slash commands, and agent skill for running a Jira-lite issue tracker inside an Obsidian vault.",
-  "version": "0.85.4",
+  "version": "0.85.5",
   "author": {
     "name": "Eugene Archibald"
   },


### PR DESCRIPTION
## Summary
- resolve tmux from known macOS/Homebrew paths so the dashboard daemon does not crash when iTerm launches without a Homebrew PATH
- probe daemon status from Settings via Node localhost HTTP so the badge reports the live daemon correctly inside Obsidian
- keep the dashboard dependency installer pinned to the preferred iTerm runtime with the current pip args/test expectations

## Testing
- python3 plugins/op-obsidian/dashboard/test_op_dashboard.py
- npm run build
- npx vitest run src/dashboardInstall.test.ts src/dashboardOpen.test.ts src/dashboardSetupModal.test.ts
- CI=1 npm test *(existing unrelated failure: src/iTermPrefs.test.ts cannot resolve the obsidian package entry)*
- node scripts/dev-sync.mjs
- obsidian vault=OP-Test eval code='app.commands.executeCommandById("op-obsidian:op-dashboard")'
- obsidian vault=OP-Test eval code='(async ()=>{ app.setting.open(); app.setting.openTabById("op-obsidian"); await new Promise(r=>setTimeout(r,2500)); const badge=document.querySelector(".op-dashboard-status"); return {text: badge?.textContent?.trim() ?? null, classes: badge?.className ?? null}; })()'