### PR TITLE
OP-268: claude-ds tests + README catch-up to the OP-267 follow-up

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,12 +115,12 @@ If you are starting from an older loose `.claude/commands/` setup, see [Migratio
 
 ## Supported runtimes
 
-The repository recognizes `claude`, `gemini`, and `copilot`, but support is not equal.
+The repository recognizes `claude`, `claude-ds`, `gemini`, and `copilot`, but support is not equal.
 
 | Runtime | Status | Notes |
 | --- | --- | --- |
 | Claude Code | Primary | The main supported runtime for the skill, plugin smoke tests, and orchestration flow |
-| `claude-ds` | Primary | 100% transparent wrapper for `claude` — point the `claude` profile at it via the per-agent `binary` overlay (`{"binary":"claude-ds"}`) in Settings → Agents. Same flags, prompts, hooks |
+| `claude-ds` | Primary | First-class sibling of `claude`. Built-in agent profile that inherits every flag, prompt, and hook from the `claude` profile but invokes the `claude-ds` binary (a transparent wrapper that points Claude Code at a DeepSeek-served backend). Pick it independently in the agent picker / launch modal / per-issue `agent:` field |
 | Gemini CLI | Experimental | Dispatch code exists, but the workflow is not exercised in normal development |
 | Copilot CLI | Experimental | Dispatch code exists, but worktree enforcement hooks are not available and the runtime is not part of the normal smoke path |
 

--- a/plugins/op-obsidian/README.md
+++ b/plugins/op-obsidian/README.md
@@ -84,7 +84,7 @@ Found at `Settings → Community plugins → Obsidian Projects (op)`.
 - **Default agent** — which agent (`claude`, `codex`, `gemini`, `aider`, …) `op: open agent for issue` launches.
 - **Always prompt for agent** — force the picker every time.
 - **Detection** — summary of which agent binaries were found on `PATH`. Click **Re-probe** after installing a new agent.
-- **Profile overlays** — per-agent JSON overlay merged over the built-in profile. Keys: `binary`, `launchFlags` (string[]), `promptPreamble`, `skillTrigger`, `label`. To use `claude-ds` (a 100% transparent wrapper for `claude`), set the `claude` profile's `binary` to `claude-ds` — every flag, prompt, and hook the `claude` profile ships with passes through unchanged.
+- **Profile overlays** — per-agent JSON overlay merged over the built-in profile. Keys: `binary`, `launchFlags` (string[]), `promptPreamble`, `skillTrigger`, `label`. The plugin ships a built-in `claude-ds` agent (the DeepSeek-backed transparent wrapper for `claude`) as a first-class sibling of `claude`, so you no longer need an overlay to use it — pick it in the agent picker or set it as your default. Overlays are still useful for custom binary paths (e.g. `{"binary":"/opt/homebrew/bin/claude"}`) or per-agent prompt tweaks.
 
 ### Injection
 

--- a/plugins/op-obsidian/manifest.json
+++ b/plugins/op-obsidian/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "op-obsidian",
   "name": "Obsidian Projects (op)",
-  "version": "0.94.0",
+  "version": "0.94.1",
   "minAppVersion": "1.5.0",
   "description": "Jira-lite issue tracker for Obsidian vaults — deterministic commands backing the op workflow.",
   "author": "Eugene Archibald",

--- a/plugins/op-obsidian/package.json
+++ b/plugins/op-obsidian/package.json
@@ -1,6 +1,6 @@
 {
   "name": "op-obsidian",
-  "version": "0.94.0",
+  "version": "0.94.1",
   "description": "Obsidian plugin that owns the deterministic half of the op workflow.",
   "main": "main.js",
   "scripts": {

--- a/plugins/op-obsidian/src/agentProfiles.test.ts
+++ b/plugins/op-obsidian/src/agentProfiles.test.ts
@@ -239,15 +239,46 @@ describe("BASE_PROFILES sanity", () => {
       expect(p.finalizePromptPreamble.length).toBeGreaterThan(0);
     }
   });
-  it("only claude ships custom-agent launch flags out of the box", () => {
+  it("the claude family ships custom-agent launch flags out of the box", () => {
     expect(BASE_PROFILES.claude.evaluateLaunchFlags.length).toBeGreaterThan(0);
+    expect(BASE_PROFILES["claude-ds"].evaluateLaunchFlags.length).toBeGreaterThan(0);
     expect(BASE_PROFILES.gemini.evaluateLaunchFlags).toEqual([]);
     expect(BASE_PROFILES.copilot.evaluateLaunchFlags).toEqual(["--autopilot", "--allow-all"]);
   });
-  it("claude and copilot ship post-launch commands out of the box", () => {
+  it("claude / claude-ds / copilot ship post-launch commands out of the box", () => {
     expect(BASE_PROFILES.claude.postLaunchCommands.length).toBeGreaterThan(0);
+    expect(BASE_PROFILES["claude-ds"].postLaunchCommands).toEqual(BASE_PROFILES.claude.postLaunchCommands);
     expect(BASE_PROFILES.gemini.postLaunchCommands).toEqual([]);
     expect(BASE_PROFILES.copilot.postLaunchCommands).toEqual(["/rename {{id}} {{title}}"]);
     expect(BASE_PROFILES.copilot.postLaunchReadinessRegex).toBe("/ commands\\s+·\\s+\\? help");
+  });
+});
+
+describe("BASE_PROFILES['claude-ds']", () => {
+  const claude = BASE_PROFILES.claude;
+  const claudeDs = BASE_PROFILES["claude-ds"];
+
+  it("is registered as its own agent id and binary", () => {
+    expect(claudeDs.id).toBe("claude-ds");
+    expect(claudeDs.binary).toBe("claude-ds");
+    expect(claudeDs.label).not.toBe(claude.label);
+    expect(AGENT_IDS).toContain("claude-ds");
+    expect(asAgentId("claude-ds")).toBe("claude-ds");
+  });
+
+  it("inherits every behaviour-bearing field from the claude profile", () => {
+    expect(claudeDs.launchFlags).toEqual(claude.launchFlags);
+    expect(claudeDs.evaluateLaunchFlags).toEqual(claude.evaluateLaunchFlags);
+    expect(claudeDs.planLaunchFlags).toEqual(claude.planLaunchFlags);
+    expect(claudeDs.reviewLaunchFlags).toEqual(claude.reviewLaunchFlags);
+    expect(claudeDs.finalizeLaunchFlags).toEqual(claude.finalizeLaunchFlags);
+    expect(claudeDs.promptPreamble).toBe(claude.promptPreamble);
+    expect(claudeDs.evaluatePromptPreamble).toBe(claude.evaluatePromptPreamble);
+    expect(claudeDs.planPromptPreamble).toBe(claude.planPromptPreamble);
+    expect(claudeDs.reviewPromptPreamble).toBe(claude.reviewPromptPreamble);
+    expect(claudeDs.finalizePromptPreamble).toBe(claude.finalizePromptPreamble);
+    expect(claudeDs.postLaunchCommands).toEqual(claude.postLaunchCommands);
+    expect(claudeDs.postLaunchReadinessRegex).toBe(claude.postLaunchReadinessRegex);
+    expect(claudeDs.skillTrigger).toBe(claude.skillTrigger);
   });
 });

--- a/plugins/op-obsidian/src/stepResolver.test.ts
+++ b/plugins/op-obsidian/src/stepResolver.test.ts
@@ -12,6 +12,11 @@ import type { WorkflowFile, WorkflowStep } from "./workflowFilePure";
 function detection(installed: Partial<Record<AgentId, boolean>>): DetectionMap {
   return {
     claude: { id: "claude", installed: installed.claude ?? false, binary: "claude" },
+    "claude-ds": {
+      id: "claude-ds",
+      installed: installed["claude-ds"] ?? false,
+      binary: "claude-ds",
+    },
     gemini: { id: "gemini", installed: installed.gemini ?? false, binary: "gemini" },
     copilot: { id: "copilot", installed: installed.copilot ?? false, binary: "copilot" },
   };

--- a/plugins/op/.claude-plugin/plugin.json
+++ b/plugins/op/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "op",
   "description": "Obsidian Projects workflow — schema, slash commands, and agent skill for running a Jira-lite issue tracker inside an Obsidian vault.",
-  "version": "0.94.0",
+  "version": "0.94.1",
   "author": {
     "name": "Eugene Archibald"
   },


### PR DESCRIPTION
## Summary

- The source-level wiring for `claude-ds` as a first-class `AgentId` already landed in #382 (the OP-267 follow-up). The user-facing READMEs and the `agentProfiles` / `stepResolver` tests still pointed at the pre-#382 model where `claude-ds` had to be configured via the `claude` profile's `binary` overlay. This catches them up.
- README.md + plugins/op-obsidian/README.md: replace the "set the `claude` overlay's `binary` to `claude-ds`" guidance with "first-class sibling of `claude`. Pick it independently in the agent picker / launch modal / per-issue `agent:` field". Overlays are still useful for custom binary paths or per-agent prompt tweaks.
- agentProfiles.test.ts: new `BASE_PROFILES['claude-ds']` test block asserts every behaviour-bearing field is identical to the `claude` profile, with only `id` / `label` / `binary` differing. Updated the "only claude ships custom-agent launch flags" assertion to also cover `claude-ds`.
- stepResolver.test.ts: extend the `detection()` helper so the synthesised `DetectionMap` literal includes the `claude-ds` slot — without this the helper drifts from the runtime shape `AgentDetector.refresh()` produces.
- Bump op-obsidian 0.94.0 → 0.94.1 (patch — additive tests + docs only).

## Test plan

- [x] `npx vitest run` (1848 pass, 0 fail; new claude-ds block covered)
- [x] OP-Test 0.94.1 smoke: detection map includes `claude-ds` as its own entry; Settings → op → Profile overlays lists `claude-ds overlay`; default-agent dropdown options = `["claude", "claude-ds", "gemini", "copilot"]`; `dev:console` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)