### PR TITLE
OP-273: new op:workflow CLI command (project|prefix)

### DIFF
--- a/plugins/op-obsidian/manifest.json
+++ b/plugins/op-obsidian/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "op-obsidian",
   "name": "Obsidian Projects (op)",
-  "version": "0.94.4",
+  "version": "0.95.0",
   "minAppVersion": "1.5.0",
   "description": "Jira-lite issue tracker for Obsidian vaults — deterministic commands backing the op workflow.",
   "author": "Eugene Archibald",

--- a/plugins/op-obsidian/package.json
+++ b/plugins/op-obsidian/package.json
@@ -1,6 +1,6 @@
 {
   "name": "op-obsidian",
-  "version": "0.94.4",
+  "version": "0.95.0",
   "description": "Obsidian plugin that owns the deterministic half of the op workflow.",
   "main": "main.js",
   "scripts": {

--- a/plugins/op-obsidian/src/cliHandlers.ts
+++ b/plugins/op-obsidian/src/cliHandlers.ts
@@ -537,6 +537,21 @@ export function parseFlushVaultHistoryParams(
   return { ok: true, value: out };
 }
 
+export function parseWorkflowParams(
+  params: Record<string, string>,
+): ParamsResult<{ project?: string; prefix?: string; step: string }> {
+  const project = nonEmptyTrim(params.project ?? params.slug);
+  const prefix = nonEmptyTrim(params.prefix);
+  if (!project && !prefix) {
+    return { ok: false, error: "op-workflow failed: --project or --prefix is required" };
+  }
+  if (project && prefix) {
+    return { ok: false, error: "op-workflow failed: pass --project or --prefix, not both" };
+  }
+  const step = nonEmptyTrim(params.step) ?? "kickoff";
+  return { ok: true, value: { project, prefix, step } };
+}
+
 export function parseListVarsParams(
   params: Record<string, string>,
 ): ParamsResult<{ project?: string; issue?: string }> {

--- a/plugins/op-obsidian/src/explainWorkflow.ts
+++ b/plugins/op-obsidian/src/explainWorkflow.ts
@@ -12,6 +12,7 @@ import {
 } from "./explainWorkflowPure";
 import { buildListVarsPayload, type ListVarsPayload } from "./listVarsPure";
 import type { WorkflowDiagnostic } from "./workflowDiagnostic";
+import { getWorkflow, type GetWorkflowResult } from "./workflow";
 
 // IO seam for OP-203's two diagnostic CLIs. Both verbs need the same
 // composed-prompt pipeline that the launcher uses (so output matches what the
@@ -202,4 +203,64 @@ function vaultBasePath(app: App): string {
 
 function today(): string {
   return new Date().toISOString().slice(0, 10);
+}
+
+export interface GetProjectWorkflowResult {
+  project: string;
+  mode: "legacy" | "modules";
+  path: string;
+  exists: boolean;
+  content: string | null;
+  size: number;
+}
+
+/** Return the project workflow per the configured `workflowMode`:
+ *  - legacy: raw WORKFLOW.md content (same as `op-get-workflow`)
+ *  - modules: the composed kickoff prompt from the modular pipeline */
+export async function getProjectWorkflow(
+  app: App,
+  settings: OpSettings,
+  args: { project: string; step?: string },
+): Promise<GetProjectWorkflowResult> {
+  const project = args.project.trim();
+  if (!project) throw new Error("op-workflow: project is required");
+  const step = args.step ?? "kickoff";
+
+  if (settings.workflowMode === "legacy") {
+    const res = await getWorkflow(app, project);
+    return { project: res.project, mode: "legacy", path: res.path, exists: res.exists, content: res.content, size: res.size };
+  }
+
+  // Modules mode: compose with a minimal render context (no issue needed).
+  const renderContext: RenderContext = {
+    id: "",
+    title: "",
+    project,
+    status: "",
+    parent: null,
+    vault_path: vaultBasePath(app),
+    vault_name: app.vault.getName(),
+    today: today(),
+    agent: settings.defaultAgent,
+    mode: step,
+  };
+
+  const projectVars = readProjectVars(app, project);
+
+  const { composed } = await loadAndComposeWorkflow(app, {
+    project,
+    step,
+    ctx: {
+      render: renderContext,
+      globalVars: settings.workflowVars ?? {},
+      projectVars,
+      maxWorkflowChars: settings.injection.maxWorkflowChars,
+    },
+  });
+
+  if (!composed) {
+    return { project, mode: "modules", path: `Projects/${project}/WORKFLOW.md`, exists: false, content: null, size: 0 };
+  }
+
+  return { project, mode: "modules", path: `Projects/${project}/WORKFLOW.md`, exists: true, content: composed.text, size: composed.sizeChars };
 }

--- a/plugins/op-obsidian/src/main.ts
+++ b/plugins/op-obsidian/src/main.ts
@@ -15,7 +15,7 @@ import { EventBus } from "./eventBus";
 import { IssueStore } from "./issueStore";
 import { createIssue, type CreateIssueInput, type Priority } from "./createIssue";
 import { findIssue } from "./findIssue";
-import { applyProjectOrder, listProjects } from "./projects";
+import { applyProjectOrder, findProjectByPrefix, findProjectBySlug, listProjects } from "./projects";
 import {
   AppendCommitModal,
   FindIssueModal,
@@ -108,6 +108,7 @@ import {
   handleOpGetSkillUri as handleOpGetSkillUriPure,
   handleOpExplainWorkflowUri as handleOpExplainWorkflowUriPure,
   handleOpListVarsUri as handleOpListVarsUriPure,
+  handleOpWorkflowUri as handleOpWorkflowUriPure,
   type UriHandlerDeps,
 } from "./uriHandlers";
 import {
@@ -137,8 +138,9 @@ import {
   parseDocCreateParams,
   parseDocEditParams,
   parseFlushVaultHistoryParams,
+  parseWorkflowParams,
 } from "./cliHandlers";
-import { explainWorkflow, listVars } from "./explainWorkflow";
+import { explainWorkflow, getProjectWorkflow, listVars } from "./explainWorkflow";
 import {
   summarizeExplainPayload,
 } from "./explainWorkflowPure";
@@ -1142,6 +1144,12 @@ export default class OpPlugin extends Plugin {
       );
     });
 
+    this.registerObsidianProtocolHandler("op-workflow", (params) => {
+      this.runUri("op-workflow", normalizeUriParams(params), (p) =>
+        this.handleOpWorkflowUri(p),
+      );
+    });
+
     this.registerObsidianProtocolHandler("op-get-skill", (params) => {
       this.runUri("op-get-skill", normalizeUriParams(params), (p) =>
         handleOpGetSkillUriPure(this.uriDeps(), p),
@@ -1493,6 +1501,26 @@ export default class OpPlugin extends Plugin {
         },
       },
       (params) => this.handleOpListVarsCli(params),
+    );
+
+    this.registerCliHandler(
+      "op-workflow",
+      "Return WORKFLOW.md (legacy) or compiled modular workflow (modules) for a project. Read-only.",
+      {
+        project: {
+          value: "<slug>",
+          description: "Project slug (folder name under Projects/). Mutually exclusive with --prefix.",
+        },
+        prefix: {
+          value: "<PREFIX>",
+          description: "Issue-ID prefix (e.g. OP). Mutually exclusive with --project.",
+        },
+        step: {
+          value: "<step>",
+          description: "Workflow step id to compose (default: kickoff). Only relevant in modules mode.",
+        },
+      },
+      (params) => this.handleOpWorkflowCli(params),
     );
 
     this.registerCliHandler(
@@ -2565,6 +2593,7 @@ export default class OpPlugin extends Plugin {
       linkCheck: (opts) => linkCheck(this.app, this.store, opts),
       migrateLinks: () => migrateLinks(this.app, this.store),
       getWorkflow: (project) => getWorkflow(this.app, project),
+      getProjectWorkflow: (args) => getProjectWorkflow(this.app, this.settings, args),
       explainWorkflow: (args) =>
         explainWorkflow(
           this.app,
@@ -2626,6 +2655,12 @@ export default class OpPlugin extends Plugin {
     params: Record<string, string>,
   ): Promise<UriResponsePayload> {
     return handleOpGetWorkflowUriPure(this.uriDeps(), params);
+  }
+
+  private handleOpWorkflowUri(
+    params: Record<string, string>,
+  ): Promise<UriResponsePayload> {
+    return handleOpWorkflowUriPure(this.uriDeps(), params);
   }
 
   private handleOpSetScopeUri(
@@ -3958,6 +3993,54 @@ export default class OpPlugin extends Plugin {
       );
       await writeUriResponse(this.app, { ok: true, command, ...payload });
       return summarizeListVarsPayload(payload);
+    } catch (err: any) {
+      const msg = err?.message ?? String(err);
+      console.error("[op-obsidian]", command, err);
+      await writeUriResponse(this.app, { ok: false, command, error: msg });
+      return `${command} failed: ${msg}`;
+    }
+  }
+
+  private async handleOpWorkflowCli(params: Record<string, string>): Promise<string> {
+    const command = "op-workflow";
+    try {
+      const parsed = parseWorkflowParams(params);
+      if (!parsed.ok) return parsed.error;
+      const { project: rawProject, prefix, step } = parsed.value;
+
+      let project: string;
+      if (rawProject) {
+        const info = findProjectBySlug(this.app, rawProject);
+        if (!info) {
+          const msg = `project not found: ${rawProject}`;
+          await writeUriResponse(this.app, { ok: false, command, error: msg });
+          return `${command} failed: ${msg}`;
+        }
+        project = info.slug;
+      } else {
+        const info = findProjectByPrefix(this.app, prefix!);
+        if (!info) {
+          const msg = `no project with prefix: ${prefix}`;
+          await writeUriResponse(this.app, { ok: false, command, error: msg });
+          return `${command} failed: ${msg}`;
+        }
+        project = info.slug;
+      }
+
+      const res = await getProjectWorkflow(this.app, this.settings, { project, step });
+      await writeUriResponse(this.app, {
+        ok: true,
+        command,
+        project: res.project,
+        mode: res.mode,
+        path: res.path,
+        exists: res.exists,
+        content: res.content,
+        size: res.size,
+      });
+      return res.exists
+        ? `${command}: ${res.project} [${res.mode}] → ${res.path} (${res.size} chars)`
+        : `${command}: ${res.project} [${res.mode}] → no WORKFLOW.md (would live at ${res.path})`;
     } catch (err: any) {
       const msg = err?.message ?? String(err);
       console.error("[op-obsidian]", command, err);

--- a/plugins/op-obsidian/src/uriHandlers.ts
+++ b/plugins/op-obsidian/src/uriHandlers.ts
@@ -16,6 +16,7 @@ import type { SetFlowResult, Flow, Complexity } from "./setFlow";
 import type { ResolveArgs, ResolveStatus } from "./resolve";
 import type { ApplyLinkResult, LinkCheckResult, MigrateLinksResult } from "./links";
 import type { GetWorkflowResult } from "./workflow";
+import type { GetProjectWorkflowResult } from "./explainWorkflow";
 import { getSkill } from "./skill";
 import type { ExplainWorkflowPayload } from "./explainWorkflowPure";
 import type { ListVarsPayload } from "./listVarsPure";
@@ -54,6 +55,7 @@ export interface UriHandlerDeps {
   linkCheck?: (opts: { repair?: boolean }) => Promise<LinkCheckResult>;
   migrateLinks?: () => Promise<MigrateLinksResult>;
   getWorkflow?: (project: string) => Promise<GetWorkflowResult>;
+  getProjectWorkflow?: (args: { project: string; step?: string }) => Promise<GetProjectWorkflowResult>;
   explainWorkflow?: (args: {
     issueId: string;
     mode: string;
@@ -421,5 +423,26 @@ export async function handleOpListVarsUri(
     ok: true,
     command: "op-list-vars",
     ...payload,
+  };
+}
+
+export async function handleOpWorkflowUri(
+  deps: UriHandlerDeps,
+  params: Record<string, string>,
+): Promise<UriResponsePayload> {
+  if (!deps.getProjectWorkflow) throw new Error("op-workflow not wired");
+  const project = params.project ?? params.slug;
+  if (!project) throw new Error("op-workflow URI requires project");
+  const step = typeof params.step === "string" ? params.step.trim() : undefined;
+  const res = await deps.getProjectWorkflow({ project, step });
+  return {
+    ok: true,
+    command: "op-workflow",
+    project: res.project,
+    mode: res.mode,
+    path: res.path,
+    exists: res.exists,
+    content: res.content,
+    size: res.size,
   };
 }

--- a/plugins/op/.claude-plugin/plugin.json
+++ b/plugins/op/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "op",
   "description": "Obsidian Projects workflow — schema, slash commands, and agent skill for running a Jira-lite issue tracker inside an Obsidian vault.",
-  "version": "0.94.4",
+  "version": "0.95.0",
   "author": {
     "name": "Eugene Archibald"
   },

--- a/plugins/op/commands/workflow.md
+++ b/plugins/op/commands/workflow.md
@@ -1,0 +1,7 @@
+---
+description: "Return WORKFLOW.md or compiled workflow for a project. Args: <PROJECT|PREFIX> — e.g. OP or obsidian-projects."
+---
+
+Invoke the `op` skill and run the **workflow** verb with arguments: `$ARGUMENTS`.
+
+Read-only. Resolves the project from a slug (folder name under Projects/) or an issue-ID prefix (e.g. OP → obsidian-projects). Returns the project's WORKFLOW.md content (legacy mode) or the compiled modular workflow (modules mode), depending on the `workflowMode` setting.


### PR DESCRIPTION
## Summary
- New `op:workflow` CLI command that returns WORKFLOW.md (legacy mode) or compiled modular workflow (modules mode)
- Accepts `project=<slug>` or `prefix=<PREFIX>` for project resolution
- Optional `step=<step>` parameter (defaults to kickoff)
- Adds slash command `plugins/op/commands/workflow.md`
- Wires through URI handler, CLI handler, param parser, and composition logic

## Test plan
- [x] `op-workflow project=testing` returns modules-mode composed output
- [x] `op-workflow prefix=TST` resolves prefix to project
- [x] `op-workflow project=nonexistent` returns clear error
- [x] Legacy mode returns raw WORKFLOW.md content
- [x] No console errors
- [x] Existing commands (op-get-workflow, op-list-vars) unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)