### PR TITLE
OP-269: claude-specific statusLine toggle (usePluginStatusline)

### DIFF
--- a/plugins/op-obsidian/manifest.json
+++ b/plugins/op-obsidian/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "op-obsidian",
   "name": "Obsidian Projects (op)",
-  "version": "0.94.1",
+  "version": "0.94.2",
   "minAppVersion": "1.5.0",
   "description": "Jira-lite issue tracker for Obsidian vaults — deterministic commands backing the op workflow.",
   "author": "Eugene Archibald",

--- a/plugins/op-obsidian/package.json
+++ b/plugins/op-obsidian/package.json
@@ -1,6 +1,6 @@
 {
   "name": "op-obsidian",
-  "version": "0.94.1",
+  "version": "0.94.2",
   "description": "Obsidian plugin that owns the deterministic half of the op workflow.",
   "main": "main.js",
   "scripts": {

--- a/plugins/op-obsidian/src/agentHooks.pretool.test.ts
+++ b/plugins/op-obsidian/src/agentHooks.pretool.test.ts
@@ -546,3 +546,83 @@ describe("installAgentHooks — new-file layer is opt-in", () => {
     expect(off.guardUninstalled.sort()).toEqual(["claude", "gemini"]);
   });
 });
+
+// OP-269: statusLine install / remove tests.
+describe("installAgentHooks — statusLine (usePluginStatusline)", () => {
+  const claudeSettings = () => path.join(tmpHome, ".claude", "settings.json");
+  const runPath = () => path.join(tmpHome, ".claude", "statusline-plugin", "run");
+
+  it("installs the statusLine when usePluginStatusline is true (default)", async () => {
+    const res = await installAgentHooks({ usePluginStatusline: true });
+    expect(res.statusLineInstalled).toBe(true);
+    expect(res.statusLineRemoved).toBe(false);
+    const json = await readJson(claudeSettings());
+    expect(json.statusLine?.command).toBe(runPath());
+    expect(json.statusLine?.type).toBe("command");
+  });
+
+  it("installs the statusLine by default (options omitted)", async () => {
+    const res = await installAgentHooks({});
+    expect(res.statusLineInstalled).toBe(true);
+    const json = await readJson(claudeSettings());
+    expect(json.statusLine?.command).toBe(runPath());
+  });
+
+  it("is idempotent — no-op when command already points to run path", async () => {
+    await installAgentHooks({ usePluginStatusline: true });
+    const res2 = await installAgentHooks({ usePluginStatusline: true });
+    expect(res2.statusLineInstalled).toBe(false);
+    expect(res2.statusLineRemoved).toBe(false);
+  });
+
+  it("does not touch a custom user statusLine command", async () => {
+    const settingsFile = claudeSettings();
+    await fs.mkdir(path.join(tmpHome, ".claude"), { recursive: true });
+    await fs.writeFile(settingsFile, JSON.stringify({ statusLine: { type: "command", command: "/custom/statusline.sh" } }));
+    const res = await installAgentHooks({ usePluginStatusline: true });
+    expect(res.statusLineInstalled).toBe(false);
+    const json = await readJson(settingsFile);
+    expect(json.statusLine?.command).toBe("/custom/statusline.sh");
+  });
+
+  it("updates old version-pinned path to the run wrapper", async () => {
+    const settingsFile = claudeSettings();
+    await fs.mkdir(path.join(tmpHome, ".claude"), { recursive: true });
+    const oldCmd = `${tmpHome}/.claude/plugins/cache/earchibald-plugins/statusline-plugin/0.6.0/bin/statusline.js`;
+    await fs.writeFile(settingsFile, JSON.stringify({ statusLine: { type: "command", command: oldCmd } }));
+    const res = await installAgentHooks({ usePluginStatusline: true });
+    expect(res.statusLineInstalled).toBe(true);
+    const json = await readJson(settingsFile);
+    expect(json.statusLine?.command).toBe(runPath());
+  });
+
+  it("removes the op-managed statusLine when usePluginStatusline is false", async () => {
+    await installAgentHooks({ usePluginStatusline: true });
+    const res = await installAgentHooks({ usePluginStatusline: false });
+    expect(res.statusLineInstalled).toBe(false);
+    expect(res.statusLineRemoved).toBe(true);
+    const json = await readJson(claudeSettings());
+    expect(json.statusLine).toBeUndefined();
+  });
+
+  it("does not remove a custom statusLine when usePluginStatusline is false", async () => {
+    const settingsFile = claudeSettings();
+    await fs.mkdir(path.join(tmpHome, ".claude"), { recursive: true });
+    await fs.writeFile(settingsFile, JSON.stringify({ statusLine: { type: "command", command: "/custom/statusline.sh" } }));
+    const res = await installAgentHooks({ usePluginStatusline: false });
+    expect(res.statusLineRemoved).toBe(false);
+    const json = await readJson(settingsFile);
+    expect(json.statusLine?.command).toBe("/custom/statusline.sh");
+  });
+
+  it("does not install the statusLine when usePluginStatusline is false", async () => {
+    const res = await installAgentHooks({ usePluginStatusline: false });
+    expect(res.statusLineInstalled).toBe(false);
+    try {
+      const json = await readJson(claudeSettings());
+      expect(json.statusLine).toBeUndefined();
+    } catch {
+      // settings.json may not exist at all — that's also fine
+    }
+  });
+});

--- a/plugins/op-obsidian/src/agentHooks.ts
+++ b/plugins/op-obsidian/src/agentHooks.ts
@@ -29,6 +29,10 @@ export interface HookInstallOptions {
    *  install/uninstall plumbing as the managed-note layer. Default **on**
    *  as of OP-263 (Phase 6 of OP-218). */
   newFileGuard?: boolean;
+  /** OP-269: when true, op-obsidian writes a `statusLine` entry in
+   *  `~/.claude/settings.json` pointing at `~/.claude/statusline-plugin/run`.
+   *  When false, any op-managed statusLine entry is removed. Default true. */
+  usePluginStatusline?: boolean;
 }
 
 export interface HookInstallResult {
@@ -39,6 +43,8 @@ export interface HookInstallResult {
   guardInstalled: string[];
   guardUninstalled: string[];
   guardSkipped: string[];
+  statusLineInstalled: boolean;
+  statusLineRemoved: boolean;
 }
 
 const MARKER = "op-obsidian-session-end";
@@ -57,6 +63,8 @@ export async function installAgentHooks(
   const enforceWorktree = !!options.enforceWorktree;
   const managedNoteGuard = !!options.managedNoteGuard;
   const newFileGuard = !!options.newFileGuard;
+  // Default true per OP-269: "use plugin statusline" on unless explicitly disabled.
+  const usePluginStatusline = options.usePluginStatusline !== false;
   await writeGuardScript(guardScriptPath, {
     enforceWorktree,
     managedNoteGuard,
@@ -111,6 +119,18 @@ export async function installAgentHooks(
     await guardStep("gemini", () => uninstallGeminiPretoolGuard(home));
   }
 
+  let statusLineInstalled = false;
+  let statusLineRemoved = false;
+  try {
+    if (usePluginStatusline) {
+      statusLineInstalled = await installClaudeStatusLine(home);
+    } else {
+      statusLineRemoved = await removeClaudeStatusLine(home);
+    }
+  } catch (err) {
+    console.warn("[op-obsidian] statusLine update skipped:", err);
+  }
+
   return {
     scriptPath,
     installed,
@@ -119,6 +139,8 @@ export async function installAgentHooks(
     guardInstalled,
     guardUninstalled,
     guardSkipped,
+    statusLineInstalled,
+    statusLineRemoved,
   };
 }
 
@@ -396,6 +418,50 @@ async function uninstallGeminiPretoolGuard(home: string): Promise<"installed" | 
     typeof entry?.command === "string" && entry.command.includes(GUARD_MARKER),
   );
   return removed ? "removed" : "noop";
+}
+
+// OP-269: The stable wrapper installed by the statusline-plugin.
+const STATUSLINE_RUN_REL = path.join(".claude", "statusline-plugin", "run");
+// Pattern matching the old version-pinned path written by earlier statusline-config skill versions.
+const STATUSLINE_OLD_PATTERN = /\.claude\/plugins\/cache\/[^/]+\/statusline-plugin\/[^/]+\/bin\/statusline\.js/;
+
+// Install the statusline-plugin run wrapper path into ~/.claude/settings.json.
+// Idempotent: no-op if the command already points at our managed path.
+// Safe: does not overwrite commands that don't look like our managed statusLine.
+// Returns true when the file was changed.
+async function installClaudeStatusLine(home: string): Promise<boolean> {
+  const file = path.join(home, ".claude", "settings.json");
+  const runPath = path.join(home, STATUSLINE_RUN_REL);
+  const json = await readJson(file);
+  const existing = json.statusLine?.command;
+  // Already pointing at our managed path — no-op.
+  if (typeof existing === "string" && existing === runPath) return false;
+  // Points at something else that isn't ours to manage — leave it alone.
+  if (typeof existing === "string" && existing !== "" && !STATUSLINE_OLD_PATTERN.test(existing)) {
+    return false;
+  }
+  // Missing, empty, or old version-pinned path — install/update.
+  json.statusLine = { type: "command", command: runPath };
+  await writeJson(file, json);
+  return true;
+}
+
+// Remove the op-managed statusLine entry from ~/.claude/settings.json.
+// Only removes entries that point at our managed run wrapper; does not touch
+// custom user-provided statusLine commands. Returns true when the file changed.
+async function removeClaudeStatusLine(home: string): Promise<boolean> {
+  const file = path.join(home, ".claude", "settings.json");
+  const runPath = path.join(home, STATUSLINE_RUN_REL);
+  let json: any;
+  try {
+    json = await readJson(file);
+  } catch {
+    return false;
+  }
+  if (json?.statusLine?.command !== runPath) return false;
+  delete json.statusLine;
+  await writeJson(file, json);
+  return true;
 }
 
 // Upsert a { matcher, hooks:[{type:"command",command}] } block into

--- a/plugins/op-obsidian/src/main.ts
+++ b/plugins/op-obsidian/src/main.ts
@@ -5550,6 +5550,7 @@ export default class OpPlugin extends Plugin {
         enforceWorktree: this.settings.agents.enforceWorktree,
         managedNoteGuard: this.settings.agentDiscipline.managedNoteGuard,
         newFileGuard: this.settings.agentDiscipline.newFileGuard,
+        usePluginStatusline: this.settings.sessionDecoration.usePluginStatusline,
       });
       if (announce) {
         const summary = res.installed.length

--- a/plugins/op-obsidian/src/settings.ts
+++ b/plugins/op-obsidian/src/settings.ts
@@ -1700,6 +1700,19 @@ export class OpSettingsTab extends PluginSettingTab {
       );
 
     new Setting(containerEl)
+      .setName("Use plugin statusline")
+      .setDesc(
+        "Install the statusline-plugin run wrapper as the `statusLine` command in `~/.claude/settings.json`. When off, op-obsidian does not modify the statusLine key so Claude's default or your own custom statusLine is used instead. Applies on the next plugin reload or settings change.",
+      )
+      .addToggle((t) =>
+        t.setValue(s.sessionDecoration.usePluginStatusline).onChange(async (v) => {
+          s.sessionDecoration.usePluginStatusline = v;
+          await this.plugin.saveSettings();
+          await this.plugin.reinstallAgentHooks();
+        }),
+      );
+
+    new Setting(containerEl)
       .setName("Color palette")
       .setDesc(
         `Comma-separated Claude prompt-bar colors. Valid values: ${CLAUDE_SESSION_COLORS.join(", ")}. Invalid entries are dropped; if none remain, the default eight are restored.`,

--- a/plugins/op-obsidian/src/settingsPure.ts
+++ b/plugins/op-obsidian/src/settingsPure.ts
@@ -207,6 +207,11 @@ export interface SessionDecorationSettings {
   autoColor: boolean;
   autoRename: boolean;
   autoRemoteControl: boolean;
+  /** OP-269: when true, op-obsidian writes a `statusLine` entry in
+   *  `~/.claude/settings.json` pointing at `~/.claude/statusline-plugin/run`
+   *  (the statusline-plugin wrapper). When false, op-obsidian leaves the
+   *  `statusLine` key in Claude's settings alone. Default true. */
+  usePluginStatusline: boolean;
   palette: string[];
   nameTemplate: string;
   interCommandDelayMs: number;
@@ -357,6 +362,7 @@ export const DEFAULT_SETTINGS: OpSettings = {
     autoColor: true,
     autoRename: true,
     autoRemoteControl: false,
+    usePluginStatusline: true,
     palette: [...CLAUDE_SESSION_COLORS],
     nameTemplate: "{{id}} {{title}}",
     interCommandDelayMs: SESSION_DECORATION_INTER_COMMAND_DEFAULT_MS,
@@ -549,6 +555,9 @@ export function mergeSettings(loaded: unknown): OpSettings {
     if (typeof d.autoRename === "boolean") base.sessionDecoration.autoRename = d.autoRename;
     if (typeof d.autoRemoteControl === "boolean") {
       base.sessionDecoration.autoRemoteControl = d.autoRemoteControl;
+    }
+    if (typeof d.usePluginStatusline === "boolean") {
+      base.sessionDecoration.usePluginStatusline = d.usePluginStatusline;
     }
     if (Array.isArray(d.palette)) {
       const sanitized = sanitizeSessionDecorationPalette(d.palette);

--- a/plugins/op/.claude-plugin/plugin.json
+++ b/plugins/op/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "op",
   "description": "Obsidian Projects workflow — schema, slash commands, and agent skill for running a Jira-lite issue tracker inside an Obsidian vault.",
-  "version": "0.94.1",
+  "version": "0.94.2",
   "author": {
     "name": "Eugene Archibald"
   },


### PR DESCRIPTION
Adds a **Use plugin statusline** boolean toggle to **Settings → Session decoration**.

## What

- New `usePluginStatusline: boolean` field on `SessionDecorationSettings` (default **true**)
- When **true**: op-obsidian writes a `statusLine` entry in `~/.claude/settings.json` pointing at `~/.claude/statusline-plugin/run` on every plugin load
- When **false**: the entry is removed (if we wrote it) and the `statusLine` key is left alone going forward

## Install / remove policy

| Current `statusLine.command` | Action (enabled) | Action (disabled) |
|---|---|---|
| Missing / empty | Install run path | No-op |
| Already our run path | No-op | Remove key |
| Old version-pinned `*/bin/statusline.js` | Update to run path | No-op |
| Custom user command | Leave untouched | Leave untouched |

## Files changed

- `settingsPure.ts` — new field + default + merge
- `agentHooks.ts` — `installClaudeStatusLine` + `removeClaudeStatusLine` + new option/result fields
- `main.ts` — thread `usePluginStatusline` into `installAgentHooks`
- `settings.ts` — toggle UI in Session decoration section
- `agentHooks.pretool.test.ts` — 8 new test cases covering all install/remove branches
- Version bump: 0.94.1 → 0.94.2