### PR TITLE
fix(notifications): make actionable notices auto-dismiss after 10 s (v0.85.9)

### DIFF
--- a/plugins/op-obsidian/manifest.json
+++ b/plugins/op-obsidian/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "op-obsidian",
   "name": "Obsidian Projects (op)",
-  "version": "0.85.8",
+  "version": "0.85.9",
   "minAppVersion": "1.5.0",
   "description": "Jira-lite issue tracker for Obsidian vaults — deterministic commands backing the op workflow.",
   "author": "Eugene Archibald",

--- a/plugins/op-obsidian/package.json
+++ b/plugins/op-obsidian/package.json
@@ -1,6 +1,6 @@
 {
   "name": "op-obsidian",
-  "version": "0.85.8",
+  "version": "0.85.9",
   "description": "Obsidian plugin that owns the deterministic half of the op workflow.",
   "main": "main.js",
   "scripts": {

--- a/plugins/op-obsidian/src/actionableNotices.test.ts
+++ b/plugins/op-obsidian/src/actionableNotices.test.ts
@@ -12,9 +12,9 @@ import { durationForActions, type NoticeAction } from "./actionableNotices";
 const a: NoticeAction = { label: "Open", onClick: () => {} };
 
 describe("durationForActions", () => {
-  it("returns 0 (sticky) when actions are present", () => {
-    expect(durationForActions([a])).toBe(0);
-    expect(durationForActions([a, a])).toBe(0);
+  it("returns 10_000 when actions are present", () => {
+    expect(durationForActions([a])).toBe(10_000);
+    expect(durationForActions([a, a])).toBe(10_000);
   });
 
   it("returns 10_000 when no actions are present", () => {

--- a/plugins/op-obsidian/src/actionableNotices.ts
+++ b/plugins/op-obsidian/src/actionableNotices.ts
@@ -15,15 +15,15 @@ export interface ActionableNoticeOptions {
   /** Inline action links rendered after the text, joined by " · ". */
   actions?: NoticeAction[];
   /**
-   * Override duration (ms). Default: `0` (sticky) when `actions` is non-empty,
-   * else `10_000` so non-actionable Notices auto-dismiss after 10 s.
+   * Override duration (ms). Default: `10_000` (10 s auto-dismiss) regardless
+   * of whether actions are present. Pass `0` explicitly for a sticky notice.
    */
   duration?: number;
 }
 
 export function durationForActions(actions: NoticeAction[], override?: number): number {
   if (typeof override === "number") return override;
-  return actions.length > 0 ? 0 : 10_000;
+  return 10_000;
 }
 
 /**

--- a/plugins/op-obsidian/src/dashboardSetupModal.ts
+++ b/plugins/op-obsidian/src/dashboardSetupModal.ts
@@ -14,7 +14,8 @@
 
 import { execFile } from "node:child_process";
 import * as fs from "fs";
-import { App, Modal, Notice, Setting } from "obsidian";
+import { App, Modal, Setting } from "obsidian";
+import { notify } from "./notificationLog";
 import {
   AUTOLAUNCH_REL_DIR,
   DAEMON_FILENAME,
@@ -125,9 +126,9 @@ export class DashboardSetupModal extends Modal {
         const writer = this.deps.copyToClipboard ?? defaultClipboardWriter;
         try {
           await writer(HOMEBREW_INSTALL_CMD);
-          new Notice("Copied install command");
+          notify("Copied install command");
         } catch (err) {
-          new Notice(`Copy failed: ${describeErr(err)}`);
+          notify(`Copy failed: ${describeErr(err)}`);
         }
       });
       gate.createEl("p", {
@@ -295,19 +296,19 @@ class InstallDaemonConfirmModal extends Modal {
           .onClick(async () => {
             const result = installDaemon(this.assets, this.targetPath);
             if (!result.ok) {
-              new Notice(`Install failed: ${result.reason}`, 8000);
+              notify(`Install failed: ${result.reason}`, 8000);
               return;
             }
             const deps = await installDashboardDependencies(os.homedir());
             if (deps.ok) {
-              new Notice(
+              notify(
                 `op-dashboard.py, client/index.html, and aiohttp installed for ${deps.runtimesInstalled} iTerm runtime${deps.runtimesInstalled === 1 ? "" : "s"}. Restart iTerm2 to start the daemon.`,
                 /* timeout */ 6000,
               );
               this.close();
               this.onInstalled();
             } else {
-              new Notice(
+              notify(
                 `Installed daemon assets, but couldn't install aiohttp into iTerm's bundled Python runtime: ${deps.reason}`,
                 8000,
               );

--- a/plugins/op/.claude-plugin/plugin.json
+++ b/plugins/op/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "op",
   "description": "Obsidian Projects workflow — schema, slash commands, and agent skill for running a Jira-lite issue tracker inside an Obsidian vault.",
-  "version": "0.85.8",
+  "version": "0.85.9",
   "author": {
     "name": "Eugene Archibald"
   },


### PR DESCRIPTION
## Changes

Root cause of screenshot bug: `durationForActions()` was returning `0` (sticky) whenever the notice had action buttons. This is why actionable notices like "op: created OP-250 · [Open] · [Start agent]" never dismissed.

### Fixes
- `actionableNotices.ts`: remove special case that returned sticky 0 for notices with actions — now returns `10_000` unconditionally. Callers that pass `duration: 0` explicitly still get sticky behaviour.
- `dashboardSetupModal.ts`: migrate all 5 bare `new Notice()` calls to `notify()`; remove `Notice` from obsidian import.
- `actionableNotices.test.ts`: update test expectation to match new behaviour.

Closes OP-250.
