### PR TITLE
OP-267 follow-up: register claude-ds as first-class AgentId

### DIFF
--- a/docs/workflow-modules/reference/workflow-schema.md
+++ b/docs/workflow-modules/reference/workflow-schema.md
@@ -82,6 +82,7 @@ node scripts/check-workflow-docs.mjs
 | Agent | Aliases (alias → canonical) | Versioned ids |
 | :--- | :--- | :--- |
 | `claude` | `opus` → `claude-opus-4-7`<br>`sonnet` → `claude-sonnet-4-6`<br>`haiku` → `claude-haiku-4-5-20251001` | `claude-opus-4-7`<br>`claude-opus-4-6`<br>`claude-opus-4-5`<br>`claude-sonnet-4-6`<br>`claude-sonnet-4-5`<br>`claude-haiku-4-5`<br>`claude-haiku-4-5-20251001` |
+| `claude-ds` | `opus` → `claude-opus-4-7`<br>`sonnet` → `claude-sonnet-4-6`<br>`haiku` → `claude-haiku-4-5-20251001` | `claude-opus-4-7`<br>`claude-opus-4-6`<br>`claude-opus-4-5`<br>`claude-sonnet-4-6`<br>`claude-sonnet-4-5`<br>`claude-haiku-4-5`<br>`claude-haiku-4-5-20251001` |
 | `gemini` | `pro` → `gemini-2.5-pro`<br>`flash` → `gemini-2.5-flash` | `gemini-2.5-pro`<br>`gemini-2.5-flash`<br>`gemini-2.0-pro`<br>`gemini-2.0-flash` |
 | `copilot` | `default` → `gpt-5` | `gpt-5`<br>`gpt-4.1` |
 <!-- /AUTO-GENERATED:model-registry-table -->

--- a/plugins/op-obsidian/manifest.json
+++ b/plugins/op-obsidian/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "op-obsidian",
   "name": "Obsidian Projects (op)",
-  "version": "0.93.2",
+  "version": "0.94.0",
   "minAppVersion": "1.5.0",
   "description": "Jira-lite issue tracker for Obsidian vaults — deterministic commands backing the op workflow.",
   "author": "Eugene Archibald",

--- a/plugins/op-obsidian/package.json
+++ b/plugins/op-obsidian/package.json
@@ -1,6 +1,6 @@
 {
   "name": "op-obsidian",
-  "version": "0.93.2",
+  "version": "0.94.0",
   "description": "Obsidian plugin that owns the deterministic half of the op workflow.",
   "main": "main.js",
   "scripts": {

--- a/plugins/op-obsidian/src/agentProfiles.ts
+++ b/plugins/op-obsidian/src/agentProfiles.ts
@@ -1,8 +1,8 @@
 import { renderTemplate } from "./renderTemplate";
 
-export type AgentId = "claude" | "gemini" | "copilot";
+export type AgentId = "claude" | "claude-ds" | "gemini" | "copilot";
 
-export const AGENT_IDS: AgentId[] = ["claude", "gemini", "copilot"];
+export const AGENT_IDS: AgentId[] = ["claude", "claude-ds", "gemini", "copilot"];
 
 export function asAgentId(value: string | null | undefined): AgentId | undefined {
   return typeof value === "string" && AGENT_IDS.includes(value as AgentId)
@@ -217,6 +217,32 @@ export const BASE_PROFILES: Readonly<Record<AgentId, AgentProfile>> = Object.fre
     id: "claude",
     label: "Claude Code",
     binary: "claude",
+    launchFlags: ["--permission-mode", "auto"],
+    evaluateLaunchFlags: [...CLAUDE_EVALUATE_LAUNCH_FLAGS],
+    planLaunchFlags: [...CLAUDE_PLAN_LAUNCH_FLAGS],
+    reviewLaunchFlags: [...CLAUDE_REVIEW_LAUNCH_FLAGS],
+    finalizeLaunchFlags: [...CLAUDE_FINALIZE_LAUNCH_FLAGS],
+    promptPreamble: DEFAULT_PREAMBLE,
+    evaluatePromptPreamble: DEFAULT_EVALUATE_PREAMBLE,
+    planPromptPreamble: DEFAULT_PLAN_PREAMBLE,
+    reviewPromptPreamble: DEFAULT_REVIEW_PREAMBLE,
+    finalizePromptPreamble: DEFAULT_FINALIZE_PREAMBLE,
+    postLaunchCommands: ["/color {{color}}", "/rename {{name}}"],
+    evaluatePostLaunchCommands: ["/color {{color}}", "/rename {{name}}"],
+    planPostLaunchCommands: ["/color {{color}}", "/rename {{name}}"],
+    reviewPostLaunchCommands: ["/color {{color}}", "/rename {{name}}"],
+    finalizePostLaunchCommands: ["/color {{color}}", "/rename {{name}}"],
+    postLaunchReadinessRegex: "\\?\\s+for\\s+shortcuts",
+    skillTrigger: "/op:issue {{id}}",
+  },
+  // 100% transparent wrapper for `claude` — same flags, prompts, hooks, and
+  // post-launch commands; only the binary name differs. Listed as a separate
+  // AgentId so `claude-ds` shows up in agent detection and the picker without
+  // forcing users to edit the `claude` profile's `binary` overlay manually.
+  "claude-ds": {
+    id: "claude-ds",
+    label: "Claude Code (claude-ds)",
+    binary: "claude-ds",
     launchFlags: ["--permission-mode", "auto"],
     evaluateLaunchFlags: [...CLAUDE_EVALUATE_LAUNCH_FLAGS],
     planLaunchFlags: [...CLAUDE_PLAN_LAUNCH_FLAGS],

--- a/plugins/op-obsidian/src/main.ts
+++ b/plugins/op-obsidian/src/main.ts
@@ -5875,6 +5875,8 @@ function defaultBinaryFor(id: AgentId): string {
   switch (id) {
     case "claude":
       return "claude";
+    case "claude-ds":
+      return "claude-ds";
     case "gemini":
       return "gemini";
     case "copilot":

--- a/plugins/op-obsidian/src/modelRegistry.ts
+++ b/plugins/op-obsidian/src/modelRegistry.ts
@@ -111,6 +111,15 @@ export const MODEL_REGISTRY: Record<string, AgentModelRegistry> = {
     },
     versioned: CLAUDE_VERSIONED,
   },
+  // 100% transparent wrapper for `claude` — same model surface.
+  "claude-ds": {
+    aliases: {
+      opus: "claude-opus-4-7",
+      sonnet: "claude-sonnet-4-6",
+      haiku: "claude-haiku-4-5-20251001",
+    },
+    versioned: CLAUDE_VERSIONED,
+  },
   gemini: {
     aliases: {
       pro: "gemini-2.5-pro",

--- a/plugins/op-obsidian/src/openAgent.ts
+++ b/plugins/op-obsidian/src/openAgent.ts
@@ -670,7 +670,7 @@ function withModelFlag(
   agentId: AgentId,
   model: string | undefined,
 ): string[] {
-  if (!model || agentId !== "claude") return launchFlags;
+  if (!model || (agentId !== "claude" && agentId !== "claude-ds")) return launchFlags;
   return [...launchFlags, "--model", model];
 }
 

--- a/plugins/op/.claude-plugin/plugin.json
+++ b/plugins/op/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "op",
   "description": "Obsidian Projects workflow — schema, slash commands, and agent skill for running a Jira-lite issue tracker inside an Obsidian vault.",
-  "version": "0.93.2",
+  "version": "0.94.0",
   "author": {
     "name": "Eugene Archibald"
   },

--- a/scripts/check-workflow-docs.mjs
+++ b/scripts/check-workflow-docs.mjs
@@ -252,22 +252,26 @@ function extractModelRegistry(src) {
   const block = sliceBalanced(src, startIdx - 1, "{", "}");
 
   // Per-agent records: <agent>: { aliases: { ... }, versioned: SET_NAME, },
+  // The agent key may be a bare identifier (`claude`) or a quoted string
+  // when the id contains characters TypeScript can't use unquoted, e.g.
+  // hyphens (`"claude-ds"`).
   const agents = [];
   const agentRe =
-    /(?<agent>\w+)\s*:\s*\{\s*aliases\s*:\s*\{(?<aliases>[^{}]*)\}\s*,\s*versioned\s*:\s*(?<setName>\w+)\s*,?\s*\}/g;
+    /(?:"(?<quotedAgent>[\w-]+)"|(?<bareAgent>\w+))\s*:\s*\{\s*aliases\s*:\s*\{(?<aliases>[^{}]*)\}\s*,\s*versioned\s*:\s*(?<setName>\w+)\s*,?\s*\}/g;
 
   let m;
   while ((m = agentRe.exec(block)) !== null) {
-    const aliasMap = parseAliasMap(m.groups.aliases, m.groups.agent);
+    const agent = m.groups.quotedAgent ?? m.groups.bareAgent;
+    const aliasMap = parseAliasMap(m.groups.aliases, agent);
     const versioned = versionedSets[m.groups.setName];
     if (!versioned) {
       fail(
-        `${rel(MODEL_REGISTRY_PATH)}: agent \`${m.groups.agent}\` references versioned set \`${m.groups.setName}\` ` +
+        `${rel(MODEL_REGISTRY_PATH)}: agent \`${agent}\` references versioned set \`${m.groups.setName}\` ` +
           `but no top-level \`const ${m.groups.setName} = new Set<string>([ … ])\` was found.`,
       );
     }
     agents.push({
-      agent: m.groups.agent,
+      agent,
       aliases: aliasMap,
       versioned,
     });


### PR DESCRIPTION
## Summary

The earlier docs-only landing for OP-267 (#381) missed the actual ask: `claude-ds` did not appear in the plugin's **Default agent** dropdown or the **Open agent (pick at runtime)** picker. Pointing the existing `claude` profile at the wrapper via overlay was insufficient — both surfaces iterate `AGENT_IDS`, so the wrapper has to be its own id.

Wires `claude-ds` end-to-end as a transparent twin of `claude`:

- `AgentId` / `AGENT_IDS` gain `"claude-ds"`.
- `BASE_PROFILES["claude-ds"]` mirrors the `claude` profile (same launchFlags, preambles, post-launch commands, readiness regex, skill trigger) — only `binary`, `label`, and `id` differ.
- `defaultBinaryFor()` in `main.ts` and `withModelFlag()` in `openAgent.ts` recognise `claude-ds`.
- `modelRegistry["claude-ds"]` mirrors the `claude` model surface so `--model` resolution works through the wrapper.

Bumps op-obsidian 0.93.2 → 0.94.0 (minor — additive user-visible runtime).

## Test plan

- [x] `npm test` — 1846 tests pass; one pre-existing iTermPrefs.test.ts suite-load failure on `main` is unaffected.
- [x] OP-Test smoke (0.94.0): `detector.refresh()` reports `claude-ds` installed at `/usr/local/bin/claude-ds`.
- [x] Settings → op → Default agent dropdown lists `claude-ds`.
- [x] AgentPickerModal pulls from `AGENT_IDS.filter(installed)` — claude-ds will surface there as soon as the binary is on PATH.

🤖 Generated with [Claude Code](https://claude.com/claude-code)