### PR TITLE
OP-228: prefer /loop for monitoring waits when agent is claude

### DIFF
--- a/plugins/op-obsidian/manifest.json
+++ b/plugins/op-obsidian/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "op-obsidian",
   "name": "Obsidian Projects (op)",
-  "version": "0.86.2",
+  "version": "0.86.3",
   "minAppVersion": "1.5.0",
   "description": "Jira-lite issue tracker for Obsidian vaults — deterministic commands backing the op workflow.",
   "author": "Eugene Archibald",

--- a/plugins/op-obsidian/package.json
+++ b/plugins/op-obsidian/package.json
@@ -1,6 +1,6 @@
 {
   "name": "op-obsidian",
-  "version": "0.86.2",
+  "version": "0.86.3",
   "description": "Obsidian plugin that owns the deterministic half of the op workflow.",
   "main": "main.js",
   "scripts": {

--- a/plugins/op-obsidian/src/skill/manual.md
+++ b/plugins/op-obsidian/src/skill/manual.md
@@ -313,6 +313,28 @@ If the issue has a `github_issue:` frontmatter field, it mirrors a GitHub issue.
 
 ---
 
+## Monitoring and polling waits
+
+When you're polling a slow async condition — CI checks settling, an adversarial Copilot review landing, a long build finishing, remote state flipping — you generally have three mechanisms: `/loop` (claude only), `ScheduleWakeup` chains, and a `gh … && sleep N` bash loop. **When the agent is `claude`, prefer `/loop`** for any wait whose cadence you are freely choosing. It handles dynamic self-pacing (pick `delaySeconds` each wake based on what you just observed), keeps the prompt cache warm if each tick stays under the 300 s TTL, and has clean exit semantics — omit `ScheduleWakeup` to stop. Standalone `ScheduleWakeup` chains lose surrounding context unless constructed carefully, and `sleep`-loops re-enter bash repeatedly without any cache benefit.
+
+The 300 s figure is concrete: under that, successive `/loop` wakes hit the warm prompt cache. Over that, every tick pays a cache miss, so longer waits are cheaper as a smaller number of larger wake-ups than as a tight loop. Defer to your own judgment for waits longer than ~5 min — `/loop` is still fine, but the cache argument no longer applies, and a single `ScheduleWakeup` further out can be a reasonable equivalent.
+
+**Other agents (`gemini`, `copilot`, anything not `claude`) do not have `/loop` available** and must continue to use whatever native polling their harness exposes — `ScheduleWakeup` if your runtime has it, otherwise a bash sleep-loop. The `/loop` preference above does not apply to non-claude agents and nothing in this section weakens the existing fallbacks for them.
+
+Carve-outs that apply to every agent (claude included):
+
+- **The user picked the cadence.** If the user asked for "every 5 minutes" or specified a particular mechanism, do what they said. The preference is about freely chosen polling strategy, not about overriding direction.
+- **Sub-60 s inline checks.** A single `gh pr view <#> --json …` probe to confirm something you expect to already be done is fine as a one-shot bash call — don't wrap it in `/loop`.
+
+**Typical claude pattern** (polling a Copilot review or CI check):
+
+```bash
+# inside the /loop body — evaluate, then either ScheduleWakeup (delaySeconds: 270) to keep waiting, or omit it to exit
+gh pr view <#> --json reviewDecision,statusCheckRollup
+```
+
+---
+
 ## Cross-project surfaces
 
 `Projects/all-projects.base` and `Projects/All Projects.md` aggregate every project — leave them alone when scaffolding/cleaning. New projects land in them automatically via the `project` frontmatter key.

--- a/plugins/op/.claude-plugin/plugin.json
+++ b/plugins/op/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "op",
   "description": "Obsidian Projects workflow — schema, slash commands, and agent skill for running a Jira-lite issue tracker inside an Obsidian vault.",
-  "version": "0.86.2",
+  "version": "0.86.3",
   "author": {
     "name": "Eugene Archibald"
   },

--- a/plugins/op/skills/op/reference/cli-gotchas.md
+++ b/plugins/op/skills/op/reference/cli-gotchas.md
@@ -64,6 +64,12 @@ Older flows used `Edit` on the markdown file or `obsidian op-set-scope mode=body
 
 **Fallback (plugin missing/disabled).** If `op-obsidian` is not enabled and you can't enable it, fall back to `obsidian read` (full file) → splice the new section in memory → `obsidian append` or `Write` the full file back. There is no raw-CLI shortcut that mirrors `op-set-section`'s scoping. The verb's payload constraints — `name` ∈ `Plan|Notes|Summary` (use `op-set-evaluation` for `## Initial Evaluation`), no `## ` H2 outside a fenced code block in `content` — apply to the in-memory splice too.
 
+## Polling waits — prefer `/loop` when the agent is claude
+
+Cross-reference: the manual's "Monitoring and polling waits" section says that when the agent is `claude`, `/loop` is preferred over `ScheduleWakeup` chains and `gh … && sleep N` bash loops for any freely chosen polling cadence (CI settling, Copilot review, long build). The reason is the 300 s prompt-cache TTL — `/loop` ticks under that window stay warm, raw `sleep`/`ScheduleWakeup` patterns do not.
+
+Non-claude agents (`gemini`, `copilot`, others) do not have `/loop` and continue to use their harness's native polling. The user explicitly directing a cadence, and sub-60 s one-shot probes, are exempt for every agent. The manual has the worked example.
+
 ## `op-append-commit` failure modes
 
 When a project's policy is to call `op-append-commit` after each commit (or batch at resolve), three failure shapes show up. The skill is workflow-agnostic about *when* you call it; this section covers what to do when the call itself fails.


### PR DESCRIPTION
## Summary

- Adds a "Monitoring and polling waits" section to the bundled op manual (`plugins/op-obsidian/src/skill/manual.md`) saying claude agents should prefer `/loop` over `ScheduleWakeup` chains and `gh ... && sleep N` bash loops for freely chosen polling cadences. Cites the 300 s prompt-cache TTL as the reason.
- Carves out user-directed cadences and sub-60 s one-shot probes for every agent; preserves existing fallbacks for non-claude agents (gemini, copilot, etc.) unchanged.
- Adds a short cross-reference in `plugins/op/skills/op/reference/cli-gotchas.md` pointing back to the manual section.
- Bumps op-obsidian 0.86.2 → 0.86.3 (patch — doc-only) and rebuilds `main.js` per CLAUDE.md guardrails.

## Test plan

- [x] `node scripts/bump-version.mjs 0.86.3` — manifest/package/plugin bumped in lockstep, build green, `main.js` fresher than `manifest.json`.
- [x] `node scripts/dev-sync.mjs` to OP-Test, plugin reloaded.
- [x] `obsidian vault=OP-Test op-get-skill` — bundled skill body (41421 chars) contains the new "## Monitoring and polling waits" section verbatim.
- [x] No existing fallback guidance for non-claude agents was removed or weakened (manual + cli-gotchas diff inspected).

🤖 Generated with [Claude Code](https://claude.com/claude-code)