### PR TITLE
OP-251: refine sidebar key matching

### DIFF
--- a/plugins/op-obsidian/manifest.json
+++ b/plugins/op-obsidian/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "op-obsidian",
   "name": "Obsidian Projects (op)",
-  "version": "0.85.10",
+  "version": "0.85.11",
   "minAppVersion": "1.5.0",
   "description": "Jira-lite issue tracker for Obsidian vaults — deterministic commands backing the op workflow.",
   "author": "Eugene Archibald",

--- a/plugins/op-obsidian/package.json
+++ b/plugins/op-obsidian/package.json
@@ -1,6 +1,6 @@
 {
   "name": "op-obsidian",
-  "version": "0.85.10",
+  "version": "0.85.11",
   "description": "Obsidian plugin that owns the deterministic half of the op workflow.",
   "main": "main.js",
   "scripts": {

--- a/plugins/op-obsidian/src/sidebarView.test.ts
+++ b/plugins/op-obsidian/src/sidebarView.test.ts
@@ -79,6 +79,7 @@ describe("filterEntries", () => {
     entry({
       id: "OP-1",
       title: "OP-1 sidebar fuzzy filter",
+      project: "obsidian-projects",
       priority: "high",
       agent: "copilot",
       pr: "https://github.com/owner/repo/pull/1",
@@ -86,8 +87,24 @@ describe("filterEntries", () => {
     entry({
       id: "OP-2",
       title: "OP-2 settings tab cleanup",
+      project: "obsidian-projects",
       status: "blocked",
       githubIssue: "https://github.com/owner/repo/issues/2",
+    }),
+    entry({
+      id: "OPD-3",
+      title: "OPD-3 demo issue",
+      project: "op-demo",
+      status: "open",
+      priority: "med",
+    }),
+    entry({
+      id: "DEV-4",
+      title: "DEV-4 docs examples",
+      project: "obsidian-plugin-development",
+      status: "in-progress",
+      priority: "med",
+      agent: "copilot-helper",
     }),
     entry({
       id: "JB-9",
@@ -101,8 +118,8 @@ describe("filterEntries", () => {
   ];
 
   it("returns all entries when query is empty", () => {
-    expect(filterEntries(items, "", subseqMatcher)).toHaveLength(3);
-    expect(filterEntries(items, "   ", subseqMatcher)).toHaveLength(3);
+    expect(filterEntries(items, "", subseqMatcher)).toHaveLength(5);
+    expect(filterEntries(items, "   ", subseqMatcher)).toHaveLength(5);
   });
 
   it("filters to fuzzy-matching entries by title", () => {
@@ -125,6 +142,25 @@ describe("filterEntries", () => {
     expect(out.map((e) => e.id)).toEqual(["OP-1", "OP-2"]);
   });
 
+  it("prefers exact project matches over broader substring matches", () => {
+    const out = filterEntries(items, "project:OP", subseqMatcher);
+    expect(out.map((e) => e.id)).toEqual(["OP-1", "OP-2"]);
+  });
+
+  it("falls back from exact to case-insensitive exact for project filters", () => {
+    expect(filterEntries(items, "project:op", subseqMatcher).map((e) => e.id)).toEqual(["OP-1", "OP-2"]);
+    expect(filterEntries(items, "project:opd", subseqMatcher).map((e) => e.id)).toEqual(["OPD-3"]);
+  });
+
+  it("falls back to substring matching only when exact tiers miss", () => {
+    expect(filterEntries(items, "project:op-de", subseqMatcher).map((e) => e.id)).toEqual(["OPD-3"]);
+    expect(filterEntries(items, "project:obsidi", subseqMatcher).map((e) => e.id)).toEqual([
+      "OP-1",
+      "OP-2",
+      "DEV-4",
+    ]);
+  });
+
   it("combines project filters with free-text fuzzy matching", () => {
     const out = filterEntries(items, "project:OP filter", subseqMatcher);
     expect(out.map((e) => e.id)).toEqual(["OP-1"]);
@@ -134,6 +170,14 @@ describe("filterEntries", () => {
     expect(filterEntries(items, "status:blocked", subseqMatcher).map((e) => e.id)).toEqual(["OP-2"]);
     expect(filterEntries(items, "priority:high", subseqMatcher).map((e) => e.id)).toEqual(["OP-1"]);
     expect(filterEntries(items, "agent:claude", subseqMatcher).map((e) => e.id)).toEqual(["JB-9"]);
+  });
+
+  it("applies the same exact/CI exact/substring fallback to non-project keys", () => {
+    expect(filterEntries(items, "status:Blocked", subseqMatcher).map((e) => e.id)).toEqual(["OP-2"]);
+    expect(filterEntries(items, "status:prog", subseqMatcher).map((e) => e.id)).toEqual(["DEV-4", "JB-9"]);
+    expect(filterEntries(items, "agent:copilot", subseqMatcher).map((e) => e.id)).toEqual(["OP-1"]);
+    expect(filterEntries(items, "agent:copilot-helper", subseqMatcher).map((e) => e.id)).toEqual(["DEV-4"]);
+    expect(filterEntries(items, "agent:helper", subseqMatcher).map((e) => e.id)).toEqual(["DEV-4"]);
   });
 
   it("parses has:* filters", () => {
@@ -153,7 +197,7 @@ describe("filterEntries", () => {
 
   it("preserves input order", () => {
     const out = filterEntries(items, "op", subseqMatcher);
-    expect(out.map((e) => e.id)).toEqual(["OP-1", "OP-2"]);
+    expect(out.map((e) => e.id)).toEqual(["OP-1", "OP-2", "OPD-3", "DEV-4"]);
   });
 });
 

--- a/plugins/op-obsidian/src/sidebarView.ts
+++ b/plugins/op-obsidian/src/sidebarView.ts
@@ -14,6 +14,7 @@ export const OP_SIDEBAR_VIEW_TYPE = "op-sidebar";
 
 type TabId = "issues" | "in-flight" | "resolved";
 type SidebarSearchKey = "project" | "status" | "priority" | "agent" | "has";
+type SidebarSearchMatchTier = 0 | 1 | 2 | 3;
 
 interface SidebarSearchFilter {
   key: SidebarSearchKey;
@@ -1081,12 +1082,14 @@ export function filterEntries(
     const legacyMatch = makeMatcher(q);
     return entries.filter((e) => legacyMatch(fuzzyTarget(e)) !== null);
   }
-  const match = parsed.textQuery ? makeMatcher(parsed.textQuery) : undefined;
-  return entries.filter((e) => {
-    if (!parsed.filters.every((filter) => matchesSidebarSearchFilter(e, filter))) return false;
-    if (!match) return true;
-    return match(fuzzyTarget(e)) !== null;
-  });
+  let filtered = entries;
+  for (const filter of parsed.filters) {
+    filtered = applySidebarSearchFilter(filtered, filter);
+    if (filtered.length === 0) return [];
+  }
+  if (!parsed.textQuery) return filtered;
+  const match = makeMatcher(parsed.textQuery);
+  return filtered.filter((e) => match(fuzzyTarget(e)) !== null);
 }
 
 function fuzzyTarget(entry: IssueEntry): string {
@@ -1133,53 +1136,79 @@ function fallbackSearchText(token: string): string {
   return token.slice(idx + 1).trim() || token;
 }
 
-function matchesSidebarSearchFilter(entry: IssueEntry, filter: SidebarSearchFilter): boolean {
-  const value = normalizeSearchValue(filter.value);
+function applySidebarSearchFilter(entries: IssueEntry[], filter: SidebarSearchFilter): IssueEntry[] {
+  const ranked = entries.map((entry) => ({
+    entry,
+    tier: sidebarSearchFilterTier(entry, filter),
+  }));
+  const bestTier = ranked.reduce<SidebarSearchMatchTier>(
+    (best, item) => (item.tier > best ? item.tier : best),
+    0,
+  );
+  if (bestTier === 0) return [];
+  return ranked.filter((item) => item.tier === bestTier).map((item) => item.entry);
+}
+
+function sidebarSearchFilterTier(entry: IssueEntry, filter: SidebarSearchFilter): SidebarSearchMatchTier {
+  return bestCandidateMatchTier(sidebarSearchCandidates(entry, filter), filter.value);
+}
+
+function sidebarSearchCandidates(entry: IssueEntry, filter: SidebarSearchFilter): string[] {
   switch (filter.key) {
     case "project":
-      return matchesProjectFilter(entry, value);
+      return compactUnique([issuePrefix(entry.id), entry.project]);
     case "status":
-      return normalizeIssueStatus(entry.status) === normalizeIssueStatus(value);
+      return compactUnique([entry.status, statusAlias(entry.status)]);
     case "priority":
-      return normalizePriority(entry.priority) === normalizePriority(value);
+      return compactUnique([entry.priority, priorityAlias(entry.priority)]);
     case "agent":
-      return matchesAgentFilter(entry, value);
+      return entry.agent ? [entry.agent] : ["none", "unassigned"];
     case "has":
-      return matchesHasFilter(entry, value);
+      return hasCandidates(entry);
   }
 }
 
-function matchesProjectFilter(entry: IssueEntry, value: string): boolean {
-  const slug = normalizeSearchValue(entry.project);
-  const prefix = normalizeSearchValue(issuePrefix(entry.id));
-  return prefix === value || slug === value || slug.includes(value);
+function bestCandidateMatchTier(
+  candidates: string[],
+  rawQuery: string,
+): SidebarSearchMatchTier {
+  const query = rawQuery.trim();
+  if (!query) return 0;
+  if (candidates.some((candidate) => candidate.trim() === query)) return 3;
+  const normalizedQuery = normalizeSearchValue(query);
+  if (!normalizedQuery) return 0;
+  if (candidates.some((candidate) => normalizeSearchValue(candidate) === normalizedQuery)) return 2;
+  if (candidates.some((candidate) => normalizeSearchValue(candidate).includes(normalizedQuery))) return 1;
+  return 0;
 }
 
-function matchesAgentFilter(entry: IssueEntry, value: string): boolean {
-  if (value === "none" || value === "unassigned") return !entry.agent;
-  return normalizeSearchValue(entry.agent) === value;
+function hasCandidates(entry: IssueEntry): string[] {
+  const out: string[] = [];
+  if (entry.pr) out.push("pr");
+  if (entry.githubIssue) out.push("github", "gh", "github-issue");
+  if (entry.agent) out.push("agent");
+  if (entry.commits?.length) out.push("commit", "commits");
+  return out;
 }
 
-function matchesHasFilter(entry: IssueEntry, value: string): boolean {
-  switch (value) {
-    case "pr":
-      return !!entry.pr;
-    case "github":
-    case "gh":
-    case "github-issue":
-      return !!entry.githubIssue;
-    case "agent":
-      return !!entry.agent;
-    case "commit":
-    case "commits":
-      return !!entry.commits?.length;
-    default:
-      return false;
-  }
+function compactUnique(values: Array<string | undefined>): string[] {
+  return [...new Set(values.map((value) => value?.trim()).filter((value): value is string => !!value))];
 }
 
 function issuePrefix(id: string): string {
   return id.split("-")[0] ?? "";
+}
+
+function statusAlias(status: string | undefined): string | undefined {
+  const normalized = normalizeIssueStatus(status);
+  if (!normalized) return undefined;
+  return normalized === status?.trim() ? undefined : normalized;
+}
+
+function priorityAlias(priority: string | undefined): string | undefined {
+  const normalized = normalizePriority(priority);
+  if (!normalized) return undefined;
+  return normalized === priority?.trim() ? undefined : normalized;
 }
 
 function normalizeIssueStatus(status: string | undefined): string {

--- a/plugins/op/.claude-plugin/plugin.json
+++ b/plugins/op/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "op",
   "description": "Obsidian Projects workflow — schema, slash commands, and agent skill for running a Jira-lite issue tracker inside an Obsidian vault.",
-  "version": "0.85.10",
+  "version": "0.85.11",
   "author": {
     "name": "Eugene Archibald"
   },


### PR DESCRIPTION
## Summary
- refine structured `key:value` sidebar filters to resolve by exact match, then case-insensitive exact match, then substring fallback
- keep exact/CI-exact hits from being widened by broader substring project matches
- add focused sidebar tests for the precedence examples and bump the plugin to `0.85.11`

## Validation
- npm run build
- CI=1 npm test -- src/sidebarView.test.ts
- CI=1 npm test *(still only the known `src/iTermPrefs.test.ts` obsidian-resolution failure)*
- OP-Test smoke on `seed/multi-project`: `project:GHB`, `project:ghb`, and `project:hub` each return the expected scoped results