### PR TITLE
OP-264: ResolveConfirmModal keyboard hint footer

### DIFF
--- a/plugins/op-obsidian/manifest.json
+++ b/plugins/op-obsidian/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "op-obsidian",
   "name": "Obsidian Projects (op)",
-  "version": "0.92.1",
+  "version": "0.93.0",
   "minAppVersion": "1.5.0",
   "description": "Jira-lite issue tracker for Obsidian vaults — deterministic commands backing the op workflow.",
   "author": "Eugene Archibald",

--- a/plugins/op-obsidian/package.json
+++ b/plugins/op-obsidian/package.json
@@ -1,6 +1,6 @@
 {
   "name": "op-obsidian",
-  "version": "0.92.1",
+  "version": "0.93.0",
   "description": "Obsidian plugin that owns the deterministic half of the op workflow.",
   "main": "main.js",
   "scripts": {

--- a/plugins/op-obsidian/src/resolve.ts
+++ b/plugins/op-obsidian/src/resolve.ts
@@ -304,6 +304,20 @@ class ResolveConfirmModal extends Modal {
           .onClick(() => this.confirm()),
       );
 
+    const hint = contentEl.createDiv({
+      cls: "prompt-instructions op-resolve-modal__hint",
+    });
+    const hintItems: Array<[string, string]> = [
+      ["Esc", "cancel"],
+      ["↵", `resolve as ${this.targetStatus}`],
+      ["⌘↵", `resolve as ${this.targetStatus}`],
+    ];
+    for (const [keys, label] of hintItems) {
+      const item = hint.createDiv({ cls: "prompt-instruction" });
+      item.createSpan({ cls: "prompt-instruction-command", text: keys });
+      item.createSpan({ text: ` ${label}` });
+    }
+
     const onEnter = (evt: KeyboardEvent) => handleResolveModalEnter(evt, () => this.confirm());
     this.scope.register([], "Enter", onEnter);
     this.scope.register(["Mod"], "Enter", onEnter);

--- a/plugins/op-obsidian/styles.css
+++ b/plugins/op-obsidian/styles.css
@@ -422,6 +422,12 @@ a.op-sidebar__agent:hover {
   border-top: 1px solid var(--background-modifier-border);
 }
 
+.op-resolve-modal__hint {
+  margin-top: 0.6rem;
+  border-top: 1px solid var(--background-modifier-border);
+  padding-top: 0.5rem;
+}
+
 .op-pick-and-act__hint-note {
   color: var(--text-faint);
   font-style: italic;

--- a/plugins/op/.claude-plugin/plugin.json
+++ b/plugins/op/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "op",
   "description": "Obsidian Projects workflow — schema, slash commands, and agent skill for running a Jira-lite issue tracker inside an Obsidian vault.",
-  "version": "0.92.1",
+  "version": "0.93.0",
   "author": {
     "name": "Eugene Archibald"
   },


### PR DESCRIPTION
## Summary

- Adds a small keyboard-hint footer below the Cancel / Resolve buttons in `ResolveConfirmModal`, using the established `.prompt-instructions` / `.prompt-instruction` pattern from `pickAndActModal`
- Three hints: `Esc cancel`, `↵ resolve as <status>`, `⌘↵ resolve as <status>`
- Adds `.op-resolve-modal__hint` CSS rule (margin-top + border-top separator) in `styles.css`
- Bumps to v0.93.0 (minor — new visible UI element)

Closes the remaining scope item from OP-264 (button hints); Enter/Cmd-Enter/Esc bindings shipped in PR #373.

## Test plan

- [x] Smoke-tested in OP-Test (v0.93.0): `hintPresent: true`, items `["Esc cancel", "↵ resolve as resolved", "⌘↵ resolve as resolved"]` ✓
- [x] `resolve.test.ts` (13 tests) passes ✓
- [x] TypeScript build clean in `resolve.ts` ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)