### PR TITLE
OP-266: tmux sessions inherit $HOME, not Obsidian's / cwd

### DIFF
--- a/plugins/op-obsidian/manifest.json
+++ b/plugins/op-obsidian/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "op-obsidian",
   "name": "Obsidian Projects (op)",
-  "version": "0.93.0",
+  "version": "0.93.1",
   "minAppVersion": "1.5.0",
   "description": "Jira-lite issue tracker for Obsidian vaults — deterministic commands backing the op workflow.",
   "author": "Eugene Archibald",

--- a/plugins/op-obsidian/package.json
+++ b/plugins/op-obsidian/package.json
@@ -1,6 +1,6 @@
 {
   "name": "op-obsidian",
-  "version": "0.93.0",
+  "version": "0.93.1",
   "description": "Obsidian plugin that owns the deterministic half of the op workflow.",
   "main": "main.js",
   "scripts": {

--- a/plugins/op-obsidian/src/orchestrator.test.ts
+++ b/plugins/op-obsidian/src/orchestrator.test.ts
@@ -258,7 +258,7 @@ describe("buildViewScript", () => {
   it("creates the per-pane grouped session and attaches with select-window", () => {
     const out = buildViewScript(baseArgs);
     expect(out).toContain(
-      `'/opt/homebrew/bin/tmux' new-session -d -s 'view-OP-172' -t 'op-agents-1' 2>/dev/null || true`,
+      `'/opt/homebrew/bin/tmux' new-session -d -s 'view-OP-172' -c "$HOME" -t 'op-agents-1' 2>/dev/null || true`,
     );
     expect(out).toContain(
       `exec '/opt/homebrew/bin/tmux' attach -t 'view-OP-172' \\; select-window -t 'view-OP-172':'OP-172'`,

--- a/plugins/op-obsidian/src/orchestrator.ts
+++ b/plugins/op-obsidian/src/orchestrator.ts
@@ -375,7 +375,9 @@ export function buildViewScript({
     "#!/bin/bash",
     "set -e",
     `export PATH="/opt/homebrew/bin:/usr/local/bin:$HOME/.local/bin:$HOME/bin:$PATH"`,
-    `${tmux} new-session -d -s ${groupSess} -t ${sess} 2>/dev/null || true`,
+    // OP-266: `-c "$HOME"` so the grouped session's default-path is the
+    // user's homedir, not Obsidian's process cwd ("/" for GUI launches).
+    `${tmux} new-session -d -s ${groupSess} -c "$HOME" -t ${sess} 2>/dev/null || true`,
     // OP-178: make set-hook non-fatal so a session-already-gone race (agent
     // crashed before this script reached set-hook) doesn't show an error
     // before the subsequent exec-attach also fails and the pane closes.

--- a/plugins/op-obsidian/src/terminalLaunch.test.ts
+++ b/plugins/op-obsidian/src/terminalLaunch.test.ts
@@ -57,7 +57,7 @@ describe("buildPrepScript", () => {
       "'/opt/homebrew/bin/tmux' has-session -t 'op-agents'",
     );
     expect(s).toContain(
-      "'/opt/homebrew/bin/tmux' new-session -d -s 'op-agents' -n 'OP-39' bash '/tmp/op-agent-xyz/agent.command'",
+      "'/opt/homebrew/bin/tmux' new-session -d -s 'op-agents' -c \"$HOME\" -n 'OP-39' bash '/tmp/op-agent-xyz/agent.command'",
     );
   });
 
@@ -70,7 +70,7 @@ describe("buildPrepScript", () => {
   it("creates a new window when the session exists but the window does not", () => {
     const s = buildPrepScript(base);
     expect(s).toContain(
-      "'/opt/homebrew/bin/tmux' new-window -t 'op-agents' -n 'OP-39' bash '/tmp/op-agent-xyz/agent.command'",
+      "'/opt/homebrew/bin/tmux' new-window -t 'op-agents' -c \"$HOME\" -n 'OP-39' bash '/tmp/op-agent-xyz/agent.command'",
     );
   });
 });

--- a/plugins/op-obsidian/src/terminalLaunch.ts
+++ b/plugins/op-obsidian/src/terminalLaunch.ts
@@ -345,13 +345,17 @@ export function buildPrepScript({ tmuxBinary, session, windowName, innerPath }: 
   const sess = shSingleQuote(session);
   const wname = shSingleQuote(windowName);
   const inner = shSingleQuote(innerPath);
+  // OP-266: pass `-c "$HOME"` so the tmux session/window default-path is the
+  // user's homedir rather than Obsidian's process cwd ("/" for GUI launches on
+  // macOS). The agent's inner script still cd's into the repo path, but any
+  // subsequent split or manually opened tmux window now inherits $HOME.
   return [
     `if ! ${tmux} has-session -t ${sess} 2>/dev/null; then`,
-    `  ${tmux} new-session -d -s ${sess} -n ${wname} bash ${inner}`,
+    `  ${tmux} new-session -d -s ${sess} -c "$HOME" -n ${wname} bash ${inner}`,
     `elif ${tmux} list-windows -t ${sess} -F '#W' | grep -Fxq ${wname}; then`,
     `  ${tmux} select-window -t ${sess}:${wname}`,
     `else`,
-    `  ${tmux} new-window -t ${sess} -n ${wname} bash ${inner}`,
+    `  ${tmux} new-window -t ${sess} -c "$HOME" -n ${wname} bash ${inner}`,
     `fi`,
   ].join("\n");
 }

--- a/plugins/op/.claude-plugin/plugin.json
+++ b/plugins/op/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "op",
   "description": "Obsidian Projects workflow — schema, slash commands, and agent skill for running a Jira-lite issue tracker inside an Obsidian vault.",
-  "version": "0.93.0",
+  "version": "0.93.1",
   "author": {
     "name": "Eugene Archibald"
   },


### PR DESCRIPTION
## Summary

- `buildPrepScript` (`terminalLaunch.ts`) and `buildViewScript` (`orchestrator.ts`) invoked tmux `new-session` / `new-window` without `-c`, so the session default-path inherited from Obsidian's process cwd — `/` for GUI-launched apps on macOS.
- Agent pane was unaffected (inner script `cd`s into the repo path), but any user-initiated tmux split or new tmux window opened at `/` instead of `$HOME`.
- Pass `-c "$HOME"` so new panes land in the user's homedir.

## Test plan

- [x] Full vitest suite (1846 pass / 0 fail)
- [x] `dev-sync.mjs` to OP-Test, plugin reloads clean (no console errors)
- [ ] Smoke: open an agent, split the iTerm pane manually (Cmd-D) — new pane should land in `$HOME`