### PR TITLE
OP-254: fix resolved sidebar search

### DIFF
--- a/plugins/op-obsidian/manifest.json
+++ b/plugins/op-obsidian/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "op-obsidian",
   "name": "Obsidian Projects (op)",
-  "version": "0.85.12",
+  "version": "0.85.14",
   "minAppVersion": "1.5.0",
   "description": "Jira-lite issue tracker for Obsidian vaults — deterministic commands backing the op workflow.",
   "author": "Eugene Archibald",

--- a/plugins/op-obsidian/package.json
+++ b/plugins/op-obsidian/package.json
@@ -1,6 +1,6 @@
 {
   "name": "op-obsidian",
-  "version": "0.85.12",
+  "version": "0.85.14",
   "description": "Obsidian plugin that owns the deterministic half of the op workflow.",
   "main": "main.js",
   "scripts": {

--- a/plugins/op-obsidian/src/settings.ts
+++ b/plugins/op-obsidian/src/settings.ts
@@ -550,7 +550,7 @@ export class OpSettingsTab extends PluginSettingTab {
         d
           .addOption("issues", "Issues")
           .addOption("in-flight", "In flight")
-          .addOption("resolved", "Recently resolved")
+          .addOption("resolved", "Resolved")
           .setValue(s.view.defaultTab)
           .onChange(async (v) => {
             s.view.defaultTab = v as SidebarTab;
@@ -1452,8 +1452,8 @@ export class OpSettingsTab extends PluginSettingTab {
     // Sidebar advanced controls — recently resolved limit, open on startup,
     // density, hover preview — fit alongside other view-flavor controls.
     new Setting(containerEl)
-      .setName("Recently resolved limit")
-      .setDesc("Max issues shown in the Recently resolved tab.")
+      .setName("Resolved default list size")
+      .setDesc("How many recent items the Resolved tab shows before you start searching.")
       .addText((t) =>
         t.setValue(String(s.view.recentResolvedLimit)).onChange(async (v) => {
           const n = parseInt(v, 10);

--- a/plugins/op-obsidian/src/sidebarView.test.ts
+++ b/plugins/op-obsidian/src/sidebarView.test.ts
@@ -28,7 +28,18 @@ vi.mock("obsidian", () => ({
   WorkspaceLeaf: class {},
   setIcon: () => {},
   setTooltip: () => {},
-  prepareFuzzySearch: () => () => null,
+  prepareFuzzySearch: (query: string) => {
+    const needle = query.toLowerCase();
+    return (text: string) => {
+      const haystack = text.toLowerCase();
+      let i = 0;
+      for (const ch of haystack) {
+        if (ch === needle[i]) i++;
+        if (i === needle.length) return { score: -1, matches: [] };
+      }
+      return null;
+    };
+  },
 }));
 
 vi.mock("./staleAgentBadges", () => ({
@@ -299,10 +310,19 @@ describe("pickIssuesForTab", () => {
     expect(tmuxDown.map((e) => e.id).sort()).toEqual(["OP-2", "OP-3", "OP-5", "OP-6"]);
   });
 
-  it("'resolved' tab returns resolved entries sorted by resolved-date desc", () => {
+  it("'resolved' tab returns only the recent resolved slice by default", () => {
     const out = pickIssuesForTab(all, "resolved" as any, {
       liveTmuxWindows: new Set(),
-      recentResolvedLimit: 20,
+      recentResolvedLimit: 2,
+    } as any);
+    expect(out.map((e) => e.id)).toEqual(["OP-6", "OP-5"]);
+  });
+
+  it("'resolved' tab can include all resolved entries for search", () => {
+    const out = pickIssuesForTab(all, "resolved" as any, {
+      liveTmuxWindows: new Set(),
+      recentResolvedLimit: 2,
+      includeAllResolved: true,
     } as any);
     expect(out.map((e) => e.id)).toEqual(["OP-6", "OP-5", "OP-4"]);
   });
@@ -456,11 +476,22 @@ describe("decideKeyAction", () => {
   });
 });
 
-function makeFakeEl(): any {
+function makeFakeEl(tag = "div", options: any = {}): any {
   const _listeners: Record<string, Array<(ev: any) => void>> = {};
+  const classes =
+    typeof options.cls === "string"
+      ? options.cls
+          .split(/\s+/)
+          .map((v: string) => v.trim())
+          .filter(Boolean)
+      : [];
   const el: any = {
+    tag,
+    text: options.text ?? "",
+    value: options.value ?? "",
+    attrs: { ...(options.attr ?? {}) },
     children: [] as any[],
-    classList: new Set<string>(),
+    classList: new Set<string>(classes),
     /** Captured handlers, keyed by event name.  Used by wiring tests. */
     _listeners,
     addClass(c: string) {
@@ -473,27 +504,32 @@ function makeFakeEl(): any {
     empty() {
       this.children.length = 0;
     },
-    createDiv(_o: any) {
-      const child = makeFakeEl();
+    createDiv(o: any) {
+      const child = makeFakeEl("div", o);
       this.children.push(child);
       return child;
     },
-    createEl(_tag: string, _o?: any) {
-      const child = makeFakeEl();
+    createEl(nextTag: string, o?: any) {
+      const child = makeFakeEl(nextTag, o);
       this.children.push(child);
       return child;
     },
-    createSpan(_o: any) {
-      const child = makeFakeEl();
+    createSpan(o: any) {
+      const child = makeFakeEl("span", o);
       this.children.push(child);
       return child;
     },
-    setAttr() {},
+    setAttr(name: string, value: string) {
+      this.attrs[name] = value;
+      if (name === "value") this.value = value;
+    },
     addEventListener(event: string, handler: (ev: any) => void) {
       (_listeners[event] ??= []).push(handler);
     },
     removeEventListener() {},
-    removeClass() {},
+    removeClass(c: string) {
+      this.classList.delete(c);
+    },
     focus() {},
     scrollIntoView() {},
   };
@@ -516,7 +552,7 @@ class FakeBus {
   emit() {}
 }
 
-function makeView(hooks?: OpSidebarHooks): any {
+function makeView(hooks?: OpSidebarHooks, settingsOverride: Record<string, unknown> = {}): any {
   const store = new FakeStore();
   const bus = new FakeBus();
   const view = new OpSidebarView(
@@ -859,6 +895,83 @@ describe("render() selection identity", () => {
     (view as any).render();
     expect((view as any).selectedIndex).toBe(0);
     expect((view as any).displayedIssues[0].id).toBe("OP-1");
+
+    await view.onClose();
+  });
+});
+
+describe("render() resolved tab behavior", () => {
+  function makeResolvedView(issues: IssueEntry[], settingsOverride: Record<string, unknown> = {}): any {
+    const bus = new FakeBus();
+    const store = {
+      byId: () => undefined,
+      issues: () => issues,
+    };
+    return new OpSidebarView(
+      {} as any,
+      store as any,
+      bus as any,
+      () =>
+        ({
+          defaultTab: "resolved",
+          recentResolvedLimit: 1,
+          openOnStartup: false,
+          density: "comfortable",
+          ...settingsOverride,
+        } as any),
+      undefined,
+      undefined,
+      undefined,
+    );
+  }
+
+  it("labels the tab Resolved and shows a truncation hint in the default view", async () => {
+    const issues = [
+      entry({ id: "OP-1", status: "resolved", resolvedFolder: true, resolved: "2026-04-20" }),
+      entry({ id: "OP-2", status: "resolved", resolvedFolder: true, resolved: "2026-04-21" }),
+    ];
+    const view = makeResolvedView(issues);
+
+    await view.onOpen();
+
+    expect(Array.from((view as any).tabButtons.values()).map((btn: any) => btn.text)).toEqual([
+      "Issues",
+      "In flight",
+      "Resolved",
+    ]);
+    expect((view as any).displayedIssues.map((e: IssueEntry) => e.id)).toEqual(["OP-2"]);
+    expect((view as any).bodyEl.children[1].text).toBe(
+      "Showing the 1 most recently resolved issue. Search to see all resolved results.",
+    );
+
+    await view.onClose();
+  });
+
+  it("searches across all resolved issues instead of only the default recent slice", async () => {
+    const issues = [
+      entry({
+        id: "OP-1",
+        title: "OP-1 older resolved needle",
+        status: "resolved",
+        resolvedFolder: true,
+        resolved: "2026-04-20",
+      }),
+      entry({
+        id: "OP-2",
+        title: "OP-2 newer resolved",
+        status: "resolved",
+        resolvedFolder: true,
+        resolved: "2026-04-21",
+      }),
+    ];
+    const view = makeResolvedView(issues);
+
+    await view.onOpen();
+    (view as any).filterQuery = "needle";
+    (view as any).render();
+
+    expect((view as any).displayedIssues.map((e: IssueEntry) => e.id)).toEqual(["OP-1"]);
+    expect((view as any).bodyEl.children).toHaveLength(1);
 
     await view.onClose();
   });

--- a/plugins/op-obsidian/src/sidebarView.ts
+++ b/plugins/op-obsidian/src/sidebarView.ts
@@ -52,7 +52,7 @@ export const SIDEBAR_SEARCH_HELP = [
 const TABS: Array<{ id: TabId; label: string }> = [
   { id: "issues", label: "Issues" },
   { id: "in-flight", label: "In flight" },
-  { id: "resolved", label: "Recently resolved" },
+  { id: "resolved", label: "Resolved" },
 ];
 
 const RELEVANT: ReadonlySet<LifecycleEvent["kind"]> = new Set([
@@ -322,6 +322,10 @@ export class OpSidebarView extends ItemView {
     this.contentEl.toggleClass("op-sidebar--density-comfortable", density !== "compact");
 
     const issues = filterEntries(this.pickFor(this.active), this.filterQuery);
+    const showResolvedTruncation =
+      this.active === "resolved" &&
+      !hasSearchQuery(this.filterQuery) &&
+      countResolvedIssues(this.store.issues()) > issues.length;
     // Preserve selection identity across re-renders by id. Without this, a new
     // issue that sorts before the current selection (e.g. OP-001 arriving
     // while OP-100 is highlighted at index 0) silently shifts the highlight
@@ -487,6 +491,12 @@ export class OpSidebarView extends ItemView {
         }
       }
     }
+    if (showResolvedTruncation) {
+      this.bodyEl.createDiv({
+        cls: "op-sidebar__hint",
+        text: resolvedTruncationHint(this.getSettings().recentResolvedLimit),
+      });
+    }
   }
 
   private renderHeader(): void {
@@ -546,6 +556,7 @@ export class OpSidebarView extends ItemView {
     return pickIssuesForTab(this.store.issues(), tab, {
       liveTmuxWindows: this.liveTmuxWindows,
       recentResolvedLimit: this.getSettings().recentResolvedLimit,
+      includeAllResolved: tab === "resolved" && hasSearchQuery(this.filterQuery),
     });
   }
 
@@ -1006,13 +1017,14 @@ function isResolved(e: IssueEntry): boolean {
  *  - `in-flight`  → in-progress / blocked AND any resolved-with-agent row whose
  *                   tmux window is still live (per OP-156 §5). Unknown-tmux
  *                   (`undefined`/`null`) does not hide rows — same rule as
- *                   {@link OpSidebarView.isAgentBadgeStale}.
- *                   The folder-resolved check runs BEFORE the status check so a
- *                   row that lives in `RESOLVED ISSUES/` but still carries a
+ *                   {@link OpSidebarView.isAgentBadgeStale}. The
+ *                   folder-resolved check runs BEFORE the status check so a row
+ *                   that lives in `RESOLVED ISSUES/` but still carries a
  *                   non-terminal `status:` (data drift like OP-197) is treated
  *                   as resolved — the folder is the source of truth here.
- *  - `resolved`   → resolved/wontfix, sorted by resolved-date desc, sliced to
- *                   `opts.recentResolvedLimit`.
+ *  - `resolved`   → resolved/wontfix, sorted by resolved-date desc. The
+ *                   default view is sliced to `opts.recentResolvedLimit`;
+ *                   `includeAllResolved` lets the search path see the full set.
  */
 export function pickIssuesForTab(
   issues: ReadonlyArray<IssueEntry>,
@@ -1020,6 +1032,7 @@ export function pickIssuesForTab(
   opts: {
     liveTmuxWindows: Set<string> | null | undefined;
     recentResolvedLimit: number;
+    includeAllResolved?: boolean;
   },
 ): IssueEntry[] {
   if (tab === "in-flight") {
@@ -1037,12 +1050,31 @@ export function pickIssuesForTab(
       .sort(byId);
   }
   if (tab === "resolved") {
-    return issues
-      .filter((e) => isResolved(e))
-      .sort(byResolvedDesc)
-      .slice(0, opts.recentResolvedLimit);
+    const resolved = listResolvedIssues(issues);
+    return opts.includeAllResolved ? resolved : resolved.slice(0, opts.recentResolvedLimit);
   }
   return issues.filter((e) => !isResolved(e)).sort(byId);
+}
+
+function hasSearchQuery(query: string): boolean {
+  return query.trim().length > 0;
+}
+
+function countResolvedIssues(issues: ReadonlyArray<IssueEntry>): number {
+  let count = 0;
+  for (const issue of issues) {
+    if (isResolved(issue)) count++;
+  }
+  return count;
+}
+
+function listResolvedIssues(issues: ReadonlyArray<IssueEntry>): IssueEntry[] {
+  return issues.filter((e) => isResolved(e)).sort(byResolvedDesc);
+}
+
+function resolvedTruncationHint(limit: number): string {
+  const noun = limit === 1 ? "issue" : "issues";
+  return `Showing the ${limit} most recently resolved ${noun}. Search to see all resolved results.`;
 }
 
 function byId(a: IssueEntry, b: IssueEntry): number {

--- a/plugins/op-obsidian/styles.css
+++ b/plugins/op-obsidian/styles.css
@@ -89,6 +89,11 @@
   padding: 0.5rem 0.25rem;
 }
 
+.op-sidebar__hint {
+  color: var(--text-faint);
+  padding: 0.5rem 0.25rem 0;
+}
+
 .op-sidebar__list {
   list-style: none;
   margin: 0;

--- a/plugins/op/.claude-plugin/plugin.json
+++ b/plugins/op/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "op",
   "description": "Obsidian Projects workflow — schema, slash commands, and agent skill for running a Jira-lite issue tracker inside an Obsidian vault.",
-  "version": "0.85.12",
+  "version": "0.85.14",
   "author": {
     "name": "Eugene Archibald"
   },


### PR DESCRIPTION
## Summary
- rename the resolved sidebar tab/copy to Resolved
- search across all resolved issues while keeping the configured recent default slice
- add a truncation hint and update tests/versioned plugin artifacts

## Testing
- CI=1 npx vitest run src/sidebarView.test.ts src/settings.test.ts
- CI=1 npm test (known src/iTermPrefs.test.ts obsidian package-resolution failure)
- node scripts/bump-version.mjs patch
- node scripts/dev-sync.mjs
- OP-Test smoke via obsidian CLI