### PR TITLE
OP-263: Phase 6 flip managed-note + new-file guard defaults to on

### DIFF
--- a/plugins/op-obsidian/manifest.json
+++ b/plugins/op-obsidian/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "op-obsidian",
   "name": "Obsidian Projects (op)",
-  "version": "0.92.0",
+  "version": "0.92.1",
   "minAppVersion": "1.5.0",
   "description": "Jira-lite issue tracker for Obsidian vaults — deterministic commands backing the op workflow.",
   "author": "Eugene Archibald",

--- a/plugins/op-obsidian/manifest.json
+++ b/plugins/op-obsidian/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "op-obsidian",
   "name": "Obsidian Projects (op)",
-  "version": "0.91.2",
+  "version": "0.92.0",
   "minAppVersion": "1.5.0",
   "description": "Jira-lite issue tracker for Obsidian vaults — deterministic commands backing the op workflow.",
   "author": "Eugene Archibald",

--- a/plugins/op-obsidian/package.json
+++ b/plugins/op-obsidian/package.json
@@ -1,6 +1,6 @@
 {
   "name": "op-obsidian",
-  "version": "0.92.0",
+  "version": "0.92.1",
   "description": "Obsidian plugin that owns the deterministic half of the op workflow.",
   "main": "main.js",
   "scripts": {

--- a/plugins/op-obsidian/package.json
+++ b/plugins/op-obsidian/package.json
@@ -1,6 +1,6 @@
 {
   "name": "op-obsidian",
-  "version": "0.91.2",
+  "version": "0.92.0",
   "description": "Obsidian plugin that owns the deterministic half of the op workflow.",
   "main": "main.js",
   "scripts": {

--- a/plugins/op-obsidian/src/agentHooks.ts
+++ b/plugins/op-obsidian/src/agentHooks.ts
@@ -22,12 +22,12 @@ export interface HookInstallOptions {
   /** OP-259: when true, the PreToolUse guard script includes the managed-note
    *  refusal layer. Independent of `enforceWorktree`: either flag (or both)
    *  triggers the hook install — the script body only contains the layers
-   *  that are enabled. Default off; Phase 6 of OP-218 owns the flip. */
+   *  that are enabled. Default **on** as of OP-263 (Phase 6 of OP-218). */
   managedNoteGuard?: boolean;
   /** OP-260: when true, the PreToolUse guard script refuses agent creation of
    *  new files under `Projects/<slug>/{ISSUES,RESOLVED ISSUES,TASKS}/`. Same
-   *  install/uninstall plumbing as the managed-note layer. Default off;
-   *  Phase 6 of OP-218 owns the flip. */
+   *  install/uninstall plumbing as the managed-note layer. Default **on**
+   *  as of OP-263 (Phase 6 of OP-218). */
   newFileGuard?: boolean;
 }
 

--- a/plugins/op-obsidian/src/settings.ts
+++ b/plugins/op-obsidian/src/settings.ts
@@ -1769,7 +1769,7 @@ export class OpSettingsTab extends PluginSettingTab {
     new Setting(containerEl)
       .setName("Refuse direct edits on managed notes")
       .setDesc(
-        "OP-259 / Phase 2 of OP-218. PreToolUse layer that blocks Edit/Write on any vault `*.md` whose frontmatter has `op_managed: true` — agents are pushed toward the `op-*` endpoints (op-set-tasks, op-task-set-status, op-task-append-note, op-doc-create/edit, op-set-section, etc.). Default off until the additive endpoints have soaked in a release. Same hook channel as the worktree guard — same agent-coverage caveats. Override per-session with OP_ALLOW_MANAGED_EDIT=1.",
+        "OP-259 / Phase 2 of OP-218. PreToolUse layer that blocks Edit/Write on any vault `*.md` whose frontmatter has `op_managed: true` — agents are pushed toward the `op-*` endpoints (op-set-tasks, op-task-set-status, op-task-append-note, op-doc-create/edit, op-set-section, etc.). Default **on** as of OP-263 (Phase 6 of OP-218). Same hook channel as the worktree guard — same agent-coverage caveats. Override per-session with OP_ALLOW_MANAGED_EDIT=1.",
       )
       .addToggle((t) =>
         t.setValue(s.agentDiscipline.managedNoteGuard).onChange(async (v) => {
@@ -1781,7 +1781,7 @@ export class OpSettingsTab extends PluginSettingTab {
     new Setting(containerEl)
       .setName("Refuse new files under ISSUES / RESOLVED ISSUES / TASKS")
       .setDesc(
-        "OP-260 / Phase 3 of OP-218. PreToolUse layer that refuses agent creation of new files anywhere under `Projects/<slug>/{ISSUES,RESOLVED ISSUES,TASKS}/` — agents are pushed toward `op-new` (new issues) and `op-task-create` (new TASK notes). RESOLVED ISSUES is plugin-managed at resolve time; direct creation there is always wrong. Existing-file edits still flow through the managed-note layer above. Default off until soak. Override per-session with OP_ALLOW_NEW_FILE=1.",
+        "OP-260 / Phase 3 of OP-218. PreToolUse layer that refuses agent creation of new files anywhere under `Projects/<slug>/{ISSUES,RESOLVED ISSUES,TASKS}/` — agents are pushed toward `op-new` (new issues) and `op-task-create` (new TASK notes). RESOLVED ISSUES is plugin-managed at resolve time; direct creation there is always wrong. Existing-file edits still flow through the managed-note layer above. Default **on** as of OP-263 (Phase 6 of OP-218). Override per-session with OP_ALLOW_NEW_FILE=1.",
       )
       .addToggle((t) =>
         t.setValue(s.agentDiscipline.newFileGuard).onChange(async (v) => {

--- a/plugins/op-obsidian/src/settingsPure.ts
+++ b/plugins/op-obsidian/src/settingsPure.ts
@@ -74,15 +74,19 @@ export interface AgentsSettings {
  * OP-259: managed-note pretool guard layer. When `managedNoteGuard` is true,
  * the PreToolUse hook script refuses agent Edit/Write/MultiEdit/NotebookEdit
  * on any vault `*.md` whose frontmatter carries `op_managed: true`. Default
- * **off** — Phase 6 (OP-218) will flip the default once the additive endpoints
- * have soaked. Override per-call via the `OP_ALLOW_MANAGED_EDIT=1` env var.
+ * **on** as of OP-263 (Phase 6 of OP-218). Override per-call via the
+ * `OP_ALLOW_MANAGED_EDIT=1` env var; users who hit a regression can opt out
+ * persistently by setting `agentDiscipline.managedNoteGuard: false` in
+ * `<vault>/.obsidian/plugins/op-obsidian/data.json` — `mergeSettings` honors
+ * any boolean explicitly persisted there.
  *
  * OP-260: new-file pretool guard layer. When `newFileGuard` is true, the same
  * PreToolUse script also refuses creation of new files under
  * `Projects/<slug>/{ISSUES,RESOLVED ISSUES,TASKS}/` — agents are pushed toward
  * `op-new` / `op-task-create`. Existing-file edits fall through to the
- * managed-note layer (or pass, if not managed). Default **off**; Phase 6 of
- * OP-218 owns the flip. Override per-call via `OP_ALLOW_NEW_FILE=1`.
+ * managed-note layer (or pass, if not managed). Default **on** as of OP-263
+ * (Phase 6 of OP-218). Override per-call via `OP_ALLOW_NEW_FILE=1`; same
+ * `data.json` opt-out path as `managedNoteGuard`.
  */
 export interface AgentDisciplineSettings {
   managedNoteGuard: boolean;
@@ -334,11 +338,12 @@ export const DEFAULT_SETTINGS: OpSettings = {
     enforceWorktree: false,
   },
   agentDiscipline: {
-    // OP-259: managed-note pretool guard layer. Default off — Phase 6 of
-    // OP-218 owns the flip after a release of soak.
-    managedNoteGuard: false,
-    // OP-260: new-file pretool guard layer. Default off — Phase 6 flips.
-    newFileGuard: false,
+    // OP-259 + OP-260: managed-note and new-file pretool guard layers.
+    // Default ON as of OP-263 (Phase 6 of OP-218). Existing installs that
+    // persisted `false` from the prior default keep their opt-out via
+    // `mergeSettings`; fresh installs get the discipline by default.
+    managedNoteGuard: true,
+    newFileGuard: true,
   },
   developer: {
     showDevCommands: false,

--- a/plugins/op/.claude-plugin/plugin.json
+++ b/plugins/op/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "op",
   "description": "Obsidian Projects workflow — schema, slash commands, and agent skill for running a Jira-lite issue tracker inside an Obsidian vault.",
-  "version": "0.92.0",
+  "version": "0.92.1",
   "author": {
     "name": "Eugene Archibald"
   },

--- a/plugins/op/.claude-plugin/plugin.json
+++ b/plugins/op/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "op",
   "description": "Obsidian Projects workflow — schema, slash commands, and agent skill for running a Jira-lite issue tracker inside an Obsidian vault.",
-  "version": "0.91.2",
+  "version": "0.92.0",
   "author": {
     "name": "Eugene Archibald"
   },

--- a/plugins/op/skills/op/reference/cli-gotchas.md
+++ b/plugins/op/skills/op/reference/cli-gotchas.md
@@ -73,13 +73,17 @@ Why this matters beyond ergonomics: every successful op-* call appends a JSONL l
 
 **Per-call overrides** (one-shot): `OP_ALLOW_MANAGED_EDIT=1` for the managed-note layer, `OP_ALLOW_NEW_FILE=1` for the new-file layer. Use sparingly — every override defeats the audit signal we use to find missing endpoints.
 
-**Persistent rollback** (when an unforeseen regression demands it): edit `<vault>/.obsidian/plugins/op-obsidian/data.json` and set
+**Persistent rollback** (when an unforeseen regression demands it): open `<vault>/.obsidian/plugins/op-obsidian/data.json` — it already contains the user's full settings tree — and set or insert just the `agentDiscipline.managedNoteGuard` / `agentDiscipline.newFileGuard` keys. **Preserve every other key in the file**; the snippet below is a partial excerpt of the relevant subtree, not a replacement for the whole file:
 
 ```json
-{ "agentDiscipline": { "managedNoteGuard": false, "newFileGuard": false } }
+// excerpt — merge into the existing data.json, do not overwrite the file
+"agentDiscipline": {
+  "managedNoteGuard": false,
+  "newFileGuard": false
+}
 ```
 
-then reload op-obsidian (Settings → Community plugins → toggle off + on, or `obsidian plugin:reload id=op-obsidian`). `mergeSettings` honors any boolean explicitly persisted in `data.json`, so the opt-out survives plugin updates. Flip individual flags rather than both if the regression is layer-specific. File an issue against `obsidian-projects` so the regression can be fixed and the guard re-enabled.
+then reload op-obsidian (Settings → Community plugins → toggle off + on, or `obsidian plugin:reload id=op-obsidian`). `mergeSettings` honors any boolean explicitly persisted in `data.json`, so the opt-out survives plugin updates. Flip individual flags rather than both if the regression is layer-specific. The same opt-out is also reachable from Settings → op → Advanced → Agent discipline (toggle "Refuse direct edits on managed notes" / "Refuse new files under ISSUES…") for users who'd rather not hand-edit JSON. File an issue against `obsidian-projects` so the regression can be fixed and the guard re-enabled.
 
 ### Eval mutation is the surviving bypass hole — do not use it
 

--- a/plugins/op/skills/op/reference/cli-gotchas.md
+++ b/plugins/op/skills/op/reference/cli-gotchas.md
@@ -69,7 +69,17 @@ Plugin-owned notes — issues, TASKS, scaffold-time DOCs — carry `op_managed: 
 | Vault-only DOC create | `obsidian op-doc-create project=<slug> doc_type=<plan\|spec\|adr\|runbook> title="…"` | Refuses `DOCS/superpowers/` (repo-symlinked). |
 | Vault-only DOC edit | `obsidian op-doc-edit path=<…> [section=<H2>] body="…"` | Section-scoped or full-body append. |
 
-Why this matters beyond ergonomics: every successful op-* call appends a JSONL line to `Projects/_scratch/op-audit.jsonl`. Raw `Edit`/`Write` skips that trail and shows up there as `bypass: true` lines (detection-after-the-fact). The Phase 2 pretool guard (OP-259) ships default-off and refuses `Edit`/`Write` on `op_managed: true` notes outright when enabled; Phase 3 (OP-260) does the same for new files under `ISSUES`/`RESOLVED ISSUES`/`TASKS`. Phase 6 will flip both to default-on.
+Why this matters beyond ergonomics: every successful op-* call appends a JSONL line to `Projects/_scratch/op-audit.jsonl`. Raw `Edit`/`Write` skips that trail and shows up there as `bypass: true` lines (detection-after-the-fact). The Phase 2 pretool guard (OP-259) refuses `Edit`/`Write` on `op_managed: true` notes outright; Phase 3 (OP-260) does the same for new files under `ISSUES`/`RESOLVED ISSUES`/`TASKS`. **Both default to on** as of OP-263 (Phase 6 of OP-218) — fresh installs get the discipline without any settings flip.
+
+**Per-call overrides** (one-shot): `OP_ALLOW_MANAGED_EDIT=1` for the managed-note layer, `OP_ALLOW_NEW_FILE=1` for the new-file layer. Use sparingly — every override defeats the audit signal we use to find missing endpoints.
+
+**Persistent rollback** (when an unforeseen regression demands it): edit `<vault>/.obsidian/plugins/op-obsidian/data.json` and set
+
+```json
+{ "agentDiscipline": { "managedNoteGuard": false, "newFileGuard": false } }
+```
+
+then reload op-obsidian (Settings → Community plugins → toggle off + on, or `obsidian plugin:reload id=op-obsidian`). `mergeSettings` honors any boolean explicitly persisted in `data.json`, so the opt-out survives plugin updates. Flip individual flags rather than both if the regression is layer-specific. File an issue against `obsidian-projects` so the regression can be fixed and the guard re-enabled.
 
 ### Eval mutation is the surviving bypass hole — do not use it
 


### PR DESCRIPTION
## Summary

Phase 6 of OP-218 (parent: [OP-257](../issues/337)). Flips the two pretool guards added in Phases 2 + 3 from default-off to default-on for fresh installs:

- `agentDiscipline.managedNoteGuard` (OP-259) — refuses agent `Edit`/`Write` on `op_managed: true` notes
- `agentDiscipline.newFileGuard` (OP-260) — refuses agent file creation under `Projects/<slug>/{ISSUES,RESOLVED ISSUES,TASKS}/`

`mergeSettings` honors any boolean explicitly persisted in `data.json`, so existing installs that had the old `false` default persisted keep their setting (and any explicit user opt-out continues to work).

Per-call escape hatches unchanged: `OP_ALLOW_MANAGED_EDIT=1` / `OP_ALLOW_NEW_FILE=1`.

Persistent rollback documented in `plugins/op/skills/op/reference/cli-gotchas.md`: edit `<vault>/.obsidian/plugins/op-obsidian/data.json` → set `agentDiscipline.{managedNoteGuard,newFileGuard}: false` → reload op-obsidian.

Closes OP-263.

## Soak verification

- Phase 2 / OP-259 shipped in `op-obsidian-v0.89.0`. Soaked through v0.90.0, v0.90.1, v0.91.1.
- Phase 3 / OP-260 shipped in `op-obsidian-v0.91.1` (≥1 tagged release containing the change).
- OP-Test `op-audit.jsonl`: 9 `bypass:true` entries, all from `build-seeds.mjs` setup. Intentional.
- Agent-Vault `op-audit.jsonl`: 558 `bypass:true` entries, all from the `op-migrate-add-managed-flag` startup backfill. Intentional + idempotent.
- Net: zero unaccounted-for bypass entries since either guard landed.

## Test plan

- [x] Targeted vitest: `settingsPure.test.ts` + `agentHooks.pretool.test.ts` — 50 PASS / 0 FAIL.
- [x] Fresh-install simulation in OP-Test (v0.92.0): stripped `agentDiscipline` from `data.json`, reloaded plugin, probed live settings → `{managedNoteGuard: true, newFileGuard: true}`.
- [x] Persisted opt-out preservation: restored `{false, false}` in `data.json`, reloaded → live settings `{false, false}`. `mergeSettings` override path verified.
- [x] Version bump 0.91.2 → 0.92.0 (minor; behavior change for fresh installs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)