### PR TITLE
OP-248: respect default note chip agent

### DIFF
--- a/plugins/op-obsidian/manifest.json
+++ b/plugins/op-obsidian/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "op-obsidian",
   "name": "Obsidian Projects (op)",
-  "version": "0.85.5",
+  "version": "0.85.6",
   "minAppVersion": "1.5.0",
   "description": "Jira-lite issue tracker for Obsidian vaults — deterministic commands backing the op workflow.",
   "author": "Eugene Archibald",

--- a/plugins/op-obsidian/package-lock.json
+++ b/plugins/op-obsidian/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "op-obsidian",
-  "version": "0.85.1",
+  "version": "0.85.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "op-obsidian",
-      "version": "0.85.1",
+      "version": "0.85.6",
       "license": "MIT",
       "dependencies": {
         "protobufjs": "^8.0.1"

--- a/plugins/op-obsidian/package.json
+++ b/plugins/op-obsidian/package.json
@@ -1,6 +1,6 @@
 {
   "name": "op-obsidian",
-  "version": "0.85.5",
+  "version": "0.85.6",
   "description": "Obsidian plugin that owns the deterministic half of the op workflow.",
   "main": "main.js",
   "scripts": {

--- a/plugins/op-obsidian/src/main.ts
+++ b/plugins/op-obsidian/src/main.ts
@@ -497,6 +497,7 @@ export default class OpPlugin extends Plugin {
       app: this.app,
       isAgentLive: (id, agent) => this.isAgentLiveSync(id, agent),
       getSettings: () => ({
+        defaultAgent: this.settings.defaultAgent,
         view: { disableInlineGithubStatus: this.settings.view.disableInlineGithubStatus },
       }),
       ghCache,

--- a/plugins/op-obsidian/src/noteChipState.test.ts
+++ b/plugins/op-obsidian/src/noteChipState.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from "vitest";
-import { isIssueFrontmatter, resolveChipState } from "./noteChipState";
+import {
+  chipPrimaryCommandForClick,
+  describeChipPrimaryAction,
+  isIssueFrontmatter,
+  resolveChipState,
+} from "./noteChipState";
 
 describe("isIssueFrontmatter", () => {
   it("rejects notes without type=issue", () => {
@@ -41,6 +46,36 @@ describe("resolveChipState — every row of the chip-state matrix", () => {
     ]);
   });
 
+  it("start-agent hover text names the configured default agent and pick hint", () => {
+    const state = resolveChipState(
+      { id: "OP-1", type: "issue", status: "open" },
+      true,
+    );
+    expect(state).not.toBeNull();
+    expect(describeChipPrimaryAction(state!, "copilot")).toBe(
+      "▶ Start agent (default: copilot; Cmd/Ctrl-click to pick agent)",
+    );
+  });
+
+  it("plain click on Start agent keeps the default-agent launch command", () => {
+    const state = resolveChipState(
+      { id: "OP-1", type: "issue", status: "open" },
+      true,
+    );
+    expect(state).not.toBeNull();
+    expect(chipPrimaryCommandForClick(state!, {})).toBe("op-open-agent");
+  });
+
+  it("Cmd/Ctrl-click on Start agent routes through the picker command", () => {
+    const state = resolveChipState(
+      { id: "OP-1", type: "issue", status: "open" },
+      true,
+    );
+    expect(state).not.toBeNull();
+    expect(chipPrimaryCommandForClick(state!, { metaKey: true })).toBe("op-open-agent-pick");
+    expect(chipPrimaryCommandForClick(state!, { ctrlKey: true })).toBe("op-open-agent-pick");
+  });
+
   it("open / agent set / not live → Re-attach (stale variant)", () => {
     const state = resolveChipState(
       { id: "OP-2", type: "issue", status: "open", agent: "claude" },
@@ -61,6 +96,16 @@ describe("resolveChipState — every row of the chip-state matrix", () => {
     expect(state?.primaryLabel).toBe("▶ Attach session");
     expect(state?.primaryCommand).toBe("op-attach-current");
     expect(state?.menu.map((m) => m.key)).toEqual(["append-commit", "set-pr", "resolve"]);
+  });
+
+  it("modified click does not rewrite non-start-agent chip commands", () => {
+    const state = resolveChipState(
+      { id: "OP-3", type: "issue", status: "in-progress", agent: "claude" },
+      true,
+    );
+    expect(state).not.toBeNull();
+    expect(chipPrimaryCommandForClick(state!, { metaKey: true })).toBe("op-attach-current");
+    expect(describeChipPrimaryAction(state!, "copilot")).toBe("▶ Attach session");
   });
 
   it("in-progress / agent set / not live → Re-attach (stale)", () => {

--- a/plugins/op-obsidian/src/noteChipState.ts
+++ b/plugins/op-obsidian/src/noteChipState.ts
@@ -90,6 +90,11 @@ export interface ChipState {
   status: IssueStatus;
 }
 
+export interface ChipPrimaryClickEvent {
+  metaKey?: boolean;
+  ctrlKey?: boolean;
+}
+
 /** Loose check: does this frontmatter shape describe an issue note we
  * should decorate? Both the resolver and the codeblock fence guard call
  * this so the gate logic only lives once. */
@@ -269,4 +274,19 @@ export function resolveChipState(
     issueId: id,
     status,
   };
+}
+
+export function describeChipPrimaryAction(state: ChipState, defaultAgent: string): string {
+  if (state.action !== "start-agent") return state.primaryLabel;
+  return `${state.primaryLabel} (default: ${defaultAgent}; Cmd/Ctrl-click to pick agent)`;
+}
+
+export function chipPrimaryCommandForClick(
+  state: ChipState,
+  ev: ChipPrimaryClickEvent,
+): string {
+  if (state.action === "start-agent" && (ev.metaKey || ev.ctrlKey)) {
+    return "op-open-agent-pick";
+  }
+  return state.primaryCommand;
 }

--- a/plugins/op-obsidian/src/noteDecorations.ts
+++ b/plugins/op-obsidian/src/noteDecorations.ts
@@ -31,6 +31,8 @@ import { StateEffect } from "@codemirror/state";
 import {
   ChipFrontmatter,
   ChipState,
+  chipPrimaryCommandForClick,
+  describeChipPrimaryAction,
   resolveChipState,
 } from "./noteChipState";
 import {
@@ -59,9 +61,9 @@ export interface ChipDeps {
    * the renderer caches the result for the widget lifetime. May return
    * `null` to mean "tmux unavailable, treat as live". */
   isAgentLive: (issueId: string, agent: string | undefined) => boolean | null;
-  /** Settings accessor — the renderer reads `view.disableInlineGithubStatus`
-   * each render, so toggling it in Settings updates without a reload. */
-  getSettings: () => { view: { disableInlineGithubStatus: boolean } };
+  /** Settings accessor — the renderer reads live note-chip-affecting settings
+   * on each render so toggling them updates without a reload. */
+  getSettings: () => { defaultAgent: string; view: { disableInlineGithubStatus: boolean } };
   /** Single in-memory cache shared across renderers (CM6 + post-processor)
    * so the strip doesn't double-fetch when both renderers run on the
    * same file during a mode toggle. */
@@ -97,21 +99,23 @@ export function renderChipDom(
     cls: `op-note-chip op-note-chip--${state.variant}`,
     text: state.primaryLabel,
   });
+  const settings = deps.getSettings();
   primary.setAttribute("type", "button");
   primary.setAttribute("aria-label", state.primaryLabel);
-  primary.title = state.primaryLabel;
+  primary.title = describeChipPrimaryAction(state, settings.defaultAgent);
   primary.addEventListener(
     "click",
     (ev) => {
       ev.preventDefault();
       ev.stopPropagation();
-      const ok = dispatchCommand(deps.app, state.primaryCommand);
+      const command = chipPrimaryCommandForClick(state, ev);
+      const ok = dispatchCommand(deps.app, command);
       if (!ok) {
         // Command unavailable (typically: not the active leaf). Surface
         // it instead of failing silently — same UX as the menu items.
         // Notice uses the bare id so the developer can grep noteChipState.ts.
         void import("./notificationLog").then(({ notify }) =>
-          notify(`op: ${state.primaryCommand} unavailable — open the issue note first.`),
+          notify(`op: ${command} unavailable — open the issue note first.`),
         );
       }
     },
@@ -485,4 +489,3 @@ export function dispatchChipRefresh(app: App): void {
     }
   });
 }
-

--- a/plugins/op/.claude-plugin/plugin.json
+++ b/plugins/op/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "op",
   "description": "Obsidian Projects workflow — schema, slash commands, and agent skill for running a Jira-lite issue tracker inside an Obsidian vault.",
-  "version": "0.85.5",
+  "version": "0.85.6",
   "author": {
     "name": "Eugene Archibald"
   },


### PR DESCRIPTION
## Summary
- show the configured default agent in the issue-note Start agent chip hover text
- route plain clicks through the default-agent launch command and Cmd/Ctrl-click through the picker
- keep op-obsidian release metadata in sync at 0.85.6

## Validation
- npx -y npm@10.8.2 ci
- npm run build
- CI=1 npm test *(known unrelated baseline failure: src/iTermPrefs.test.ts obsidian package resolution)*
- node scripts/reset-test-vault.mjs mid-flow
- node scripts/dev-sync.mjs
- OP-Test smoke probe on TST-3 for title + click dispatch