### PR TITLE
OP-227: drop redundant default_branch decl from pr-required example

### DIFF
--- a/docs/examples/workflow-library/Projects/_op-modules/pr-required.md
+++ b/docs/examples/workflow-library/Projects/_op-modules/pr-required.md
@@ -5,7 +5,6 @@ type: workflow-module
 scope: review
 order: 10
 vars:
-  - default_branch=main
   - { name: pr_title_pattern, default: "<ID>: <subject>", description: "Required PR title shape; <ID> is the issue id, <subject> is the imperative-mood summary." }
   - merge_command=gh pr merge --squash --delete-branch
 ---


### PR DESCRIPTION
## Summary

- The `branching` workflow module already declares `default_branch=main`. The `pr-required` module had a redundant `default_branch=main` declaration in its own `vars:` block.
- The composer (`composeWorkflowPure.ts:446`) builds `allModulesByVarName` from every loaded module, so `{{vars.default_branch}}` references in `pr-required.md` continue to resolve via `branching.md`'s declaration without the duplicate.
- This PR drops the duplicate from the curated example at `docs/examples/workflow-library/Projects/_op-modules/pr-required.md` to keep it aligned with the same cleanup applied to the live Agent-Vault copy.
- No plugin code touched, no version bump, no behavior change for end users.

## Test plan

- [x] `obsidian vault=Agent-Vault op-explain-workflow issue=OP-227 mode=kickoff` → `12851 chars, 10 vars, 0E/0W/1I` (1I is the unrelated size-budget notice; matches pre-change shape).
- [x] Composed output renders `main` everywhere `{{vars.default_branch}}` appeared; no unrendered tokens.

Closes #295

🤖 Generated with [Claude Code](https://claude.com/claude-code)