### PR TITLE
OP-259: Phase 2 managed-note pretool guard layer (default-off)

### DIFF
--- a/plugins/op-obsidian/manifest.json
+++ b/plugins/op-obsidian/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "op-obsidian",
   "name": "Obsidian Projects (op)",
-  "version": "0.88.0",
+  "version": "0.89.0",
   "minAppVersion": "1.5.0",
   "description": "Jira-lite issue tracker for Obsidian vaults — deterministic commands backing the op workflow.",
   "author": "Eugene Archibald",

--- a/plugins/op-obsidian/package.json
+++ b/plugins/op-obsidian/package.json
@@ -1,6 +1,6 @@
 {
   "name": "op-obsidian",
-  "version": "0.88.0",
+  "version": "0.89.0",
   "description": "Obsidian plugin that owns the deterministic half of the op workflow.",
   "main": "main.js",
   "scripts": {

--- a/plugins/op-obsidian/src/agentHooks.pretool.test.ts
+++ b/plugins/op-obsidian/src/agentHooks.pretool.test.ts
@@ -188,3 +188,150 @@ describe("pretool-worktree-guard.sh — runtime behavior", () => {
     expect(r.code).toBe(0);
   });
 });
+
+// OP-259: managed-note refusal layer. Exercises the layer in isolation by
+// installing it in a worktree (so the worktree layer is a no-op) and feeding
+// the script a Claude-Code-style PreToolUse JSON payload on stdin.
+describe("pretool-worktree-guard.sh — managed-note layer", () => {
+  let scriptPath: string;
+  let repo: string;
+  let wt: string;
+
+  async function runGuard(
+    env: NodeJS.ProcessEnv,
+    cwd: string,
+    stdin: string,
+  ): Promise<{ code: number; stderr: string }> {
+    try {
+      execFileSync("bash", [scriptPath], {
+        cwd,
+        env: { ...process.env, ...env },
+        input: stdin,
+        stdio: ["pipe", "pipe", "pipe"],
+      });
+      return { code: 0, stderr: "" };
+    } catch (err: any) {
+      return { code: err.status ?? -1, stderr: String(err.stderr ?? "") };
+    }
+  }
+
+  function payload(filePath: string): string {
+    return JSON.stringify({
+      session_id: "s",
+      tool_name: "Edit",
+      tool_input: { file_path: filePath, old_string: "a", new_string: "b" },
+    });
+  }
+
+  beforeEach(async () => {
+    const res = await installAgentHooks({
+      enforceWorktree: true,
+      managedNoteGuard: true,
+    });
+    scriptPath = res.guardScriptPath;
+    repo = await mkTmp("op-managed-repo-");
+    execFileSync("git", ["init", "-q", "-b", "main", repo]);
+    execFileSync("git", ["-C", repo, "config", "user.email", "t@t"]);
+    execFileSync("git", ["-C", repo, "config", "user.name", "t"]);
+    await fs.writeFile(path.join(repo, "f.txt"), "hi\n");
+    execFileSync("git", ["-C", repo, "add", "."]);
+    execFileSync("git", ["-C", repo, "commit", "-q", "-m", "init"]);
+    // Linked worktree → worktree layer is a no-op; managed-note layer alone is
+    // exercised.
+    wt = await mkTmp("op-managed-wt-");
+    await fs.rm(wt, { recursive: true, force: true });
+    execFileSync("git", ["-C", repo, "worktree", "add", "-q", "-b", "wt-x", wt]);
+  });
+
+  afterEach(async () => {
+    await fs.rm(repo, { recursive: true, force: true });
+    await fs.rm(wt, { recursive: true, force: true });
+  });
+
+  it("refuses Edit on a managed note", async () => {
+    const note = path.join(wt, "ISSUES", "OP-9 some issue.md");
+    await fs.mkdir(path.dirname(note), { recursive: true });
+    await fs.writeFile(
+      note,
+      "---\nid: OP-9\nop_managed: true\n---\n\n# OP-9\n",
+    );
+    const r = await runGuard({ OP_ISSUE_ID: "OP-9" }, wt, payload(note));
+    expect(r.code).toBe(2);
+    expect(r.stderr).toMatch(/refusing edit on managed note/);
+    // Path-based hint resolves to the issue endpoints.
+    expect(r.stderr).toMatch(/op-set-tasks/);
+    expect(r.stderr).toMatch(/OP_ALLOW_MANAGED_EDIT=1/);
+  });
+
+  it("OP_ALLOW_MANAGED_EDIT=1 permits the edit", async () => {
+    const note = path.join(wt, "ISSUES", "OP-9 some issue.md");
+    await fs.mkdir(path.dirname(note), { recursive: true });
+    await fs.writeFile(
+      note,
+      "---\nid: OP-9\nop_managed: true\n---\n",
+    );
+    const r = await runGuard(
+      { OP_ISSUE_ID: "OP-9", OP_ALLOW_MANAGED_EDIT: "1" },
+      wt,
+      payload(note),
+    );
+    expect(r.code).toBe(0);
+  });
+
+  it("allows edits on an unmanaged note", async () => {
+    const note = path.join(wt, "ISSUES", "OP-9 some issue.md");
+    await fs.mkdir(path.dirname(note), { recursive: true });
+    await fs.writeFile(note, "---\nid: OP-9\n---\n\n# OP-9\n");
+    const r = await runGuard({ OP_ISSUE_ID: "OP-9" }, wt, payload(note));
+    expect(r.code).toBe(0);
+  });
+
+  it("emits a TASK-specific hint for TASK note paths", async () => {
+    const note = path.join(wt, "TASKS", "OP-9.1 task.md");
+    await fs.mkdir(path.dirname(note), { recursive: true });
+    await fs.writeFile(note, "---\nop_managed: true\n---\n");
+    const r = await runGuard({ OP_ISSUE_ID: "OP-9" }, wt, payload(note));
+    expect(r.code).toBe(2);
+    expect(r.stderr).toMatch(/op-task-set-status|op-task-append-note/);
+  });
+});
+
+// OP-259: when managedNoteGuard is off but enforceWorktree is on, the script
+// must contain the worktree layer and *not* the managed layer — so a managed
+// note in a linked worktree is allowed (the layer is absent entirely).
+describe("installAgentHooks — managed layer is opt-in", () => {
+  it("omits the managed-note layer when managedNoteGuard is false", async () => {
+    const res = await installAgentHooks({
+      enforceWorktree: true,
+      managedNoteGuard: false,
+    });
+    const body = await fs.readFile(res.guardScriptPath, "utf8");
+    expect(body).toMatch(/Layer 1: worktree refusal/);
+    expect(body).not.toMatch(/Layer 2: managed-note refusal/);
+    // The header comment mentions `OP_ALLOW_MANAGED_EDIT` and `op_managed` for
+    // documentation purposes regardless of layer presence — assert against the
+    // actual layer-2 logic strings instead.
+    expect(body).not.toMatch(/refusing edit on managed note/);
+    expect(body).not.toMatch(/Path-based hint/);
+  });
+
+  it("installs the guard hook when only managedNoteGuard is true", async () => {
+    const res = await installAgentHooks({
+      enforceWorktree: false,
+      managedNoteGuard: true,
+    });
+    expect(res.guardInstalled.sort()).toEqual(["claude", "gemini"]);
+    const body = await fs.readFile(res.guardScriptPath, "utf8");
+    expect(body).not.toMatch(/Layer 1: worktree refusal/);
+    expect(body).toMatch(/Layer 2: managed-note refusal/);
+  });
+
+  it("uninstalls the guard when both layers are off", async () => {
+    await installAgentHooks({ enforceWorktree: true, managedNoteGuard: true });
+    const off = await installAgentHooks({
+      enforceWorktree: false,
+      managedNoteGuard: false,
+    });
+    expect(off.guardUninstalled.sort()).toEqual(["claude", "gemini"]);
+  });
+});

--- a/plugins/op-obsidian/src/agentHooks.ts
+++ b/plugins/op-obsidian/src/agentHooks.ts
@@ -19,6 +19,11 @@ import * as path from "path";
 
 export interface HookInstallOptions {
   enforceWorktree?: boolean;
+  /** OP-259: when true, the PreToolUse guard script includes the managed-note
+   *  refusal layer. Independent of `enforceWorktree`: either flag (or both)
+   *  triggers the hook install — the script body only contains the layers
+   *  that are enabled. Default off; Phase 6 of OP-218 owns the flip. */
+  managedNoteGuard?: boolean;
 }
 
 export interface HookInstallResult {
@@ -44,7 +49,9 @@ export async function installAgentHooks(
   const scriptPath = path.join(home, SCRIPT_REL);
   const guardScriptPath = path.join(home, GUARD_SCRIPT_REL);
   await writeScript(scriptPath);
-  await writeGuardScript(guardScriptPath);
+  const enforceWorktree = !!options.enforceWorktree;
+  const managedNoteGuard = !!options.managedNoteGuard;
+  await writeGuardScript(guardScriptPath, { enforceWorktree, managedNoteGuard });
 
   const installed: string[] = [];
   const skipped: string[] = [];
@@ -66,7 +73,11 @@ export async function installAgentHooks(
   const guardInstalled: string[] = [];
   const guardUninstalled: string[] = [];
   const guardSkipped: string[] = [];
-  const enforce = !!options.enforceWorktree;
+  // The guard hook is installed when *either* layer is enabled. Within the
+  // installed script, only the enabled layers actually run (writeGuardScript
+  // emits them conditionally), so an enabled flag matrix of {worktree:true,
+  // managed:false} still installs the hook but the managed layer is absent.
+  const wantInstall = enforceWorktree || managedNoteGuard;
 
   const guardStep = async (label: string, fn: () => Promise<"installed" | "removed" | "noop">) => {
     try {
@@ -74,12 +85,12 @@ export async function installAgentHooks(
       if (r === "installed") guardInstalled.push(label);
       else if (r === "removed") guardUninstalled.push(label);
     } catch (err) {
-      console.warn(`[op-obsidian] pretool guard ${enforce ? "install" : "uninstall"} skipped for ${label}:`, err);
+      console.warn(`[op-obsidian] pretool guard ${wantInstall ? "install" : "uninstall"} skipped for ${label}:`, err);
       guardSkipped.push(label);
     }
   };
 
-  if (enforce) {
+  if (wantInstall) {
     await guardStep("claude", () => installClaudePretoolGuard(home, guardScriptPath));
     await guardStep("gemini", () => installGeminiPretoolGuard(home, guardScriptPath));
     // Copilot CLI has no pre-tool gate; record the gap for the caller.
@@ -128,42 +139,122 @@ async function writeScript(scriptPath: string): Promise<void> {
   await fs.chmod(scriptPath, 0o755);
 }
 
-async function writeGuardScript(scriptPath: string): Promise<void> {
+interface GuardScriptLayers {
+  enforceWorktree: boolean;
+  managedNoteGuard: boolean;
+}
+
+async function writeGuardScript(
+  scriptPath: string,
+  layers: GuardScriptLayers,
+): Promise<void> {
   await fs.mkdir(path.dirname(scriptPath), { recursive: true });
-  const body = [
+  const body: string[] = [];
+  body.push(
     "#!/bin/bash",
     `# ${GUARD_MARKER}`,
-    "# PreToolUse guard. Blocks Edit/Write/MultiEdit/NotebookEdit when an",
-    "# op-launched agent is operating inside the main working tree of a git repo",
-    "# whose HEAD is the default branch. Exits 2 with stderr to signal refusal.",
-    "# No-op in any of: session not op-launched, escape-hatch set, not inside a",
-    "# repo, in a linked worktree, on a non-default branch, detached HEAD.",
+    "# PreToolUse guard for op-launched agents. Up to two layers, gated by",
+    "# the plugin's settings (the install path emits only the layers that are",
+    "# enabled — flip a setting → re-run installAgentHooks → script body is",
+    "# rewritten):",
+    "#",
+    "#   1. Worktree refusal — blocks Edit/Write on the main checkout of a git",
+    "#      repo whose HEAD is the default branch. Override per-call via",
+    "#      OP_ALLOW_MAIN_EDIT=1.",
+    "#",
+    "#   2. Managed-note refusal (OP-259) — refuses Edit/Write of any vault",
+    "#      `*.md` whose frontmatter contains `op_managed: true`. Override",
+    "#      per-call via OP_ALLOW_MANAGED_EDIT=1.",
+    "#",
+    "# Both layers exit 2 with stderr on refusal; otherwise exit 0. The whole",
+    "# script is a no-op when the session isn't op-launched ($OP_ISSUE_ID",
+    "# unset).",
+    "",
     'if [ -z "${OP_ISSUE_ID:-}" ]; then',
     "  exit 0",
     "fi",
-    'if [ "${OP_ALLOW_MAIN_EDIT:-}" = "1" ]; then',
+    "",
+  );
+
+  if (layers.enforceWorktree) {
+    body.push(
+    "# === Layer 1: worktree refusal ===",
+    'if [ "${OP_ALLOW_MAIN_EDIT:-}" != "1" ] \\',
+    "    && command -v git >/dev/null 2>&1 \\",
+    "    && git rev-parse --is-inside-work-tree >/dev/null 2>&1; then",
+    "  gitdir=$(git rev-parse --git-dir 2>/dev/null)",
+    '  case "$gitdir" in',
+    '    *".git/worktrees/"*) ;;  # linked worktree — fall through',
+    "    *)",
+    '      branch=$(git symbolic-ref --short HEAD 2>/dev/null || echo "")',
+    '      if [ -n "$branch" ]; then',
+    "        default=$(git symbolic-ref --short refs/remotes/origin/HEAD 2>/dev/null | sed 's|^origin/||')",
+    "        default=${default:-main}",
+    '        if [ "$branch" = "$default" ] || [ "$branch" = "main" ] || [ "$branch" = "master" ]; then',
+    '          echo "op-obsidian: refusing edit on main checkout for $OP_ISSUE_ID." >&2',
+    '          echo "Run: git worktree add ../$(basename \\"$PWD\\")-$OP_ISSUE_ID -b worktree-$OP_ISSUE_ID" >&2',
+    '          echo "Or export OP_ALLOW_MAIN_EDIT=1 for a one-line edit." >&2',
+    "          exit 2",
+    "        fi",
+    "      fi",
+    "      ;;",
+    "  esac",
+    "fi",
+    "",
+    );
+  }
+
+  if (layers.managedNoteGuard) {
+    body.push(
+    "# === Layer 2: managed-note refusal ===",
+    'if [ "${OP_ALLOW_MANAGED_EDIT:-}" = "1" ]; then',
     "  exit 0",
     "fi",
-    "command -v git >/dev/null 2>&1 || exit 0",
-    "git rev-parse --is-inside-work-tree >/dev/null 2>&1 || exit 0",
-    "gitdir=$(git rev-parse --git-dir 2>/dev/null)",
-    'case "$gitdir" in',
-    '  *".git/worktrees/"*) exit 0 ;;',
+    "# PreToolUse hook receives the tool invocation as JSON on stdin",
+    '# (`{"tool_input": {"file_path": "/abs/path", ...}, ...}`). Extract the',
+    "# first file_path with a tolerant sed — we restrict to a JSON-string form,",
+    "# matching the trivial single-line shape Claude Code emits. If stdin is",
+    "# empty or unparseable, fall through (no refusal).",
+    "input=$(cat 2>/dev/null || true)",
+    '[ -z "$input" ] && exit 0',
+    'file=$(printf %s "$input" | sed -n \'s/.*"file_path"[[:space:]]*:[[:space:]]*"\\([^"]*\\)".*/\\1/p\' | head -n1)',
+    '[ -z "$file" ] && exit 0',
+    'case "$file" in',
+    "  *.md) ;;",
+    "  *) exit 0 ;;",
     "esac",
-    'branch=$(git symbolic-ref --short HEAD 2>/dev/null || echo "")',
-    '[ -z "$branch" ] && exit 0',
-    "default=$(git symbolic-ref --short refs/remotes/origin/HEAD 2>/dev/null | sed 's|^origin/||')",
-    "default=${default:-main}",
-    'if [ "$branch" = "$default" ] || [ "$branch" = "main" ] || [ "$branch" = "master" ]; then',
-    '  echo "op-obsidian: refusing edit on main checkout for $OP_ISSUE_ID." >&2',
-    '  echo "Run: git worktree add ../$(basename \\"$PWD\\")-$OP_ISSUE_ID -b worktree-$OP_ISSUE_ID" >&2',
-    '  echo "Or export OP_ALLOW_MAIN_EDIT=1 for a one-line edit." >&2',
-    "  exit 2",
+    '[ -f "$file" ] || exit 0',
+    "# Frontmatter parse stays in pure shell (awk). We only recognize the",
+    "# trivial single-line `op_managed: true` form the migration writes —",
+    "# nested/quoted/multi-line variants fall through without refusal.",
+    "managed=$(awk '",
+    '  BEGIN { infm = 0 }',
+    '  NR == 1 && $0 == "---" { infm = 1; next }',
+    '  infm == 1 && $0 == "---" { exit }',
+    '  infm == 1 && /^op_managed:[[:space:]]*true[[:space:]]*$/ { print "yes"; exit }',
+    "' \"$file\")",
+    'if [ "$managed" != "yes" ]; then',
+    "  exit 0",
     "fi",
-    "exit 0",
+    "# Path-based hint at the right op-* endpoint.",
+    'case "$file" in',
+    '  */TASKS/*.md)             hint="Use op-task-set-status (status flips) or op-task-append-note (progress notes); op-task-create for new TASK notes." ;;',
+    '  */ISSUES/*.md|*/RESOLVED\\ ISSUES/*.md)',
+    '                            hint="Use op-set-tasks (## Tasks checklist), op-set-section (Plan/Notes/Summary), op-set-scope (Scope), op-append-commit, op-set-pr, op-resolve. Frontmatter status/agent flips have dedicated verbs." ;;',
+    '  */STATUS.md)              hint="STATUS.md is plugin-managed; use op-scaffold or the dedicated STATUS endpoint instead of editing in place." ;;',
+    '  */DOCS/*.md)              hint="Use op-doc-create (new vault DOC) or op-doc-edit (existing). Repo-tracked DOCS under DOCS/superpowers/ follow the repo workflow." ;;',
+    '  *)                        hint="Use the appropriate op-* endpoint instead of editing the managed note directly." ;;',
+    "esac",
+    'echo "op-obsidian: refusing edit on managed note: $file" >&2',
+    'echo "$hint" >&2',
+    'echo "Override with OP_ALLOW_MANAGED_EDIT=1 for a one-line edit." >&2',
+    "exit 2",
     "",
-  ].join("\n");
-  await fs.writeFile(scriptPath, body, { mode: 0o755 });
+    );
+  }
+
+  body.push("exit 0", "");
+  await fs.writeFile(scriptPath, body.join("\n"), { mode: 0o755 });
   await fs.chmod(scriptPath, 0o755);
 }
 

--- a/plugins/op-obsidian/src/main.ts
+++ b/plugins/op-obsidian/src/main.ts
@@ -5341,6 +5341,7 @@ export default class OpPlugin extends Plugin {
     try {
       const res: HookInstallResult = await installAgentHooks({
         enforceWorktree: this.settings.agents.enforceWorktree,
+        managedNoteGuard: this.settings.agentDiscipline.managedNoteGuard,
       });
       if (announce) {
         const summary = res.installed.length

--- a/plugins/op-obsidian/src/settings.ts
+++ b/plugins/op-obsidian/src/settings.ts
@@ -1754,6 +1754,18 @@ export class OpSettingsTab extends PluginSettingTab {
           await this.plugin.reinstallAgentHooks();
         }),
       );
+    new Setting(containerEl)
+      .setName("Refuse direct edits on managed notes")
+      .setDesc(
+        "OP-259 / Phase 2 of OP-218. PreToolUse layer that blocks Edit/Write on any vault `*.md` whose frontmatter has `op_managed: true` — agents are pushed toward the `op-*` endpoints (op-set-tasks, op-task-set-status, op-task-append-note, op-doc-create/edit, op-set-section, etc.). Default off until the additive endpoints have soaked in a release. Same hook channel as the worktree guard — same agent-coverage caveats. Override per-session with OP_ALLOW_MANAGED_EDIT=1.",
+      )
+      .addToggle((t) =>
+        t.setValue(s.agentDiscipline.managedNoteGuard).onChange(async (v) => {
+          s.agentDiscipline.managedNoteGuard = v;
+          await this.plugin.saveSettings();
+          await this.plugin.reinstallAgentHooks();
+        }),
+      );
   }
 
   private renderFlowChaining(containerEl: HTMLElement): void {

--- a/plugins/op-obsidian/src/settingsPure.ts
+++ b/plugins/op-obsidian/src/settingsPure.ts
@@ -70,6 +70,17 @@ export interface AgentsSettings {
   enforceWorktree: boolean;
 }
 
+/**
+ * OP-259: managed-note pretool guard layer. When `managedNoteGuard` is true,
+ * the PreToolUse hook script refuses agent Edit/Write/MultiEdit/NotebookEdit
+ * on any vault `*.md` whose frontmatter carries `op_managed: true`. Default
+ * **off** — Phase 6 (OP-218) will flip the default once the additive endpoints
+ * have soaked. Override per-call via the `OP_ALLOW_MANAGED_EDIT=1` env var.
+ */
+export interface AgentDisciplineSettings {
+  managedNoteGuard: boolean;
+}
+
 export interface DeveloperSettings {
   // When true, `op-dev:*` debugging commands appear in the command palette.
   // Default false so end-user palettes aren't crowded with plugin-author
@@ -194,6 +205,7 @@ export interface OpSettings {
   view: ViewSettings;
   github: GithubSettings;
   agents: AgentsSettings;
+  agentDiscipline: AgentDisciplineSettings;
   developer: DeveloperSettings;
   flow: FlowSettings;
   sessionDecoration: SessionDecorationSettings;
@@ -286,6 +298,11 @@ export const DEFAULT_SETTINGS: OpSettings = {
   },
   agents: {
     enforceWorktree: false,
+  },
+  agentDiscipline: {
+    // OP-259: managed-note pretool guard layer. Default off — Phase 6 of
+    // OP-218 owns the flip after a release of soak.
+    managedNoteGuard: false,
   },
   developer: {
     showDevCommands: false,
@@ -442,6 +459,12 @@ export function mergeSettings(loaded: unknown): OpSettings {
     const a = l.agents as Partial<AgentsSettings>;
     if (typeof a.enforceWorktree === "boolean") {
       base.agents.enforceWorktree = a.enforceWorktree;
+    }
+  }
+  if (l.agentDiscipline && typeof l.agentDiscipline === "object") {
+    const ad = l.agentDiscipline as Partial<AgentDisciplineSettings>;
+    if (typeof ad.managedNoteGuard === "boolean") {
+      base.agentDiscipline.managedNoteGuard = ad.managedNoteGuard;
     }
   }
   if (l.developer && typeof l.developer === "object") {

--- a/plugins/op/.claude-plugin/plugin.json
+++ b/plugins/op/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "op",
   "description": "Obsidian Projects workflow — schema, slash commands, and agent skill for running a Jira-lite issue tracker inside an Obsidian vault.",
-  "version": "0.88.0",
+  "version": "0.89.0",
   "author": {
     "name": "Eugene Archibald"
   },

--- a/plugins/op/skills/op/reference/schema.md
+++ b/plugins/op/skills/op/reference/schema.md
@@ -273,6 +273,8 @@ Notes that do **not** get the flag:
 
 The startup migration (`op-migrate-add-managed-flag`) is idempotent and runs once per plugin upgrade. Existing notes from before this release pick up the flag silently the first time the upgraded plugin loads; rerunning it on a fully migrated vault is a fast scan with zero writes.
 
+**Phase 2 guard layer (OP-259, default off).** Setting `agentDiscipline.managedNoteGuard` (Settings → op-obsidian → Worktree enforcement → "Refuse direct edits on managed notes") gates a second layer in `~/.op-obsidian/hooks/pretool-worktree-guard.sh`. When on, the script extracts the `tool_input.file_path` from the PreToolUse JSON on stdin, checks the file's frontmatter for the trivial single-line `op_managed: true` form the migration writes, and exits 2 with a path-aware hint at the right `op-*` endpoint (TASK → `op-task-set-status` / `op-task-append-note`; ISSUE → `op-set-tasks` / `op-set-section` / `op-set-scope` / `op-append-commit` / `op-set-pr` / `op-resolve`; STATUS → `op-scaffold`; DOCS → `op-doc-create` / `op-doc-edit`). Per-call escape hatch: `OP_ALLOW_MANAGED_EDIT=1`, mirroring `OP_ALLOW_MAIN_EDIT=1`. Coverage and gaps mirror the worktree guard exactly — Claude Code verified, Gemini install is best-effort/untested, Copilot CLI has no PreToolUse hook so the guard does not apply there. The settings flip rewrites the on-disk script (each layer is emitted only when its setting is on); changes take effect for the next agent session. Phase 6 of OP-218 will flip the default to on after a release of soak.
+
 ## Audit log
 
 Every successful mutating `op-*` call appends one JSONL line to `Projects/_scratch/op-audit.jsonl`:


### PR DESCRIPTION
## Summary

- Extend `pretool-worktree-guard.sh` with a second layer that refuses agent `Edit|Write|MultiEdit|NotebookEdit` on any vault `*.md` whose frontmatter carries `op_managed: true`. Frontmatter parse is pure-shell awk; restricted to the trivial single-line form the migration writes. Per-call escape hatch: `OP_ALLOW_MANAGED_EDIT=1` (mirrors `OP_ALLOW_MAIN_EDIT=1`).
- New plugin setting `agentDiscipline.managedNoteGuard` (default **off**) — Phase 6 of OP-218 owns the flip after a release of soak. The two layers are emitted independently: `writeGuardScript` only writes the layer whose owning setting is on, so `managedNoteGuard:false` produces a script with no managed-note logic at all.
- Refusal hint is path-aware: TASK → `op-task-set-status`/`op-task-append-note`; ISSUE → `op-set-tasks`/`op-set-section`/`op-set-scope`/`op-append-commit`/`op-set-pr`/`op-resolve`; STATUS → `op-scaffold`; DOCS → `op-doc-create`/`op-doc-edit`.
- Schema doc + Settings UI updated. New toggle row lives next to the worktree-enforcement toggle.

## Test plan

- [x] `npx vitest run` — 1797/1797 pass (new managed-note `describe` block + opt-in/opt-out matrix).
- [x] Manual smoke against the live OP-Test guard script (with the setting toggled on): managed-note Edit refused (exit 2 + `op-set-tasks` hint), `OP_ALLOW_MANAGED_EDIT=1` permits (exit 0), unmanaged note allowed (exit 0).
- [x] Settings probe: both toggles render under `data-op-section="worktreeEnforcement"`; default state off; toggling on rewrites the on-disk script with the layer-2 block.
- [ ] Soak in a release before the Phase 6 default flip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)