### PR TITLE
OP-249: migrate iTerm launches back to legacy

### DIFF
--- a/plugins/op-obsidian/manifest.json
+++ b/plugins/op-obsidian/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "op-obsidian",
   "name": "Obsidian Projects (op)",
-  "version": "0.85.6",
+  "version": "0.85.7",
   "minAppVersion": "1.5.0",
   "description": "Jira-lite issue tracker for Obsidian vaults — deterministic commands backing the op workflow.",
   "author": "Eugene Archibald",

--- a/plugins/op-obsidian/package.json
+++ b/plugins/op-obsidian/package.json
@@ -1,6 +1,6 @@
 {
   "name": "op-obsidian",
-  "version": "0.85.6",
+  "version": "0.85.7",
   "description": "Obsidian plugin that owns the deterministic half of the op workflow.",
   "main": "main.js",
   "scripts": {

--- a/plugins/op-obsidian/src/settings.test.ts
+++ b/plugins/op-obsidian/src/settings.test.ts
@@ -121,6 +121,7 @@ describe("mergeSettings", () => {
 
   it("clamps and floors orchestrator maxRows/maxCols to [1,3]", () => {
     const out = mergeSettings({
+      legacyITermMigrationCompleted: true,
       orchestrator: { maxRows: 2.7, maxCols: 1.9, enabled: true, preferred: "2x2" },
     });
     expect(out.orchestrator.maxRows).toBe(2);
@@ -143,6 +144,21 @@ describe("mergeSettings", () => {
       mergeSettings({ orchestrator: { preferred: "9x9" as unknown as string } }).orchestrator
         .preferred,
     ).toBe(DEFAULT_SETTINGS.orchestrator.preferred);
+  });
+
+  it("migrates pre-legacy-fallback installs off orchestrator when the migration bit is absent", () => {
+    const out = mergeSettings({ orchestrator: { enabled: true } });
+    expect(out.legacyITermMigrationCompleted).toBe(true);
+    expect(out.orchestrator.enabled).toBe(false);
+  });
+
+  it("preserves manual orchestrator opt-in after the legacy-fallback migration has completed", () => {
+    const out = mergeSettings({
+      legacyITermMigrationCompleted: true,
+      orchestrator: { enabled: true },
+    });
+    expect(out.legacyITermMigrationCompleted).toBe(true);
+    expect(out.orchestrator.enabled).toBe(true);
   });
 
   it("view.recentResolvedLimit > 0 and floored; openOnStartup boolean", () => {

--- a/plugins/op-obsidian/src/settingsPure.ts
+++ b/plugins/op-obsidian/src/settingsPure.ts
@@ -164,6 +164,12 @@ export interface OpSettings {
    *  in the `op-dashboard` palette command + URI handler. */
   dashboard: DashboardSettings;
   orchestrator: OrchestratorSettings;
+  /** OP-249: one-shot compatibility bit for the retreat back to legacy iTerm
+   *  `tmux -CC` launches. Older data.json files lack this key; if they also
+   *  had `orchestrator.enabled=true`, `mergeSettings` flips them back to
+   *  legacy once. After the bit is present, explicit user opt-ins are
+   *  preserved across reloads. */
+  legacyITermMigrationCompleted: boolean;
   orchestratorState: RegistryData;
   // User-curated display order for project pickers, by slug. Slugs not in this
   // list (e.g. newly-discovered projects) sort lexically at the tail. Empty
@@ -269,6 +275,7 @@ export const DEFAULT_SETTINGS: OpSettings = {
     maxCols: 3,
     preferred: "2x3",
   },
+  legacyITermMigrationCompleted: true,
   orchestratorState: emptyRegistry(),
   projectOrder: [],
   recent: [],
@@ -299,6 +306,9 @@ export function mergeSettings(loaded: unknown): OpSettings {
   const base: OpSettings = JSON.parse(JSON.stringify(DEFAULT_SETTINGS));
   if (!loaded || typeof loaded !== "object") return base;
   const l = loaded as Partial<OpSettings>;
+  const hasLegacyITermMigrationCompleted =
+    typeof (l as { legacyITermMigrationCompleted?: unknown }).legacyITermMigrationCompleted ===
+    "boolean";
   if (l.defaultAgent && AGENT_IDS.includes(l.defaultAgent as AgentId)) {
     base.defaultAgent = l.defaultAgent as AgentId;
   }
@@ -372,6 +382,13 @@ export function mergeSettings(loaded: unknown): OpSettings {
     if (o.preferred && LAYOUT_IDS.includes(o.preferred as LayoutId)) {
       base.orchestrator.preferred = o.preferred as LayoutId;
     }
+  }
+  if (hasLegacyITermMigrationCompleted) {
+    base.legacyITermMigrationCompleted = (
+      l as { legacyITermMigrationCompleted: boolean }
+    ).legacyITermMigrationCompleted;
+  } else if (base.orchestrator.enabled) {
+    base.orchestrator.enabled = false;
   }
   base.orchestratorState = mergeRegistry((l as { orchestratorState?: unknown }).orchestratorState);
   if (l.github && typeof l.github === "object") {

--- a/plugins/op/.claude-plugin/plugin.json
+++ b/plugins/op/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "op",
   "description": "Obsidian Projects workflow — schema, slash commands, and agent skill for running a Jira-lite issue tracker inside an Obsidian vault.",
-  "version": "0.85.6",
+  "version": "0.85.7",
   "author": {
     "name": "Eugene Archibald"
   },


### PR DESCRIPTION
## Summary
- add a one-time settings migration that flips pre-existing orchestrator-enabled installs back to legacy iTerm tmux -CC launches
- preserve explicit future opt-in by honoring orchestrator.enabled once the migration bit exists
- bump op-obsidian and op plugin versions to 0.85.7

## Verification
- npm test -- --run src/settings.test.ts
- node scripts/reset-test-vault.mjs empty
- node scripts/dev-sync.mjs
- obsidian vault=OP-Test eval code=... reload migration smoke
- CI=1 npm test (known standing failure remains in src/iTermPrefs.test.ts)