### PR TITLE
OP-276: refresh launch-time agent detection

### DIFF
--- a/plugins/op-obsidian/manifest.json
+++ b/plugins/op-obsidian/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "op-obsidian",
   "name": "Obsidian Projects (op)",
-  "version": "0.96.0",
+  "version": "0.96.1",
   "minAppVersion": "1.5.0",
   "description": "Jira-lite issue tracker for Obsidian vaults — deterministic commands backing the op workflow.",
   "author": "Eugene Archibald",

--- a/plugins/op-obsidian/package.json
+++ b/plugins/op-obsidian/package.json
@@ -1,6 +1,6 @@
 {
   "name": "op-obsidian",
-  "version": "0.96.0",
+  "version": "0.96.1",
   "description": "Obsidian plugin that owns the deterministic half of the op workflow.",
   "main": "main.js",
   "scripts": {

--- a/plugins/op-obsidian/src/agentDetect.test.ts
+++ b/plugins/op-obsidian/src/agentDetect.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  AgentDetector,
+  refreshAgentDetection,
+  type DetectionMap,
+} from "./agentDetect";
+
+function detectionMap(binary = "copilot"): DetectionMap {
+  return {
+    claude: { id: "claude", installed: true, path: "/tmp/claude", binary: "claude" },
+    gemini: { id: "gemini", installed: false, binary: "gemini" },
+    copilot: { id: "copilot", installed: true, path: `/tmp/${binary}`, binary },
+  };
+}
+
+describe("refreshAgentDetection", () => {
+  it("clears cached detection before re-probing", async () => {
+    const detector = new AgentDetector((id) => id);
+    (detector as unknown as { cache?: DetectionMap }).cache = detectionMap("stale");
+    const refreshSpy = vi.spyOn(detector, "refresh").mockImplementation(async () => {
+      expect(detector.get()).toBeUndefined();
+      return detectionMap("fresh");
+    });
+
+    await expect(refreshAgentDetection(detector)).resolves.toEqual(detectionMap("fresh"));
+    expect(refreshSpy).toHaveBeenCalledOnce();
+  });
+
+  it("returns the freshly probed detection map", async () => {
+    const detector = new AgentDetector((id) => id);
+    const fresh = detectionMap("fresh");
+    vi.spyOn(detector, "refresh").mockResolvedValue(fresh);
+
+    await expect(refreshAgentDetection(detector)).resolves.toBe(fresh);
+  });
+});

--- a/plugins/op-obsidian/src/agentDetect.ts
+++ b/plugins/op-obsidian/src/agentDetect.ts
@@ -51,6 +51,11 @@ export class AgentDetector {
   }
 }
 
+export async function refreshAgentDetection(detector: AgentDetector): Promise<DetectionMap> {
+  detector.invalidate();
+  return detector.refresh();
+}
+
 async function probeBinary(id: AgentId, binary: string): Promise<AgentDetection> {
   // If the configured binary is an absolute path, stat via `command -v` equivalent; else use `which`.
   const env = augmentedPathEnv();

--- a/plugins/op-obsidian/src/editModule.ts
+++ b/plugins/op-obsidian/src/editModule.ts
@@ -8,7 +8,7 @@ import {
   launchFlagsFor,
   mergeProfile,
 } from "./agentProfiles";
-import type { AgentDetector } from "./agentDetect";
+import { refreshAgentDetection, type AgentDetector } from "./agentDetect";
 import { AgentPickerModal } from "./modals";
 import { launchInTerminal } from "./terminalLaunch";
 import { resolveWorkingDirForSlug } from "./workingDir";
@@ -69,7 +69,7 @@ export async function editModule(
     return undefined;
   }
 
-  const detection = detector.get() ?? (await detector.refresh());
+  const detection = await refreshAgentDetection(detector);
   const installed = AGENT_IDS.filter((id) => detection?.[id]?.installed);
   if (installed.length === 0) {
     notify("op: no supported agent binaries found on PATH");

--- a/plugins/op-obsidian/src/editWorkflow.ts
+++ b/plugins/op-obsidian/src/editWorkflow.ts
@@ -8,7 +8,7 @@ import {
   launchFlagsFor,
   mergeProfile,
 } from "./agentProfiles";
-import type { AgentDetector } from "./agentDetect";
+import { refreshAgentDetection, type AgentDetector } from "./agentDetect";
 import { AgentPickerModal } from "./modals";
 import { currentProjectsRoot, statusPathFor } from "./projectPaths";
 import { launchInTerminal } from "./terminalLaunch";
@@ -43,7 +43,7 @@ export async function editWorkflow(
     return undefined;
   }
 
-  const detection = detector.get() ?? (await detector.refresh());
+  const detection = await refreshAgentDetection(detector);
   const installed = AGENT_IDS.filter((id) => detection?.[id]?.installed);
   if (installed.length === 0) {
     notify("op: no supported agent binaries found on PATH");

--- a/plugins/op-obsidian/src/main.ts
+++ b/plugins/op-obsidian/src/main.ts
@@ -149,7 +149,7 @@ import {
 import { summarizeListVarsPayload } from "./listVarsPure";
 import type { IssueEntry, LifecycleEvent } from "./types";
 import { DEFAULT_SETTINGS, mergeSettings, OpSettingsTab, type OpSettings } from "./settings";
-import { AgentDetector } from "./agentDetect";
+import { AgentDetector, refreshAgentDetection } from "./agentDetect";
 import {
   AGENT_IDS,
   asAgentId,
@@ -5211,7 +5211,7 @@ export default class OpPlugin extends Plugin {
 
   private async runDebugAgentLaunch(): Promise<void> {
     try {
-      const detection = this.detector.get() ?? (await this.detector.refresh());
+      const detection = await refreshAgentDetection(this.detector);
       const agentId: AgentId = AGENT_IDS.find((id) => detection[id]?.installed) ?? this.settings.defaultAgent;
       const profile = resolveProfile(this.settings, agentId);
       const det = detection[agentId];
@@ -5290,7 +5290,7 @@ export default class OpPlugin extends Plugin {
       });
       let effectiveLaunchVars = opts.launchVars;
       if (opts.forcePick) {
-        const detection = this.detector.get() ?? (await this.detector.refresh());
+        const detection = await refreshAgentDetection(this.detector);
         const installed = AGENT_IDS.filter((id) => detection?.[id]?.installed);
         if (installed.length === 0) {
           notify("op: no supported agent binaries found on PATH");

--- a/plugins/op-obsidian/src/openAgent.ts
+++ b/plugins/op-obsidian/src/openAgent.ts
@@ -28,7 +28,11 @@ import { buildRenderContext } from "./pluginVarRegistry";
 import { renderTemplate } from "./renderTemplate";
 import { colorRegistry } from "./colorRegistry";
 import { dispatchPostLaunch } from "./postLaunchDispatch";
-import type { AgentDetector, DetectionMap } from "./agentDetect";
+import {
+  refreshAgentDetection,
+  type AgentDetector,
+  type DetectionMap,
+} from "./agentDetect";
 import { AgentPickerModal } from "./modals";
 import { userError } from "./userError";
 import { iTermDefaultsDomainPresent, showITermTmuxPrefsNotice } from "./iTermPrefs";
@@ -121,7 +125,7 @@ interface AgentSelection {
  *
  * High-level flow:
  *  1. Resolve an agent id (arg override → default → picker modal).
- *  2. Verify the agent binary is on PATH via the cached {@link AgentDetector}.
+ *  2. Verify the agent binary is on PATH via a fresh {@link AgentDetector} probe.
  *  3. Resolve the working directory; abort with a `Notice` if none configured.
  *  4. Write `fm.agent` up front so the sidebar badge reflects intent even if
  *     the terminal launch later throws (OP-71).
@@ -144,7 +148,7 @@ export async function openAgent(
   saveSettings: () => Promise<void>,
   args: OpenAgentArgs,
 ): Promise<OpenAgentResult | undefined> {
-  const detection = detector.get() ?? (await detector.refresh());
+  const detection = await refreshAgentDetection(detector);
   const mode: AgentLaunchMode = args.mode ?? "work";
 
   // OP-200 (2c): per-step resolver. Skipped when the user has explicitly

--- a/plugins/op-obsidian/src/previewWorkflowModal.ts
+++ b/plugins/op-obsidian/src/previewWorkflowModal.ts
@@ -12,7 +12,11 @@ import { resolveProfile } from "./openAgent";
 import { loadAndComposeWorkflow } from "./composeWorkflow";
 import type { ComposedPrompt } from "./composeWorkflowPure";
 import { buildIssueRenderContext, readProjectVars } from "./explainWorkflow";
-import type { AgentDetector } from "./agentDetect";
+import {
+  refreshAgentDetection,
+  type AgentDetector,
+  type DetectionMap,
+} from "./agentDetect";
 import { IssuePickerModal } from "./modals";
 
 // OP-206 (3f): Settings → Workflows group → "Preview composed prompt" entry.
@@ -48,6 +52,7 @@ export interface PreviewWorkflowModalArgs {
 export class PreviewWorkflowModal extends Modal {
   private currentIssue: IssueEntry;
   private agentId: AgentId;
+  private detection: DetectionMap | undefined;
   private mode: AgentLaunchMode = "implement";
   private composed: ComposedPrompt | null = null;
   private composing = false;
@@ -69,19 +74,15 @@ export class PreviewWorkflowModal extends Modal {
     const initial =
       args.issues.find((e) => e.id === args.initialIssueId) ?? args.issues[0];
     this.currentIssue = initial;
-
-    const detection = args.detector.get();
-    const installed = AGENT_IDS.filter((id) => detection?.[id]?.installed);
-    const fallback = installed[0] ?? args.settings.defaultAgent;
-    this.agentId = installed.includes(args.settings.defaultAgent)
-      ? args.settings.defaultAgent
-      : fallback;
+    this.detection = args.detector.get();
+    this.agentId = pickAvailableAgent(undefined, installedAgents(this.detection), args.settings.defaultAgent);
   }
 
   async onOpen(): Promise<void> {
     const { contentEl, titleEl } = this;
     titleEl.setText("Preview composed prompt");
     contentEl.addClass("op-preview-modal");
+    await this.refreshDetection();
 
     // Issue picker — opens a sub-modal because the issue list can be long.
     const issueRow = new Setting(contentEl).setName("Issue");
@@ -110,8 +111,7 @@ export class PreviewWorkflowModal extends Modal {
       });
 
     // Agent picker — only installed agents.
-    const detection = this.args.detector.get();
-    const installed = AGENT_IDS.filter((id) => detection?.[id]?.installed);
+    const installed = installedAgents(this.detection);
     if (installed.length > 0) {
       new Setting(contentEl)
         .setName("Agent")
@@ -155,6 +155,20 @@ export class PreviewWorkflowModal extends Modal {
   private refreshIssueDesc(): void {
     if (!this.headerEl) return;
     this.headerEl.setText(`${this.currentIssue.id} — ${this.currentIssue.title} (${this.currentIssue.project})`);
+  }
+
+  private async refreshDetection(): Promise<void> {
+    try {
+      this.detection = await refreshAgentDetection(this.args.detector);
+    } catch (err) {
+      console.warn("[op-obsidian] preview modal agent refresh failed", err);
+      this.detection = this.args.detector.get();
+    }
+    this.agentId = pickAvailableAgent(
+      this.agentId,
+      installedAgents(this.detection),
+      this.args.settings.defaultAgent,
+    );
   }
 
   private async recompose(): Promise<void> {
@@ -253,6 +267,20 @@ function formatPreviewSummary(sizeChars: number, diagnosticCount: number): strin
       : `${sizeChars} chars`;
   const diagLabel = `${diagnosticCount} diagnostic${diagnosticCount === 1 ? "" : "s"}`;
   return `${charLabel} · ${diagLabel}`;
+}
+
+function installedAgents(detection: DetectionMap | undefined): AgentId[] {
+  return AGENT_IDS.filter((id) => detection?.[id]?.installed);
+}
+
+function pickAvailableAgent(
+  current: AgentId | undefined,
+  installed: AgentId[],
+  defaultAgent: AgentId,
+): AgentId {
+  if (current && installed.includes(current)) return current;
+  if (installed.includes(defaultAgent)) return defaultAgent;
+  return installed[0] ?? defaultAgent;
 }
 
 async function copyToClipboard(text: string): Promise<boolean> {

--- a/plugins/op-obsidian/src/settings.ts
+++ b/plugins/op-obsidian/src/settings.ts
@@ -35,6 +35,7 @@ import { existsSync } from "fs";
 import * as os from "os";
 import * as path from "path";
 import type OpPlugin from "./main";
+import { refreshAgentDetection } from "./agentDetect";
 import {
   buildAutoLaunchPaths,
   buildDashboardUrl,
@@ -1590,8 +1591,7 @@ export class OpSettingsTab extends PluginSettingTab {
       .setDesc(detectionSummary(this.plugin))
       .addButton((b) =>
         b.setButtonText("Re-probe").onClick(async () => {
-          this.plugin.detector.invalidate();
-          await this.plugin.detector.refresh();
+          await refreshAgentDetection(this.plugin.detector);
           notify("op: agent detection refreshed");
           this.rerenderSection("profileOverlays");
         }),

--- a/plugins/op/.claude-plugin/plugin.json
+++ b/plugins/op/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "op",
   "description": "Obsidian Projects workflow — schema, slash commands, and agent skill for running a Jira-lite issue tracker inside an Obsidian vault.",
-  "version": "0.96.0",
+  "version": "0.96.1",
   "author": {
     "name": "Eugene Archibald"
   },


### PR DESCRIPTION
## Summary
- add a shared `refreshAgentDetection()` helper so user-facing launchers and pickers always invalidate stale detector state before deciding what is installed
- use the fresh probe for note/sidebar launches, force-pick flows, workflow/module editor launches, the preview modal, the debug launch command, and the Settings re-probe button
- add `agentDetect.test.ts` coverage for the fresh-detection helper

## Testing
- `node scripts/bump-version.mjs patch`
- `cd plugins/op-obsidian && npx vitest run src/agentDetect.test.ts`
- `cd plugins/op-obsidian && CI=1 npm test` *(still only fails at the pre-existing `src/iTermPrefs.test.ts` `obsidian` package-resolution issue)*
- `node scripts/dev-sync.mjs` *(sync succeeded, but OP-Test smoke remained blocked by the existing OP-Test vault repo/ETIMEDOUT issues)*

Closes #399