### PR TITLE
OP-251: parse sidebar search keys

### DIFF
--- a/plugins/op-obsidian/manifest.json
+++ b/plugins/op-obsidian/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "op-obsidian",
   "name": "Obsidian Projects (op)",
-  "version": "0.85.9",
+  "version": "0.85.10",
   "minAppVersion": "1.5.0",
   "description": "Jira-lite issue tracker for Obsidian vaults — deterministic commands backing the op workflow.",
   "author": "Eugene Archibald",

--- a/plugins/op-obsidian/package.json
+++ b/plugins/op-obsidian/package.json
@@ -1,6 +1,6 @@
 {
   "name": "op-obsidian",
-  "version": "0.85.9",
+  "version": "0.85.10",
   "description": "Obsidian plugin that owns the deterministic half of the op workflow.",
   "main": "main.js",
   "scripts": {

--- a/plugins/op-obsidian/src/sidebarView.test.ts
+++ b/plugins/op-obsidian/src/sidebarView.test.ts
@@ -43,6 +43,7 @@ import {
   OpSidebarView,
   pickIssuesForTab,
   prNumber,
+  sidebarSearchHelpText,
   shouldShowProjectChip,
   TMUX_PROBE_INTERVAL_MS,
   type OpSidebarHooks,
@@ -75,9 +76,28 @@ const subseqMatcher = (q: string) => (text: string) => {
 
 describe("filterEntries", () => {
   const items = [
-    entry({ id: "OP-1", title: "OP-1 sidebar fuzzy filter" }),
-    entry({ id: "OP-2", title: "OP-2 settings tab cleanup" }),
-    entry({ id: "JB-9", title: "JB-9 link escaping", project: "jira-bases" }),
+    entry({
+      id: "OP-1",
+      title: "OP-1 sidebar fuzzy filter",
+      priority: "high",
+      agent: "copilot",
+      pr: "https://github.com/owner/repo/pull/1",
+    }),
+    entry({
+      id: "OP-2",
+      title: "OP-2 settings tab cleanup",
+      status: "blocked",
+      githubIssue: "https://github.com/owner/repo/issues/2",
+    }),
+    entry({
+      id: "JB-9",
+      title: "JB-9 link escaping",
+      project: "jira-bases",
+      status: "in-progress",
+      priority: "low",
+      agent: "claude",
+      commits: ["abc1234 initial import"],
+    }),
   ];
 
   it("returns all entries when query is empty", () => {
@@ -100,6 +120,33 @@ describe("filterEntries", () => {
     expect(out.map((e) => e.id)).toEqual(["JB-9"]);
   });
 
+  it("parses project filters by prefix", () => {
+    const out = filterEntries(items, "project:OP", subseqMatcher);
+    expect(out.map((e) => e.id)).toEqual(["OP-1", "OP-2"]);
+  });
+
+  it("combines project filters with free-text fuzzy matching", () => {
+    const out = filterEntries(items, "project:OP filter", subseqMatcher);
+    expect(out.map((e) => e.id)).toEqual(["OP-1"]);
+  });
+
+  it("parses status, priority, and agent filters", () => {
+    expect(filterEntries(items, "status:blocked", subseqMatcher).map((e) => e.id)).toEqual(["OP-2"]);
+    expect(filterEntries(items, "priority:high", subseqMatcher).map((e) => e.id)).toEqual(["OP-1"]);
+    expect(filterEntries(items, "agent:claude", subseqMatcher).map((e) => e.id)).toEqual(["JB-9"]);
+  });
+
+  it("parses has:* filters", () => {
+    expect(filterEntries(items, "has:pr", subseqMatcher).map((e) => e.id)).toEqual(["OP-1"]);
+    expect(filterEntries(items, "has:github", subseqMatcher).map((e) => e.id)).toEqual(["OP-2"]);
+    expect(filterEntries(items, "has:commits", subseqMatcher).map((e) => e.id)).toEqual(["JB-9"]);
+  });
+
+  it("treats unsupported key:value tokens as plain text when structured filters are present", () => {
+    const out = filterEntries(items, "project:OP title:filter", subseqMatcher);
+    expect(out.map((e) => e.id)).toEqual(["OP-1"]);
+  });
+
   it("returns empty when nothing matches", () => {
     expect(filterEntries(items, "zzznotpresent", subseqMatcher)).toEqual([]);
   });
@@ -107,6 +154,18 @@ describe("filterEntries", () => {
   it("preserves input order", () => {
     const out = filterEntries(items, "op", subseqMatcher);
     expect(out.map((e) => e.id)).toEqual(["OP-1", "OP-2"]);
+  });
+});
+
+describe("sidebarSearchHelpText", () => {
+  it("lists supported structured keys and a combined example", () => {
+    const text = sidebarSearchHelpText();
+    expect(text).toContain("project:<slug|PREFIX>");
+    expect(text).toContain("status:<open|in-progress|blocked|resolved|wontfix>");
+    expect(text).toContain("priority:<low|med|high>");
+    expect(text).toContain("agent:<name|none>");
+    expect(text).toContain("has:<pr|github|agent|commits>");
+    expect(text).toContain("project:OP sidebar");
   });
 });
 

--- a/plugins/op-obsidian/src/sidebarView.ts
+++ b/plugins/op-obsidian/src/sidebarView.ts
@@ -13,6 +13,40 @@ import { tmuxWindowName } from "./terminalLaunch";
 export const OP_SIDEBAR_VIEW_TYPE = "op-sidebar";
 
 type TabId = "issues" | "in-flight" | "resolved";
+type SidebarSearchKey = "project" | "status" | "priority" | "agent" | "has";
+
+interface SidebarSearchFilter {
+  key: SidebarSearchKey;
+  value: string;
+}
+
+export const SIDEBAR_SEARCH_HELP = [
+  {
+    key: "project:<slug|PREFIX>",
+    description: "Match a project by slug or issue prefix.",
+    example: "project:OP",
+  },
+  {
+    key: "status:<open|in-progress|blocked|resolved|wontfix>",
+    description: "Filter by issue status.",
+    example: "status:blocked",
+  },
+  {
+    key: "priority:<low|med|high>",
+    description: "Filter by priority.",
+    example: "priority:high",
+  },
+  {
+    key: "agent:<name|none>",
+    description: "Filter by attached agent, or rows without one.",
+    example: "agent:copilot",
+  },
+  {
+    key: "has:<pr|github|agent|commits>",
+    description: "Require a populated field on the issue.",
+    example: "has:pr",
+  },
+] as const;
 
 const TABS: Array<{ id: TabId; label: string }> = [
   { id: "issues", label: "Issues" },
@@ -160,7 +194,8 @@ export class OpSidebarView extends ItemView {
       this.tabButtons.set(t.id, btn);
     }
 
-    this.filterInput = root.createEl("input", {
+    const filterRow = root.createDiv({ cls: "op-sidebar__filter-row" });
+    this.filterInput = filterRow.createEl("input", {
       cls: "op-sidebar__filter",
       attr: {
         type: "search",
@@ -173,6 +208,15 @@ export class OpSidebarView extends ItemView {
       this.filterQuery = this.filterInput.value;
       this.scheduleRender();
     });
+    const filterHelp = filterRow.createEl("button", {
+      cls: "op-sidebar__filter-help",
+      text: "?",
+      attr: {
+        type: "button",
+        "aria-label": "Sidebar search help",
+      },
+    });
+    setTooltip(filterHelp, sidebarSearchHelpText(), { delay: 250 });
 
     this.bodyEl = root.createDiv({ cls: "op-sidebar__body" });
 
@@ -1017,6 +1061,14 @@ function stripIdPrefix(title: string, id: string): string {
 
 type MatcherFactory = (query: string) => (text: string) => unknown;
 
+export function sidebarSearchHelpText(): string {
+  return [
+    "Search keys",
+    ...SIDEBAR_SEARCH_HELP.map((item) => `${item.key} — ${item.description} Example: ${item.example}`),
+    "Combine keys with free text, e.g. project:OP sidebar",
+  ].join("\n");
+}
+
 export function filterEntries(
   entries: IssueEntry[],
   query: string,
@@ -1024,11 +1076,126 @@ export function filterEntries(
 ): IssueEntry[] {
   const q = query.trim();
   if (!q) return entries;
-  const match = makeMatcher(q);
+  const parsed = parseSidebarSearchQuery(q);
+  if (parsed.filters.length === 0) {
+    const legacyMatch = makeMatcher(q);
+    return entries.filter((e) => legacyMatch(fuzzyTarget(e)) !== null);
+  }
+  const match = parsed.textQuery ? makeMatcher(parsed.textQuery) : undefined;
   return entries.filter((e) => {
-    const target = `${e.id} ${stripIdPrefix(e.title, e.id)} ${e.project}`;
-    return match(target) !== null;
+    if (!parsed.filters.every((filter) => matchesSidebarSearchFilter(e, filter))) return false;
+    if (!match) return true;
+    return match(fuzzyTarget(e)) !== null;
   });
+}
+
+function fuzzyTarget(entry: IssueEntry): string {
+  return `${entry.id} ${stripIdPrefix(entry.title, entry.id)} ${entry.project}`;
+}
+
+function parseSidebarSearchQuery(query: string): {
+  filters: SidebarSearchFilter[];
+  textQuery: string;
+} {
+  const filters: SidebarSearchFilter[] = [];
+  const text: string[] = [];
+  for (const token of query.split(/\s+/).filter(Boolean)) {
+    const parsed = parseSidebarSearchToken(token);
+    if (parsed) {
+      filters.push(parsed);
+      continue;
+    }
+    text.push(fallbackSearchText(token));
+  }
+  return {
+    filters,
+    textQuery: text.filter(Boolean).join(" "),
+  };
+}
+
+function parseSidebarSearchToken(token: string): SidebarSearchFilter | null {
+  const idx = token.indexOf(":");
+  if (idx <= 0 || idx === token.length - 1) return null;
+  const key = normalizeSearchValue(token.slice(0, idx));
+  const value = token.slice(idx + 1).trim();
+  if (!value) return null;
+  if (!isSidebarSearchKey(key)) return null;
+  return { key, value };
+}
+
+function isSidebarSearchKey(key: string): key is SidebarSearchKey {
+  return key === "project" || key === "status" || key === "priority" || key === "agent" || key === "has";
+}
+
+function fallbackSearchText(token: string): string {
+  const idx = token.indexOf(":");
+  if (idx <= 0 || idx === token.length - 1) return token;
+  return token.slice(idx + 1).trim() || token;
+}
+
+function matchesSidebarSearchFilter(entry: IssueEntry, filter: SidebarSearchFilter): boolean {
+  const value = normalizeSearchValue(filter.value);
+  switch (filter.key) {
+    case "project":
+      return matchesProjectFilter(entry, value);
+    case "status":
+      return normalizeIssueStatus(entry.status) === normalizeIssueStatus(value);
+    case "priority":
+      return normalizePriority(entry.priority) === normalizePriority(value);
+    case "agent":
+      return matchesAgentFilter(entry, value);
+    case "has":
+      return matchesHasFilter(entry, value);
+  }
+}
+
+function matchesProjectFilter(entry: IssueEntry, value: string): boolean {
+  const slug = normalizeSearchValue(entry.project);
+  const prefix = normalizeSearchValue(issuePrefix(entry.id));
+  return prefix === value || slug === value || slug.includes(value);
+}
+
+function matchesAgentFilter(entry: IssueEntry, value: string): boolean {
+  if (value === "none" || value === "unassigned") return !entry.agent;
+  return normalizeSearchValue(entry.agent) === value;
+}
+
+function matchesHasFilter(entry: IssueEntry, value: string): boolean {
+  switch (value) {
+    case "pr":
+      return !!entry.pr;
+    case "github":
+    case "gh":
+    case "github-issue":
+      return !!entry.githubIssue;
+    case "agent":
+      return !!entry.agent;
+    case "commit":
+    case "commits":
+      return !!entry.commits?.length;
+    default:
+      return false;
+  }
+}
+
+function issuePrefix(id: string): string {
+  return id.split("-")[0] ?? "";
+}
+
+function normalizeIssueStatus(status: string | undefined): string {
+  const normalized = normalizeSearchValue(status);
+  if (normalized === "inprogress") return "in-progress";
+  return normalized;
+}
+
+function normalizePriority(priority: string | undefined): string {
+  const normalized = normalizeSearchValue(priority);
+  if (normalized === "medium") return "med";
+  return normalized;
+}
+
+function normalizeSearchValue(value: string | undefined): string {
+  return value?.trim().toLowerCase() ?? "";
 }
 
 function ghIssueNumber(url: string): number | undefined {

--- a/plugins/op-obsidian/styles.css
+++ b/plugins/op-obsidian/styles.css
@@ -30,9 +30,16 @@
   border-bottom-color: var(--text-accent);
 }
 
+.op-sidebar__filter-row {
+  display: flex;
+  align-items: center;
+  gap: 0.35rem;
+  margin-bottom: 0.4rem;
+}
+
 .op-sidebar__filter {
   width: 100%;
-  margin-bottom: 0.4rem;
+  margin-bottom: 0;
   padding: 0.3rem 0.5rem;
   font-size: var(--font-ui-small);
   color: var(--text-normal);
@@ -40,11 +47,36 @@
   border: 1px solid var(--background-modifier-border);
   border-radius: 4px;
   box-shadow: none;
+  min-width: 0;
+  flex: 1 1 auto;
 }
 
 .op-sidebar__filter:focus {
   outline: none;
   border-color: var(--interactive-accent);
+}
+
+.op-sidebar__filter-help {
+  width: 1.9rem;
+  height: 1.9rem;
+  min-width: 1.9rem;
+  padding: 0;
+  border: 1px solid var(--background-modifier-border);
+  border-radius: 999px;
+  background: var(--background-secondary);
+  color: var(--text-muted);
+  font-size: var(--font-ui-small);
+  font-weight: 700;
+  line-height: 1;
+  cursor: help;
+  box-shadow: none;
+}
+
+.op-sidebar__filter-help:hover,
+.op-sidebar__filter-help:focus-visible {
+  color: var(--text-normal);
+  border-color: var(--interactive-accent);
+  outline: none;
 }
 
 .op-sidebar__body {

--- a/plugins/op/.claude-plugin/plugin.json
+++ b/plugins/op/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "op",
   "description": "Obsidian Projects workflow — schema, slash commands, and agent skill for running a Jira-lite issue tracker inside an Obsidian vault.",
-  "version": "0.85.9",
+  "version": "0.85.10",
   "author": {
     "name": "Eugene Archibald"
   },


### PR DESCRIPTION
## Summary
- parse structured sidebar search keys so `project:PREFIX` works against issue prefixes and project slugs
- support adjacent sidebar filters for `status:`, `priority:`, `agent:`, and `has:` while preserving fuzzy free-text matching
- add a `?` help affordance beside the filter input and cover the new behavior in sidebar tests

## Validation
- npm run build
- CI=1 npm test -- src/sidebarView.test.ts
- CI=1 npm test *(still only the known `src/iTermPrefs.test.ts` obsidian-resolution failure)*
- OP-Test smoke: `project:GHB` narrows the multi-project seed to `GHB-1` and the help button renders the documented key list