### PR TITLE
OP-225: shared worktreeBranchName helper + slug tail in branch convention

### DIFF
--- a/docs/workflow-modules/05-variables-and-templating.md
+++ b/docs/workflow-modules/05-variables-and-templating.md
@@ -48,7 +48,7 @@ generated reference docs) reads from there.
 | **Repo / vault** | `{{repo_path}}` | Absolute path to the project's code repo; undefined for meta-only projects. | `/Users/you/Projects/obsidian-projects` |
 |  | `{{vault_path}}` | Absolute path to the active vault. | `/Users/you/work/Agent-Vault` |
 |  | `{{vault_name}}` | Display name of the active vault. | `Agent-Vault` |
-|  | `{{branch}}` | Git branch the agent is on; undefined before the worktree exists. | `worktree-OP-212` |
+|  | `{{branch}}` | Git branch the agent is on; undefined before the worktree exists. | `worktree-OP-220-add-slug-plugin-var-and-extract-shared` |
 | **Run context** | `{{today}}` | ISO `YYYY-MM-DD`, computed by the launching surface. | `2026-04-26` |
 |  | `{{agent}}` | Agent id launching this session. | `claude` |
 |  | `{{model}}` | Resolved model id; undefined when the agent doesn't pick one per launch. | `claude-opus-4-7` |

--- a/docs/workflow-modules/reference/plugin-vars.md
+++ b/docs/workflow-modules/reference/plugin-vars.md
@@ -54,7 +54,7 @@ The issue id is {{id}} — branch is {{branch}}, today is {{today}}.
 | `{{repo_path}}` | `/Users/you/Projects/obsidian-projects` | Absolute path to the project's code repository — undefined for meta-only projects. |
 | `{{vault_path}}` | `/Users/you/work/Agent-Vault` | Absolute path to the active Obsidian vault. |
 | `{{vault_name}}` | `Agent-Vault` | Display name of the active Obsidian vault. |
-| `{{branch}}` | `worktree-OP-194` | The git branch the agent is operating on — undefined before the worktree exists or for meta-only projects. |
+| `{{branch}}` | `worktree-OP-220-add-slug-plugin-var-and-extract-shared` | The git branch the agent is operating on — undefined before the worktree exists or for meta-only projects. |
 | `{{today}}` | `2026-04-26` | Today's date in ISO YYYY-MM-DD form, computed by the launching surface. |
 | `{{agent}}` | `claude` | The agent id launching this session (claude, gemini, copilot). |
 | `{{model}}` | `claude-opus-4-7` | The resolved model id for this launch — undefined if the agent has no per-launch model selection. |

--- a/plugins/op-obsidian/manifest.json
+++ b/plugins/op-obsidian/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "op-obsidian",
   "name": "Obsidian Projects (op)",
-  "version": "0.86.0",
+  "version": "0.86.1",
   "minAppVersion": "1.5.0",
   "description": "Jira-lite issue tracker for Obsidian vaults — deterministic commands backing the op workflow.",
   "author": "Eugene Archibald",

--- a/plugins/op-obsidian/manifest.json
+++ b/plugins/op-obsidian/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "op-obsidian",
   "name": "Obsidian Projects (op)",
-  "version": "0.85.14",
+  "version": "0.86.0",
   "minAppVersion": "1.5.0",
   "description": "Jira-lite issue tracker for Obsidian vaults — deterministic commands backing the op workflow.",
   "author": "Eugene Archibald",

--- a/plugins/op-obsidian/manifest.json
+++ b/plugins/op-obsidian/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "op-obsidian",
   "name": "Obsidian Projects (op)",
-  "version": "0.86.1",
+  "version": "0.86.2",
   "minAppVersion": "1.5.0",
   "description": "Jira-lite issue tracker for Obsidian vaults — deterministic commands backing the op workflow.",
   "author": "Eugene Archibald",

--- a/plugins/op-obsidian/package.json
+++ b/plugins/op-obsidian/package.json
@@ -1,6 +1,6 @@
 {
   "name": "op-obsidian",
-  "version": "0.86.0",
+  "version": "0.86.1",
   "description": "Obsidian plugin that owns the deterministic half of the op workflow.",
   "main": "main.js",
   "scripts": {

--- a/plugins/op-obsidian/package.json
+++ b/plugins/op-obsidian/package.json
@@ -1,6 +1,6 @@
 {
   "name": "op-obsidian",
-  "version": "0.86.1",
+  "version": "0.86.2",
   "description": "Obsidian plugin that owns the deterministic half of the op workflow.",
   "main": "main.js",
   "scripts": {

--- a/plugins/op-obsidian/package.json
+++ b/plugins/op-obsidian/package.json
@@ -1,6 +1,6 @@
 {
   "name": "op-obsidian",
-  "version": "0.85.14",
+  "version": "0.86.0",
   "description": "Obsidian plugin that owns the deterministic half of the op workflow.",
   "main": "main.js",
   "scripts": {

--- a/plugins/op-obsidian/src/__fixtures__/integration/composed.snapshot.md
+++ b/plugins/op-obsidian/src/__fixtures__/integration/composed.snapshot.md
@@ -1,7 +1,7 @@
 ## STEP: kickoff
 
 
-You are working on **OP-FIX-1** (Integration fixture issue) in project `fixture-project` on branch `worktree-OP-FIX-1`. Always create an isolated worktree before making changes — no exceptions, including one-line tweaks. The main checkout may be held by the agent that delegated to you.
+You are working on **OP-FIX-1** (Integration fixture issue) in project `fixture-project` on branch `worktree-OP-FIX-1-integration-fixture-issue`. Always create an isolated worktree before making changes — no exceptions, including one-line tweaks. The main checkout may be held by the agent that delegated to you.
 
 
 

--- a/plugins/op-obsidian/src/agentHooks.ts
+++ b/plugins/op-obsidian/src/agentHooks.ts
@@ -155,7 +155,7 @@ async function writeGuardScript(scriptPath: string): Promise<void> {
     "default=${default:-main}",
     'if [ "$branch" = "$default" ] || [ "$branch" = "main" ] || [ "$branch" = "master" ]; then',
     '  echo "op-obsidian: refusing edit on main checkout for $OP_ISSUE_ID." >&2',
-    '  echo "Run: git worktree add ../$(basename \\"$PWD\\")-$OP_ISSUE_ID -b $OP_ISSUE_ID" >&2',
+    '  echo "Run: git worktree add ../$(basename \\"$PWD\\")-$OP_ISSUE_ID -b worktree-$OP_ISSUE_ID" >&2',
     '  echo "Or export OP_ALLOW_MAIN_EDIT=1 for a one-line edit." >&2',
     "  exit 2",
     "fi",

--- a/plugins/op-obsidian/src/integration.test.ts
+++ b/plugins/op-obsidian/src/integration.test.ts
@@ -18,6 +18,7 @@ import { TFile } from "obsidian";
 import { loadModuleSources } from "./composeWorkflow";
 import { composeWorkflow } from "./composeWorkflowPure";
 import type { RenderContext } from "./pluginVarRegistry";
+import { worktreeBranchName } from "./worktreeBranch";
 
 // End-to-end integration test for OP-197. Drives the FM-parser → loader →
 // composer → renderer chain against a realistic 3-step workflow fixture and
@@ -172,7 +173,7 @@ const RENDER_CTX: RenderContext = {
   repo_path: "/repo",
   vault_path: "/vault",
   vault_name: "Agent-Vault",
-  branch: "worktree-OP-FIX-1-integration-fixture-issue",
+  branch: worktreeBranchName("OP-FIX-1", "Integration fixture issue"),
   today: "2026-04-26",
   agent: "claude",
   model: "claude-opus-4-7",

--- a/plugins/op-obsidian/src/integration.test.ts
+++ b/plugins/op-obsidian/src/integration.test.ts
@@ -172,7 +172,7 @@ const RENDER_CTX: RenderContext = {
   repo_path: "/repo",
   vault_path: "/vault",
   vault_name: "Agent-Vault",
-  branch: "worktree-OP-FIX-1",
+  branch: "worktree-OP-FIX-1-integration-fixture-issue",
   today: "2026-04-26",
   agent: "claude",
   model: "claude-opus-4-7",

--- a/plugins/op-obsidian/src/pluginVarRegistry.test.ts
+++ b/plugins/op-obsidian/src/pluginVarRegistry.test.ts
@@ -21,7 +21,7 @@ const FIXTURE_CTX: RenderContext = {
   repo_path: "/Users/me/Projects/obsidian-projects",
   vault_path: "/Users/me/work/Agent-Vault",
   vault_name: "Agent-Vault",
-  branch: "worktree-OP-194",
+  branch: "worktree-OP-194-generic-var-renderer-context-builder",
   today: "2026-04-26",
   agent: "claude",
   model: "claude-opus-4-7",
@@ -252,7 +252,7 @@ describe("buildRenderContext", () => {
   const launch: LaunchContext = {
     mode: "implement",
     model: "claude-opus-4-7",
-    branch: "worktree-OP-194",
+    branch: "worktree-OP-194-generic-var-renderer-context-builder",
     repo_path: "/Users/me/Projects/obsidian-projects",
     vault_path: "/Users/me/work/Agent-Vault",
     vault_name: "Agent-Vault",

--- a/plugins/op-obsidian/src/pluginVarRegistry.test.ts
+++ b/plugins/op-obsidian/src/pluginVarRegistry.test.ts
@@ -8,10 +8,15 @@ import {
 } from "./pluginVarRegistry";
 import { BASE_PROFILES } from "./agentProfiles";
 import type { IssueEntry } from "./types";
+import { worktreeBranchName } from "./worktreeBranch";
+
+const FIXTURE_ID = "OP-194";
+const FIXTURE_TITLE = "Generic {{var}} renderer + context builder";
+const FIXTURE_BRANCH = worktreeBranchName(FIXTURE_ID, FIXTURE_TITLE);
 
 const FIXTURE_CTX: RenderContext = {
-  id: "OP-194",
-  title: "Generic {{var}} renderer + context builder",
+  id: FIXTURE_ID,
+  title: FIXTURE_TITLE,
   project: "obsidian-projects",
   status: "in-progress",
   priority: "high",
@@ -21,7 +26,7 @@ const FIXTURE_CTX: RenderContext = {
   repo_path: "/Users/me/Projects/obsidian-projects",
   vault_path: "/Users/me/work/Agent-Vault",
   vault_name: "Agent-Vault",
-  branch: "worktree-OP-194-generic-var-renderer-context-builder",
+  branch: FIXTURE_BRANCH,
   today: "2026-04-26",
   agent: "claude",
   model: "claude-opus-4-7",
@@ -31,7 +36,7 @@ const FIXTURE_CTX: RenderContext = {
 const FIXTURE_ENTRY: IssueEntry = {
   path: "Projects/obsidian-projects/ISSUES/OP-194.md",
   type: "issue",
-  id: "OP-194",
+  id: FIXTURE_ID,
   project: "obsidian-projects",
   status: "in-progress",
   priority: "high",
@@ -40,7 +45,7 @@ const FIXTURE_ENTRY: IssueEntry = {
   pr: "https://github.com/earchibald/obsidian-projects/pull/232",
   githubIssue: "https://github.com/earchibald/obsidian-projects/issues/232",
   agent: "claude",
-  title: "Generic {{var}} renderer + context builder",
+  title: FIXTURE_TITLE,
   resolvedFolder: false,
 };
 
@@ -81,6 +86,12 @@ describe("PLUGIN_VAR_REGISTRY", () => {
       expect(entry.description.length, `${name}.description`).toBeGreaterThan(0);
       expect(entry.example.length, `${name}.example`).toBeGreaterThan(0);
     }
+  });
+
+  it("keeps the branch example aligned with worktreeBranchName()", () => {
+    expect(PLUGIN_VAR_REGISTRY.branch.example).toBe(
+      worktreeBranchName("OP-220", "Add slug plugin var and extract shared slugify util"),
+    );
   });
 
   describe("compute() against a fully populated fixture", () => {
@@ -252,7 +263,7 @@ describe("buildRenderContext", () => {
   const launch: LaunchContext = {
     mode: "implement",
     model: "claude-opus-4-7",
-    branch: "worktree-OP-194-generic-var-renderer-context-builder",
+    branch: FIXTURE_BRANCH,
     repo_path: "/Users/me/Projects/obsidian-projects",
     vault_path: "/Users/me/work/Agent-Vault",
     vault_name: "Agent-Vault",

--- a/plugins/op-obsidian/src/pluginVarRegistry.ts
+++ b/plugins/op-obsidian/src/pluginVarRegistry.ts
@@ -174,7 +174,7 @@ export const PLUGIN_VAR_REGISTRY: Readonly<Record<string, PluginVar>> = Object.f
     name: "branch",
     description:
       "The git branch the agent is operating on — undefined before the worktree exists or for meta-only projects.",
-    example: "worktree-OP-194",
+    example: "worktree-OP-220-add-slug-plugin-var-and-extract-shared",
     compute: (ctx) => ctx.branch,
   },
 

--- a/plugins/op-obsidian/src/worktreeBranch.test.ts
+++ b/plugins/op-obsidian/src/worktreeBranch.test.ts
@@ -31,14 +31,14 @@ describe("worktreeBranchName", () => {
   });
 
   it("caps the slug tail at 40 chars on a `-` boundary (inherits from {{slug}} preset)", () => {
-    const branch = worktreeBranchName(
-      "OP-9",
-      "Add slug plugin var and extract shared slugify util and other goodies",
+    expect(
+      worktreeBranchName("OP-9", "Add slug plugin var and extract shared slugify util and other goodies"),
+    ).toBe("worktree-OP-9-add-slug-plugin-var-and-extract-shared");
+  });
+
+  it("flat-truncates when the first `-` boundary would land beyond the 40-char cap", () => {
+    expect(worktreeBranchName("OP-9", "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")).toBe(
+      "worktree-OP-9-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
     );
-    // The "worktree-OP-9-" prefix is 14 chars; the slug tail itself is capped at 40.
-    const tail = branch.slice("worktree-OP-9-".length);
-    expect(tail.length).toBeLessThanOrEqual(40);
-    expect(tail.endsWith("-")).toBe(false);
-    expect(branch.startsWith("worktree-OP-9-add-slug-plugin-var")).toBe(true);
   });
 });

--- a/plugins/op-obsidian/src/worktreeBranch.test.ts
+++ b/plugins/op-obsidian/src/worktreeBranch.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+import { worktreeBranchName } from "./worktreeBranch";
+
+describe("worktreeBranchName", () => {
+  it("appends a kebab-cased slug derived from the title", () => {
+    expect(worktreeBranchName("OP-220", "Add slug plugin var and extract shared slugify util")).toBe(
+      "worktree-OP-220-add-slug-plugin-var-and-extract-shared",
+    );
+  });
+
+  it("strips a leading `NN[a-z]?:` task prefix from the title (matches {{slug}} preset)", () => {
+    expect(
+      worktreeBranchName("OP-194", "10b: Authoring tutorials with checked-in examples"),
+    ).toBe("worktree-OP-194-authoring-tutorials-with-checked-in");
+  });
+
+  it("falls back to bare `worktree-<id>` (no trailing dash) when title is all punctuation", () => {
+    expect(worktreeBranchName("OP-1", "???")).toBe("worktree-OP-1");
+  });
+
+  it("falls back to bare `worktree-<id>` for whitespace-only titles", () => {
+    expect(worktreeBranchName("OP-1", "   ")).toBe("worktree-OP-1");
+  });
+
+  it("falls back to bare `worktree-<id>` for empty-string titles", () => {
+    expect(worktreeBranchName("OP-1", "")).toBe("worktree-OP-1");
+  });
+
+  it("falls back to bare `worktree-<id>` when title is undefined", () => {
+    expect(worktreeBranchName("OP-1", undefined)).toBe("worktree-OP-1");
+  });
+
+  it("caps the slug tail at 40 chars on a `-` boundary (inherits from {{slug}} preset)", () => {
+    const branch = worktreeBranchName(
+      "OP-9",
+      "Add slug plugin var and extract shared slugify util and other goodies",
+    );
+    // The "worktree-OP-9-" prefix is 14 chars; the slug tail itself is capped at 40.
+    const tail = branch.slice("worktree-OP-9-".length);
+    expect(tail.length).toBeLessThanOrEqual(40);
+    expect(tail.endsWith("-")).toBe(false);
+    expect(branch.startsWith("worktree-OP-9-add-slug-plugin-var")).toBe(true);
+  });
+});

--- a/plugins/op-obsidian/src/worktreeBranch.ts
+++ b/plugins/op-obsidian/src/worktreeBranch.ts
@@ -1,0 +1,20 @@
+// Worktree-branch name construction — single source of truth for the
+// `worktree-<id>[-<slug>]` convention. Consumes the same `slugify` preset as
+// the `{{slug}}` plugin var (caseFold + maxLen 40 + leading-task-prefix strip)
+// so the descriptive tail an agent sees inline in modules matches the branch
+// produced here.
+//
+// Returns bare `worktree-<id>` (no trailing dash) when `title` slugs to empty
+// — all-punctuation, whitespace-only, or empty input. That fallback preserves
+// the existing convention for unlabeled or just-created issues. Extracted in
+// OP-225.
+import { slugify } from "./slug";
+
+export function worktreeBranchName(issueId: string, title: string | undefined): string {
+  const slug = slugify(title ?? "", {
+    caseFold: true,
+    maxLen: 40,
+    stripLeadingTaskPrefix: true,
+  });
+  return slug ? `worktree-${issueId}-${slug}` : `worktree-${issueId}`;
+}

--- a/plugins/op/.claude-plugin/plugin.json
+++ b/plugins/op/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "op",
   "description": "Obsidian Projects workflow — schema, slash commands, and agent skill for running a Jira-lite issue tracker inside an Obsidian vault.",
-  "version": "0.86.1",
+  "version": "0.86.2",
   "author": {
     "name": "Eugene Archibald"
   },

--- a/plugins/op/.claude-plugin/plugin.json
+++ b/plugins/op/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "op",
   "description": "Obsidian Projects workflow — schema, slash commands, and agent skill for running a Jira-lite issue tracker inside an Obsidian vault.",
-  "version": "0.86.0",
+  "version": "0.86.1",
   "author": {
     "name": "Eugene Archibald"
   },

--- a/plugins/op/.claude-plugin/plugin.json
+++ b/plugins/op/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "op",
   "description": "Obsidian Projects workflow — schema, slash commands, and agent skill for running a Jira-lite issue tracker inside an Obsidian vault.",
-  "version": "0.85.14",
+  "version": "0.86.0",
   "author": {
     "name": "Eugene Archibald"
   },


### PR DESCRIPTION
## Summary

- New `plugins/op-obsidian/src/worktreeBranch.ts` exporting `worktreeBranchName(issueId, title)` that consumes the existing `{{slug}}` preset (`caseFold: true, maxLen: 40, stripLeadingTaskPrefix: true`) — single source of truth for the `worktree-<id>[-<slug>]` convention.
- Falls back to bare `worktree-<id>` (no trailing dash) when the title slugs to empty (all-punctuation, whitespace-only, undefined).
- Lifts the visible examples to the new form: `pluginVarRegistry.ts` `branch.example`, `__fixtures__/integration/composed.snapshot.md`, `integration.test.ts` fixture, `docs/workflow-modules/05-variables-and-templating.md` example column. Auto-gen `reference/plugin-vars.md` regenerated via `check-workflow-docs.mjs` (OP-220 CI gotcha).

## Scope notes

The OP-225 spec listed `terminalLaunch.ts` / `orchestrator.ts` as call sites per the OP-220 audit. A codebase scan shows no plugin code today actually constructs `worktree-{{id}}` — branch creation happens externally (EnterWorktree, manual `git worktree add`). The new helper exists so future construction sites have one source of truth; the visible-example surfaces consume the new convention now. `tmuxWindowName` keys on `{{id}}` only via its own `slugify(id, …)` preset and is unchanged (regression contract preserved).

`agentHooks.ts:158`'s advisory stderr message uses `-b $OP_ISSUE_ID` with no `worktree-` prefix at all (pre-existing inconsistency); the bash hook lacks the title at execution time and the issue scopes this out under "no other call sites today".

## Test plan

- [x] `worktreeBranch.test.ts` — normal title → `worktree-<id>-<slug>`; all-punctuation / whitespace / empty / undefined → bare `worktree-<id>`; leading `NN[a-z]?:` stripped; 40-char tail cap on `-` boundary.
- [x] `pluginVarRegistry.test.ts` + `integration.test.ts` updated fixtures pass.
- [x] Full plugin suite: 1741 tests pass.
- [x] `check-workflow-docs.mjs`: re-run, regenerated `reference/plugin-vars.md` committed.
- [x] Smoke: dev-sync into OP-Test, `op-list-vars project=testing issue=TST-5` confirms the new `branch.example` resolves correctly. (Workflow-modules seed not initialized in this env — same state as OP-220 notes; live probe sufficient.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)