### PR TITLE
OP-267: document claude-ds as supported transparent wrapper

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,7 @@ The repository recognizes `claude`, `gemini`, and `copilot`, but support is not 
 | Runtime | Status | Notes |
 | --- | --- | --- |
 | Claude Code | Primary | The main supported runtime for the skill, plugin smoke tests, and orchestration flow |
+| `claude-ds` | Primary | 100% transparent wrapper for `claude` — point the `claude` profile at it via the per-agent `binary` overlay (`{"binary":"claude-ds"}`) in Settings → Agents. Same flags, prompts, hooks |
 | Gemini CLI | Experimental | Dispatch code exists, but the workflow is not exercised in normal development |
 | Copilot CLI | Experimental | Dispatch code exists, but worktree enforcement hooks are not available and the runtime is not part of the normal smoke path |
 

--- a/plugins/op-obsidian/README.md
+++ b/plugins/op-obsidian/README.md
@@ -84,7 +84,7 @@ Found at `Settings → Community plugins → Obsidian Projects (op)`.
 - **Default agent** — which agent (`claude`, `codex`, `gemini`, `aider`, …) `op: open agent for issue` launches.
 - **Always prompt for agent** — force the picker every time.
 - **Detection** — summary of which agent binaries were found on `PATH`. Click **Re-probe** after installing a new agent.
-- **Profile overlays** — per-agent JSON overlay merged over the built-in profile. Keys: `binary`, `launchFlags` (string[]), `promptPreamble`, `skillTrigger`, `label`.
+- **Profile overlays** — per-agent JSON overlay merged over the built-in profile. Keys: `binary`, `launchFlags` (string[]), `promptPreamble`, `skillTrigger`, `label`. To use `claude-ds` (a 100% transparent wrapper for `claude`), set the `claude` profile's `binary` to `claude-ds` — every flag, prompt, and hook the `claude` profile ships with passes through unchanged.
 
 ### Injection
 

--- a/plugins/op-obsidian/manifest.json
+++ b/plugins/op-obsidian/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "op-obsidian",
   "name": "Obsidian Projects (op)",
-  "version": "0.93.1",
+  "version": "0.93.2",
   "minAppVersion": "1.5.0",
   "description": "Jira-lite issue tracker for Obsidian vaults — deterministic commands backing the op workflow.",
   "author": "Eugene Archibald",

--- a/plugins/op-obsidian/package.json
+++ b/plugins/op-obsidian/package.json
@@ -1,6 +1,6 @@
 {
   "name": "op-obsidian",
-  "version": "0.93.1",
+  "version": "0.93.2",
   "description": "Obsidian plugin that owns the deterministic half of the op workflow.",
   "main": "main.js",
   "scripts": {

--- a/plugins/op/.claude-plugin/plugin.json
+++ b/plugins/op/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "op",
   "description": "Obsidian Projects workflow — schema, slash commands, and agent skill for running a Jira-lite issue tracker inside an Obsidian vault.",
-  "version": "0.93.1",
+  "version": "0.93.2",
   "author": {
     "name": "Eugene Archibald"
   },


### PR DESCRIPTION
## Summary

- Adds `claude-ds` to the README "Supported runtimes" table as a Primary-tier transparent wrapper for `claude`.
- Notes in `plugins/op-obsidian/README.md` (Settings → Agents) that the per-agent `binary` profile overlay accepts `claude-ds`.
- No code change — claude-ds is a 100% transparent wrapper, so every existing flag/prompt/hook on the `claude` profile passes through unchanged.
- Bumps op-obsidian 0.93.1 → 0.93.2 (patch, docs-only) per the in-lockstep version rule.

Closes OP-267 / #380.

## Test plan

- [x] `node scripts/bump-version.mjs 0.93.2` — green build, main.js fresher than manifest.
- [x] `node scripts/dev-sync.mjs` — copied + reloaded into OP-Test cleanly.
- [x] OP-Test reports `op-obsidian 0.93.2` after reload, no console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)