### PR TITLE
OP-264: ResolveConfirmModal Enter / Cmd-Enter to confirm

### DIFF
--- a/plugins/op-obsidian/manifest.json
+++ b/plugins/op-obsidian/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "op-obsidian",
   "name": "Obsidian Projects (op)",
-  "version": "0.90.0",
+  "version": "0.90.1",
   "minAppVersion": "1.5.0",
   "description": "Jira-lite issue tracker for Obsidian vaults — deterministic commands backing the op workflow.",
   "author": "Eugene Archibald",

--- a/plugins/op-obsidian/package.json
+++ b/plugins/op-obsidian/package.json
@@ -1,6 +1,6 @@
 {
   "name": "op-obsidian",
-  "version": "0.90.0",
+  "version": "0.90.1",
   "description": "Obsidian plugin that owns the deterministic half of the op workflow.",
   "main": "main.js",
   "scripts": {

--- a/plugins/op-obsidian/src/resolve.test.ts
+++ b/plugins/op-obsidian/src/resolve.test.ts
@@ -32,7 +32,7 @@ vi.mock("./projects", () => ({
   ],
 }));
 
-import { runResolve } from "./resolve";
+import { runResolve, handleResolveModalEnter } from "./resolve";
 import type { IssueEntry } from "./types";
 
 interface Recorded {
@@ -287,5 +287,49 @@ describe("runResolve — graceful failure when frontmatter write throws", () => 
     const res = await runResolve(app, store, { path: e.path, confirmed: true });
     expect(res.ok).toBe(true);
     expect(res.frontmatterWriteError).toBeUndefined();
+  });
+});
+
+describe("handleResolveModalEnter", () => {
+  function fakeEvt(target: { tagName?: string } | null) {
+    let prevented = false;
+    return {
+      evt: { target, preventDefault: () => (prevented = true) },
+      get prevented() {
+        return prevented;
+      },
+    };
+  }
+
+  it("calls onConfirm and preventDefault for a non-input target", () => {
+    const onConfirm = vi.fn();
+    const e = fakeEvt({ tagName: "DIV" });
+    handleResolveModalEnter(e.evt, onConfirm);
+    expect(onConfirm).toHaveBeenCalledOnce();
+    expect(e.prevented).toBe(true);
+  });
+
+  it("skips when an INPUT is focused", () => {
+    const onConfirm = vi.fn();
+    const e = fakeEvt({ tagName: "INPUT" });
+    handleResolveModalEnter(e.evt, onConfirm);
+    expect(onConfirm).not.toHaveBeenCalled();
+    expect(e.prevented).toBe(false);
+  });
+
+  it("skips when a TEXTAREA is focused", () => {
+    const onConfirm = vi.fn();
+    const e = fakeEvt({ tagName: "TEXTAREA" });
+    handleResolveModalEnter(e.evt, onConfirm);
+    expect(onConfirm).not.toHaveBeenCalled();
+    expect(e.prevented).toBe(false);
+  });
+
+  it("confirms when target is null", () => {
+    const onConfirm = vi.fn();
+    const e = fakeEvt(null);
+    handleResolveModalEnter(e.evt, onConfirm);
+    expect(onConfirm).toHaveBeenCalledOnce();
+    expect(e.prevented).toBe(true);
   });
 });

--- a/plugins/op-obsidian/src/resolve.ts
+++ b/plugins/op-obsidian/src/resolve.ts
@@ -222,6 +222,21 @@ function linksIssue(task: TaskEntry, issue: IssueEntry): boolean {
   return basename.length > 0 && link.includes(basename);
 }
 
+/**
+ * Resolve modal's Enter / Mod+Enter handler. Skips when an input/textarea is
+ * focused so typing in any future field doesn't accidentally confirm; otherwise
+ * suppresses the default and calls `onConfirm`.
+ */
+export function handleResolveModalEnter(
+  evt: { target?: EventTarget | null; preventDefault: () => void },
+  onConfirm: () => void,
+): void {
+  const t = evt.target as { tagName?: string } | null | undefined;
+  if (t && (t.tagName === "INPUT" || t.tagName === "TEXTAREA")) return;
+  evt.preventDefault();
+  onConfirm();
+}
+
 function confirmModal(
   app: App,
   issue: IssueEntry,
@@ -289,12 +304,7 @@ class ResolveConfirmModal extends Modal {
           .onClick(() => this.confirm()),
       );
 
-    const onEnter = (evt: KeyboardEvent) => {
-      const t = evt.target as HTMLElement | null;
-      if (t && (t.tagName === "INPUT" || t.tagName === "TEXTAREA")) return;
-      evt.preventDefault();
-      this.confirm();
-    };
+    const onEnter = (evt: KeyboardEvent) => handleResolveModalEnter(evt, () => this.confirm());
     this.scope.register([], "Enter", onEnter);
     this.scope.register(["Mod"], "Enter", onEnter);
   }

--- a/plugins/op-obsidian/src/resolve.ts
+++ b/plugins/op-obsidian/src/resolve.ts
@@ -286,12 +286,24 @@ class ResolveConfirmModal extends Modal {
         b
           .setButtonText(`Resolve as ${this.targetStatus}`)
           .setCta()
-          .onClick(() => {
-            this.decided = true;
-            this.done(true);
-            this.close();
-          }),
+          .onClick(() => this.confirm()),
       );
+
+    const onEnter = (evt: KeyboardEvent) => {
+      const t = evt.target as HTMLElement | null;
+      if (t && (t.tagName === "INPUT" || t.tagName === "TEXTAREA")) return;
+      evt.preventDefault();
+      this.confirm();
+    };
+    this.scope.register([], "Enter", onEnter);
+    this.scope.register(["Mod"], "Enter", onEnter);
+  }
+
+  private confirm(): void {
+    if (this.decided) return;
+    this.decided = true;
+    this.done(true);
+    this.close();
   }
 
   onClose(): void {

--- a/plugins/op/.claude-plugin/plugin.json
+++ b/plugins/op/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "op",
   "description": "Obsidian Projects workflow — schema, slash commands, and agent skill for running a Jira-lite issue tracker inside an Obsidian vault.",
-  "version": "0.90.0",
+  "version": "0.90.1",
   "author": {
     "name": "Eugene Archibald"
   },


### PR DESCRIPTION
## Summary

- Adds Enter and Cmd-Enter (Mod+Enter) keyboard shortcuts to the op-resolve confirm modal that trigger the CTA action.
- Escape→cancel was already free from Obsidian's Modal default.
- Handler skips when an INPUT/TEXTAREA is focused (defensive; matches launchAgentModal idiom).

## Test plan

- [x] `npx vitest run src/resolve.test.ts` (9 tests pass — existing tests bypass the modal with `confirmed: true`)
- [x] OP-Test smoke (v0.90.1): scope shows `+Escape`, `+Enter`, `Meta+Enter`; Escape cancels, Enter/Cmd-Enter resolve and move the file to `RESOLVED ISSUES/`, INPUT-focused Enter returns early.

🤖 Generated with [Claude Code](https://claude.com/claude-code)