### PR TITLE
OP-275: support configurable Projects path

### DIFF
--- a/plugins/op-obsidian/manifest.json
+++ b/plugins/op-obsidian/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "op-obsidian",
   "name": "Obsidian Projects (op)",
-  "version": "0.95.0",
+  "version": "0.96.0",
   "minAppVersion": "1.5.0",
   "description": "Jira-lite issue tracker for Obsidian vaults — deterministic commands backing the op workflow.",
   "author": "Eugene Archibald",

--- a/plugins/op-obsidian/package.json
+++ b/plugins/op-obsidian/package.json
@@ -1,6 +1,6 @@
 {
   "name": "op-obsidian",
-  "version": "0.95.0",
+  "version": "0.96.0",
   "description": "Obsidian plugin that owns the deterministic half of the op workflow.",
   "main": "main.js",
   "scripts": {

--- a/plugins/op-obsidian/src/agentHooks.ts
+++ b/plugins/op-obsidian/src/agentHooks.ts
@@ -1,6 +1,7 @@
 import { promises as fs } from "fs";
 import * as os from "os";
 import * as path from "path";
+import { normalizeProjectsRoot } from "./projectPaths";
 
 // Installs a SessionEnd hook for each supported agent (Claude Code, Gemini CLI,
 // Copilot CLI). The hook invokes a shared shell script that opens an
@@ -33,6 +34,8 @@ export interface HookInstallOptions {
    *  `~/.claude/settings.json` pointing at `~/.claude/statusline-plugin/run`.
    *  When false, any op-managed statusLine entry is removed. Default true. */
   usePluginStatusline?: boolean;
+  /** Configured vault-relative root that contains project folders. */
+  projectsRoot?: string;
 }
 
 export interface HookInstallResult {
@@ -65,10 +68,12 @@ export async function installAgentHooks(
   const newFileGuard = !!options.newFileGuard;
   // Default true per OP-269: "use plugin statusline" on unless explicitly disabled.
   const usePluginStatusline = options.usePluginStatusline !== false;
+  const projectsRoot = normalizeProjectsRoot(options.projectsRoot);
   await writeGuardScript(guardScriptPath, {
     enforceWorktree,
     managedNoteGuard,
     newFileGuard,
+    projectsRoot,
   });
 
   const installed: string[] = [];
@@ -176,6 +181,7 @@ interface GuardScriptLayers {
   enforceWorktree: boolean;
   managedNoteGuard: boolean;
   newFileGuard: boolean;
+  projectsRoot: string;
 }
 
 async function writeGuardScript(
@@ -305,23 +311,23 @@ async function writeGuardScript(
   if (layers.newFileGuard) {
     body.push(
     "# === Layer 3: new-file refusal ===",
+    `projects_root=${shQuote(layers.projectsRoot)}`,
+    'projects_root_re=$(printf %s "$projects_root" | sed \'s/[][(){}.^$+*?|\\/]/\\\\&/g\')',
     'if [ "${OP_ALLOW_NEW_FILE:-}" != "1" ] && [ -n "$file" ]; then',
-    '  case "$file" in',
-    '    */Projects/*/ISSUES/*|*/Projects/*/RESOLVED\\ ISSUES/*|*/Projects/*/TASKS/*)',
-    '      if [ ! -e "$file" ]; then',
-    '        case "$file" in',
-    '          */Projects/*/ISSUES/*)             new_hint="Use op-new project=<slug> title=\\"...\\" to create new issues — the plugin owns ID numbering, filename sanitization, and the schema-conformant frontmatter." ;;',
-    '          */Projects/*/TASKS/*)              new_hint="Use op-task-create issue=<id> title=\\"...\\" to create new TASK notes — the plugin links them to the parent issue and sets the schema." ;;',
-    '          */Projects/*/RESOLVED\\ ISSUES/*)  new_hint="" ;;',
-    '          *)                                 new_hint="" ;;',
-    "        esac",
+    '  if printf %s "$file" | grep -Eq "/${projects_root_re}/[^/]+/(ISSUES|RESOLVED ISSUES|TASKS)/"; then',
+    '    if [ ! -e "$file" ]; then',
+    '      new_hint=""',
+    '      if printf %s "$file" | grep -Eq "/${projects_root_re}/[^/]+/ISSUES/"; then',
+    '        new_hint="Use op-new project=<slug> title=\\"...\\" to create new issues — the plugin owns ID numbering, filename sanitization, and the schema-conformant frontmatter."',
+    '      elif printf %s "$file" | grep -Eq "/${projects_root_re}/[^/]+/TASKS/"; then',
+    '        new_hint="Use op-task-create issue=<id> title=\\"...\\" to create new TASK notes — the plugin links them to the parent issue and sets the schema."',
+    "      fi",
     '        echo "op-obsidian: refusing creation of new file under managed folder: $file" >&2',
     '        if [ -n "$new_hint" ]; then echo "$new_hint" >&2; fi',
     '        echo "Override with OP_ALLOW_NEW_FILE=1 for a one-line edit." >&2',
     "        exit 2",
-    "      fi",
-    "      ;;",
-    "  esac",
+    '    fi',
+    '  fi',
     "fi",
     "",
     );

--- a/plugins/op-obsidian/src/auditLog.ts
+++ b/plugins/op-obsidian/src/auditLog.ts
@@ -7,6 +7,7 @@ import {
   shouldRotate,
   type AuditEntry,
 } from "./auditLogPure";
+import { currentProjectsRoot, scratchFilePath } from "./projectPaths";
 
 export type AuditEntryInput = Omit<AuditEntry, "ts"> & { ts?: string };
 
@@ -27,7 +28,9 @@ export async function appendAuditLine(app: App, input: AuditEntryInput): Promise
     const line = encodeAuditLine(entry);
 
     const adapter = app.vault.adapter;
-    const path = normalizePath(AUDIT_LOG_PATH);
+    const path = normalizePath(
+      scratchFilePath("op-audit.jsonl", currentProjectsRoot(app)),
+    );
     const folder = path.split("/").slice(0, -1).join("/");
     if (folder && !(await adapter.exists(folder))) {
       await adapter.mkdir(folder);

--- a/plugins/op-obsidian/src/auditLogPure.ts
+++ b/plugins/op-obsidian/src/auditLogPure.ts
@@ -1,8 +1,10 @@
+import { scratchFilePath } from "./projectPaths";
+
 // Pure helpers for the op-audit JSONL writer. Splitting the encode + rotation
 // logic from the obsidian-bound writer (`auditLog.ts`) keeps it vitest-friendly
 // and lets the bypass detector reuse the same encoding path.
 
-export const AUDIT_LOG_PATH = "Projects/_scratch/op-audit.jsonl";
+export const AUDIT_LOG_PATH = scratchFilePath("op-audit.jsonl");
 export const AUDIT_ROTATE_BYTES = 10 * 1024 * 1024; // 10 MB
 export const AUDIT_MAX_BACKUPS = 5;
 

--- a/plugins/op-obsidian/src/composeWorkflowPure.ts
+++ b/plugins/op-obsidian/src/composeWorkflowPure.ts
@@ -417,14 +417,14 @@ export function composeWorkflow(args: ComposeArgs): ComposedPrompt {
   for (const id of stepRecord.modules) {
     const lm = moduleById.get(id);
     if (!lm) {
-      diagnostics.push({
-        code: "unknown-module",
-        severity: "error",
-        message: `composeWorkflow: step "${step}" references module "${id}" but no loaded module has that id. Check the module file exists at Projects/_op-modules/${id}.md or Projects/<slug>/MODULES/${id}.md.`,
-        stepId: step,
-        moduleId: id,
-        extra: { step, moduleId: id },
-      });
+        diagnostics.push({
+          code: "unknown-module",
+          severity: "error",
+          message: `composeWorkflow: step "${step}" references module "${id}" but no loaded module has that id. Check the module file exists in the configured global modules folder or in <project>/MODULES/${id}.md.`,
+          stepId: step,
+          moduleId: id,
+          extra: { step, moduleId: id },
+        });
       continue;
     }
     orderedModules.push(lm);

--- a/plugins/op-obsidian/src/createIssue.ts
+++ b/plugins/op-obsidian/src/createIssue.ts
@@ -2,6 +2,7 @@ import { App, TFile, normalizePath } from "obsidian";
 import type { IssueStore } from "./issueStore";
 import { findProjectBySlug, type ProjectInfo } from "./projects";
 import { nextIssueNumberFromVault } from "./findIssue";
+import { joinVaultPath } from "./projectPaths";
 import { issueFilename } from "./sanitize";
 import { renderIssueNote, type Priority } from "./issueTemplate";
 import type { IssueEntry } from "./types";
@@ -47,8 +48,8 @@ export async function createIssue(
     );
   }
 
-  const folder = `Projects/${project.slug}/ISSUES`;
-  const resolvedFolder = `Projects/${project.slug}/RESOLVED ISSUES`;
+  const folder = joinVaultPath(project.folderPath, "ISSUES");
+  const resolvedFolder = joinVaultPath(project.folderPath, "RESOLVED ISSUES");
   await ensureFolder(app, folder);
 
   let n = nextIssueNumberFromVault(app, { slug: project.slug, prefix: project.prefix });

--- a/plugins/op-obsidian/src/docCreate.ts
+++ b/plugins/op-obsidian/src/docCreate.ts
@@ -1,5 +1,6 @@
 import { App, TFile, normalizePath } from "obsidian";
 import { findProjectBySlug } from "./projects";
+import { joinVaultPath } from "./projectPaths";
 import { sanitizeIssueTitle } from "./sanitize";
 import { renderDocNote, isDocType, type DocType } from "./docCreatePure";
 
@@ -34,7 +35,7 @@ export async function docCreate(app: App, input: DocCreateInput): Promise<DocCre
     throw new Error("op-doc-create: title sanitizes to empty — pass a non-empty title");
   }
 
-  const docsFolder = `Projects/${project.slug}/DOCS`;
+  const docsFolder = joinVaultPath(project.folderPath, "DOCS");
   if (!app.vault.getAbstractFileByPath(docsFolder)) {
     await app.vault.createFolder(docsFolder);
   }

--- a/plugins/op-obsidian/src/editModule.ts
+++ b/plugins/op-obsidian/src/editModule.ts
@@ -12,6 +12,7 @@ import type { AgentDetector } from "./agentDetect";
 import { AgentPickerModal } from "./modals";
 import { launchInTerminal } from "./terminalLaunch";
 import { resolveWorkingDirForSlug } from "./workingDir";
+import { currentProjectsRoot, globalModulesDirPath, statusPathFor } from "./projectPaths";
 import { userError } from "./userError";
 import {
   buildEditModulePrompt,
@@ -94,7 +95,9 @@ export async function editModule(
   if (!wd) {
     userError(
       `op-edit-module: working directory required for ${slugForCwd} — launch cancelled`,
-      `Set \`repo_path:\` in Projects/${slugForCwd}/STATUS.md, or re-run the command and fill in the working-dir prompt.`,
+      args.projectSlug?.trim()
+        ? `Set \`repo_path:\` in ${statusPathFor(args.projectSlug.trim(), currentProjectsRoot(app))}, or re-run the command and fill in the working-dir prompt.`
+        : `Global modules live under ${globalModulesDirPath(currentProjectsRoot(app))}/ and do not have a STATUS.md; re-run the command and fill in the working-dir prompt.`,
     );
     return undefined;
   }
@@ -103,6 +106,7 @@ export async function editModule(
     scopeKind: args.scopeKind,
     projectSlug: args.projectSlug,
     moduleId,
+    projectsRoot: currentProjectsRoot(app),
   });
 
   const { existingContent, hasFrontmatter } = await readModuleBody(app, modulePath);

--- a/plugins/op-obsidian/src/editModulePure.ts
+++ b/plugins/op-obsidian/src/editModulePure.ts
@@ -1,3 +1,8 @@
+import {
+  globalModulePath,
+  modulesFolderPath,
+} from "./projectPaths";
+
 // Pure helpers for op-edit-module. Kept separate from editModule.ts so they
 // can be unit-tested without loading the obsidian module.
 
@@ -112,15 +117,16 @@ export function modulePathFor(args: {
   scopeKind: ModuleScopeKind;
   projectSlug?: string;
   moduleId: string;
+  projectsRoot?: string;
 }): string {
-  const { scopeKind, projectSlug, moduleId } = args;
+  const { scopeKind, projectSlug, moduleId, projectsRoot } = args;
   const id = moduleId.trim();
   if (!id) throw new Error("modulePathFor: moduleId is required");
   if (scopeKind === "global") {
-    return `Projects/_op-modules/${id}.md`;
+    return globalModulePath(id, projectsRoot);
   }
   if (!projectSlug || !projectSlug.trim()) {
     throw new Error("modulePathFor: projectSlug is required for scopeKind=project");
   }
-  return `Projects/${projectSlug.trim()}/MODULES/${id}.md`;
+  return `${modulesFolderPath(projectSlug.trim(), projectsRoot)}/${id}.md`;
 }

--- a/plugins/op-obsidian/src/editWorkflow.ts
+++ b/plugins/op-obsidian/src/editWorkflow.ts
@@ -10,6 +10,7 @@ import {
 } from "./agentProfiles";
 import type { AgentDetector } from "./agentDetect";
 import { AgentPickerModal } from "./modals";
+import { currentProjectsRoot, statusPathFor } from "./projectPaths";
 import { launchInTerminal } from "./terminalLaunch";
 import { resolveWorkingDirForSlug } from "./workingDir";
 import { workflowPathFor } from "./workflow";
@@ -64,12 +65,12 @@ export async function editWorkflow(
   if (!wd) {
     userError(
       `op-edit-workflow: working directory required for ${trimmed} — launch cancelled`,
-      `Set \`repo_path:\` in Projects/${trimmed}/STATUS.md, or re-run the command and fill in the working-dir prompt.`,
+      `Set \`repo_path:\` in ${statusPathFor(trimmed, currentProjectsRoot(app))}, or re-run the command and fill in the working-dir prompt.`,
     );
     return undefined;
   }
 
-  const workflowPath = workflowPathFor(trimmed);
+  const workflowPath = workflowPathFor(trimmed, currentProjectsRoot(app));
   const existingContent = await readWorkflowBody(app, workflowPath);
 
   const vaultBasePath = getVaultBasePath(app);

--- a/plugins/op-obsidian/src/editorWorkflowValidator.test.ts
+++ b/plugins/op-obsidian/src/editorWorkflowValidator.test.ts
@@ -122,6 +122,12 @@ describe("classifyFile", () => {
       project: "",
     });
   });
+  it("classifies files under a configured root", () => {
+    expect(classifyFile("Workspace/Projects/demo/WORKFLOW.md", "Workspace/Projects")).toEqual({
+      kind: "workflow",
+      project: "demo",
+    });
+  });
   it("rejects unrelated paths", () => {
     expect(classifyFile("Projects/demo/ISSUES/OP-1.md")).toBeNull();
     expect(classifyFile("Projects/_op-modules/sub/nested.md")).toBeNull();

--- a/plugins/op-obsidian/src/editorWorkflowValidator.ts
+++ b/plugins/op-obsidian/src/editorWorkflowValidator.ts
@@ -25,11 +25,13 @@ import {
   summarizeStatus,
   type ValidatorSummary,
 } from "./editorWorkflowValidatorPure";
+import {
+  globalModulesDirPath,
+  normalizeProjectsRoot,
+  projectsRootFromApp,
+} from "./projectPaths";
 
-const PROJECTS_ROOT = "Projects/";
-const GLOBAL_MODULES_DIR = "Projects/_op-modules/";
 const PER_PROJECT_MODULES_INFIX = "/MODULES/";
-const GLOBAL_WORKFLOW_PATH = "Projects/_op-workflow.md";
 
 export type ValidatedFileKind = "module" | "workflow";
 
@@ -52,12 +54,17 @@ export interface ValidatedFileInfo {
  * The global-scoped variants resolve to project: "" — the validator picks an
  * arbitrary project to compose under (or skips when none is available).
  */
-export function classifyFile(path: string): ValidatedFileInfo | null {
-  if (path === GLOBAL_WORKFLOW_PATH) {
+export function classifyFile(path: string, projectsRoot?: string): ValidatedFileInfo | null {
+  const root = normalizeProjectsRoot(projectsRoot);
+  const projectsRootPrefix = `${root}/`;
+  const globalModulesDir = `${globalModulesDirPath(root)}/`;
+  const globalWorkflowPath = `${root}/_op-workflow.md`;
+
+  if (path === globalWorkflowPath) {
     return { kind: "workflow", project: "" };
   }
-  if (path.startsWith(GLOBAL_MODULES_DIR)) {
-    const rel = path.slice(GLOBAL_MODULES_DIR.length);
+  if (path.startsWith(globalModulesDir)) {
+    const rel = path.slice(globalModulesDir.length);
     if (rel.includes("/")) return null;
     if (!rel.endsWith(".md")) return null;
     return { kind: "module", project: "" };
@@ -68,14 +75,14 @@ export function classifyFile(path: string): ValidatedFileInfo | null {
     const slugStart = beforeInfix.lastIndexOf("/");
     if (slugStart === -1) return null;
     const slug = beforeInfix.slice(slugStart + 1);
-    if (!slug || beforeInfix !== `${PROJECTS_ROOT.slice(0, -1)}/${slug}`) return null;
+    if (!slug || beforeInfix !== `${root}/${slug}`) return null;
     const after = path.slice(moduleIdx + PER_PROJECT_MODULES_INFIX.length);
     if (after.includes("/")) return null;
     return { kind: "module", project: slug };
   }
   // Per-project workflow file.
-  if (path.startsWith(PROJECTS_ROOT) && path.endsWith("/WORKFLOW.md")) {
-    const rel = path.slice(PROJECTS_ROOT.length, -"/WORKFLOW.md".length);
+  if (path.startsWith(projectsRootPrefix) && path.endsWith("/WORKFLOW.md")) {
+    const rel = path.slice(projectsRootPrefix.length, -"/WORKFLOW.md".length);
     if (!rel || rel.includes("/")) return null;
     return { kind: "workflow", project: rel };
   }
@@ -112,7 +119,7 @@ export async function validateFile(
   file: TFile,
   deps: ValidatorDeps,
 ): Promise<ValidationResult> {
-  const info = classifyFile(file.path);
+  const info = classifyFile(file.path, deps.settings.projectsRoot);
   if (!info) return EMPTY_RESULT("");
 
   const project = info.project || pickProjectForGlobalFile(app);
@@ -171,11 +178,12 @@ function installedAgentIds(detector: AgentDetector | undefined): string[] {
  * authored-once-shared-everywhere global module.
  */
 function pickProjectForGlobalFile(app: App): string {
+  const projectsRootPrefix = `${projectsRootFromApp(app)}/`;
   const files = app.vault.getMarkdownFiles();
   for (const f of files) {
     if (!f.path.endsWith("/WORKFLOW.md")) continue;
-    if (!f.path.startsWith(PROJECTS_ROOT)) continue;
-    const rel = f.path.slice(PROJECTS_ROOT.length, -"/WORKFLOW.md".length);
+    if (!f.path.startsWith(projectsRootPrefix)) continue;
+    const rel = f.path.slice(projectsRootPrefix.length, -"/WORKFLOW.md".length);
     if (rel && !rel.includes("/")) return rel;
   }
   return "";

--- a/plugins/op-obsidian/src/editorWorkflowValidatorExtension.ts
+++ b/plugins/op-obsidian/src/editorWorkflowValidatorExtension.ts
@@ -128,7 +128,7 @@ function makeViewPlugin(deps: ValidatorExtensionDeps) {
         const path = file?.path ?? null;
         if (path === this.currentPath) return;
         this.currentPath = path;
-        if (!path || !classifyFile(path)) {
+        if (!path || !classifyFile(path, deps.getSettings().projectsRoot)) {
           this.clear();
           return;
         }

--- a/plugins/op-obsidian/src/errorLog.ts
+++ b/plugins/op-obsidian/src/errorLog.ts
@@ -1,6 +1,5 @@
 import { App, TFile, normalizePath } from "obsidian";
-
-export const ERROR_LOG_PATH = "Projects/_scratch/op-last-error.md";
+import { currentProjectsRoot, scratchFilePath } from "./projectPaths";
 
 /**
  * Persist a single op error to a vault-side scratch note so the user (or a
@@ -14,7 +13,7 @@ export async function writeErrorLog(
   category: string,
   details: string,
 ): Promise<string> {
-  const path = normalizePath(ERROR_LOG_PATH);
+  const path = normalizePath(scratchFilePath("op-last-error.md", currentProjectsRoot(app)));
   const folder = path.split("/").slice(0, -1).join("/");
   if (folder && !(await app.vault.adapter.exists(folder))) {
     await app.vault.createFolder(folder).catch(() => {});
@@ -31,7 +30,7 @@ export async function writeErrorLog(
 }
 
 export async function openErrorLog(app: App): Promise<void> {
-  const path = normalizePath(ERROR_LOG_PATH);
+  const path = normalizePath(scratchFilePath("op-last-error.md", currentProjectsRoot(app)));
   const f = app.vault.getAbstractFileByPath(path);
   if (f instanceof TFile) {
     await app.workspace.getLeaf(false).openFile(f);

--- a/plugins/op-obsidian/src/explainWorkflow.ts
+++ b/plugins/op-obsidian/src/explainWorkflow.ts
@@ -11,6 +11,7 @@ import {
   type ExplainWorkflowPayload,
 } from "./explainWorkflowPure";
 import { buildListVarsPayload, type ListVarsPayload } from "./listVarsPure";
+import { findProjectBySlug } from "./projects";
 import type { WorkflowDiagnostic } from "./workflowDiagnostic";
 import { getWorkflow, type GetWorkflowResult } from "./workflow";
 
@@ -182,7 +183,8 @@ function readParent(app: App, issuePath: string): string | null {
 }
 
 export function readProjectVars(app: App, project: string): Record<string, string> {
-  const statusPath = `Projects/${project}/STATUS.md`;
+  const statusPath = findProjectBySlug(app, project)?.statusPath;
+  if (!statusPath) return {};
   const file = app.vault.getAbstractFileByPath(statusPath);
   if (!(file instanceof TFile)) return {};
   const fm = app.metadataCache.getFileCache(file)?.frontmatter;

--- a/plugins/op-obsidian/src/exportImportPure.test.ts
+++ b/plugins/op-obsidian/src/exportImportPure.test.ts
@@ -267,6 +267,19 @@ describe("planImport", () => {
     expect(plan.rewrittenProject).toBe("new-slug");
   });
 
+  it("targets the configured root when projectsRoot is provided", () => {
+    const plan = planImport({
+      module: baseModule,
+      body: baseBody,
+      targetScope: "project",
+      targetProjectSlug: "demo",
+      projectsRoot: "Workspace/Projects",
+      globalVars: {},
+      projectVars: {},
+    });
+    expect(plan.targetPath).toBe("Workspace/Projects/demo/MODULES/orient.md");
+  });
+
   it("throws when scope=project lacks a slug", () => {
     expect(() =>
       planImport({

--- a/plugins/op-obsidian/src/exportImportPure.ts
+++ b/plugins/op-obsidian/src/exportImportPure.ts
@@ -24,6 +24,12 @@ import {
   type VarDecl,
   type WorkflowModule,
 } from "./workflowModulePure";
+import {
+  globalModulePath,
+  importHistoryDirPath,
+  modulesFolderPath,
+  normalizeProjectsRoot,
+} from "./projectPaths";
 import type { WorkflowDiagnostic } from "./workflowDiagnostic";
 
 // ---------------------------------------------------------------------------
@@ -295,6 +301,8 @@ export interface PlanImportArgs {
   targetScope: ImportScopeKind;
   /** Required when `targetScope === "project"`. */
   targetProjectSlug?: string;
+  /** Vault-relative Projects root to land under. Defaults to `Projects`. */
+  projectsRoot?: string;
   /**
    * The user's pre-supplied answers for any var the importer would otherwise
    * prompt for. Keyed by var name. Empty string is preserved as a real answer.
@@ -391,10 +399,11 @@ export function planImport(args: PlanImportArgs): ImportPlan {
     throw new Error("planImport: targetProjectSlug is required when targetScope=project");
   }
 
+  const projectsRoot = normalizeProjectsRoot(args.projectsRoot);
   const targetPath =
     targetScope === "global"
-      ? `Projects/_op-modules/${module.id}.md`
-      : `Projects/${targetProjectSlug!.trim()}/MODULES/${module.id}.md`;
+      ? globalModulePath(module.id, projectsRoot)
+      : `${modulesFolderPath(targetProjectSlug!.trim(), projectsRoot)}/${module.id}.md`;
 
   // Project rewrite: per-project landings always set `project:` to the slug
   // they land under. Global landings preserve the source `project:` field.
@@ -506,7 +515,7 @@ function hasExplicitDefault(decl: VarDecl): boolean {
 // Transaction record
 // ---------------------------------------------------------------------------
 
-export const TRANSACTION_HISTORY_DIR = "Projects/_op-import-history";
+export const TRANSACTION_HISTORY_DIR = importHistoryDirPath();
 export const TRANSACTION_VERSION = 1;
 
 export interface TransactionModuleEntry {

--- a/plugins/op-obsidian/src/exportModule.ts
+++ b/plugins/op-obsidian/src/exportModule.ts
@@ -1,5 +1,6 @@
 import { App, TFile, normalizePath } from "obsidian";
 import { loadModules } from "./workflowModule";
+import { currentProjectsRoot, exportDirPath } from "./projectPaths";
 import type { WorkflowModule } from "./workflowModulePure";
 import { formatExportFile } from "./exportImportPure";
 
@@ -13,7 +14,7 @@ import { formatExportFile } from "./exportImportPure";
 //                        project modules + globals carrying that `project:`)
 //                        to `Projects/_op-export/<slug>/<id>.md`.
 
-export const EXPORT_DIR = "Projects/_op-export";
+export const EXPORT_DIR = exportDirPath();
 
 export interface ExportSingleArgs {
   kind: "id";
@@ -52,6 +53,7 @@ export interface ExportResult {
  * half-written bundle.
  */
 export async function exportModules(app: App, args: ExportArgs): Promise<ExportResult> {
+  const exportDir = exportDirPath(currentProjectsRoot(app));
   const { modules: discovered, diagnostics } = loadModules(app);
   const fatal = diagnostics.filter((d) => d.severity === "error");
   if (fatal.length > 0) {
@@ -69,8 +71,8 @@ export async function exportModules(app: App, args: ExportArgs): Promise<ExportR
     );
   }
 
-  await ensureFolder(app, EXPORT_DIR);
-  const subfolder = args.kind === "project" ? `${EXPORT_DIR}/${args.projectSlug}` : null;
+  await ensureFolder(app, exportDir);
+  const subfolder = args.kind === "project" ? `${exportDir}/${args.projectSlug}` : null;
   if (subfolder) await ensureFolder(app, subfolder);
 
   const out: ExportedFile[] = [];
@@ -84,7 +86,7 @@ export async function exportModules(app: App, args: ExportArgs): Promise<ExportR
     const raw = await app.vault.read(tfile);
     const body = stripFrontmatter(raw);
     const exportPath = normalizePath(
-      subfolder ? `${subfolder}/${module.id}.md` : `${EXPORT_DIR}/${module.id}.md`,
+      subfolder ? `${subfolder}/${module.id}.md` : `${exportDir}/${module.id}.md`,
     );
     const content = formatExportFile({ module, body });
     await writeFile(app, exportPath, content);

--- a/plugins/op-obsidian/src/findIssue.ts
+++ b/plugins/op-obsidian/src/findIssue.ts
@@ -1,5 +1,7 @@
 import type { App, TFolder, TAbstractFile } from "obsidian";
 import type { IssueStore } from "./issueStore";
+import { currentProjectsRoot, projectFolderPath } from "./projectPaths";
+import { findProjectBySlug } from "./projects";
 import type { IssueEntry } from "./types";
 import type { ProjectInfo } from "./projects";
 
@@ -100,9 +102,12 @@ export function nextIssueNumberFromVault(
   app: App,
   project: { slug: string; prefix: string },
 ): number {
+  const projectFolder =
+    findProjectBySlug(app, project.slug)?.folderPath ??
+    projectFolderPath(project.slug, currentProjectsRoot(app));
   const folders = [
-    `Projects/${project.slug}/ISSUES`,
-    `Projects/${project.slug}/RESOLVED ISSUES`,
+    `${projectFolder}/ISSUES`,
+    `${projectFolder}/RESOLVED ISSUES`,
   ];
   const re = new RegExp(`^${escapeRegex(project.prefix)}-(\\d+)(?:\\b|[ .-])`);
   let max = 0;

--- a/plugins/op-obsidian/src/firstRunReadme.ts
+++ b/plugins/op-obsidian/src/firstRunReadme.ts
@@ -16,23 +16,29 @@
 
 import type { App } from "obsidian";
 import { normalizePath } from "obsidian";
+import {
+  DEFAULT_PROJECTS_ROOT,
+  currentProjectsRoot,
+  demoProjectFolderPath,
+  onboardingReadmePath,
+} from "./projectPaths";
 
-export const README_PATH = "Projects/_op-readme.md";
+export const README_PATH = onboardingReadmePath();
 export const DEMO_PROJECT_SLUG = "op-demo";
 export const DEMO_PROJECT_PREFIX = "DEMO";
-export const DEMO_PROJECT_FOLDER = `Projects/${DEMO_PROJECT_SLUG}`;
+export const DEMO_PROJECT_FOLDER = demoProjectFolderPath();
 
 /**
  * Pure markdown body for the first-run README. Kept pure so tests can
  * assert the chip codeblocks are present without spinning up an
  * Obsidian app instance.
  */
-export function buildReadmeBody(): string {
+export function buildReadmeBody(projectsRoot = DEFAULT_PROJECTS_ROOT): string {
   return [
     "# Welcome to op",
     "",
     "Obsidian Projects (op) is a tiny issue tracker that lives in this vault.",
-    "Issues are markdown notes under `Projects/<slug>/ISSUES/`; commands sit",
+    `Issues are markdown notes under \`${projectsRoot}/<slug>/ISSUES/\`; commands sit`,
     "under `op:` in the command palette; agents launch into tmux. Dismiss",
     "this README by deleting it — it won't come back.",
     "",
@@ -70,8 +76,8 @@ export function buildReadmeBody(): string {
     "## Workflow modules",
     "",
     "op composes the prompt your agents receive out of small markdown",
-    "modules under `Projects/_op-modules/` (global) and",
-    "`Projects/<slug>/MODULES/` (per-project). Read the docs to see how",
+    `modules under \`${projectsRoot}/_op-modules/\` (global) and`,
+    `\`${projectsRoot}/<slug>/MODULES/\` (per-project). Read the docs to see how`,
     "the precedence chain fits together and how to author your first",
     "module:",
     "",
@@ -209,6 +215,7 @@ export function buildDemoIssueNote(seed: DemoIssueSeed): string {
  */
 export interface FirstRunSettings {
   firstRunCompleted: boolean;
+  projectsRoot?: string;
 }
 
 /** Pure decision: should we scaffold the README on this load? */
@@ -237,11 +244,11 @@ export async function scaffoldFirstRunReadme(
   writer: ReadmeWriter,
   saveSettings: () => Promise<void>,
 ): Promise<{ scaffolded: boolean; readmePath: string }> {
-  const path = README_PATH;
+  const path = onboardingReadmePath(settings.projectsRoot);
   if (!shouldScaffoldReadme(settings, writer.exists(path))) {
     return { scaffolded: false, readmePath: path };
   }
-  await writer.write(path, buildReadmeBody());
+  await writer.write(path, buildReadmeBody(settings.projectsRoot));
   settings.firstRunCompleted = true;
   await saveSettings();
   return { scaffolded: true, readmePath: path };
@@ -277,15 +284,16 @@ export async function scaffoldDemoProject(app: App): Promise<{
   created: boolean;
   statusPath: string;
 }> {
-  const statusPath = `${DEMO_PROJECT_FOLDER}/STATUS.md`;
+  const demoFolder = demoProjectFolderPath(currentProjectsRoot(app));
+  const statusPath = `${demoFolder}/STATUS.md`;
   if (app.vault.getAbstractFileByPath(statusPath)) {
     return { created: false, statusPath };
   }
-  const issuesDir = `${DEMO_PROJECT_FOLDER}/ISSUES`;
-  await ensureFolder(app, DEMO_PROJECT_FOLDER);
+  const issuesDir = `${demoFolder}/ISSUES`;
+  await ensureFolder(app, demoFolder);
   await ensureFolder(app, issuesDir);
   await app.vault.create(statusPath, demoStatusFrontmatter(app.vault.getName()) + buildDemoStatusBody());
-  await app.vault.create(`${DEMO_PROJECT_FOLDER}/${DEMO_PROJECT_SLUG}.base`, demoBaseBody());
+  await app.vault.create(`${demoFolder}/${DEMO_PROJECT_SLUG}.base`, demoBaseBody());
   for (const seed of DEMO_ISSUES) {
     const filename = `${DEMO_PROJECT_PREFIX}-${seed.number} ${seed.title}.md`;
     await app.vault.create(`${issuesDir}/${filename}`, buildDemoIssueNote(seed));
@@ -308,10 +316,11 @@ async function ensureFolder(app: App, path: string): Promise<void> {
 export async function removeDemoProject(
   app: App,
 ): Promise<{ removed: boolean; folder: string }> {
-  const folder = app.vault.getAbstractFileByPath(DEMO_PROJECT_FOLDER);
-  if (!folder) return { removed: false, folder: DEMO_PROJECT_FOLDER };
+  const demoFolder = demoProjectFolderPath(currentProjectsRoot(app));
+  const folder = app.vault.getAbstractFileByPath(demoFolder);
+  if (!folder) return { removed: false, folder: demoFolder };
   await app.vault.trash(folder, true);
-  return { removed: true, folder: DEMO_PROJECT_FOLDER };
+  return { removed: true, folder: demoFolder };
 }
 
 /** Public for tests + the codeblock chip parser. */

--- a/plugins/op-obsidian/src/importModule.ts
+++ b/plugins/op-obsidian/src/importModule.ts
@@ -14,6 +14,13 @@ import {
   serializeTransaction,
   transactionFilename,
 } from "./exportImportPure";
+import {
+  currentProjectsRoot,
+  globalModulePath,
+  importHistoryDirPath,
+  modulesFolderPath,
+  statusPathFor,
+} from "./projectPaths";
 import type { WorkflowModule, VarDecl } from "./workflowModulePure";
 
 /**
@@ -23,7 +30,7 @@ import type { WorkflowModule, VarDecl } from "./workflowModulePure";
  * a vitest run that mocks `obsidian` minimally.
  */
 function readProjectVars(app: App, project: string): Record<string, string> {
-  const statusPath = `Projects/${project}/STATUS.md`;
+  const statusPath = statusPathFor(project, currentProjectsRoot(app));
   const file = app.vault.getAbstractFileByPath(statusPath);
   if (!(file instanceof TFile)) return {};
   const fm = app.metadataCache.getFileCache(file)?.frontmatter;
@@ -131,8 +138,8 @@ export async function prepareImport(
 
   const targetPath =
     args.targetScope === "global"
-      ? `Projects/_op-modules/${parsed.module.id}.md`
-      : `Projects/${args.targetProjectSlug!.trim()}/MODULES/${parsed.module.id}.md`;
+      ? globalModulePath(parsed.module.id, currentProjectsRoot(app))
+      : `${modulesFolderPath(args.targetProjectSlug!.trim(), currentProjectsRoot(app))}/${parsed.module.id}.md`;
 
   const existing = app.vault.getAbstractFileByPath(normalizePath(targetPath));
   const existingTargetPath = existing instanceof TFile ? existing.path : undefined;
@@ -146,6 +153,7 @@ export async function prepareImport(
     module: parsed.module,
     body: parsed.body,
     targetScope: args.targetScope,
+    projectsRoot: currentProjectsRoot(app),
     globalVars: settings.workflowVars,
     projectVars,
   };
@@ -220,10 +228,11 @@ export async function commitImport(
 
   const date = now();
   const tsFilename = transactionFilename(date);
-  const backupRoot = `${TRANSACTION_HISTORY_DIR}/${tsFilename}.bak`;
-  const transactionPath = `${TRANSACTION_HISTORY_DIR}/${tsFilename}.json`;
+  const historyDir = importHistoryDirPath(currentProjectsRoot(app));
+  const backupRoot = `${historyDir}/${tsFilename}.bak`;
+  const transactionPath = `${historyDir}/${tsFilename}.json`;
 
-  await ensureFolder(app, TRANSACTION_HISTORY_DIR);
+  await ensureFolder(app, historyDir);
 
   // 1. Back up an existing file at the target, if any.
   let backupPath: string | undefined;
@@ -345,7 +354,9 @@ async function applyVarWrite(
   if (!w.projectSlug) {
     throw new Error(`applyVarWrite: project-scope write missing projectSlug for ${w.name}`);
   }
-  const statusPath = normalizePath(`Projects/${w.projectSlug}/STATUS.md`);
+  const statusPath = normalizePath(
+    statusPathFor(w.projectSlug, currentProjectsRoot(app)),
+  );
   const file = app.vault.getAbstractFileByPath(statusPath);
   if (!(file instanceof TFile)) {
     throw new Error(

--- a/plugins/op-obsidian/src/issueStore.ts
+++ b/plugins/op-obsidian/src/issueStore.ts
@@ -1,5 +1,6 @@
 import { App, TFile, Component, CachedMetadata, EventRef } from "obsidian";
 import type { EventBus } from "./eventBus";
+import { currentProjectsRoot, isWithinProjectsRoot } from "./projectPaths";
 import type {
   IssueEntry,
   IssueStatus,
@@ -7,8 +8,6 @@ import type {
   TaskEntry,
   TaskStatus,
 } from "./types";
-
-const PROJECTS_ROOT = "Projects/";
 
 export class IssueStore extends Component {
   private entries = new Map<string, StoreEntry>();
@@ -47,8 +46,9 @@ export class IssueStore extends Component {
 
   rebuild(): void {
     this.entries.clear();
+    const root = currentProjectsRoot(this.app);
     for (const file of this.app.vault.getMarkdownFiles()) {
-      if (!file.path.startsWith(PROJECTS_ROOT)) continue;
+      if (!isWithinProjectsRoot(file.path, root)) continue;
       const cache = this.app.metadataCache.getFileCache(file);
       const entry = this.parse(file, cache);
       if (entry) this.entries.set(file.path, entry);
@@ -79,7 +79,7 @@ export class IssueStore extends Component {
   }
 
   private handleChange(file: TFile): void {
-    if (!file.path.startsWith(PROJECTS_ROOT)) return;
+    if (!isWithinProjectsRoot(file.path, currentProjectsRoot(this.app))) return;
     const cache = this.app.metadataCache.getFileCache(file);
     const next = this.parse(file, cache);
     const prev = this.entries.get(file.path);

--- a/plugins/op-obsidian/src/launchAgentModal.ts
+++ b/plugins/op-obsidian/src/launchAgentModal.ts
@@ -488,7 +488,7 @@ class LaunchAgentModal extends Modal {
         cls: "op-launch-modal__preview-hint",
         text: this.workflowFile
           ? "(no composed prompt — WORKFLOW.md loaded but the kickoff step produced empty output; check module bodies and variable bindings)"
-          : "(no composed prompt — no WORKFLOW.md found for this project; create one under Projects/<project>/ to enable prompt composition)",
+          : "(no composed prompt — no WORKFLOW.md found for this project; create one for this project under the configured Projects root to enable prompt composition)",
       });
     }
 

--- a/plugins/op-obsidian/src/main.ts
+++ b/plugins/op-obsidian/src/main.ts
@@ -185,6 +185,7 @@ import { notify, notifyAction, registerApp, unregisterApp, openNotificationLog }
 import { probeLiveTmuxWindows, selectStaleAgentBadges } from "./staleAgentBadges";
 import { appendRecency, mostRecent } from "./recencyLog";
 import { deriveTitle, packScope, resolveCaptureProject } from "./quickCapture";
+import { currentProjectsRoot, isWithinProjectsRoot, scratchDirPath } from "./projectPaths";
 import { openErrorLog, writeErrorLog } from "./errorLog";
 import { configureClient } from "./iterm/client";
 import { closeWindow as itermCloseWindow, openBrowserTab as itermOpenBrowserTab } from "./iterm/driver";
@@ -600,9 +601,10 @@ export default class OpPlugin extends Plugin {
       this.app.vault.on("modify", (file) => {
         if (!file || !(file instanceof TFile)) return;
         const path = file.path;
-        if (!path.startsWith("Projects/")) return;
+        const projectsRoot = currentProjectsRoot(this.app, this.settings);
+        if (!isWithinProjectsRoot(path, projectsRoot)) return;
         if (!path.endsWith(".md")) return;
-        if (path.startsWith("Projects/_scratch/")) return;
+        if (path.startsWith(`${scratchDirPath(projectsRoot)}/`)) return;
         if (this.inFlightOpWritePaths.has(path)) return;
         void appendAuditLine(this.app, {
           cmd: "bypass",
@@ -1553,7 +1555,7 @@ export default class OpPlugin extends Plugin {
         project: {
           value: "<slug>",
           description:
-            "Project slug — required for per-project modules; omit for globals (Projects/_op-modules/).",
+            "Project slug — required for per-project modules; omit for globals (the configured global modules folder).",
         },
         scope: {
           value: "<global|project>",
@@ -1566,7 +1568,7 @@ export default class OpPlugin extends Plugin {
 
     this.registerCliHandler(
       "op-export-module",
-      "Export workflow module(s) to Projects/_op-export/. Pass --id <id> for a single module or --project <slug> to bundle all modules visible to that project.",
+      "Export workflow module(s) to the configured _op-export/ folder. Pass --id <id> for a single module or --project <slug> to bundle all modules visible to that project.",
       {
         id: { value: "<id>", description: "Module id (filename basename, no .md). Single-module mode." },
         project: {
@@ -1580,7 +1582,7 @@ export default class OpPlugin extends Plugin {
 
     this.registerCliHandler(
       "op-import-module",
-      "Import a workflow module from a vault path or absolute filesystem path. Bootstraps missing vars at the chosen scope; backs up any existing target file; writes a transaction record under Projects/_op-import-history/.",
+      "Import a workflow module from a vault path or absolute filesystem path. Bootstraps missing vars at the chosen scope; backs up any existing target file; writes a transaction record under the configured _op-import-history/ folder.",
       {
         path: {
           value: "<path>",
@@ -5720,6 +5722,7 @@ export default class OpPlugin extends Plugin {
         managedNoteGuard: this.settings.agentDiscipline.managedNoteGuard,
         newFileGuard: this.settings.agentDiscipline.newFileGuard,
         usePluginStatusline: this.settings.sessionDecoration.usePluginStatusline,
+        projectsRoot: this.settings.projectsRoot,
       });
       if (announce) {
         const summary = res.installed.length
@@ -5836,9 +5839,9 @@ export default class OpPlugin extends Plugin {
     try {
       const result = await scaffoldDemoProject(this.app);
       if (!result.created) {
-        notify("op: demo project already present at " + DEMO_PROJECT_FOLDER);
+        notify("op: demo project already present at " + result.statusPath.replace(/\/STATUS\.md$/, ""));
       } else {
-        notify("op: demo project scaffolded at " + DEMO_PROJECT_FOLDER);
+        notify("op: demo project scaffolded at " + result.statusPath.replace(/\/STATUS\.md$/, ""));
         const status = this.app.vault.getAbstractFileByPath(result.statusPath);
         if (status instanceof TFile) {
           await this.app.workspace.getLeaf(false).openFile(status);

--- a/plugins/op-obsidian/src/modals.ts
+++ b/plugins/op-obsidian/src/modals.ts
@@ -13,6 +13,13 @@ import {
   validateSha,
   validateSubject,
 } from "./modalValidation";
+import {
+  currentProjectsRoot,
+  exportDirPath,
+  globalModulesDirPath,
+  importHistoryDirPath,
+  modulesFolderPath,
+} from "./projectPaths";
 
 export class AgentPickerModal extends FuzzySuggestModal<AgentId> {
   constructor(
@@ -143,8 +150,8 @@ export class NewModuleIdModal extends Modal {
     contentEl.empty();
     const where =
       this.scopeKind === "global"
-        ? "Projects/_op-modules/"
-        : `Projects/${this.projectSlug ?? ""}/MODULES/`;
+        ? `${globalModulesDirPath(currentProjectsRoot(this.app))}/`
+        : `${modulesFolderPath(this.projectSlug ?? "", currentProjectsRoot(this.app))}/`;
     contentEl.createEl("h2", { text: "New workflow module" });
     contentEl.createEl("p", {
       text: `The new module will be created at ${where}<id>.md when the agent writes it.`,
@@ -653,9 +660,10 @@ export class ExportModulePromptModal extends Modal {
   onOpen(): void {
     const { contentEl } = this;
     contentEl.empty();
+    const projectsRoot = currentProjectsRoot(this.app);
     contentEl.createEl("h2", { text: "Export workflow module(s)" });
     contentEl.createEl("p", {
-      text: "Writes to Projects/_op-export/. Pick id (single module) or project (bundle).",
+      text: `Writes to ${exportDirPath(projectsRoot)}/. Pick id (single module) or project (bundle).`,
     });
     new Setting(contentEl)
       .setName("Mode")
@@ -722,15 +730,16 @@ export class ImportModulePromptModal extends Modal {
   onOpen(): void {
     const { contentEl } = this;
     contentEl.empty();
+    const projectsRoot = currentProjectsRoot(this.app);
     contentEl.createEl("h2", { text: "Import workflow module" });
     contentEl.createEl("p", {
-      text: "Reads from a vault path or absolute filesystem path. Backs up any existing target file and writes a transaction record under Projects/_op-import-history/.",
+      text: `Reads from a vault path or absolute filesystem path. Backs up any existing target file and writes a transaction record under ${importHistoryDirPath(projectsRoot)}/.`,
     });
     new Setting(contentEl)
       .setName("Source path")
       .setDesc("Vault-relative or absolute path to the bundle .md file.")
       .addText((t) =>
-        t.setPlaceholder("Projects/_op-export/orient.md").onChange((v) => {
+        t.setPlaceholder(`${exportDirPath(projectsRoot)}/orient.md`).onChange((v) => {
           this.sourcePath = v;
         }),
       );
@@ -738,8 +747,8 @@ export class ImportModulePromptModal extends Modal {
       .setName("Land as")
       .addDropdown((d) =>
         d
-          .addOption("global", "Global (Projects/_op-modules/)")
-          .addOption("project", "Per-project (Projects/<slug>/MODULES/)")
+          .addOption("global", `Global (${globalModulesDirPath(projectsRoot)}/)`)
+          .addOption("project", `Per-project (${projectsRoot}/<slug>/MODULES/)`)
           .setValue("global")
           .onChange((v) => {
             this.targetScope = v as "global" | "project";

--- a/plugins/op-obsidian/src/notificationLog.ts
+++ b/plugins/op-obsidian/src/notificationLog.ts
@@ -1,7 +1,8 @@
 import { App, Notice, TFile, normalizePath } from "obsidian";
 import { showActionableNotice, type ActionableNoticeOptions } from "./actionableNotices";
+import { currentProjectsRoot, scratchFilePath } from "./projectPaths";
 
-export const NOTIFICATION_LOG_PATH = "Projects/_scratch/op-notifications.md";
+export const NOTIFICATION_LOG_PATH = scratchFilePath("op-notifications.md");
 export const MAX_LOG_ENTRIES = 500;
 
 const HEADER =
@@ -86,7 +87,9 @@ export function appendNotification(
 }
 
 async function writeOnce(app: App, entry: NotificationEntry): Promise<void> {
-  const path = normalizePath(NOTIFICATION_LOG_PATH);
+  const path = normalizePath(
+    scratchFilePath("op-notifications.md", currentProjectsRoot(app)),
+  );
   const folder = path.split("/").slice(0, -1).join("/");
   if (folder && !(await app.vault.adapter.exists(folder))) {
     await app.vault.createFolder(folder).catch(() => {});
@@ -125,7 +128,9 @@ export function notifyAction(opts: ActionableNoticeOptions): Notice {
 }
 
 export async function openNotificationLog(app: App): Promise<void> {
-  const path = normalizePath(NOTIFICATION_LOG_PATH);
+  const path = normalizePath(
+    scratchFilePath("op-notifications.md", currentProjectsRoot(app)),
+  );
   const existing = app.vault.getAbstractFileByPath(path);
   if (existing instanceof TFile) {
     await app.workspace.getLeaf(false).openFile(existing);

--- a/plugins/op-obsidian/src/openAgent.ts
+++ b/plugins/op-obsidian/src/openAgent.ts
@@ -21,6 +21,7 @@ import { buildRenderContext } from "./pluginVarRegistry";
 import { workIssue } from "./workIssue";
 import { dispatchPostLaunch } from "./postLaunchDispatch";
 import { renderTemplate } from "./renderTemplate";
+import { currentProjectsRoot, statusPathFor } from "./projectPaths";
 import { resolveWorkingDir } from "./workingDir";
 import { launchInTerminal } from "./terminalLaunch";
 import { buildRenderContext } from "./pluginVarRegistry";
@@ -215,7 +216,7 @@ export async function openAgent(
   if (!wd) {
     userError(
       `op: working directory required for ${args.entry.project} — launch cancelled`,
-      `Set \`repo_path:\` in Projects/${args.entry.project}/STATUS.md, or re-open the agent and fill in the working-dir prompt.`,
+      `Set \`repo_path:\` in ${statusPathFor(args.entry.project, currentProjectsRoot(app))}, or re-open the agent and fill in the working-dir prompt.`,
     );
     return undefined;
   }

--- a/plugins/op-obsidian/src/projectPaths.ts
+++ b/plugins/op-obsidian/src/projectPaths.ts
@@ -1,0 +1,179 @@
+import type { App } from "obsidian";
+
+export const DEFAULT_PROJECTS_ROOT = "Projects";
+
+export interface ProjectsRootSettingsLike {
+  projectsRoot?: string;
+}
+
+export type ProjectsRootValidation =
+  | { ok: true; value: string }
+  | { ok: false; error: string };
+
+export function normalizeProjectsRoot(raw: string | null | undefined): string {
+  const normalized = normalizeVaultRelativePath(raw ?? "");
+  return normalized || DEFAULT_PROJECTS_ROOT;
+}
+
+export function validateProjectsRootInput(raw: string): ProjectsRootValidation {
+  const trimmed = raw.trim();
+  if (!trimmed) {
+    return { ok: false, error: "Projects path is required" };
+  }
+  if (trimmed.startsWith("/")) {
+    return { ok: false, error: "Projects path must be vault-relative, not absolute" };
+  }
+  const parts = trimmed.replace(/\\/g, "/").split("/").map((part) => part.trim()).filter(Boolean);
+  if (parts.some((part) => part === "..")) {
+    return { ok: false, error: "Projects path must stay inside the vault" };
+  }
+  const normalized = normalizeVaultRelativePath(trimmed);
+  if (!normalized) {
+    return { ok: false, error: "Projects path must stay inside the vault" };
+  }
+  return { ok: true, value: normalized };
+}
+
+export function projectsRootFromApp(app: App | null | undefined): string {
+  const raw = app && typeof app === "object"
+    ? (app as App & {
+        plugins?: { plugins?: Record<string, { settings?: ProjectsRootSettingsLike }> };
+      }).plugins?.plugins?.["op-obsidian"]?.settings?.projectsRoot
+    : undefined;
+  return normalizeProjectsRoot(raw);
+}
+
+export function currentProjectsRoot(
+  app?: App | null,
+  settings?: ProjectsRootSettingsLike | null,
+): string {
+  return settings?.projectsRoot !== undefined
+    ? normalizeProjectsRoot(settings.projectsRoot)
+    : projectsRootFromApp(app);
+}
+
+export function isWithinProjectsRoot(path: string, root = DEFAULT_PROJECTS_ROOT): boolean {
+  const normalizedPath = normalizeVaultRelativePath(path);
+  const normalizedRoot = normalizeProjectsRoot(root);
+  return normalizedPath === normalizedRoot || normalizedPath.startsWith(`${normalizedRoot}/`);
+}
+
+export function projectFolderPath(slug: string, root = DEFAULT_PROJECTS_ROOT): string {
+  return joinVaultPath(normalizeProjectsRoot(root), slug.trim());
+}
+
+export function statusPathFor(slug: string, root = DEFAULT_PROJECTS_ROOT): string {
+  return joinVaultPath(projectFolderPath(slug, root), "STATUS.md");
+}
+
+export function workflowPathForProject(slug: string, root = DEFAULT_PROJECTS_ROOT): string {
+  return joinVaultPath(projectFolderPath(slug, root), "WORKFLOW.md");
+}
+
+export function issuesFolderPath(slug: string, root = DEFAULT_PROJECTS_ROOT): string {
+  return joinVaultPath(projectFolderPath(slug, root), "ISSUES");
+}
+
+export function resolvedIssuesFolderPath(slug: string, root = DEFAULT_PROJECTS_ROOT): string {
+  return joinVaultPath(projectFolderPath(slug, root), "RESOLVED ISSUES");
+}
+
+export function tasksFolderPath(slug: string, root = DEFAULT_PROJECTS_ROOT): string {
+  return joinVaultPath(projectFolderPath(slug, root), "TASKS");
+}
+
+export function docsFolderPath(slug: string, root = DEFAULT_PROJECTS_ROOT): string {
+  return joinVaultPath(projectFolderPath(slug, root), "DOCS");
+}
+
+export function modulesFolderPath(slug: string, root = DEFAULT_PROJECTS_ROOT): string {
+  return joinVaultPath(projectFolderPath(slug, root), "MODULES");
+}
+
+export function globalModulesDirPath(root = DEFAULT_PROJECTS_ROOT): string {
+  return joinVaultPath(normalizeProjectsRoot(root), "_op-modules");
+}
+
+export function globalModulePath(moduleId: string, root = DEFAULT_PROJECTS_ROOT): string {
+  return joinVaultPath(globalModulesDirPath(root), `${moduleId.trim()}.md`);
+}
+
+export function exportDirPath(root = DEFAULT_PROJECTS_ROOT): string {
+  return joinVaultPath(normalizeProjectsRoot(root), "_op-export");
+}
+
+export function importHistoryDirPath(root = DEFAULT_PROJECTS_ROOT): string {
+  return joinVaultPath(normalizeProjectsRoot(root), "_op-import-history");
+}
+
+export function scratchDirPath(root = DEFAULT_PROJECTS_ROOT): string {
+  return joinVaultPath(normalizeProjectsRoot(root), "_scratch");
+}
+
+export function scratchFilePath(filename: string, root = DEFAULT_PROJECTS_ROOT): string {
+  return joinVaultPath(scratchDirPath(root), filename);
+}
+
+export function onboardingReadmePath(root = DEFAULT_PROJECTS_ROOT): string {
+  return joinVaultPath(normalizeProjectsRoot(root), "_op-readme.md");
+}
+
+export function demoProjectFolderPath(root = DEFAULT_PROJECTS_ROOT): string {
+  return projectFolderPath("op-demo", root);
+}
+
+export function projectFolderFromStatusPath(path: string): string | undefined {
+  const normalized = normalizeVaultRelativePath(path);
+  const suffix = "/STATUS.md";
+  return normalized.endsWith(suffix) ? normalized.slice(0, -suffix.length) : undefined;
+}
+
+export function projectFolderFromManagedNotePath(path: string): string | undefined {
+  const normalized = normalizeVaultRelativePath(path);
+  for (const marker of ["/ISSUES/", "/RESOLVED ISSUES/", "/TASKS/", "/DOCS/", "/MODULES/"]) {
+    const index = normalized.indexOf(marker);
+    if (index !== -1) {
+      return normalized.slice(0, index);
+    }
+  }
+  return projectFolderFromStatusPath(normalized);
+}
+
+export function projectSlugFromFolder(path: string): string | undefined {
+  const normalized = normalizeVaultRelativePath(path);
+  if (!normalized) return undefined;
+  const parts = normalized.split("/");
+  const slug = parts[parts.length - 1];
+  return slug || undefined;
+}
+
+export function joinVaultPath(...segments: Array<string | null | undefined>): string {
+  const out: string[] = [];
+  for (const segment of segments) {
+    if (!segment) continue;
+    const normalized = normalizeVaultRelativePath(segment);
+    if (!normalized) continue;
+    out.push(...normalized.split("/"));
+  }
+  return out.join("/");
+}
+
+function normalizeVaultRelativePath(raw: string): string {
+  const parts = raw
+    .trim()
+    .replace(/\\/g, "/")
+    .split("/")
+    .map((part) => part.trim())
+    .filter(Boolean);
+  const out: string[] = [];
+  for (const part of parts) {
+    if (part === ".") continue;
+    if (part === "..") {
+      if (out.length === 0) return "";
+      out.pop();
+      continue;
+    }
+    out.push(part);
+  }
+  return out.join("/");
+}

--- a/plugins/op-obsidian/src/projects.ts
+++ b/plugins/op-obsidian/src/projects.ts
@@ -1,24 +1,30 @@
 import { App, TFile } from "obsidian";
+import {
+  currentProjectsRoot,
+  isWithinProjectsRoot,
+  projectFolderFromStatusPath,
+} from "./projectPaths";
 
 export interface ProjectInfo {
   slug: string;
   prefix?: string;
   statusPath: string;
+  folderPath: string;
 }
-
-const PROJECTS_ROOT = "Projects/";
 
 export function listProjects(app: App): ProjectInfo[] {
   const out: ProjectInfo[] = [];
+  const root = currentProjectsRoot(app);
   for (const file of app.vault.getMarkdownFiles()) {
-    if (!file.path.startsWith(PROJECTS_ROOT)) continue;
+    if (!isWithinProjectsRoot(file.path, root)) continue;
     if (!file.path.endsWith("/STATUS.md")) continue;
     const fm = app.metadataCache.getFileCache(file)?.frontmatter;
     if (fm?.type !== "project-status") continue;
-    const slug = slugFromStatusPath(file);
-    if (!slug) continue;
+    const folderPath = projectFolderFromStatusPath(file.path);
+    const slug = folderPath?.split("/").pop();
+    if (!folderPath || !slug) continue;
     const prefix = typeof fm.prefix === "string" ? fm.prefix : undefined;
-    out.push({ slug, prefix, statusPath: file.path });
+    out.push({ slug, prefix, statusPath: file.path, folderPath });
   }
   return out.sort((a, b) => a.slug.localeCompare(b.slug));
 }
@@ -53,10 +59,4 @@ export function findProjectByPrefix(app: App, prefix: string): ProjectInfo | und
 
 export function findProjectBySlug(app: App, slug: string): ProjectInfo | undefined {
   return listProjects(app).find((p) => p.slug === slug);
-}
-
-function slugFromStatusPath(file: TFile): string | undefined {
-  const parts = file.path.split("/");
-  if (parts.length < 3) return undefined;
-  return parts[parts.length - 2];
 }

--- a/plugins/op-obsidian/src/repoPath.ts
+++ b/plugins/op-obsidian/src/repoPath.ts
@@ -1,5 +1,6 @@
 import { App, TFile } from "obsidian";
 import type { OpSettings } from "./settings";
+import { findProjectBySlug } from "./projects";
 
 export function resolveRepoPath(
   app: App,
@@ -13,7 +14,8 @@ export function resolveRepoPath(
 }
 
 function readRepoPathFromStatus(app: App, slug: string): string | undefined {
-  const path = `Projects/${slug}/STATUS.md`;
+  const path = findProjectBySlug(app, slug)?.statusPath;
+  if (!path) return undefined;
   const f = app.vault.getAbstractFileByPath(path);
   if (!(f instanceof TFile)) return undefined;
   const fm = app.metadataCache.getFileCache(f)?.frontmatter;

--- a/plugins/op-obsidian/src/resolve.ts
+++ b/plugins/op-obsidian/src/resolve.ts
@@ -1,5 +1,11 @@
 import { App, Modal, Setting, TFile, normalizePath } from "obsidian";
 import type { IssueStore } from "./issueStore";
+import {
+  currentProjectsRoot,
+  joinVaultPath,
+  projectFolderFromManagedNotePath,
+  projectFolderPath,
+} from "./projectPaths";
 import type { IssueEntry, TaskEntry } from "./types";
 import { findIssue } from "./findIssue";
 import { listProjects } from "./projects";
@@ -95,7 +101,11 @@ export async function runResolve(
   if (!(file instanceof TFile)) return { ok: false, error: "Issue file missing", issueId: entry.id };
 
   const tasks = store.tasks().filter((t) => linksIssue(t, entry));
-  const targetDir = `Projects/${entry.project}/RESOLVED ISSUES`;
+  const targetDir = joinVaultPath(
+    projectFolderFromManagedNotePath(entry.path) ??
+      projectFolderPath(entry.project, currentProjectsRoot(app)),
+    "RESOLVED ISSUES",
+  );
   const targetPath = normalizePath(`${targetDir}/${file.name}`);
 
   if (!args.confirmed) {

--- a/plugins/op-obsidian/src/scaffoldProject.ts
+++ b/plugins/op-obsidian/src/scaffoldProject.ts
@@ -1,6 +1,11 @@
 import { App, normalizePath } from "obsidian";
 import type { IssueStore } from "./issueStore";
 import { createIssue, type CreateIssueResult, type Priority } from "./createIssue";
+import {
+  currentProjectsRoot,
+  isWithinProjectsRoot,
+  projectFolderPath,
+} from "./projectPaths";
 
 export interface ScaffoldProjectInput {
   slug: string;
@@ -53,14 +58,15 @@ export async function scaffoldProject(
     }
   }
 
-  const projectFolder = normalizePath(`Projects/${slug}`);
+  const root = currentProjectsRoot(app);
+  const projectFolder = projectFolderPath(slug, root);
   if (app.vault.getAbstractFileByPath(projectFolder)) {
     throw new Error(`Project folder already exists: ${projectFolder}`);
   }
 
   // Enforce unique prefix across projects.
   for (const file of app.vault.getMarkdownFiles()) {
-    if (!file.path.startsWith("Projects/") || !file.path.endsWith("/STATUS.md")) continue;
+    if (!isWithinProjectsRoot(file.path, root) || !file.path.endsWith("/STATUS.md")) continue;
     const fm = app.metadataCache.getFileCache(file)?.frontmatter;
     if (fm?.type === "project-status" && fm?.prefix === prefix) {
       throw new Error(`Prefix "${prefix}" already in use by ${file.path}`);
@@ -70,7 +76,7 @@ export async function scaffoldProject(
   await app.vault.createFolder(projectFolder);
 
   const basePath = normalizePath(`${projectFolder}/${slug}.base`);
-  await app.vault.create(basePath, renderBase(slug));
+  await app.vault.create(basePath, renderBase(slug, projectFolder));
 
   const statusPath = normalizePath(`${projectFolder}/STATUS.md`);
   // OP-265: record the resolved vault name so launched agents can derive the
@@ -156,8 +162,10 @@ function renderStatus(slug: string, prefix: string, vault: string, repoPath?: st
   return lines.join("\n");
 }
 
-function renderBase(slug: string): string {
-  return DEFAULT_BASE_TEMPLATE.replaceAll("<slug>", slug);
+function renderBase(slug: string, projectFolder: string): string {
+  return DEFAULT_BASE_TEMPLATE
+    .replaceAll("<slug>", slug)
+    .replaceAll("<project-folder>", projectFolder);
 }
 
 /**
@@ -205,7 +213,7 @@ function renderDefaultWorkflow(slug: string): string {
 
 const DEFAULT_BASE_TEMPLATE = `filters:
   and:
-    - file.inFolder("Projects/<slug>")
+    - file.inFolder("<project-folder>")
     - project == "<slug>"
 properties:
   id:

--- a/plugins/op-obsidian/src/settings.ts
+++ b/plugins/op-obsidian/src/settings.ts
@@ -64,7 +64,12 @@ import { validateOverlay } from "./overlayValidate";
 import { detectTmux } from "./tmuxDetect";
 import { userError } from "./userError";
 import { execFileSync } from "child_process";
-import { README_PATH } from "./firstRunReadme";
+import {
+  currentProjectsRoot,
+  globalModulesDirPath,
+  onboardingReadmePath,
+  validateProjectsRootInput,
+} from "./projectPaths";
 import {
   EXTRA_PREAMBLE_MAX,
   CLAUDE_SESSION_COLORS,
@@ -573,19 +578,20 @@ export class OpSettingsTab extends PluginSettingTab {
   }
 
   private renderDailyOnboarding(containerEl: HTMLElement): void {
+    const readmePath = onboardingReadmePath(this.plugin.settings.projectsRoot);
     new Setting(containerEl)
       .setName("Onboarding README")
       .setDesc(
-        `Open the op onboarding README — a short tour of the most-used commands and workflows. Located at \`${README_PATH}\`. Deletes don't come back automatically; use the Start tour command from the palette to re-scaffold a demo project.`,
+        `Open the op onboarding README — a short tour of the most-used commands and workflows. Located at \`${readmePath}\`. Deletes don't come back automatically; use the Start tour command from the palette to re-scaffold a demo project.`,
       )
       .addButton((b) =>
         b.setButtonText("Open README").setCta().onClick(async () => {
-          const file = this.app.vault.getAbstractFileByPath(README_PATH);
+          const file = this.app.vault.getAbstractFileByPath(readmePath);
           if (!file) {
-            notify(`op: README not found at ${README_PATH}. Run “op: start guided tour” to re-scaffold.`);
+            notify(`op: README not found at ${readmePath}. Run “op: start guided tour” to re-scaffold.`);
             return;
           }
-          await this.app.workspace.openLinkText(README_PATH, "");
+          await this.app.workspace.openLinkText(readmePath, "");
         }),
       );
   }
@@ -699,7 +705,7 @@ export class OpSettingsTab extends PluginSettingTab {
     new Setting(empty)
       .setName("Install example library")
       .setDesc(
-        `Writes ${EXAMPLE_MODULES.length} starter modules into Projects/_op-modules/. Existing files are never overwritten — safe to click again. Open the installed files to see complete, valid module shape.`,
+        `Writes ${EXAMPLE_MODULES.length} starter modules into ${globalModulesDirPath(this.plugin.settings.projectsRoot)}/. Existing files are never overwritten — safe to click again. Open the installed files to see complete, valid module shape.`,
       )
       .addButton((b) =>
         b
@@ -1050,6 +1056,30 @@ export class OpSettingsTab extends PluginSettingTab {
 
   private renderWorkingDirsAndProjectOrder(containerEl: HTMLElement): void {
     const s = this.plugin.settings;
+    const currentRoot = currentProjectsRoot(this.app, s);
+
+    let nextProjectsRoot = currentRoot;
+    new Setting(containerEl)
+      .setName("Projects path")
+      .setDesc(
+        "Vault-relative folder that contains project folders plus op-owned global files like _scratch/, _op-modules/, and the onboarding README. Changing it offers to move the existing tree so issues, modules, and scratch files keep working.",
+      )
+      .addText((t) => {
+        t.setPlaceholder("Projects");
+        t.setValue(currentRoot);
+        t.inputEl.style.width = "100%";
+        t.onChange((v) => (nextProjectsRoot = v));
+      })
+      .addButton((b) =>
+        b.setButtonText("Apply").setCta().onClick(async () => {
+          const validated = validateProjectsRootInput(nextProjectsRoot);
+          if (!validated.ok) {
+            notify(`projectsRoot: ${validated.error}`);
+            return;
+          }
+          await this.applyProjectsRootChange(currentRoot, validated.value);
+        }),
+      );
 
     containerEl.createEl("p", {
       text: "Per-project repository paths. Overridden by repo_path in STATUS.md frontmatter.",
@@ -2308,6 +2338,47 @@ export class OpSettingsTab extends PluginSettingTab {
     }, ms);
     this.debounceTimers.set(key, handle);
   }
+
+  private async applyProjectsRootChange(oldRoot: string, newRoot: string): Promise<void> {
+    if (oldRoot === newRoot) return;
+    const oldEntry = this.app.vault.getAbstractFileByPath(oldRoot);
+    const targetExists = !!this.app.vault.getAbstractFileByPath(newRoot);
+
+    let moved = false;
+    if (oldEntry) {
+      const canMove = !targetExists && !isNestedVaultPath(oldRoot, newRoot);
+      const action = await promptProjectsRootMigration(this.app, {
+        oldRoot,
+        newRoot,
+        canMove,
+        targetExists,
+      });
+      if (action === "cancel") return;
+      if (action === "move") {
+        await ensureVaultFolder(this.app, parentVaultPath(newRoot));
+        await this.app.fileManager.renameFile(oldEntry, newRoot);
+        moved = true;
+      }
+    }
+
+    this.plugin.settings.projectsRoot = newRoot;
+    await this.plugin.saveSettings();
+    this.plugin.store.rebuild();
+    await this.plugin.reinstallAgentHooks();
+    this.rerenderSection("onboarding");
+    this.rerenderSection("workingDirs");
+    this.rerenderSection("workflows");
+
+    if (moved) {
+      notify(`op: moved ${oldRoot} → ${newRoot}`);
+      return;
+    }
+    if (oldEntry) {
+      notify(`op: Projects path set to ${newRoot}. Existing notes remain under ${oldRoot} until you move them.`);
+      return;
+    }
+    notify(`op: Projects path set to ${newRoot}`);
+  }
 }
 
 // ─── Helpers (module-scoped) ──────────────────────────────────────────────
@@ -2339,6 +2410,39 @@ function detectionSummary(plugin: OpPlugin): string {
   const d = plugin.detector.get();
   if (!d) return "Not probed yet. Click Re-probe to run detection.";
   return AGENT_IDS.map((id) => `${id}: ${d[id].installed ? d[id].path ?? "found" : "not found"}`).join(" · ");
+}
+
+type ProjectsRootMigrationAction = "move" | "switch" | "cancel";
+
+function promptProjectsRootMigration(
+  app: App,
+  args: { oldRoot: string; newRoot: string; canMove: boolean; targetExists: boolean },
+): Promise<ProjectsRootMigrationAction> {
+  return new Promise((resolve) => {
+    new ProjectsRootMigrationModal(app, args, resolve).open();
+  });
+}
+
+function parentVaultPath(path: string): string {
+  const idx = path.lastIndexOf("/");
+  return idx === -1 ? "" : path.slice(0, idx);
+}
+
+async function ensureVaultFolder(app: App, path: string): Promise<void> {
+  if (!path) return;
+  const parts = path.split("/");
+  let cumulative = "";
+  for (const part of parts) {
+    if (!part) continue;
+    cumulative = cumulative ? `${cumulative}/${part}` : part;
+    if (!app.vault.getAbstractFileByPath(cumulative)) {
+      await app.vault.createFolder(cumulative);
+    }
+  }
+}
+
+function isNestedVaultPath(a: string, b: string): boolean {
+  return a.startsWith(`${b}/`) || b.startsWith(`${a}/`);
 }
 
 /**
@@ -2599,6 +2703,63 @@ export class HotkeyPresetResultsModal extends Modal {
           }),
       )
       .addButton((b) => b.setButtonText("Close").onClick(() => this.close()));
+  }
+
+  onClose(): void {
+    this.contentEl.empty();
+  }
+}
+
+class ProjectsRootMigrationModal extends Modal {
+  constructor(
+    app: App,
+    private args: { oldRoot: string; newRoot: string; canMove: boolean; targetExists: boolean },
+    private done: (action: ProjectsRootMigrationAction) => void,
+  ) {
+    super(app);
+  }
+
+  onOpen(): void {
+    const { contentEl, titleEl } = this;
+    titleEl.setText("Change Projects path");
+    contentEl.createEl("p", { text: `Current path: ${this.args.oldRoot}` });
+    contentEl.createEl("p", { text: `New path: ${this.args.newRoot}` });
+
+    if (this.args.canMove) {
+      contentEl.createEl("p", {
+        text: "Move the existing tree to keep issues, modules, scratch files, and onboarding notes working without any manual follow-up.",
+      });
+    } else if (this.args.targetExists) {
+      contentEl.createEl("p", {
+        text: "The target path already exists, so op-obsidian will not auto-move the current tree into it. You can switch the setting now and merge or move files manually afterward.",
+      });
+    } else {
+      contentEl.createEl("p", {
+        text: "The new path is nested under the current one (or vice versa), so auto-move is disabled to avoid moving a folder into itself. You can still switch the setting and move files manually afterward.",
+      });
+    }
+
+    const buttons = new Setting(contentEl);
+    buttons.addButton((b) =>
+      b.setButtonText("Cancel").onClick(() => {
+        this.done("cancel");
+        this.close();
+      }),
+    );
+    buttons.addButton((b) =>
+      b.setButtonText("Switch only").onClick(() => {
+        this.done("switch");
+        this.close();
+      }),
+    );
+    if (this.args.canMove) {
+      buttons.addButton((b) =>
+        b.setButtonText("Move existing tree").setCta().onClick(() => {
+          this.done("move");
+          this.close();
+        }),
+      );
+    }
   }
 
   onClose(): void {

--- a/plugins/op-obsidian/src/settingsPure.ts
+++ b/plugins/op-obsidian/src/settingsPure.ts
@@ -3,6 +3,7 @@ import type { ITermPlacement } from "./terminalLaunch";
 import { LAYOUT_IDS, type LayoutId } from "./layout/layouts";
 import { type RegistryData, emptyRegistry, mergeRegistry } from "./layout/registry";
 import type { OrchestratorSettings } from "./orchestrator";
+import { DEFAULT_PROJECTS_ROOT, normalizeProjectsRoot } from "./projectPaths";
 import { type RecencyEntry, sanitizeRecency } from "./recencyLog";
 
 export const EXTRA_PREAMBLE_MAX = 4000;
@@ -221,6 +222,7 @@ export interface OpSettings {
   defaultAgent: AgentId;
   alwaysPick: boolean;
   agentOverlays: Partial<Record<AgentId, ProfileOverlay>>;
+  projectsRoot: string;
   injection: InjectionSettings;
   workingDirs: Record<string, string>;
   terminal: "Terminal" | "iTerm";
@@ -303,6 +305,7 @@ export const DEFAULT_SETTINGS: OpSettings = {
   defaultAgent: "claude",
   alwaysPick: false,
   agentOverlays: {},
+  projectsRoot: DEFAULT_PROJECTS_ROOT,
   injection: {
     injectBody: true,
     maxBodyChars: 8000,
@@ -422,6 +425,11 @@ export function mergeSettings(loaded: unknown): OpSettings {
   if (typeof l.alwaysPick === "boolean") base.alwaysPick = l.alwaysPick;
   if (l.agentOverlays && typeof l.agentOverlays === "object") {
     base.agentOverlays = l.agentOverlays;
+  }
+  if (typeof (l as { projectsRoot?: unknown }).projectsRoot === "string") {
+    base.projectsRoot = normalizeProjectsRoot(
+      (l as { projectsRoot: string }).projectsRoot,
+    );
   }
   if (l.injection && typeof l.injection === "object") {
     base.injection = { ...base.injection, ...l.injection };

--- a/plugins/op-obsidian/src/taskCreate.ts
+++ b/plugins/op-obsidian/src/taskCreate.ts
@@ -1,5 +1,6 @@
 import { App, TFile, normalizePath } from "obsidian";
 import type { IssueStore } from "./issueStore";
+import { joinVaultPath, projectFolderFromManagedNotePath } from "./projectPaths";
 import type { IssueEntry } from "./types";
 import { issueFilename } from "./sanitize";
 import {
@@ -36,7 +37,11 @@ export async function taskCreate(
   input: TaskCreateInput,
 ): Promise<TaskCreateResult> {
   const issue = findIssueById(store, input.issueId);
-  const folder = `Projects/${issue.project}/TASKS`;
+  const projectFolder = projectFolderFromManagedNotePath(issue.path);
+  if (!projectFolder) {
+    throw new Error(`op-task-create: could not derive project folder from ${issue.path}`);
+  }
+  const folder = joinVaultPath(projectFolder, "TASKS");
   if (!app.vault.getAbstractFileByPath(folder)) {
     await app.vault.createFolder(folder);
   }

--- a/plugins/op-obsidian/src/undoLastImport.ts
+++ b/plugins/op-obsidian/src/undoLastImport.ts
@@ -5,6 +5,7 @@ import {
   parseTransaction,
   type TransactionRecord,
 } from "./exportImportPure";
+import { currentProjectsRoot, importHistoryDirPath, statusPathFor } from "./projectPaths";
 
 // IO seam for `op-undo-last-import` (OP-187 / Child 4 of OP-181).
 // Reverses the most recent transaction record in `Projects/_op-import-history/`:
@@ -100,7 +101,9 @@ export async function undoLastImport(
     }
     // project scope
     if (!v.projectSlug) continue;
-    const statusPath = normalizePath(`Projects/${v.projectSlug}/STATUS.md`);
+    const statusPath = normalizePath(
+      statusPathFor(v.projectSlug, currentProjectsRoot(app)),
+    );
     const statusFile = app.vault.getAbstractFileByPath(statusPath);
     if (!(statusFile instanceof TFile)) continue;
     await app.fileManager.processFrontMatter(
@@ -148,7 +151,9 @@ export async function undoLastImport(
 async function findLatestTransaction(
   app: App,
 ): Promise<{ file: TFile; record: TransactionRecord } | null> {
-  const dir = app.vault.getAbstractFileByPath(normalizePath(TRANSACTION_HISTORY_DIR));
+  const dir = app.vault.getAbstractFileByPath(
+    normalizePath(importHistoryDirPath(currentProjectsRoot(app))),
+  );
   if (!dir || dir instanceof TFile) return null;
   // TFolder duck-typed (`children` array).
   const children = (dir as { children?: Array<unknown> }).children ?? [];

--- a/plugins/op-obsidian/src/uriResponse.ts
+++ b/plugins/op-obsidian/src/uriResponse.ts
@@ -1,6 +1,10 @@
 import { App, normalizePath } from "obsidian";
+import {
+  currentProjectsRoot,
+  scratchFilePath,
+} from "./projectPaths";
 
-export const SCRATCH_PATH = "Projects/_scratch/op-last-response.md";
+export const SCRATCH_PATH = scratchFilePath("op-last-response.md");
 
 export interface UriResponsePayload {
   ok: boolean;
@@ -26,7 +30,7 @@ export async function writeUriResponse(app: App, payload: UriResponsePayload): P
     "",
   ].join("\n");
 
-  const path = normalizePath(SCRATCH_PATH);
+  const path = normalizePath(scratchFilePath("op-last-response.md", currentProjectsRoot(app)));
   const folder = path.slice(0, path.lastIndexOf("/"));
   if (!app.vault.getAbstractFileByPath(folder)) {
     await app.vault.createFolder(folder);

--- a/plugins/op-obsidian/src/varSuggest.test.ts
+++ b/plugins/op-obsidian/src/varSuggest.test.ts
@@ -353,6 +353,13 @@ describe("isWorkflowFile / classifyWorkflowFile", () => {
     });
   });
 
+  it("recognises workflow files under a configured root", () => {
+    expect(classifyWorkflowFile("Workspace/Projects/demo/WORKFLOW.md", "Workspace/Projects")).toEqual({
+      kind: "workflow",
+      slug: "demo",
+    });
+  });
+
   it("rejects regular issue notes", () => {
     expect(isWorkflowFile("Projects/demo/ISSUES/OP-1 something.md")).toBe(false);
     expect(classifyWorkflowFile("Projects/demo/ISSUES/OP-1 something.md")).toBeNull();

--- a/plugins/op-obsidian/src/varSuggest.ts
+++ b/plugins/op-obsidian/src/varSuggest.ts
@@ -30,6 +30,7 @@ import {
   precedenceScopeLabel,
   type PrecedenceScope,
 } from "./workflowDiagnosticFormat";
+import { globalModulesDirPath, normalizeProjectsRoot } from "./projectPaths";
 import type { VarDecl, WorkflowModule } from "./workflowModulePure";
 
 // ---------------------------------------------------------------------------
@@ -425,8 +426,6 @@ function scopeSourcePhrase(scope: PrecedenceScope, sourceId: string): string {
 // File-path classification (pure)
 // ---------------------------------------------------------------------------
 
-const PROJECTS_ROOT = "Projects/";
-const GLOBAL_MODULES_DIR = "Projects/_op-modules/";
 const PER_PROJECT_MODULES_INFIX = "/MODULES/";
 const WORKFLOW_FILENAME = "WORKFLOW.md";
 
@@ -443,19 +442,22 @@ export type WorkflowFileKind =
  * `workflowModule.ts` + `workflowFile.ts`; keep both in lockstep when the
  * directory layout evolves.
  */
-export function isWorkflowFile(path: string): boolean {
-  return classifyWorkflowFile(path) !== null;
+export function isWorkflowFile(path: string, projectsRoot?: string): boolean {
+  return classifyWorkflowFile(path, projectsRoot) !== null;
 }
 
-export function classifyWorkflowFile(path: string): WorkflowFileKind | null {
-  if (!path.startsWith(PROJECTS_ROOT)) return null;
-  if (path.startsWith(GLOBAL_MODULES_DIR)) {
-    const rel = path.slice(GLOBAL_MODULES_DIR.length);
+export function classifyWorkflowFile(path: string, projectsRoot?: string): WorkflowFileKind | null {
+  const root = normalizeProjectsRoot(projectsRoot);
+  const rootPrefix = `${root}/`;
+  const globalModulesDir = `${globalModulesDirPath(root)}/`;
+  if (!path.startsWith(rootPrefix)) return null;
+  if (path.startsWith(globalModulesDir)) {
+    const rel = path.slice(globalModulesDir.length);
     if (rel.includes("/") || !rel.endsWith(".md")) return null;
     return { kind: "global-module", id: rel.slice(0, -3) };
   }
   if (path.endsWith(`/${WORKFLOW_FILENAME}`)) {
-    const trimmed = path.slice(PROJECTS_ROOT.length);
+    const trimmed = path.slice(rootPrefix.length);
     const slugEnd = trimmed.indexOf("/");
     if (slugEnd === -1) return null;
     const slug = trimmed.slice(0, slugEnd);
@@ -467,7 +469,7 @@ export function classifyWorkflowFile(path: string): WorkflowFileKind | null {
   const slugStart = before.lastIndexOf("/");
   if (slugStart === -1) return null;
   const slug = before.slice(slugStart + 1);
-  if (!slug || before !== `${PROJECTS_ROOT.slice(0, -1)}/${slug}`) return null;
+  if (!slug || before !== `${root}/${slug}`) return null;
   const after = path.slice(moduleIdx + PER_PROJECT_MODULES_INFIX.length);
   if (after.includes("/") || !after.endsWith(".md")) return null;
   return { kind: "project-module", slug, id: after.slice(0, -3) };

--- a/plugins/op-obsidian/src/varSuggestObsidian.ts
+++ b/plugins/op-obsidian/src/varSuggestObsidian.ts
@@ -17,6 +17,7 @@ import {
   type VarCandidate,
 } from "./varSuggest";
 import { loadModules } from "./workflowModule";
+import { currentProjectsRoot } from "./projectPaths";
 import {
   parseModule,
   type WorkflowModule,
@@ -72,7 +73,8 @@ export class VarEditorSuggest extends EditorSuggest<Suggestion> {
 
   onTrigger(cursor: EditorPosition, editor: Editor, file: TFile | null): EditorSuggestTriggerInfo | null {
     if (!file) { this.pending = null; return null; }
-    if (!isWorkflowFile(file.path)) { this.pending = null; return null; }
+    const projectsRoot = currentProjectsRoot(this.app);
+    if (!isWorkflowFile(file.path, projectsRoot)) { this.pending = null; return null; }
 
     // 1. vars: block snippet — fires only on an empty bullet line.
     const lines = editor.getValue().split("\n");
@@ -206,7 +208,7 @@ interface VarSuggestContext {
 }
 
 function loadVarSuggestContext(app: App, file: TFile): VarSuggestContext {
-  const cls = classifyWorkflowFile(file.path);
+  const cls = classifyWorkflowFile(file.path, currentProjectsRoot(app));
   if (!cls) return { currentModule: null, globalModules: [], projectModules: [] };
 
   const slug =

--- a/plugins/op-obsidian/src/workIssue.ts
+++ b/plugins/op-obsidian/src/workIssue.ts
@@ -1,5 +1,11 @@
 import { App, TFile } from "obsidian";
 import type { IssueStore } from "./issueStore";
+import {
+  currentProjectsRoot,
+  joinVaultPath,
+  projectFolderFromManagedNotePath,
+  projectFolderPath,
+} from "./projectPaths";
 import type { IssueEntry } from "./types";
 
 export interface WorkIssueArgs {
@@ -161,7 +167,10 @@ function nonEmpty(v: unknown): string | undefined {
 }
 
 async function createDefaultTask(app: App, entry: IssueEntry): Promise<string> {
-  const folder = `Projects/${entry.project}/TASKS`;
+  const folder =
+    projectFolderFromManagedNotePath(entry.path)
+      ? joinVaultPath(projectFolderFromManagedNotePath(entry.path), "TASKS")
+      : joinVaultPath(projectFolderPath(entry.project, currentProjectsRoot(app)), "TASKS");
   if (!app.vault.getAbstractFileByPath(folder)) {
     await app.vault.createFolder(folder);
   }

--- a/plugins/op-obsidian/src/workflow.ts
+++ b/plugins/op-obsidian/src/workflow.ts
@@ -1,4 +1,5 @@
 import { App, TFile, normalizePath } from "obsidian";
+import { currentProjectsRoot, workflowPathForProject } from "./projectPaths";
 
 export interface GetWorkflowResult {
   project: string;
@@ -8,14 +9,17 @@ export interface GetWorkflowResult {
   size: number;
 }
 
-export function workflowPathFor(project: string): string {
-  return normalizePath(`Projects/${project}/WORKFLOW.md`);
+export function workflowPathFor(
+  project: string,
+  projectsRoot = currentProjectsRoot(undefined),
+): string {
+  return normalizePath(workflowPathForProject(project, projectsRoot));
 }
 
 export async function getWorkflow(app: App, project: string): Promise<GetWorkflowResult> {
   const slug = project.trim();
   if (!slug) throw new Error("project is required");
-  const path = workflowPathFor(slug);
+  const path = workflowPathFor(slug, currentProjectsRoot(app));
   const f = app.vault.getAbstractFileByPath(path);
   if (!(f instanceof TFile)) {
     return { project: slug, path, exists: false, content: null, size: 0 };

--- a/plugins/op-obsidian/src/workflowDiagnosticFormat.ts
+++ b/plugins/op-obsidian/src/workflowDiagnosticFormat.ts
@@ -175,7 +175,7 @@ const HINTS: Readonly<Record<WorkflowDiagnosticCode, string>> = Object.freeze({
   "missing-var":
     "Declare a default in the module's `vars:` block, or supply a value at the next-higher precedence scope.",
   "unknown-module":
-    "Check the spelling, or create the module file at `Projects/_op-modules/<id>.md`.",
+    "Check the spelling, or create the module file in the configured global modules folder.",
   "schema-mismatch":
     "Update the module to the current schema version. See docs/schema.md for the migration.",
   "import-collision":

--- a/plugins/op-obsidian/src/workflowExamples.ts
+++ b/plugins/op-obsidian/src/workflowExamples.ts
@@ -1,4 +1,5 @@
 import type { App } from "obsidian";
+import { currentProjectsRoot, globalModulesDirPath } from "./projectPaths";
 
 // Inline example workflow-module library for the Settings → Workflows
 // empty-state. The "Install example library" button writes these files into
@@ -12,7 +13,7 @@ import type { App } from "obsidian";
 // one with a `vars:` block. They serve double duty as documentation — opening
 // either file shows a complete, valid module.
 
-const EXAMPLES_DIR = "Projects/_op-modules/";
+const EXAMPLES_DIR = `${globalModulesDirPath()}/`;
 
 export interface ExampleModule {
   /** Module id — used for the filename, must match the frontmatter `id:`. */
@@ -97,9 +98,10 @@ export interface InstallExamplesResult {
 export async function installExampleLibrary(app: App): Promise<InstallExamplesResult> {
   const installed: string[] = [];
   const skipped: string[] = [];
-  await ensureDir(app, EXAMPLES_DIR);
+  const examplesDir = `${globalModulesDirPath(currentProjectsRoot(app))}/`;
+  await ensureDir(app, examplesDir);
   for (const ex of EXAMPLE_MODULES) {
-    const filePath = `${EXAMPLES_DIR}${ex.id}.md`;
+    const filePath = `${examplesDir}${ex.id}.md`;
     if (await app.vault.adapter.exists(filePath)) {
       skipped.push(filePath);
       continue;

--- a/plugins/op-obsidian/src/workflowFile.ts
+++ b/plugins/op-obsidian/src/workflowFile.ts
@@ -7,6 +7,7 @@ import {
   type WorkflowFile,
   type WorkflowStep,
 } from "./workflowFilePure";
+import { currentProjectsRoot, workflowPathForProject } from "./projectPaths";
 import type { WorkflowDiagnostic } from "./workflowDiagnostic";
 
 export type {
@@ -32,8 +33,6 @@ export {
   synthesizeLegacyWorkflow,
   validateWorkflowModels,
 } from "./workflowFilePure";
-
-const PROJECTS_ROOT = "Projects/";
 
 export interface LoadWorkflowResult {
   /** Resolved + merged workflow, or `null` if the file couldn't be salvaged. */
@@ -83,7 +82,9 @@ export async function loadWorkflowFile(
       ],
     };
   }
-  const path = normalizePath(`${PROJECTS_ROOT}${slug}/WORKFLOW.md`);
+  const path = normalizePath(
+    workflowPathForProject(slug, currentProjectsRoot(app)),
+  );
   return loadAtPath(app, { path, project: slug, allowExtends: true });
 }
 

--- a/plugins/op-obsidian/src/workflowModule.ts
+++ b/plugins/op-obsidian/src/workflowModule.ts
@@ -5,6 +5,12 @@ import {
   type ModuleSource,
   type WorkflowModule,
 } from "./workflowModulePure";
+import {
+  currentProjectsRoot,
+  globalModulesDirPath,
+  isWithinProjectsRoot,
+  joinVaultPath,
+} from "./projectPaths";
 import type { WorkflowDiagnostic } from "./workflowDiagnostic";
 
 // Workflow-module IO loader. Walks the vault, parses each module file via the
@@ -36,8 +42,6 @@ export {
   validateIntraScopeCollisions,
 } from "./workflowModulePure";
 
-const PROJECTS_ROOT = "Projects/";
-const GLOBAL_MODULES_DIR = "Projects/_op-modules/";
 const PER_PROJECT_MODULES_INFIX = "/MODULES/";
 
 export interface LoadModulesOptions {
@@ -77,16 +81,18 @@ export function loadModules(app: App, opts: LoadModulesOptions = {}): LoadModule
 
   const globals: Bucket[] = [];
   const perProject: Bucket[] = [];
+  const projectsRoot = currentProjectsRoot(app);
+  const globalModulesDir = `${globalModulesDirPath(projectsRoot)}/`;
 
   for (const file of app.vault.getMarkdownFiles()) {
     const path = file.path;
-    if (!path.startsWith(PROJECTS_ROOT)) continue;
+    if (!isWithinProjectsRoot(path, projectsRoot)) continue;
 
     const id = file.basename;
 
-    if (path.startsWith(GLOBAL_MODULES_DIR)) {
+    if (path.startsWith(globalModulesDir)) {
       // Global modules live exactly one directory deep below GLOBAL_MODULES_DIR.
-      const rel = path.slice(GLOBAL_MODULES_DIR.length);
+      const rel = path.slice(globalModulesDir.length);
       if (rel.includes("/")) continue;
       globals.push({ file, id, source: { kind: "global", path } });
       continue;
@@ -98,7 +104,7 @@ export function loadModules(app: App, opts: LoadModulesOptions = {}): LoadModule
     const slugStart = beforeInfix.lastIndexOf("/");
     if (slugStart === -1) continue;
     const slug = beforeInfix.slice(slugStart + 1);
-    if (!slug || beforeInfix !== `${PROJECTS_ROOT.slice(0, -1)}/${slug}`) continue;
+    if (!slug || beforeInfix !== joinVaultPath(projectsRoot, slug)) continue;
     const afterInfix = path.slice(moduleIdx + PER_PROJECT_MODULES_INFIX.length);
     if (afterInfix.includes("/")) continue;
     perProject.push({

--- a/plugins/op-obsidian/src/workingDir.ts
+++ b/plugins/op-obsidian/src/workingDir.ts
@@ -2,6 +2,7 @@ import { App, Modal, Setting, TFile } from "obsidian";
 import type { OpSettings } from "./settings";
 import type { IssueEntry } from "./types";
 import { validateWorkingDirInput } from "./modalValidation";
+import { findProjectBySlug } from "./projects";
 
 export interface ResolvedWorkingDir {
   path: string;
@@ -41,7 +42,8 @@ export async function resolveWorkingDirForSlug(
 }
 
 function readRepoPathFromStatus(app: App, slug: string): string | undefined {
-  const path = `Projects/${slug}/STATUS.md`;
+  const path = findProjectBySlug(app, slug)?.statusPath;
+  if (!path) return undefined;
   const f = app.vault.getAbstractFileByPath(path);
   if (!(f instanceof TFile)) return undefined;
   const fm = app.metadataCache.getFileCache(f)?.frontmatter;

--- a/plugins/op/.claude-plugin/plugin.json
+++ b/plugins/op/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "op",
   "description": "Obsidian Projects workflow — schema, slash commands, and agent skill for running a Jira-lite issue tracker inside an Obsidian vault.",
-  "version": "0.95.0",
+  "version": "0.96.0",
   "author": {
     "name": "Eugene Archibald"
   },


### PR DESCRIPTION
## Summary
- add a configurable vault-relative Projects root and shared path helpers across op-obsidian
- wire settings UX and migration flows so changing the root can safely move or switch the existing tree
- add non-default-root regression coverage and bump op-obsidian to 0.96.0

Closes #398