### PR TITLE
OP-270: fix stale loc in healFrontmatter causing frontmatter corruption

### DIFF
--- a/plugins/op-obsidian/manifest.json
+++ b/plugins/op-obsidian/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "op-obsidian",
   "name": "Obsidian Projects (op)",
-  "version": "0.94.2",
+  "version": "0.94.3",
   "minAppVersion": "1.5.0",
   "description": "Jira-lite issue tracker for Obsidian vaults — deterministic commands backing the op workflow.",
   "author": "Eugene Archibald",

--- a/plugins/op-obsidian/package.json
+++ b/plugins/op-obsidian/package.json
@@ -1,6 +1,6 @@
 {
   "name": "op-obsidian",
-  "version": "0.94.2",
+  "version": "0.94.3",
   "description": "Obsidian plugin that owns the deterministic half of the op workflow.",
   "main": "main.js",
   "scripts": {

--- a/plugins/op-obsidian/src/healFrontmatter.test.ts
+++ b/plugins/op-obsidian/src/healFrontmatter.test.ts
@@ -283,6 +283,41 @@ describe("healFrontmatter", () => {
     });
   });
 
+  describe("OP-270: stale loc after concurrent rename", () => {
+    it("does not apply staleTerminal when file was moved to RESOLVED ISSUES mid-pass", async () => {
+      // Scenario: healFrontmatter captures a candidate at ISSUES/OP-270.md, then
+      // a concurrent runResolve:
+      //   1. renames the file → RESOLVED ISSUES/OP-270 resolved.md
+      //   2. writes fm.status = "resolved"
+      // By the time healFrontmatter's processFrontMatter lock is acquired, file.path
+      // is already the target path. The staleTerminal rule must NOT fire.
+      const tf = Object.assign(
+        new FakeTFile("Projects/p/ISSUES/OP-270 test.md"),
+        { stat: { mtime: 0, ctime: 0 }, fm: { ...FULL_ISSUE_FM, status: "in-progress" } },
+      );
+
+      const app = {
+        vault: {
+          getMarkdownFiles: () => [tf],
+        },
+        fileManager: {
+          processFrontMatter: async (file: any, fn: (fm: Record<string, any>) => void) => {
+            // Simulate: rename completed (and runResolve wrote status) before
+            // the heal callback acquires the lock.
+            file.path = "Projects/p/RESOLVED ISSUES/OP-270 test resolved.md";
+            file.fm.status = "resolved";
+            fn(file.fm);
+          },
+        },
+      } as any;
+
+      const res = await healFrontmatter(app);
+      expect(tf.fm.status).toBe("resolved");
+      const rules = res.fixed[0]?.rules ?? [];
+      expect(rules).not.toContain("issue.status.staleTerminal");
+    });
+  });
+
   describe("error handling", () => {
     it("captures errors per-file without aborting the pass", async () => {
       const ok: FakeFile = { path: "Projects/p/ISSUES/OP-1.md", fm: {} };

--- a/plugins/op-obsidian/src/healFrontmatter.ts
+++ b/plugins/op-obsidian/src/healFrontmatter.ts
@@ -49,11 +49,17 @@ export async function healFrontmatter(app: App): Promise<HealResult> {
   }
 
   for (const file of candidates) {
-    const loc = classify(file.path);
-    if (!loc) continue;
     try {
       let appliedRules: string[] = [];
       await app.fileManager.processFrontMatter(file, (fm) => {
+        // OP-270: re-classify at write time. `file.path` is updated by Obsidian
+        // whenever the TFile is renamed — a concurrent `runResolve` can move the
+        // file to RESOLVED ISSUES/ between this loop iteration's await boundary
+        // and the moment the processFrontMatter lock is acquired. Using a `loc`
+        // captured before the await would carry a stale `resolvedFolder: false`,
+        // causing the `staleTerminal` rule to reset `status` back to `"open"`.
+        const loc = classify(file.path);
+        if (!loc) return;
         appliedRules = applyRules(fm, file, loc);
       });
       if (appliedRules.length > 0) {

--- a/plugins/op-obsidian/src/main.ts
+++ b/plugins/op-obsidian/src/main.ts
@@ -421,8 +421,9 @@ export default class OpPlugin extends Plugin {
     // configured). Agent-owned issues (`entry.agent` non-empty) are skipped
     // so the agent's own lifecycle isn't preempted. Re-entrancy is blocked
     // by `inFlightResolvePaths` (belt) and the prev-vs-next terminal guard
-    // inside `shouldAutoResolve` (suspenders) — `runResolve` writes
-    // frontmatter before renaming, which fires `issue:status-changed` again.
+    // inside `shouldAutoResolve` (suspenders) — `runResolve` renames first
+    // then writes frontmatter (OP-221 order), each of which fires
+    // `issue:status-changed`; both events are short-circuited by the guards.
     this.bus.on("issue:status-changed", (ev) => {
       const args = shouldAutoResolve(ev, this.inFlightResolvePaths);
       if (!args) {
@@ -3288,8 +3289,8 @@ export default class OpPlugin extends Plugin {
   /**
    * Call {@link runResolve} while tracking the issue's vault path in
    * {@link inFlightResolvePaths}. The `issue:status-changed` auto-mover
-   * consults that set to skip the re-entrant event `runResolve` emits when it
-   * writes `status`/`resolved` frontmatter before renaming.
+   * consults that set to skip the re-entrant events `runResolve` emits when it
+   * renames the file and then writes frontmatter (OP-221 order).
    *
    * Best-effort path resolution: we try to resolve args to a vault path up
    * front so we can register it before any frontmatter write. If we can't

--- a/plugins/op-obsidian/src/resolve.test.ts
+++ b/plugins/op-obsidian/src/resolve.test.ts
@@ -80,8 +80,11 @@ function makeFakes(entry: IssueEntry, fmInitial: Record<string, unknown>) {
       ) => {
         cb(fm);
       },
-      renameFile: async (_f: unknown, target: string) => {
+      renameFile: async (f: any, target: string) => {
         recorded.renamedTo = target;
+        // Mimic real Obsidian: TFile.path updates to the target path after rename.
+        f.path = target;
+        f.name = target.split("/").pop() ?? target;
       },
     },
   };

--- a/plugins/op/.claude-plugin/plugin.json
+++ b/plugins/op/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "op",
   "description": "Obsidian Projects workflow — schema, slash commands, and agent skill for running a Jira-lite issue tracker inside an Obsidian vault.",
-  "version": "0.94.2",
+  "version": "0.94.3",
   "author": {
     "name": "Eugene Archibald"
   },


### PR DESCRIPTION
## Root Cause

`healFrontmatter` captured `loc = classify(file.path)` **before** calling `await processFrontMatter(file, cb)`. The `await` yields the JavaScript event loop, allowing a concurrent `runResolve` to run during that window. `runResolve` calls `app.fileManager.renameFile(file, targetPath)`, which causes Obsidian to update `file.path` to the target path — but the heal callback still held a stale `loc` with `resolvedFolder: false`.


## Fix

Move `classify(file.path)` inside the `processFrontMatter` callback so it reads the **current** `file.path` at the moment the lock is acquired, after any concurrent rename has completed. If the file has moved out of managed scope entirely, `classify` returns `null` and the callback returns early.

## Changes

- **`healFrontmatter.ts`**: Re-classify `file.path` inside the `processFrontMatter` callback (the fix).
- **`healFrontmatter.test.ts`**: Regression test — simulates a concurrent rename completing before the heal callback runs; verifies `staleTerminal` does not fire.
- **`resolve.test.ts`**: Fix `makeFakes.renameFile` mock to update `file.path` to the target path, matching real Obsidian behaviour post-rename.
- **`main.ts`**: Fix two stale comments that said "runResolve writes frontmatter before renaming" (incorrect since OP-221 swapped the order).