### PR TITLE
OP-256: option B agent-launch precedence (Explicit > Stored > Settings > Workflow)

### DIFF
--- a/plugins/op-obsidian/manifest.json
+++ b/plugins/op-obsidian/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "op-obsidian",
   "name": "Obsidian Projects (op)",
-  "version": "0.94.3",
+  "version": "0.94.4",
   "minAppVersion": "1.5.0",
   "description": "Jira-lite issue tracker for Obsidian vaults — deterministic commands backing the op workflow.",
   "author": "Eugene Archibald",

--- a/plugins/op-obsidian/package.json
+++ b/plugins/op-obsidian/package.json
@@ -1,6 +1,6 @@
 {
   "name": "op-obsidian",
-  "version": "0.94.3",
+  "version": "0.94.4",
   "description": "Obsidian plugin that owns the deterministic half of the op workflow.",
   "main": "main.js",
   "scripts": {

--- a/plugins/op-obsidian/src/agentProfiles.test.ts
+++ b/plugins/op-obsidian/src/agentProfiles.test.ts
@@ -69,8 +69,64 @@ describe("preferredLaunchAgentOverride", () => {
     ).toBe("gemini");
   });
 
+  it("explicit override beats Settings default too", () => {
+    expect(
+      preferredLaunchAgentOverride({
+        agentOverride: "gemini",
+        defaultAgent: "copilot",
+        interactive: true,
+      }),
+    ).toBe("gemini");
+  });
+
   it("reuses the stored issue agent for normal launches", () => {
     expect(preferredLaunchAgentOverride({ issueAgent: "copilot" })).toBe("copilot");
+  });
+
+  it("stored issue agent beats Settings default (option B: stored > defaults)", () => {
+    expect(
+      preferredLaunchAgentOverride({
+        issueAgent: "claude",
+        defaultAgent: "copilot",
+        interactive: true,
+      }),
+    ).toBe("claude");
+  });
+
+  it("seeds Settings default for interactive launches with no stored agent (option B)", () => {
+    expect(
+      preferredLaunchAgentOverride({
+        defaultAgent: "copilot",
+        interactive: true,
+      }),
+    ).toBe("copilot");
+  });
+
+  it("treats undefined interactive as interactive (chip/palette/sidebar default)", () => {
+    expect(
+      preferredLaunchAgentOverride({
+        defaultAgent: "copilot",
+      }),
+    ).toBe("copilot");
+  });
+
+  it("does NOT seed Settings default for auto-advance launches (interactive: false)", () => {
+    expect(
+      preferredLaunchAgentOverride({
+        defaultAgent: "copilot",
+        interactive: false,
+      }),
+    ).toBeUndefined();
+  });
+
+  it("auto-advance still honours stored issue agent over the workflow file", () => {
+    expect(
+      preferredLaunchAgentOverride({
+        issueAgent: "claude",
+        defaultAgent: "copilot",
+        interactive: false,
+      }),
+    ).toBe("claude");
   });
 
   it("suppresses stored issue agents when force-pick is requested", () => {
@@ -82,8 +138,22 @@ describe("preferredLaunchAgentOverride", () => {
     ).toBeUndefined();
   });
 
+  it("force-pick suppresses Settings default seed too", () => {
+    expect(
+      preferredLaunchAgentOverride({
+        defaultAgent: "copilot",
+        forcePick: true,
+        interactive: true,
+      }),
+    ).toBeUndefined();
+  });
+
   it("ignores unknown stored agent values", () => {
     expect(preferredLaunchAgentOverride({ issueAgent: "bogus" })).toBeUndefined();
+  });
+
+  it("falls through to undefined when nothing fires (workflow resolver wins)", () => {
+    expect(preferredLaunchAgentOverride({})).toBeUndefined();
   });
 });
 

--- a/plugins/op-obsidian/src/agentProfiles.ts
+++ b/plugins/op-obsidian/src/agentProfiles.ts
@@ -10,14 +10,31 @@ export function asAgentId(value: string | null | undefined): AgentId | undefined
     : undefined;
 }
 
+/**
+ * OP-256 (option B): manual-launch agent precedence.
+ *
+ *   explicit override > forcePick → undefined > stored issue agent >
+ *   settings default (interactive only) > undefined (workflow resolver wins)
+ *
+ * Returning a non-undefined value here makes `openAgent` skip
+ * `loadAndResolveStep`, so seeding `defaultAgent` for interactive launches is
+ * how Settings → Default agent beats the project's `WORKFLOW.md`
+ * `default_agent:`. Auto-advance launches pass `interactive: false` and skip
+ * the seed, leaving workflow-driven per-step agent selection intact.
+ */
 export function preferredLaunchAgentOverride(opts: {
   agentOverride?: AgentId;
   issueAgent?: string;
   forcePick?: boolean;
+  defaultAgent?: AgentId;
+  interactive?: boolean;
 }): AgentId | undefined {
   if (opts.agentOverride) return opts.agentOverride;
   if (opts.forcePick) return undefined;
-  return asAgentId(opts.issueAgent);
+  const stored = asAgentId(opts.issueAgent);
+  if (stored) return stored;
+  if (opts.interactive !== false && opts.defaultAgent) return opts.defaultAgent;
+  return undefined;
 }
 
 const DEFAULT_PREAMBLE =

--- a/plugins/op-obsidian/src/main.ts
+++ b/plugins/op-obsidian/src/main.ts
@@ -5115,10 +5115,17 @@ export default class OpPlugin extends Plugin {
       // in the gap right after a chip/sidebar action writes `agent:`.
       const storedIssueAgent = asAgentId(entry.agent);
       const liveIssueAgent = await readIssueAgentOverride(this.app, entry.path);
+      // OP-256: pass defaultAgent + interactive so manual launches (chip,
+      // palette, sidebar) seed Settings → Default agent ahead of the
+      // project's `WORKFLOW.md` `default_agent:`. `interactive: false` from
+      // `advanceFlowAndLaunch` opts out and lets the workflow resolver win
+      // for auto-advance.
       let effectiveAgentOverride = preferredLaunchAgentOverride({
         agentOverride: opts.agentOverride,
         issueAgent: liveIssueAgent ?? entry.agent,
         forcePick: opts.forcePick,
+        defaultAgent: this.settings.defaultAgent,
+        interactive: opts.interactive,
       });
       let effectiveLaunchVars = opts.launchVars;
       if (opts.forcePick) {

--- a/plugins/op-obsidian/src/noteChipState.test.ts
+++ b/plugins/op-obsidian/src/noteChipState.test.ts
@@ -189,6 +189,46 @@ describe("resolveChipState — every row of the chip-state matrix", () => {
       false,
     );
     expect(state?.action).toBe("start-agent");
+    expect(state?.storedAgent).toBeUndefined();
+  });
+
+  it("storedAgent is surfaced from frontmatter agent field", () => {
+    const state = resolveChipState(
+      { id: "OP-10", type: "issue", status: "in-progress", agent: "claude" },
+      true,
+    );
+    expect(state?.storedAgent).toBe("claude");
+  });
+
+  it("OP-256: tooltip honours storedAgent over the settings default (option B)", () => {
+    const state = resolveChipState(
+      { id: "OP-11", type: "issue", status: "open", agent: "claude" },
+      false,
+    );
+    // re-attach state — not start-agent, so the standard label
+    expect(state?.action).toBe("reattach-fresh");
+    // For start-agent specifically, build a fresh state with no stored agent:
+    const start = resolveChipState({ id: "OP-12", type: "issue", status: "open" }, true);
+    expect(describeChipPrimaryAction(start!, "copilot")).toBe(
+      "▶ Start agent (default: copilot; Cmd/Ctrl-click to pick agent)",
+    );
+    // And one with a stored agent (in-progress without live tmux session):
+    const stored = resolveChipState(
+      { id: "OP-13", type: "issue", status: "in-progress" },
+      true,
+    );
+    // OP-13 has no stored agent, so this case still falls back to defaultAgent.
+    // To exercise stored-agent tooltip routing we manually craft the state
+    // because no current row produces a start-agent ChipState carrying a
+    // stored agent (start-agent only fires when hasAgent is false). The
+    // tooltip routing is still useful as defensive code: if a future row
+    // carries both, the tooltip MUST show the stored agent.
+    expect(
+      describeChipPrimaryAction(
+        { ...stored!, action: "start-agent", storedAgent: "gemini" },
+        "copilot",
+      ),
+    ).toBe("▶ Start agent (default: gemini; Cmd/Ctrl-click to pick agent)");
   });
 
   it("primaryCommand is always a bare id — no op-obsidian: prefix (dispatch contract)", () => {

--- a/plugins/op-obsidian/src/noteChipState.ts
+++ b/plugins/op-obsidian/src/noteChipState.ts
@@ -88,6 +88,10 @@ export interface ChipState {
   /** Status used by the resolver, normalized — surfaced so the strip helper
    * can reuse it without re-parsing. */
   status: IssueStatus;
+  /** OP-256: stored `agent:` from frontmatter, surfaced so the chip tooltip
+   * can advertise the *actual* agent the click will launch under option-B
+   * precedence (stored > settings default). Empty/missing → undefined. */
+  storedAgent?: string;
 }
 
 export interface ChipPrimaryClickEvent {
@@ -157,7 +161,9 @@ export function resolveChipState(
   const status = normalizeStatus(fm!.status);
   if (!status) return null;
   const id = fm!.id!;
-  const hasAgent = typeof fm!.agent === "string" && fm!.agent.trim().length > 0;
+  const rawAgent = typeof fm!.agent === "string" ? fm!.agent.trim() : "";
+  const hasAgent = rawAgent.length > 0;
+  const storedAgent = hasAgent ? rawAgent : undefined;
   const githubIssue = typeof fm!.githubIssue === "string" && fm!.githubIssue.trim().length > 0;
 
   if (status === "resolved" || status === "wontfix") {
@@ -179,6 +185,7 @@ export function resolveChipState(
       menu,
       issueId: id,
       status,
+      storedAgent,
     };
   }
 
@@ -192,6 +199,7 @@ export function resolveChipState(
       menu: [APPEND_COMMIT_MENU, SET_PR_MENU, RESOLVE_MENU],
       issueId: id,
       status,
+      storedAgent,
     };
   }
 
@@ -213,6 +221,7 @@ export function resolveChipState(
       ],
       issueId: id,
       status,
+      storedAgent,
     };
   }
 
@@ -234,6 +243,7 @@ export function resolveChipState(
       ],
       issueId: id,
       status,
+      storedAgent,
     };
   }
 
@@ -273,12 +283,20 @@ export function resolveChipState(
     menu: startMenu,
     issueId: id,
     status,
+    storedAgent,
   };
 }
 
+/**
+ * OP-256: tooltip reflects the *actual* agent the click will launch under
+ * option-B precedence (stored > settings default). When the issue has a
+ * stored `agent:`, advertise it; otherwise fall back to Settings → Default
+ * agent.
+ */
 export function describeChipPrimaryAction(state: ChipState, defaultAgent: string): string {
   if (state.action !== "start-agent") return state.primaryLabel;
-  return `${state.primaryLabel} (default: ${defaultAgent}; Cmd/Ctrl-click to pick agent)`;
+  const resolved = state.storedAgent && state.storedAgent.length > 0 ? state.storedAgent : defaultAgent;
+  return `${state.primaryLabel} (default: ${resolved}; Cmd/Ctrl-click to pick agent)`;
 }
 
 export function chipPrimaryCommandForClick(

--- a/plugins/op/.claude-plugin/plugin.json
+++ b/plugins/op/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "op",
   "description": "Obsidian Projects workflow — schema, slash commands, and agent skill for running a Jira-lite issue tracker inside an Obsidian vault.",
-  "version": "0.94.3",
+  "version": "0.94.4",
   "author": {
     "name": "Eugene Archibald"
   },


### PR DESCRIPTION
## Summary

- Restores Settings → Default agent precedence over the project's `WORKFLOW.md` `default_agent:` for **manual** launches (chip, palette, sidebar) — the reported bug from @ea.
- Keeps OP-253's "stored `agent:` wins" semantics intact: explicit > stored > settings default > workflow.
- Auto-advance launches (`interactive: false` from `advanceFlowAndLaunch`) opt out of the seed and keep per-step workflow-driven agent selection.
- Chip tooltip now names the *actual* agent the click will launch (stored `agent:` if present, else Settings default), so the UX no longer lies under any precedence.

## Background

OP-253 (commit `671a586`, shipped 0.85.12) replaced OP-245's `manualLaunchAgentOverride` with `preferredLaunchAgentOverride`, which only honored explicit override + stored `agent:`. Manual launches on un-attached issues fell through to the workflow resolver, which for `obsidian-projects` picks `default_agent: claude` from `Projects/obsidian-projects/WORKFLOW.md` line 5 — silently overriding `defaultAgent: copilot` in Settings. See OP-256 issue note for the full investigation log.

@ea picked **option B** from the issue body's three precedence options.

## Changes

- `plugins/op-obsidian/src/agentProfiles.ts` — extend `preferredLaunchAgentOverride` with `defaultAgent` + `interactive` params; new precedence: explicit > forcePick→undefined > stored > defaults (when interactive) > undefined.
- `plugins/op-obsidian/src/main.ts` (`doOpenAgent`) — pass `this.settings.defaultAgent` and `opts.interactive` so chip / palette / sidebar launches seed the Settings default; `advanceFlowAndLaunch` already passes `interactive: false` and opts out.
- `plugins/op-obsidian/src/noteChipState.ts` — add `storedAgent?: string` to `ChipState`; `describeChipPrimaryAction` honours it over `defaultAgent`.
- Exhaustive precedence tests in `agentProfiles.test.ts` (10 cases covering every cell of the matrix). Tooltip routing test in `noteChipState.test.ts`.
- Patch bump 0.94.3 → 0.94.4.

## Test plan

- [x] `npm test` — agentProfiles + noteChipState suites green (68/68 cases). Full suite: 1867/1867 pass; the 1 failed *suite* (`iTermPrefs.test.ts`) is preexisting on `main` and unrelated to this diff.
- [x] `npx tsc --noEmit` — clean.
- [x] dev-sync to OP-Test, plugin reloads cleanly at 0.94.4, no console errors.
- [ ] User acceptance: on `obsidian-projects` (Settings → Default agent = `copilot`, `WORKFLOW.md` `default_agent: claude`), clicking "▶ Start agent" on a fresh issue should now launch `copilot` and the tooltip should advertise `copilot`. On an issue with stored `agent: claude`, the chip should still launch `claude` and advertise `claude`.

## Behavior change worth a CHANGELOG note

Users who set `default_agent:` in `WORKFLOW.md` expecting it to win over `Settings → Default agent` for manual launches will see Settings win after this lands. Auto-advance launches still honour the workflow file (interactive: false bypass). Mention in `CHANGELOG.md` at release time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)