### PR TITLE
OP-192: skill emission for lazy: true workflow modules

### DIFF
--- a/docs/superpowers/plans/2026-05-15-lazy-skill-emission.md
+++ b/docs/superpowers/plans/2026-05-15-lazy-skill-emission.md
@@ -1,0 +1,1077 @@
+# Lazy Skill Emission Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let a workflow module flagged `lazy: true` be materialized as an on-demand Claude Code skill the agent pulls into its worktree, instead of burning kickoff context inlining it.
+
+**Architecture:** Pure schema/composer changes partition `lazy` modules out of the inlined prompt into a `ComposedPrompt.lazySkills[]` data array (vars fully resolved, one `info` diagnostic each). A new `op-emit-lazy-skills` CLI — invoked by the agent from inside its worktree — recomposes the kickoff step and writes each lazy skill to `<dir>/.claude/skills/op-module-<id>/SKILL.md` with a self-ignoring `.gitignore`, pruning orphans. `composeWorkflowSection` appends a 3-line pointer at kickoff (or inlines the bodies when the project has no working dir).
+
+**Tech Stack:** TypeScript, Obsidian plugin API, vitest, Node `fs`/`path`. Strict pure/IO split (mirror `composeWorkflowPure.ts` ↔ `composeWorkflow.ts`).
+
+**Spec:** `docs/superpowers/specs/2026-05-15-lazy-skill-emission-design.md`
+
+**Test commands:** from `plugins/op-obsidian/`: `npx vitest run <file>` (single file), `npm test` (full suite), `npm run build` (esbuild). All paths below are relative to `plugins/op-obsidian/` unless absolute.
+
+---
+
+### Task 1: Schema — `lazy` + `description` on workflow modules
+
+**Files:**
+- Modify: `src/workflowModulePure.ts` (`WorkflowModule` interface ~line 59; `parseModule` ~line 378–417)
+- Modify: `src/workflowDiagnostic.ts` (`WorkflowDiagnosticCode` union ~line 10–22)
+- Test: `src/workflowModulePure.test.ts`
+
+- [ ] **Step 1: Add the `lazy-skill` diagnostic code**
+
+In `src/workflowDiagnostic.ts`, add to the `WorkflowDiagnosticCode` union (after `"size-budget"`):
+
+```ts
+  | "size-budget"
+  // OP-192: emitted when a `lazy: true` module is partitioned out of the
+  // inlined prompt into a skill (`info`), or when such a module lacks a
+  // `description:` and falls back to its title (`warning`).
+  | "lazy-skill";
+```
+
+- [ ] **Step 2: Write failing tests for the schema fields**
+
+Append to `src/workflowModulePure.test.ts`:
+
+```ts
+describe("parseModule lazy + description (OP-192)", () => {
+  const baseFm = { id: "m", title: "M", type: "workflow-module", scope: "kickoff" };
+  const src = { kind: "global" as const, path: "Projects/_op-modules/m.md" };
+
+  it("defaults lazy to false and description to undefined", () => {
+    const r = parseModule({ id: "m", frontmatter: { ...baseFm }, source: src });
+    expect(r.module).not.toBeNull();
+    expect(r.module!.lazy).toBe(false);
+    expect(r.module!.description).toBeUndefined();
+  });
+
+  it("accepts lazy: true and a string description", () => {
+    const r = parseModule({
+      id: "m",
+      frontmatter: { ...baseFm, lazy: true, description: "tmux gotchas catalog" },
+      source: src,
+    });
+    expect(r.module!.lazy).toBe(true);
+    expect(r.module!.description).toBe("tmux gotchas catalog");
+  });
+
+  it("rejects non-boolean lazy without coercion (still loadable)", () => {
+    const r = parseModule({ id: "m", frontmatter: { ...baseFm, lazy: "true" }, source: src });
+    expect(r.module).toBeNull();
+    expect(r.diagnostics.some(d => d.code === "malformed-frontmatter" && /lazy/.test(d.message))).toBe(true);
+  });
+
+  it("rejects non-string description", () => {
+    const r = parseModule({ id: "m", frontmatter: { ...baseFm, description: 42 }, source: src });
+    expect(r.module).toBeNull();
+    expect(r.diagnostics.some(d => d.code === "malformed-frontmatter" && /description/.test(d.message))).toBe(true);
+  });
+});
+```
+
+- [ ] **Step 3: Run tests to verify they fail**
+
+Run: `npx vitest run src/workflowModulePure.test.ts -t "OP-192"`
+Expected: FAIL — `r.module!.lazy` is `undefined` (field not parsed yet).
+
+- [ ] **Step 4: Add the fields to the interface and parser**
+
+In `src/workflowModulePure.ts`, add to the `WorkflowModule` interface (after `order: number;`):
+
+```ts
+  /** OP-192: when true, this module is emitted as an on-demand skill instead
+   *  of being inlined into the composed prompt. Default false. */
+  lazy: boolean;
+  /** OP-192: one-line activation hint used as the emitted skill's
+   *  `description:`. Optional; lazy modules without it fall back to `title`. */
+  description?: string;
+```
+
+In `parseModule`, after the `order` block (ends ~line 388, before `const varsResult =`):
+
+```ts
+  let lazy = false;
+  if (Object.prototype.hasOwnProperty.call(frontmatter, "lazy")) {
+    const v = frontmatter.lazy;
+    if (v !== undefined && v !== null) {
+      if (typeof v !== "boolean") {
+        diagnostics.push(invalidFieldDiag(path, id, "lazy", v, "boolean"));
+      } else {
+        lazy = v;
+      }
+    }
+  }
+
+  let description: string | undefined;
+  if (Object.prototype.hasOwnProperty.call(frontmatter, "description")) {
+    const v = frontmatter.description;
+    if (v !== undefined && v !== null) {
+      if (typeof v !== "string") {
+        diagnostics.push(invalidFieldDiag(path, id, "description", v, "string"));
+      } else if (v.trim().length > 0) {
+        description = v;
+      }
+    }
+  }
+```
+
+Then add both to the constructed `module` object (after `order,`):
+
+```ts
+    order,
+    lazy,
+    ...(description !== undefined ? { description } : {}),
+    vars: varsResult.decls,
+```
+
+Note: `invalidFieldDiag` pushes a hard-fail diagnostic, so a bad `lazy`/`description` makes `parseModule` return `module: null` via the existing `hardFail` check — matching the test expectations.
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `npx vitest run src/workflowModulePure.test.ts`
+Expected: PASS (all existing + new OP-192 cases).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/workflowModulePure.ts src/workflowDiagnostic.ts src/workflowModulePure.test.ts
+git commit -m "OP-192: parse lazy + description on workflow modules
+
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 2: Pure composer — partition lazy modules into `lazySkills`
+
+**Files:**
+- Modify: `src/composeWorkflowPure.ts` (`ComposedPrompt` ~line 88; `composeWorkflow` loop ~line 475–499; `finaliseComposed` ~line 512; `emptyComposed` ~line 536)
+- Test: `src/composeWorkflowPure.test.ts`
+
+- [ ] **Step 1: Write failing tests**
+
+Append to `src/composeWorkflowPure.test.ts` (reuse the file's existing test helpers — `makeModule`/`makeWorkflow`-style builders already present near the top of that file; match their signatures):
+
+```ts
+describe("lazy skill partition (OP-192)", () => {
+  it("excludes lazy modules from text/orderedChunks and emits them as lazySkills with an info diagnostic", () => {
+    const normal = loaded({ id: "intro", scope: "kickoff", body: "Normal body" });
+    const lazyMod = loaded({
+      id: "tmux", scope: "kickoff", lazy: true,
+      description: "tmux gotchas catalog", body: "Lazy body {{id}}",
+    });
+    const wf = workflowWith("kickoff", ["intro", "tmux"]);
+    const r = composeWorkflow({
+      loadedModules: [normal, lazyMod], workflow: wf, step: "kickoff",
+      ctx: { render: renderCtx({ id: "OP-1" }) },
+    });
+    expect(r.text).toBe("Normal body");
+    expect(r.orderedChunks.map(c => c.moduleId)).toEqual(["intro"]);
+    expect(r.lazySkills).toEqual([
+      { id: "tmux", name: "op-module-tmux", description: "tmux gotchas catalog", body: "Lazy body OP-1" },
+    ]);
+    expect(r.diagnostics.some(d => d.code === "lazy-skill" && d.severity === "info" && d.moduleId === "tmux")).toBe(true);
+  });
+
+  it("falls back to title with a lazy-skill warning when a lazy module has no description", () => {
+    const lazyMod = loaded({ id: "tmux", scope: "kickoff", lazy: true, title: "Tmux Notes", body: "Body" });
+    const wf = workflowWith("kickoff", ["tmux"]);
+    const r = composeWorkflow({ loadedModules: [lazyMod], workflow: wf, step: "kickoff", ctx: { render: renderCtx({}) } });
+    expect(r.lazySkills[0].description).toBe("Tmux Notes");
+    expect(r.diagnostics.some(d => d.code === "lazy-skill" && d.severity === "warning" && /no .description/.test(d.message))).toBe(true);
+  });
+});
+```
+
+> If the existing test file uses different builder names, adapt `loaded`/`workflowWith`/`renderCtx` to whatever that file already defines (it has helpers that build `LoadedModule`, a `WorkflowFile`, and a `RenderContext`). Do NOT introduce new builders if equivalents exist — reuse keeps the suite DRY.
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `npx vitest run src/composeWorkflowPure.test.ts -t "lazy skill partition"`
+Expected: FAIL — `r.lazySkills` is `undefined`.
+
+- [ ] **Step 3: Add the `LazySkill` type and field to `ComposedPrompt`**
+
+In `src/composeWorkflowPure.ts`, after the `ComposedChunk` interface (~line 84):
+
+```ts
+/**
+ * One `lazy: true` module, fully rendered, ready to be written as a Claude
+ * Code skill by the IO layer (`emitLazySkills.ts`). Not part of the inlined
+ * prompt `text`.
+ */
+export interface LazySkill {
+  /** Module id (post-shadowing). */
+  id: string;
+  /** Derived, Claude-Code-valid skill name (`op-module-<id>` slugified). */
+  name: string;
+  /** SKILL.md `description:` — module.description, else module.title. */
+  description: string;
+  /** Fully var-resolved module body. */
+  body: string;
+}
+```
+
+Add to the `ComposedPrompt` interface (after `orderedChunks: ComposedChunk[];`):
+
+```ts
+  /** OP-192: `lazy: true` modules, partitioned out of `text`. Empty when no
+   *  composed module is lazy. */
+  lazySkills: LazySkill[];
+```
+
+- [ ] **Step 4: Import the slugifier and partition in the compose loop**
+
+At the top of `src/composeWorkflowPure.ts`, add to the imports:
+
+```ts
+import { slugifySkillName } from "./lazySkillPure";
+```
+
+> `slugifySkillName` is created in Task 3. Tasks may be implemented out of order; if Task 3 is not yet done, create a minimal `src/lazySkillPure.ts` exporting `export function slugifySkillName(id: string): string { return ("op-module-" + id).toLowerCase().replace(/[^a-z0-9-]+/g, "-").replace(/-+/g, "-").replace(/^-|-$/g, "").slice(0, 64); }` — Task 3 replaces it with the tested version and adds the renderer.
+
+Replace the `orderedChunks` build loop (currently ~line 475–491):
+
+```ts
+  const orderedChunks: ComposedChunk[] = [];
+  const lazySkills: LazySkill[] = [];
+  for (const lm of orderedModules) {
+    const r = renderModule({
+      module: lm.module,
+      body: lm.body,
+      allModulesByVarName,
+      perVarSourceMap,
+      ctx,
+    });
+    diagnostics.push(...r.diagnostics);
+    if (lm.module.lazy) {
+      let description = lm.module.description;
+      if (description === undefined) {
+        description = lm.module.title;
+        diagnostics.push({
+          code: "lazy-skill",
+          severity: "warning",
+          message: `Module ${lm.module.id} is lazy but has no \`description:\` — using its title as the skill activation hint, which may reduce activation accuracy.`,
+          moduleId: lm.module.id,
+        });
+      }
+      diagnostics.push({
+        code: "lazy-skill",
+        severity: "info",
+        message: `Module ${lm.module.id} emitted as on-demand skill op-module-${lm.module.id}, not inlined. Run op-emit-lazy-skills to materialize it.`,
+        moduleId: lm.module.id,
+      });
+      lazySkills.push({
+        id: lm.module.id,
+        name: slugifySkillName(lm.module.id),
+        description,
+        body: r.text,
+      });
+      continue;
+    }
+    orderedChunks.push({
+      moduleId: lm.module.id,
+      scope: lm.module.scope,
+      text: r.text,
+      sizeChars: r.text.length,
+    });
+  }
+```
+
+- [ ] **Step 5: Thread `lazySkills` through `finaliseComposed` / `emptyComposed`**
+
+Change `FinaliseArgs` to add `lazySkills: LazySkill[];`. In `finaliseComposed`, accept and return it on the `ComposedPrompt`. In `emptyComposed`, return `lazySkills: []`. Update the three `finaliseComposed({...})` call sites in `composeWorkflow` (legacy-kickoff path, the `orderedModules.length === 0` path, and the final return) to pass `lazySkills`:
+- legacy-kickoff path and empty-modules path: `lazySkills: []`
+- final return: `lazySkills` (the array built in Step 4)
+
+Concretely, `finaliseComposed`:
+
+```ts
+interface FinaliseArgs {
+  orderedChunks: ComposedChunk[];
+  lazySkills: LazySkill[];
+  perVarSourceMap: Record<string, UserVarSource>;
+  diagnostics: WorkflowDiagnostic[];
+  maxChars: number;
+}
+
+function finaliseComposed(args: FinaliseArgs): ComposedPrompt {
+  const text = args.orderedChunks.map((c) => c.text).join("\n\n");
+  const sizeChars = text.length;
+  const diagnostics = [...args.diagnostics];
+  if (sizeChars > args.maxChars) {
+    diagnostics.push({
+      code: "size-budget",
+      severity: "info",
+      message:
+        `Composed workflow is ${sizeChars} chars (cap ${args.maxChars}). ` +
+        `Modern models tolerate this comfortably; the cap is a guardrail, not a constraint. ` +
+        `Consider splitting a module if this surprises you.`,
+      extra: { sizeChars, maxWorkflowChars: args.maxChars },
+    });
+  }
+  return {
+    text,
+    orderedChunks: args.orderedChunks,
+    lazySkills: args.lazySkills,
+    perVarSourceMap: args.perVarSourceMap,
+    sizeChars,
+    diagnostics,
+  };
+}
+
+function emptyComposed(diagnostics: WorkflowDiagnostic[]): ComposedPrompt {
+  return {
+    text: "",
+    orderedChunks: [],
+    lazySkills: [],
+    perVarSourceMap: {},
+    sizeChars: 0,
+    diagnostics,
+  };
+}
+```
+
+- [ ] **Step 6: Run the full composer test file**
+
+Run: `npx vitest run src/composeWorkflowPure.test.ts`
+Expected: PASS (existing tests still green — `lazySkills: []` added everywhere — plus the two new ones).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/composeWorkflowPure.ts src/composeWorkflowPure.test.ts
+git commit -m "OP-192: partition lazy modules into ComposedPrompt.lazySkills
+
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 3: Pure SKILL.md renderer + skill-name slugifier
+
+**Files:**
+- Create: `src/lazySkillPure.ts`
+- Test: `src/lazySkillPure.test.ts`
+
+- [ ] **Step 1: Write failing tests**
+
+Create `src/lazySkillPure.test.ts`:
+
+```ts
+import { describe, it, expect } from "vitest";
+import { slugifySkillName, renderSkillMd } from "./lazySkillPure";
+
+describe("slugifySkillName (OP-192)", () => {
+  it("prefixes op-module- and lowercases", () => {
+    expect(slugifySkillName("Tmux-Gotchas")).toBe("op-module-tmux-gotchas");
+  });
+  it("replaces invalid chars and collapses dashes", () => {
+    expect(slugifySkillName("a b/c__d")).toBe("op-module-a-b-c-d");
+  });
+  it("trims leading/trailing dashes and caps at 64 chars", () => {
+    const long = "x".repeat(100);
+    const out = slugifySkillName(long);
+    expect(out.length).toBeLessThanOrEqual(64);
+    expect(out.startsWith("op-module-")).toBe(true);
+    expect(/^[a-z0-9-]+$/.test(out)).toBe(true);
+    expect(out.endsWith("-")).toBe(false);
+  });
+});
+
+describe("renderSkillMd (OP-192)", () => {
+  it("emits valid YAML frontmatter + body", () => {
+    const md = renderSkillMd({ name: "op-module-tmux", description: "tmux gotchas", body: "Body here" });
+    expect(md).toBe(
+      "---\nname: op-module-tmux\ndescription: \"tmux gotchas\"\n---\n\nBody here\n",
+    );
+  });
+  it("YAML-escapes a description containing quotes, colons, and newlines", () => {
+    const md = renderSkillMd({
+      name: "op-module-x",
+      description: 'has: a "quote" and\nnewline',
+      body: "B",
+    });
+    const fm = md.split("---")[1];
+    expect(fm).toContain('description: "has: a \\"quote\\" and\\nnewline"');
+    expect(md.endsWith("B\n")).toBe(true);
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `npx vitest run src/lazySkillPure.test.ts`
+Expected: FAIL — module not found / `renderSkillMd` not exported (if Task 2's minimal stub exists, `renderSkillMd` is still missing).
+
+- [ ] **Step 3: Implement `src/lazySkillPure.ts`**
+
+```ts
+// OP-192: pure helpers for emitting `lazy: true` workflow modules as Claude
+// Code skills. No I/O — `emitLazySkills.ts` owns filesystem writes.
+
+/**
+ * Derive a Claude-Code-valid skill name from a module id. Claude Code skill
+ * names: lowercase letters, digits, hyphens only; max 64 chars. The
+ * `op-module-` prefix namespaces emitted skills away from the canonical `op`
+ * skill so the agent's skill list is unambiguous.
+ */
+export function slugifySkillName(id: string): string {
+  const slug = `op-module-${id}`
+    .toLowerCase()
+    .replace(/[^a-z0-9-]+/g, "-")
+    .replace(/-+/g, "-")
+    .replace(/^-+|-+$/g, "");
+  return slug.slice(0, 64).replace(/-+$/g, "");
+}
+
+export interface RenderSkillMdArgs {
+  name: string;
+  description: string;
+  body: string;
+}
+
+/**
+ * Render a SKILL.md document. `description` is emitted as a YAML double-quoted
+ * scalar with `\`, `"`, and newlines escaped so an arbitrary one-liner can
+ * never corrupt the frontmatter. Body is appended verbatim with a single
+ * trailing newline.
+ */
+export function renderSkillMd(args: RenderSkillMdArgs): string {
+  const desc = args.description
+    .replace(/\\/g, "\\\\")
+    .replace(/"/g, '\\"')
+    .replace(/\n/g, "\\n");
+  const body = args.body.replace(/\n+$/, "");
+  return `---\nname: ${args.name}\ndescription: "${desc}"\n---\n\n${body}\n`;
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `npx vitest run src/lazySkillPure.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Re-run the composer suite (it imports `slugifySkillName`)**
+
+Run: `npx vitest run src/composeWorkflowPure.test.ts`
+Expected: PASS — confirms Task 2's import resolves against the real implementation.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/lazySkillPure.ts src/lazySkillPure.test.ts
+git commit -m "OP-192: pure SKILL.md renderer + skill-name slugifier
+
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 4: IO seam — `emitLazySkills` (recompose + write/prune)
+
+**Files:**
+- Create: `src/emitLazySkills.ts`
+- Test: `src/emitLazySkills.test.ts`
+
+- [ ] **Step 1: Write failing tests**
+
+Create `src/emitLazySkills.test.ts`. The pure write/prune planner is the testable core; mock nothing — test `planSkillEmission` (pure) which decides files to write and dirs to prune:
+
+```ts
+import { describe, it, expect } from "vitest";
+import { planSkillEmission } from "./emitLazySkills";
+
+describe("planSkillEmission (OP-192)", () => {
+  const lazy = [
+    { id: "tmux", name: "op-module-tmux", description: "d", body: "B1" },
+    { id: "git", name: "op-module-git", description: "d", body: "B2" },
+  ];
+
+  it("plans a SKILL.md + self-ignoring .gitignore per lazy skill", () => {
+    const plan = planSkillEmission({ destDir: "/wt", lazySkills: lazy, existingOpModuleDirs: [] });
+    expect(plan.writes).toEqual([
+      { path: "/wt/.claude/skills/op-module-tmux/SKILL.md", kind: "skill", skill: lazy[0] },
+      { path: "/wt/.claude/skills/op-module-tmux/.gitignore", kind: "gitignore" },
+      { path: "/wt/.claude/skills/op-module-git/SKILL.md", kind: "skill", skill: lazy[1] },
+      { path: "/wt/.claude/skills/op-module-git/.gitignore", kind: "gitignore" },
+    ]);
+    expect(plan.prunes).toEqual([]);
+  });
+
+  it("prunes orphaned op-module-* dirs not in the current set", () => {
+    const plan = planSkillEmission({
+      destDir: "/wt",
+      lazySkills: [lazy[0]],
+      existingOpModuleDirs: ["op-module-tmux", "op-module-stale"],
+    });
+    expect(plan.prunes).toEqual(["/wt/.claude/skills/op-module-stale"]);
+  });
+
+  it("prunes ALL op-module-* dirs when there are no lazy skills", () => {
+    const plan = planSkillEmission({
+      destDir: "/wt",
+      lazySkills: [],
+      existingOpModuleDirs: ["op-module-tmux"],
+    });
+    expect(plan.writes).toEqual([]);
+    expect(plan.prunes).toEqual(["/wt/.claude/skills/op-module-tmux"]);
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `npx vitest run src/emitLazySkills.test.ts`
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Implement `src/emitLazySkills.ts`**
+
+```ts
+import { promises as fs } from "fs";
+import path from "path";
+import { App } from "obsidian";
+import type { IssueEntry } from "./types";
+import type { OpSettings } from "./settings";
+import { resolveProfile } from "./openAgent";
+import { AGENT_IDS, type AgentId } from "./agentProfiles";
+import { loadAndComposeWorkflow } from "./composeWorkflow";
+import {
+  buildIssueRenderContext,
+  readProjectVars,
+} from "./explainWorkflow";
+import { renderSkillMd } from "./lazySkillPure";
+import type { LazySkill } from "./composeWorkflowPure";
+
+// IO seam for OP-192. Recomposes the kickoff step for an issue, takes
+// `composed.lazySkills`, and writes each as `<dir>/.claude/skills/
+// op-module-<id>/SKILL.md` (+ a self-ignoring `.gitignore`), pruning any
+// stale `op-module-*` dir. The write/prune decision is the pure
+// `planSkillEmission`; this file owns the filesystem.
+
+export interface SkillWrite {
+  path: string;
+  kind: "skill" | "gitignore";
+  skill?: LazySkill;
+}
+
+export interface EmissionPlan {
+  writes: SkillWrite[];
+  prunes: string[];
+}
+
+/**
+ * Pure: given the destination dir, the lazy skills to emit, and the
+ * `op-module-*` dir names already on disk under `<dir>/.claude/skills/`,
+ * decide exactly which files to write and which dirs to remove. A dir is
+ * pruned iff it matches `op-module-*` and is not in the current emit set.
+ */
+export function planSkillEmission(args: {
+  destDir: string;
+  lazySkills: LazySkill[];
+  existingOpModuleDirs: string[];
+}): EmissionPlan {
+  const skillsRoot = path.join(args.destDir, ".claude", "skills");
+  const keep = new Set(args.lazySkills.map((s) => s.name));
+  const writes: SkillWrite[] = [];
+  for (const s of args.lazySkills) {
+    const dir = path.join(skillsRoot, s.name);
+    writes.push({ path: path.join(dir, "SKILL.md"), kind: "skill", skill: s });
+    writes.push({ path: path.join(dir, ".gitignore"), kind: "gitignore" });
+  }
+  const prunes = args.existingOpModuleDirs
+    .filter((d) => d.startsWith("op-module-") && !keep.has(d))
+    .map((d) => path.join(skillsRoot, d));
+  return { writes, prunes };
+}
+
+export interface EmitLazySkillsDeps {
+  settings: OpSettings;
+  resolveIssue: (id: string) => IssueEntry;
+}
+
+export interface EmitLazySkillsResult {
+  issueId: string;
+  project: string;
+  destDir: string;
+  written: string[];
+  pruned: string[];
+  skillNames: string[];
+  /** True when there were no lazy skills (still a success — nothing to do). */
+  empty: boolean;
+}
+
+/**
+ * Recompose the issue's kickoff step, then materialize its lazy skills under
+ * `destDir`. `destDir` is the agent's working directory — the agent passes
+ * `dir="$(pwd)"` from inside its worktree so the files land where Claude Code
+ * will discover them (a worktree is its own skill-discovery root). Falls back
+ * to the issue's resolved repo path when `destDir` is omitted.
+ */
+export async function emitLazySkills(
+  app: App,
+  deps: EmitLazySkillsDeps,
+  args: { issueId: string; destDir?: string },
+): Promise<EmitLazySkillsResult> {
+  const entry = deps.resolveIssue(args.issueId);
+  const project = entry.project;
+  if (!project) {
+    throw new Error(`op-emit-lazy-skills: issue ${args.issueId} has no project`);
+  }
+
+  const agentRaw = entry.agent ?? deps.settings.defaultAgent;
+  const agentId = (AGENT_IDS as readonly string[]).includes(agentRaw)
+    ? (agentRaw as AgentId)
+    : deps.settings.defaultAgent;
+  const profile = resolveProfile(deps.settings, agentId);
+  const renderContext = buildIssueRenderContext(app, deps.settings, entry, profile, "kickoff");
+  const projectVars = readProjectVars(app, project);
+
+  const { composed } = await loadAndComposeWorkflow(app, {
+    project,
+    step: "kickoff",
+    ctx: {
+      render: renderContext,
+      globalVars: deps.settings.workflowVars ?? {},
+      projectVars,
+      launchVars: {},
+      maxWorkflowChars: deps.settings.injection.maxWorkflowChars,
+    },
+  });
+
+  const lazySkills: LazySkill[] = composed?.lazySkills ?? [];
+
+  const destDir =
+    (args.destDir && args.destDir.trim()) ||
+    renderContext.repo_path ||
+    "";
+  if (!destDir) {
+    throw new Error(
+      `op-emit-lazy-skills: no destination — issue ${args.issueId}'s project has no repo path; pass dir="$(pwd)" from inside your working directory.`,
+    );
+  }
+
+  const skillsRoot = path.join(destDir, ".claude", "skills");
+  let existing: string[] = [];
+  try {
+    existing = (await fs.readdir(skillsRoot, { withFileTypes: true }))
+      .filter((e) => e.isDirectory())
+      .map((e) => e.name);
+  } catch {
+    existing = []; // skills root doesn't exist yet — nothing to prune
+  }
+
+  const plan = planSkillEmission({ destDir, lazySkills, existingOpModuleDirs: existing });
+
+  for (const p of plan.prunes) {
+    await fs.rm(p, { recursive: true, force: true });
+  }
+  const written: string[] = [];
+  for (const w of plan.writes) {
+    await fs.mkdir(path.dirname(w.path), { recursive: true });
+    if (w.kind === "gitignore") {
+      await fs.writeFile(w.path, "*\n", "utf8");
+    } else {
+      await fs.writeFile(
+        w.path,
+        renderSkillMd({ name: w.skill!.name, description: w.skill!.description, body: w.skill!.body }),
+        "utf8",
+      );
+    }
+    written.push(w.path);
+  }
+
+  return {
+    issueId: args.issueId,
+    project,
+    destDir,
+    written,
+    pruned: plan.prunes,
+    skillNames: lazySkills.map((s) => s.name),
+    empty: lazySkills.length === 0,
+  };
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `npx vitest run src/emitLazySkills.test.ts`
+Expected: PASS (the pure `planSkillEmission` cases).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/emitLazySkills.ts src/emitLazySkills.test.ts
+git commit -m "OP-192: emitLazySkills IO seam + pure planSkillEmission
+
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 5: CLI param parser for `op-emit-lazy-skills`
+
+**Files:**
+- Modify: `src/cliHandlers.ts` (add `parseEmitLazySkillsParams` next to `parseExplainWorkflowParams` ~line 309)
+- Test: `src/cliHandlers.test.ts`
+
+- [ ] **Step 1: Write failing tests**
+
+Append to `src/cliHandlers.test.ts` (match the file's existing import of the parsers):
+
+```ts
+import { parseEmitLazySkillsParams } from "./cliHandlers";
+
+describe("parseEmitLazySkillsParams (OP-192)", () => {
+  it("requires issue", () => {
+    const r = parseEmitLazySkillsParams({});
+    expect(r.ok).toBe(false);
+  });
+  it("accepts issue and optional dir, trimming dir", () => {
+    const r = parseEmitLazySkillsParams({ issue: "OP-1", dir: "  /wt  " });
+    expect(r).toEqual({ ok: true, value: { issueId: "OP-1", destDir: "/wt" } });
+  });
+  it("accepts id as an alias and omits destDir when dir absent", () => {
+    const r = parseEmitLazySkillsParams({ id: "OP-2" });
+    expect(r).toEqual({ ok: true, value: { issueId: "OP-2" } });
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `npx vitest run src/cliHandlers.test.ts -t "parseEmitLazySkillsParams"`
+Expected: FAIL — `parseEmitLazySkillsParams` not exported.
+
+- [ ] **Step 3: Implement the parser**
+
+In `src/cliHandlers.ts`, after `parseExplainWorkflowParams` (~line 330):
+
+```ts
+export function parseEmitLazySkillsParams(
+  params: Record<string, string>,
+): ParamsResult<{ issueId: string; destDir?: string }> {
+  const id = params.issue ?? params.id;
+  if (!id) return { ok: false, error: "op-emit-lazy-skills failed: --issue is required" };
+  const dir = nonEmptyTrim(params.dir);
+  const out: { issueId: string; destDir?: string } = { issueId: id };
+  if (dir !== undefined) out.destDir = dir;
+  return { ok: true, value: out };
+}
+```
+
+(`nonEmptyTrim` and `ParamsResult` are already defined/used in this file — reuse them.)
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `npx vitest run src/cliHandlers.test.ts -t "parseEmitLazySkillsParams"`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/cliHandlers.ts src/cliHandlers.test.ts
+git commit -m "OP-192: parseEmitLazySkillsParams CLI parser
+
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 6: Wire `op-emit-lazy-skills` into the plugin (CLI + URI)
+
+**Files:**
+- Modify: `src/main.ts` (import ~line 144 region; `registerObsidianProtocolHandler` block ~line 1181; `registerCliHandler` block ~line 1515; new `handleOpEmitLazySkillsCli` method near `handleOpExplainWorkflowCli` ~line 4028)
+- Modify: `src/uriHandlers.ts` (new `handleOpEmitLazySkillsUri` near `handleOpListVarsUri` ~line 410; add to `UriHandlerDeps` if that interface gates verbs)
+- Test: manual smoke (Task 8) — wiring is exercised by the smoke harness; no new unit test (consistent with how `op-explain-workflow` wiring is covered).
+
+- [ ] **Step 1: Add the import in `main.ts`**
+
+Near the other workflow imports in `src/main.ts` (search for `from "./explainWorkflow"`), add:
+
+```ts
+import { emitLazySkills } from "./emitLazySkills";
+import { parseEmitLazySkillsParams } from "./cliHandlers";
+```
+
+(If `cliHandlers` is already imported as a grouped `import { ... } from "./cliHandlers"`, add `parseEmitLazySkillsParams` to that existing group instead of a new line.)
+
+- [ ] **Step 2: Register the CLI handler**
+
+In the `registerCliHandler` sequence (immediately after the `op-list-vars` block ~line 1527):
+
+```ts
+    this.registerCliHandler(
+      "op-emit-lazy-skills",
+      "Materialize this issue's `lazy: true` workflow modules as on-demand Claude Code skills under <dir>/.claude/skills/. Run from inside your working directory.",
+      {
+        issue: { value: "<id>", description: "Issue id (e.g. OP-34)" },
+        dir: {
+          value: "<abs-path>",
+          description: 'Absolute path of your working directory. Pass dir="$(pwd)" from inside your worktree. Defaults to the project repo path.',
+        },
+      },
+      (params) => this.handleOpEmitLazySkillsCli(params),
+    );
+```
+
+- [ ] **Step 3: Register the protocol (URI) handler**
+
+After the `op-list-vars` `registerObsidianProtocolHandler` block (~line 1186):
+
+```ts
+    this.registerObsidianProtocolHandler("op-emit-lazy-skills", (params) => {
+      this.runUri("op-emit-lazy-skills", normalizeUriParams(params), (p) =>
+        handleOpEmitLazySkillsUri(this.uriDeps(), p),
+      );
+    });
+```
+
+Add `handleOpEmitLazySkillsUri` to the import from `./uriHandlers` in `main.ts`.
+
+- [ ] **Step 4: Add the CLI handler method**
+
+Immediately after `handleOpExplainWorkflowCli` (~line 4049) in `src/main.ts`:
+
+```ts
+  private async handleOpEmitLazySkillsCli(params: Record<string, string>): Promise<string> {
+    const command = "op-emit-lazy-skills";
+    try {
+      const parsed = parseEmitLazySkillsParams(params);
+      if (!parsed.ok) return parsed.error;
+      const args: { issueId: string; destDir?: string } = { issueId: parsed.value.issueId };
+      if (parsed.value.destDir !== undefined) args.destDir = parsed.value.destDir;
+      const payload = await emitLazySkills(
+        this.app,
+        { settings: this.settings, resolveIssue: (i) => this.resolveByIdOrThrow(i) },
+        args,
+      );
+      await writeUriResponse(this.app, { ok: true, command, ...payload });
+      return payload.empty
+        ? `${command}: ${payload.issueId} — no lazy modules; nothing to emit`
+        : `${command}: ${payload.issueId} → wrote ${payload.skillNames.length} skill(s) to ${payload.destDir}/.claude/skills/ (pruned ${payload.pruned.length})`;
+    } catch (err: any) {
+      const msg = err?.message ?? String(err);
+      console.error("[op-obsidian]", command, err);
+      await writeUriResponse(this.app, { ok: false, command, error: msg });
+      return `${command} failed: ${msg}`;
+    }
+  }
+```
+
+- [ ] **Step 5: Add the URI handler in `uriHandlers.ts`**
+
+After `handleOpListVarsUri` (~line 427) in `src/uriHandlers.ts`:
+
+```ts
+export async function handleOpEmitLazySkillsUri(
+  deps: UriHandlerDeps,
+  params: Record<string, string>,
+): Promise<UriResponsePayload> {
+  if (!deps.emitLazySkills) throw new Error("op-emit-lazy-skills not wired");
+  const id = trimOrUndef(params.issue ?? params.id);
+  if (!id) throw new Error("op-emit-lazy-skills URI: issue is required");
+  const dir = trimOrUndef(params.dir);
+  const args: { issueId: string; destDir?: string } = { issueId: id };
+  if (dir) args.destDir = dir;
+  const payload = await deps.emitLazySkills(args);
+  return { ok: true, command: "op-emit-lazy-skills", ...payload };
+}
+```
+
+Add an optional `emitLazySkills?: (args: { issueId: string; destDir?: string }) => Promise<...>` to the `UriHandlerDeps` interface and wire it in `this.uriDeps()` (mirror exactly how `explainWorkflow` / `listVars` are added to `UriHandlerDeps` and `uriDeps()` — search `explainWorkflow:` in `main.ts` and `uriHandlers.ts` and copy the shape, substituting `emitLazySkills`).
+
+- [ ] **Step 6: Typecheck + build**
+
+Run: `npx tsc --noEmit && npm run build`
+Expected: no type errors; `main.js` rebuilt.
+
+- [ ] **Step 7: Run the full suite**
+
+Run: `npm test`
+Expected: PASS (no regressions).
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/main.ts src/uriHandlers.ts
+git commit -m "OP-192: wire op-emit-lazy-skills CLI + URI handlers
+
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 7: Kickoff pointer block (and meta-only inline fallback)
+
+**Files:**
+- Modify: `src/promptBuild.ts` (`composeWorkflowSection` ~line 233–238)
+- Test: `src/promptBuild.test.ts`
+
+- [ ] **Step 1: Write failing tests**
+
+In `src/promptBuild.test.ts`, add cases that drive `composeWorkflowSection` with a composed result containing `lazySkills`. Mirror the existing test setup in that file (it already stubs `loadAndComposeWorkflow` or composes against fixtures — reuse that harness; do not invent a new one). Two cases:
+
+```ts
+describe("composeWorkflowSection lazy skills (OP-192)", () => {
+  it("appends a pointer block (not the bodies) when repoPath is set and lazySkills present", async () => {
+    // Arrange a composed result: text "Inline" + lazySkills:[{id:'tmux',...,body:'LAZY BODY'}]
+    // and args.repoPath = "/wt".
+    const out = await composeWorkflowSection(app, argsWithLazy({ repoPath: "/wt" }));
+    expect(out).toContain("Inline");
+    expect(out).not.toContain("LAZY BODY");
+    expect(out).toContain("op-emit-lazy-skills");
+    expect(out).toContain('dir="$(pwd)"');
+  });
+
+  it("inlines lazy bodies under a reference heading when no repoPath (meta-only)", async () => {
+    const out = await composeWorkflowSection(app, argsWithLazy({ repoPath: undefined }));
+    expect(out).toContain("LAZY BODY");
+    expect(out).toContain("## Optional reference (no working directory");
+  });
+});
+```
+
+> Use the file's existing app/fixture builders. `argsWithLazy` is shorthand for "the test's existing `BuildPromptArgs` builder, with a workflow whose kickoff step includes a `lazy: true` module". If the test file composes against real fixtures rather than stubs, add a `lazy: true` fixture module under `src/__fixtures__/integration/` and reference it from the kickoff step there.
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `npx vitest run src/promptBuild.test.ts -t "lazy skills"`
+Expected: FAIL — pointer block / inline fallback not implemented.
+
+- [ ] **Step 3: Implement the pointer / inline fallback**
+
+In `src/promptBuild.ts`, replace the tail of `composeWorkflowSection` (the block starting `const text = composed.text.trim();` ~line 233):
+
+```ts
+  const text = composed.text.trim();
+  const lazy = composed.lazySkills ?? [];
+
+  // Lazy modules: emit a pointer (agent pulls them into its worktree) when a
+  // working directory exists; otherwise inline the bodies so meta-only
+  // projects never lose the content.
+  let lazySection = "";
+  if (lazy.length > 0) {
+    if (args.repoPath) {
+      const names = lazy.map((s) => s.name).join(", ");
+      lazySection =
+        `## Optional reference skills\n\n` +
+        `This issue has ${lazy.length} optional reference module(s) (${names}) available as on-demand skills. ` +
+        `From inside your working directory (after creating your worktree) run:\n\n` +
+        "```bash\n" +
+        `obsidian op-emit-lazy-skills issue=${entry.id} dir="$(pwd)"\n` +
+        "```\n\n" +
+        `Then activate the relevant one via the Skill tool when needed. Skipping this is safe — they are reference-only.`;
+    } else {
+      lazySection =
+        `## Optional reference (no working directory — inlined)\n\n` +
+        lazy.map((s) => `### ${s.name}\n\n${s.body}`).join("\n\n");
+    }
+  }
+
+  // Non-null but empty inline text: suppress the workflow section, but still
+  // surface lazy content/pointer if any.
+  if (!text) {
+    return lazySection ? lazySection : "";
+  }
+  const section = `## Project workflow\n\n${text}`;
+  return lazySection ? `${section}\n\n${lazySection}` : section;
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `npx vitest run src/promptBuild.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Full suite + build**
+
+Run: `npm test && npm run build`
+Expected: PASS; build clean.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/promptBuild.ts src/promptBuild.test.ts src/__fixtures__ 2>/dev/null
+git commit -m "OP-192: kickoff pointer block + meta-only inline fallback
+
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 8: Version bump, dev-sync, smoke test
+
+**Files:**
+- Modify: `plugins/op-obsidian/manifest.json`, `plugins/op-obsidian/package.json`, `plugins/op/.claude-plugin/plugin.json` (via the bump script)
+- Modify: `scripts/smoke-workflow-modules.mjs` (extend with a lazy assertion)
+- Modify: `scripts/build-seeds.mjs` (add one `lazy: true` module to the `seed/workflow-modules` checkpoint)
+
+- [ ] **Step 1: Bump version + build (from repo root)**
+
+Run: `node scripts/bump-version.mjs minor`
+(Minor — `op-emit-lazy-skills` is a new additive CLI verb + two new optional schema fields. No breaking change.)
+Expected: three JSON files move in lockstep; `npm run build` runs; `main.js` fresher than `manifest.json`.
+
+- [ ] **Step 2: Add a lazy module to the workflow-modules seed**
+
+In `scripts/build-seeds.mjs`, locate where the `seed/workflow-modules` checkpoint writes its per-project module(s) (search for `workflow-modules` / `MODULES/`). Add one module file with frontmatter `type: workflow-module`, `id: tmux-gotchas`, `title: "Tmux gotchas"`, `scope: kickoff`, `lazy: true`, `description: "Tmux pane/window gotchas — activate when wrangling tmux"`, body `"Known tmux gotchas: ..."`, and add `tmux-gotchas` to the kickoff step's `modules:` list in that seed's `_op-workflow.md`. Keep it minimal — one extra module, mirroring the existing seed module's shape exactly.
+
+- [ ] **Step 3: Rebuild seeds**
+
+Run: `node scripts/build-seeds.mjs`
+Expected: seeds rebuilt; `git -C ~/Documents/OP-Test/OP-Test tag` lists `seed/workflow-modules`.
+
+- [ ] **Step 4: Extend the smoke harness**
+
+In `scripts/smoke-workflow-modules.mjs`, after the existing `op-explain-workflow` assertions, add:
+- assert the explain payload's diagnostics include a `lazy-skill` `info` entry for `tmux-gotchas`;
+- assert the composed `text` does NOT contain the tmux-gotchas body;
+- run `obsidian vault=OP-Test op-emit-lazy-skills issue=TST-5 dir=<OP-Test repo tmp path>` and assert `<dir>/.claude/skills/op-module-tmux-gotchas/SKILL.md` exists, contains `name: op-module-tmux-gotchas`, and a sibling `.gitignore` containing `*`;
+- re-run it and assert idempotency (same files, no error);
+- assert a stale `op-module-zzz` dir created beforehand is pruned.
+
+Match the harness's existing assertion style (it already shells `obsidian vault=OP-Test ...` and reads `Projects/_scratch/op-last-response.md`).
+
+- [ ] **Step 5: Sync + reload + smoke (per project CLAUDE.md)**
+
+Run (OP-Test must be open in Obsidian, any window):
+
+```bash
+node scripts/dev-sync.mjs
+node scripts/reset-test-vault.mjs workflow-modules
+node scripts/smoke-workflow-modules.mjs
+obsidian vault=OP-Test op-explain-workflow issue=TST-5 mode=kickoff
+```
+
+Expected: smoke harness exits 0; explain payload shows the `lazy-skill` info diagnostic and excludes the tmux body; `op-last-response.md` has no `error`-severity diagnostics for the seed checkpoint.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add plugins/op-obsidian/manifest.json plugins/op-obsidian/package.json plugins/op/.claude-plugin/plugin.json scripts/smoke-workflow-modules.mjs scripts/build-seeds.mjs
+git commit -m "OP-192: version bump + lazy-module seed + smoke coverage
+
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- §1 schema (`lazy`, `description`, no global setting, boolean type-check) → Task 1 ✓
+- §2 pure-composer partition + info diagnostic + description→title warning fallback → Task 2 ✓
+- §3 skill-name slug + YAML-safe SKILL.md render → Task 3 ✓
+- §4 `op-emit-lazy-skills` CLI: recompose, write, self-ignoring `.gitignore`, prune, idempotent, JSON payload → Tasks 4–6 ✓
+- §5 emit at kickoff only (pointer injected by `composeWorkflowSection`) → Task 7 ✓
+- §6 edge cases: meta-only inline fallback (Task 7), stale prune (Task 4), shadowing→single id (inherent — composer partitions post-shadow loaded modules), concurrency (writes into agent's own worktree dir — no shared path) ✓
+- Testing section (pure unit, IO, smoke + seed) → Tasks 1–8 ✓
+- Out-of-scope items: no global setting, no per-step emission, no plugin-push — none implemented ✓
+
+**Placeholder scan:** No TBD/TODO. Test-helper reuse notes ("adapt to existing builders") are explicit instructions, not deferred work — the builder semantics are specified. Every code step shows full code.
+
+**Type consistency:** `LazySkill` (`{id,name,description,body}`) defined in Task 2, consumed identically in Tasks 3 (`renderSkillMd` args subset), 4 (`planSkillEmission`/`emitLazySkills`), 7 (`s.name`/`s.body`). `parseEmitLazySkillsParams` returns `{issueId, destDir?}` (Task 5) consumed unchanged in Task 6. `emitLazySkills` deps `{settings, resolveIssue}` mirror `explainWorkflow`'s. `lazy-skill` diagnostic code added in Task 1, emitted in Task 2, asserted in Task 8. Consistent.

--- a/docs/superpowers/specs/2026-05-15-lazy-skill-emission-design.md
+++ b/docs/superpowers/specs/2026-05-15-lazy-skill-emission-design.md
@@ -1,0 +1,207 @@
+---
+doc_type: spec
+issue: OP-192
+parent: OP-181
+date: 2026-05-15
+title: "Skill emission for lazy: true workflow modules"
+status: approved
+---
+
+# Skill emission for `lazy: true` workflow modules (OP-192)
+
+## Problem
+
+Workflow modules (OP-181) are all inlined into the agent's composed prompt at
+launch. Rarely-needed reference modules (e.g. a "tmux gotchas catalog") burn
+kickoff context every launch even when the agent never consults them.
+
+OP-192 adds an **opt-in** path: a module flagged `lazy: true` is *not* inlined.
+Instead it is materialized as a Claude Code skill the agent activates on demand
+via the Skill tool. The feature is genuinely optional — the system ships and
+works without any module ever setting `lazy: true`.
+
+## Key finding that shaped the design
+
+Claude Code discovers project skills by walking `.claude/skills/` from the cwd
+up to the **git repo root** (a linked worktree is its *own* root) plus
+`~/.claude/skills/`. op's worktree-per-issue flow means the launched agent
+creates its own worktree *after* launch and `cd`s into it. A skill file the
+plugin writes to `repoPath/.claude/skills/` at launch time is therefore
+**invisible** once the agent enters its worktree: the untracked file is not in
+the worktree's working tree, and parent-chain discovery cannot escape upward
+past the worktree's own root.
+
+Consequence: the plugin **cannot push** issue-scoped skill files that survive
+the worktree flow. The only correct mechanisms are (a) push to the global
+`~/.claude/skills/`, or (b) have the agent *pull* them from inside its worktree.
+We chose **agent-pull** (decision below) — it keeps skills issue-scoped,
+avoids global-namespace pollution and cross-launch races, and matches op's
+existing "all mutation through `op-*` dispatch, agent-driven" model.
+
+## Design
+
+### 1. Schema additions (`workflowModulePure.ts`, pure)
+
+Two optional frontmatter fields on a workflow module, parsed in `parseModule`:
+
+| Field | Type | Validation | Default |
+|---|---|---|---|
+| `lazy` | boolean | non-boolean → `invalidFieldDiag` (`malformed-frontmatter`, error). Not truthy-coerced — `lazy: "true"` is an error. | `false` |
+| `description` | string | non-string → `invalidFieldDiag`. | absent |
+
+`WorkflowModule` gains `lazy: boolean` (always present, defaulted `false`) and
+`description?: string`. Both follow the existing optional-field pattern
+(`project`/`agent`/`order` at `workflowModulePure.ts:351-388`).
+
+Forward/backward compatibility: unknown-key tolerance (`parseModule` already
+ignores unknown frontmatter) means a `lazy: true` module loaded by a plugin
+build *without* this feature simply inlines as a normal module. That graceful
+degradation is why **no global enable setting is needed** — per-module
+`lazy: true` is the sole opt-in, and it fails safe by construction. Adding a
+global kill-switch would silently nullify author intent and add a settings
+surface, migration, docs, and a smoke-matrix entry for a feature that already
+ships dormant (rejected as YAGNI).
+
+### 2. Pure-composer partition (`composeWorkflowPure.ts`, pure)
+
+The partition is a *shape decision* and stays in the pure layer (consistent
+with the strict pure/IO split documented in `composeWorkflowPure.ts` /
+`composeWorkflow.ts`). `composeWorkflow` already walks `stepRecord.modules`,
+loads bodies, and renders var substitution. Change:
+
+- A module with `module.lazy === true` is **excluded** from `orderedChunks`
+  and the joined `text`.
+- Its body is still rendered through the **same** var-precedence chain
+  (Module → Global → Project → Launch) and `renderTemplate` plugin-var pass —
+  a lazy skill body is not a second-class citizen that skips resolution.
+- `ComposedPrompt` gains:
+
+  ```ts
+  lazySkills: Array<{
+    id: string;          // module id (post-shadowing)
+    name: string;        // derived skill name, validated [a-z0-9-], <=64
+    description: string;  // module.description, else module.title (fallback)
+    body: string;        // fully var-resolved module body
+  }>
+  ```
+
+- One `info`-severity `WorkflowDiagnostic` per emitted lazy module:
+  *"module `<id>` emitted as on-demand skill `op-module-<id>`, not inlined"*.
+  This makes the feature visible in `op-explain-workflow` / dry-run — a stated
+  decision, not optional polish. Without it, "why didn't the agent see my
+  notes?" has no debugging trail.
+- A lazy module missing `description` falls back to `title` (a required field,
+  always present) and emits a **`warning`** diagnostic: *"module `<id>` is
+  lazy but has no `description:`; using title as the skill activation hint —
+  activation accuracy may suffer"*. A missing one-line summary must **never**
+  hard-fail a launch (consistent with the composer's "diagnose, don't
+  detonate" convention — `parseModule` keeps modules loadable despite var
+  diagnostics).
+
+### 3. Skill name derivation
+
+- Skill directory: `op-module-<id>`. The `op-module-` prefix namespaces away
+  from the canonical first-class `op` skill so the agent's skill list doesn't
+  show two ambiguous "op" entries.
+- SKILL.md `name:` = `op-module-<id>` slugified to Claude Code's rules
+  (lowercase, `[a-z0-9-]`, ≤64 chars; invalid chars → `-`, collapse repeats,
+  trim, truncate to 64). Module ids are already filename-basename-constrained
+  so this is mostly a guard.
+- `description:` is YAML-safe-encoded when written (quoted/escaped block
+  scalar), **never** interpolated verbatim — a description containing `:`,
+  `#`, a newline, or a leading `>`/`|` must not corrupt the SKILL.md
+  frontmatter.
+
+### 4. Delivery: agent-pull via `op-emit-lazy-skills` CLI
+
+The pure composer produces `lazySkills` data. Delivery is **agent-driven**:
+
+- When `composeWorkflowSection` (kickoff step only — see §5) has a non-empty
+  `lazySkills` set, it appends a short, fixed pointer block to the composed
+  prompt (≈3 lines, not the module bodies):
+
+  > *Optional reference skills are available for this issue. Run
+  > `obsidian op-emit-lazy-skills issue=<ID>` from inside your working
+  > directory after creating your worktree to materialize them into
+  > `.claude/skills/`, then activate the relevant one via the Skill tool when
+  > needed. Skipping this is safe — they are reference-only.*
+
+- New CLI command **`op-emit-lazy-skills`** (`key=value` args, JSON payload to
+  `Projects/_scratch/op-last-response.md` like every `op-*`):
+  - Required: `issue=<PREFIX-N>` (resolves project + kickoff step).
+  - Recomposes the kickoff step, takes `composed.lazySkills`.
+  - Writes each to `<cwd>/.claude/skills/op-module-<id>/SKILL.md` where `cwd`
+    is the **process working directory of the CLI invocation** (the agent's
+    worktree — worktree-correct because the agent runs it from inside).
+  - Writes a self-ignoring `<dir>/.gitignore` containing `*` so the emitted
+    skills never appear in the agent's `git status` and we never mutate the
+    consumer repo's root `.gitignore`.
+  - **Prune**: before writing, remove any existing `.claude/skills/op-module-*`
+    directory whose id is not in the current lazy set (handles a module that
+    flipped `lazy:true`→`false`, was renamed, or deleted — otherwise the agent
+    could activate stale guidance).
+  - Idempotent: re-running overwrites + re-prunes; safe to run every step.
+  - Emits the JSON payload listing written/pruned paths + any warnings.
+
+This is the one place that does filesystem I/O for this feature; it is a thin
+consumer of the pure `lazySkills` data.
+
+### 5. Emission trigger
+
+`lazySkills` is computed for the **kickoff step only** and the pointer block is
+injected at kickoff. Reference material ("tmux gotchas") is session-ambient,
+not step-specific. Per-step re-emission was rejected: it rewrites skill files
+6×/issue (churn the agent sees in `git status`), and introduces a "lazy in
+step A, inline in step B" combinatorial question the issue never asked.
+`op-emit-lazy-skills` itself is idempotent so an agent re-running it across
+steps is harmless, but the prompt only nudges once.
+
+### 6. Failure modes & edge cases
+
+- **Meta-only / no working dir**: `op-emit-lazy-skills` writes relative to the
+  CLI cwd; if the agent never created a worktree it writes into the main
+  checkout's `.claude/skills/` (still discoverable there pre-worktree). If a
+  lazy module exists but the project is meta-only with no repo, the composer
+  falls back to **inlining** the module + a `warning` diagnostic — content is
+  never silently lost.
+- **id collision across global/project shadowing**: shadowing resolves to a
+  single surviving module before partition, so `op-module-<id>` is stable.
+- **Stale skill files**: handled by the prune step in §4.
+- **Concurrency**: agent-pull writes into the agent's *own* worktree cwd, so
+  parallel launches for different issues do not race (each agent's worktree is
+  distinct). Documented, no extra code.
+- **Agent ignores the pointer**: safe by design — the modules are reference-
+  only; skipping emission loses nothing kickoff-critical.
+
+## Components & boundaries
+
+| Unit | Responsibility | Depends on | Pure? |
+|---|---|---|---|
+| `parseModule` (extended) | parse/validate `lazy`, `description` | — | yes |
+| `composeWorkflow` (extended) | partition lazy out, build `lazySkills`, diagnostics | schema | yes |
+| skill-name slug helper | id → valid Claude Code skill name | — | yes |
+| SKILL.md renderer | `lazySkills[i]` → YAML-safe SKILL.md text | — | yes |
+| `op-emit-lazy-skills` handler | recompose, write/prune files, JSON payload | composer, FS | no (IO seam) |
+| `composeWorkflowSection` (extended) | append pointer block when lazySkills non-empty (kickoff) | composer | no (IO seam) |
+
+## Testing
+
+- **Pure unit**: `parseModule` lazy/description type-checks & defaults;
+  composer partition (lazy excluded from text, present in `lazySkills`, vars
+  resolved); description fallback + warning diagnostic; info diagnostic per
+  emitted; name slugification edge cases; YAML-escaping of nasty descriptions.
+- **IO**: `op-emit-lazy-skills` writes expected tree, self-ignoring `.gitignore`,
+  prunes orphans, idempotent re-run; meta-only inline fallback.
+- **Smoke** (per project CLAUDE.md, against an OP-Test seed): seed a lazy
+  module, `op-explain-workflow` shows the info diagnostic and excludes it from
+  inline chunks; run `op-emit-lazy-skills` and assert the SKILL.md tree +
+  prune behavior. Extend `scripts/smoke-workflow-modules.mjs`.
+
+## Out of scope
+
+- Global enable/disable setting (rejected — YAGNI).
+- Per-step lazy emission (rejected — churn/combinatorics).
+- Pushing skills from the plugin at launch (rejected — broken by worktree
+  discovery).
+- Auto-running `op-emit-lazy-skills` on the agent's behalf (the agent decides;
+  the pointer nudges).

--- a/docs/workflow-modules/03-troubleshooting.md
+++ b/docs/workflow-modules/03-troubleshooting.md
@@ -246,6 +246,23 @@ If latency hasn't visibly increased, you can also raise
 `maxWorkflowChars` in Settings → Advanced → Injection. The cap is
 informational, not enforced.
 
+### `lazy-skill`
+
+**What it means.** A module with `lazy: true` was partitioned out of the
+inlined prompt and will be emitted as an on-demand Claude Code skill
+instead. This is **info-only** when the module has a `description:`
+field; it is **warning** when the description is absent and the skill
+falls back to the module's title.
+
+**When to act.**
+
+- **Run `op-emit-lazy-skills`** to materialize the skill files for every
+  `lazy: true` module in the workflow. Without this step the skill files
+  on disk are stale (or absent) and the agent cannot invoke them.
+- **Add a `description:` field** to the module frontmatter to suppress
+  the warning variant. A one-sentence description of what the skill does
+  is enough.
+
 ## Diagnostic surfaces vs. the recovery dialog
 
 A few diagnostics open dedicated recovery UI rather than just rendering

--- a/plugins/op-obsidian/manifest.json
+++ b/plugins/op-obsidian/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "op-obsidian",
   "name": "Obsidian Projects (op)",
-  "version": "0.96.1",
+  "version": "0.97.0",
   "minAppVersion": "1.5.0",
   "description": "Jira-lite issue tracker for Obsidian vaults — deterministic commands backing the op workflow.",
   "author": "Eugene Archibald",

--- a/plugins/op-obsidian/package.json
+++ b/plugins/op-obsidian/package.json
@@ -1,6 +1,6 @@
 {
   "name": "op-obsidian",
-  "version": "0.96.1",
+  "version": "0.97.0",
   "description": "Obsidian plugin that owns the deterministic half of the op workflow.",
   "main": "main.js",
   "scripts": {

--- a/plugins/op-obsidian/src/cliHandlers.test.ts
+++ b/plugins/op-obsidian/src/cliHandlers.test.ts
@@ -446,6 +446,7 @@ describe("parseEmitLazySkillsParams (OP-192)", () => {
   it("requires issue", () => {
     const r = parseEmitLazySkillsParams({});
     expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.error).toMatch(/--issue/);
   });
   it("accepts issue and optional dir, trimming dir", () => {
     const r = parseEmitLazySkillsParams({ issue: "OP-1", dir: "  /wt  " });
@@ -466,5 +467,15 @@ describe("parseEmitLazySkillsParams (OP-192)", () => {
   it("accepts an absolute dir", () => {
     const r = parseEmitLazySkillsParams({ issue: "OP-1", dir: "/Users/x/wt" });
     expect(r).toEqual({ ok: true, value: { issueId: "OP-1", destDir: "/Users/x/wt" } });
+  });
+  it("rejects a tilde dir with a tilde-specific message", () => {
+    const r = parseEmitLazySkillsParams({ issue: "OP-1", dir: "~/wt" });
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.error).toMatch(/tilde/);
+  });
+  it("still rejects a plain relative dir", () => {
+    const r = parseEmitLazySkillsParams({ issue: "OP-1", dir: "rel/path" });
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.error).toMatch(/absolute path/);
   });
 });

--- a/plugins/op-obsidian/src/cliHandlers.test.ts
+++ b/plugins/op-obsidian/src/cliHandlers.test.ts
@@ -17,6 +17,7 @@ import {
   parseListVarsParams,
   parseExportModuleParams,
   parseImportModuleParams,
+  parseEmitLazySkillsParams,
 } from "./cliHandlers";
 
 describe("parseWorkParams", () => {
@@ -438,5 +439,32 @@ describe("parseImportModuleParams", () => {
       vars: "tone=quiet",
     });
     expect(r.ok && r.value.varAnswers.tone).toBe("quiet");
+  });
+});
+
+describe("parseEmitLazySkillsParams (OP-192)", () => {
+  it("requires issue", () => {
+    const r = parseEmitLazySkillsParams({});
+    expect(r.ok).toBe(false);
+  });
+  it("accepts issue and optional dir, trimming dir", () => {
+    const r = parseEmitLazySkillsParams({ issue: "OP-1", dir: "  /wt  " });
+    expect(r).toEqual({ ok: true, value: { issueId: "OP-1", destDir: "/wt" } });
+  });
+  it("accepts id as an alias and omits destDir when dir absent", () => {
+    const r = parseEmitLazySkillsParams({ id: "OP-2" });
+    expect(r).toEqual({ ok: true, value: { issueId: "OP-2" } });
+  });
+  it("rejects a relative dir (must be absolute)", () => {
+    const r = parseEmitLazySkillsParams({ issue: "OP-1", dir: "relative/path" });
+    expect(r.ok).toBe(false);
+  });
+  it("rejects a '.' dir", () => {
+    const r = parseEmitLazySkillsParams({ issue: "OP-1", dir: "." });
+    expect(r.ok).toBe(false);
+  });
+  it("accepts an absolute dir", () => {
+    const r = parseEmitLazySkillsParams({ issue: "OP-1", dir: "/Users/x/wt" });
+    expect(r).toEqual({ ok: true, value: { issueId: "OP-1", destDir: "/Users/x/wt" } });
   });
 });

--- a/plugins/op-obsidian/src/cliHandlers.ts
+++ b/plugins/op-obsidian/src/cliHandlers.ts
@@ -329,6 +329,29 @@ export function parseExplainWorkflowParams(
   return { ok: true, value: out };
 }
 
+// POSIX/absolute check without a Node `path` dependency — keeps this module
+// pure. Treats a leading "/" (POSIX) or a Windows drive / UNC root as absolute.
+function isAbsolutePath(p: string): boolean {
+  return p.startsWith("/") || /^[A-Za-z]:[\\/]/.test(p) || p.startsWith("\\\\");
+}
+
+export function parseEmitLazySkillsParams(
+  params: Record<string, string>,
+): ParamsResult<{ issueId: string; destDir?: string }> {
+  const id = params.issue ?? params.id;
+  if (!id) return { ok: false, error: "op-emit-lazy-skills failed: --issue is required" };
+  const dir = nonEmptyTrim(params.dir);
+  if (dir !== undefined && !isAbsolutePath(dir)) {
+    return {
+      ok: false,
+      error: `op-emit-lazy-skills failed: --dir must be an absolute path (got ${JSON.stringify(dir)}); pass dir="$(pwd)" from inside your working directory`,
+    };
+  }
+  const out: { issueId: string; destDir?: string } = { issueId: id };
+  if (dir !== undefined) out.destDir = dir;
+  return { ok: true, value: out };
+}
+
 export function parseExportModuleParams(
   params: Record<string, string>,
 ): ParamsResult<

--- a/plugins/op-obsidian/src/cliHandlers.ts
+++ b/plugins/op-obsidian/src/cliHandlers.ts
@@ -329,10 +329,10 @@ export function parseExplainWorkflowParams(
   return { ok: true, value: out };
 }
 
-// POSIX/absolute check without a Node `path` dependency — keeps this module
-// pure. Treats a leading "/" (POSIX) or a Windows drive / UNC root as absolute.
+// POSIX absolute-path check. This plugin targets macOS/Linux only, so a
+// leading "/" is the sole absolute form (no Windows-drive / UNC handling).
 function isAbsolutePath(p: string): boolean {
-  return p.startsWith("/") || /^[A-Za-z]:[\\/]/.test(p) || p.startsWith("\\\\");
+  return p.startsWith("/");
 }
 
 export function parseEmitLazySkillsParams(
@@ -341,6 +341,12 @@ export function parseEmitLazySkillsParams(
   const id = params.issue ?? params.id;
   if (!id) return { ok: false, error: "op-emit-lazy-skills failed: --issue is required" };
   const dir = nonEmptyTrim(params.dir);
+  if (dir !== undefined && dir.startsWith("~")) {
+    return {
+      ok: false,
+      error: `op-emit-lazy-skills failed: --dir must be an absolute path; tilde paths are not expanded (got ${JSON.stringify(dir)}); use dir="$HOME/..." or dir="$(pwd)"`,
+    };
+  }
   if (dir !== undefined && !isAbsolutePath(dir)) {
     return {
       ok: false,

--- a/plugins/op-obsidian/src/composeWorkflowPure.test.ts
+++ b/plugins/op-obsidian/src/composeWorkflowPure.test.ts
@@ -564,4 +564,35 @@ describe("lazy skill partition (OP-192)", () => {
     expect(r.lazySkills[0].description).toBe("Tmux Notes");
     expect(r.diagnostics.some(d => d.code === "lazy-skill" && d.severity === "warning" && /no .description/.test(d.message))).toBe(true);
   });
+
+  it("resolves {{vars.x}} user-var tokens in lazy module bodies through the precedence chain", () => {
+    // Module declares greeting with a default; the body references it.
+    // Proves user-var substitution runs on lazy bodies (not just inlined chunks).
+    const lazyMod = loaded({
+      id: "greeter",
+      scope: "kickoff",
+      lazy: true,
+      description: "A greeting module",
+      vars: [{ kind: "default", name: "greeting", value: "hi" }],
+      body: "Lazy {{vars.greeting}}",
+    });
+    const wf = workflowWith("kickoff", ["greeter"]);
+    const r = composeWorkflow({
+      loadedModules: [lazyMod],
+      workflow: wf,
+      step: "kickoff",
+      ctx: { render: renderCtx({}) },
+    });
+    // The lazy skill's body should have the var substituted, not left as a token.
+    expect(r.lazySkills[0].body).toBe("Lazy hi");
+    // The var must appear in perVarSourceMap, resolved from the module default.
+    expect(r.perVarSourceMap.greeting).toMatchObject({
+      value: "hi",
+      scope: "module",
+      source: "greeter",
+    });
+    // The lazy module is NOT inlined.
+    expect(r.text).toBe("");
+    expect(r.orderedChunks).toEqual([]);
+  });
 });

--- a/plugins/op-obsidian/src/composeWorkflowPure.test.ts
+++ b/plugins/op-obsidian/src/composeWorkflowPure.test.ts
@@ -38,6 +38,7 @@ function makeModule(args: {
   project?: string;
   agent?: string;
   order?: number;
+  lazy?: boolean;
   pathPrefix?: "global" | "project";
 }): WorkflowModule {
   const path =
@@ -55,6 +56,7 @@ function makeModule(args: {
     project: args.project,
     agent: args.agent,
     order: args.order ?? 0,
+    lazy: args.lazy ?? false,
     vars: args.vars ?? [],
     source,
   };

--- a/plugins/op-obsidian/src/composeWorkflowPure.test.ts
+++ b/plugins/op-obsidian/src/composeWorkflowPure.test.ts
@@ -39,6 +39,8 @@ function makeModule(args: {
   agent?: string;
   order?: number;
   lazy?: boolean;
+  title?: string;
+  description?: string;
   pathPrefix?: "global" | "project";
 }): WorkflowModule {
   const path =
@@ -51,15 +53,32 @@ function makeModule(args: {
       : { kind: "global" as const, path };
   return {
     id: args.id,
-    title: args.id,
+    title: args.title ?? args.id,
     scope: args.scope,
     project: args.project,
     agent: args.agent,
     order: args.order ?? 0,
     lazy: args.lazy ?? false,
+    description: args.description,
     vars: args.vars ?? [],
     source,
   };
+}
+
+/** Build a LoadedModule (module + body) for use in composeWorkflow tests. */
+function loaded(args: Parameters<typeof makeModule>[0] & { body?: string }): LoadedModule {
+  const { body, ...moduleArgs } = args;
+  return { module: makeModule(moduleArgs), body: body ?? "" };
+}
+
+/** Build a single-step WorkflowFile from a step id and module id list. */
+function workflowWith(step: string, modules: string[]) {
+  return makeWorkflow([{ step, modules }]);
+}
+
+/** Build a RenderContext by merging overrides into RENDER_CTX. */
+function renderCtx(overrides: Partial<RenderContext>): RenderContext {
+  return { ...RENDER_CTX, ...overrides };
 }
 
 function makeWorkflow(steps: WorkflowStep[]): WorkflowFile {
@@ -511,5 +530,38 @@ describe("token whitespace", () => {
     ];
     const r = composeWorkflow({ loadedModules: loaded, workflow, step: "kickoff", ctx: baseCtx });
     expect(r.text).toBe("a FOO b FOO c");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Lazy skill partition (OP-192)
+// ---------------------------------------------------------------------------
+
+describe("lazy skill partition (OP-192)", () => {
+  it("excludes lazy modules from text/orderedChunks and emits them as lazySkills with an info diagnostic", () => {
+    const normal = loaded({ id: "intro", scope: "kickoff", body: "Normal body" });
+    const lazyMod = loaded({
+      id: "tmux", scope: "kickoff", lazy: true,
+      description: "tmux gotchas catalog", body: "Lazy body {{id}}",
+    });
+    const wf = workflowWith("kickoff", ["intro", "tmux"]);
+    const r = composeWorkflow({
+      loadedModules: [normal, lazyMod], workflow: wf, step: "kickoff",
+      ctx: { render: renderCtx({ id: "OP-1" }) },
+    });
+    expect(r.text).toBe("Normal body");
+    expect(r.orderedChunks.map(c => c.moduleId)).toEqual(["intro"]);
+    expect(r.lazySkills).toEqual([
+      { id: "tmux", name: "op-module-tmux", description: "tmux gotchas catalog", body: "Lazy body OP-1" },
+    ]);
+    expect(r.diagnostics.some(d => d.code === "lazy-skill" && d.severity === "info" && d.moduleId === "tmux")).toBe(true);
+  });
+
+  it("falls back to title with a lazy-skill warning when a lazy module has no description", () => {
+    const lazyMod = loaded({ id: "tmux", scope: "kickoff", lazy: true, title: "Tmux Notes", body: "Body" });
+    const wf = workflowWith("kickoff", ["tmux"]);
+    const r = composeWorkflow({ loadedModules: [lazyMod], workflow: wf, step: "kickoff", ctx: { render: renderCtx({}) } });
+    expect(r.lazySkills[0].description).toBe("Tmux Notes");
+    expect(r.diagnostics.some(d => d.code === "lazy-skill" && d.severity === "warning" && /no .description/.test(d.message))).toBe(true);
   });
 });

--- a/plugins/op-obsidian/src/composeWorkflowPure.ts
+++ b/plugins/op-obsidian/src/composeWorkflowPure.ts
@@ -522,7 +522,7 @@ export function composeWorkflow(args: ComposeArgs): ComposedPrompt {
       diagnostics.push({
         code: "lazy-skill",
         severity: "info",
-        message: `Module ${lm.module.id} emitted as on-demand skill ${skillName}, not inlined. Run op-emit-lazy-skills to materialize it.`,
+        message: `Module ${lm.module.id} is lazy: emitted as the on-demand skill ${skillName} when a working directory is available, otherwise inlined as optional reference. Not part of the always-inlined prompt body.`,
         moduleId: lm.module.id,
       });
       lazySkills.push({

--- a/plugins/op-obsidian/src/composeWorkflowPure.ts
+++ b/plugins/op-obsidian/src/composeWorkflowPure.ts
@@ -110,10 +110,12 @@ export interface ComposedPrompt {
    *  composed module is lazy. */
   lazySkills: LazySkill[];
   /**
-   * For every user var that was *referenced* anywhere in any composed chunk,
-   * the resolved value + the precedence layer that supplied it. Vars never
-   * referenced are absent from the map (callers asking for a complete dump
-   * should iterate the module declarations instead).
+   * For every user var referenced during this composition pass — including vars
+   * referenced only in `lazy: true` module bodies, which are partitioned out of
+   * `orderedChunks`/`text` but still rendered — the resolved value + the
+   * precedence layer that supplied it. Vars never referenced are absent from
+   * the map. To see only vars feeding the inlined prompt, cross-reference
+   * `orderedChunks` module ids against the module declarations.
    */
   perVarSourceMap: Record<string, UserVarSource>;
   /**
@@ -506,6 +508,7 @@ export function composeWorkflow(args: ComposeArgs): ComposedPrompt {
     });
     diagnostics.push(...r.diagnostics);
     if (lm.module.lazy) {
+      const skillName = slugifySkillName(lm.module.id);
       let description = lm.module.description;
       if (description === undefined) {
         description = lm.module.title;
@@ -519,12 +522,12 @@ export function composeWorkflow(args: ComposeArgs): ComposedPrompt {
       diagnostics.push({
         code: "lazy-skill",
         severity: "info",
-        message: `Module ${lm.module.id} emitted as on-demand skill op-module-${lm.module.id}, not inlined. Run op-emit-lazy-skills to materialize it.`,
+        message: `Module ${lm.module.id} emitted as on-demand skill ${skillName}, not inlined. Run op-emit-lazy-skills to materialize it.`,
         moduleId: lm.module.id,
       });
       lazySkills.push({
         id: lm.module.id,
-        name: slugifySkillName(lm.module.id),
+        name: skillName,
         description,
         body: r.text,
       });

--- a/plugins/op-obsidian/src/composeWorkflowPure.ts
+++ b/plugins/op-obsidian/src/composeWorkflowPure.ts
@@ -6,6 +6,7 @@ import { renderTemplate } from "./renderTemplate";
 import type { WorkflowDiagnostic } from "./workflowDiagnostic";
 import type { VarDecl, WorkflowModule } from "./workflowModulePure";
 import type { WorkflowFile, WorkflowStep } from "./workflowFilePure";
+import { slugifySkillName } from "./lazySkillPure";
 
 // Pure composition: turn the (loaded modules, parsed workflow file, mode,
 // render context) tuple into a single composed prompt with per-var source
@@ -83,12 +84,31 @@ export interface ComposedChunk {
 }
 
 /**
+ * One `lazy: true` module, fully rendered, ready to be written as a Claude
+ * Code skill by the IO layer (`emitLazySkills.ts`). Not part of the inlined
+ * prompt `text`.
+ */
+export interface LazySkill {
+  /** Module id (post-shadowing). */
+  id: string;
+  /** Derived, Claude-Code-valid skill name (`op-module-<id>` slugified). */
+  name: string;
+  /** SKILL.md `description:` — module.description, else module.title. */
+  description: string;
+  /** Fully var-resolved module body. */
+  body: string;
+}
+
+/**
  * Result of `composeWorkflow`. Pure data — no methods, no live references.
  */
 export interface ComposedPrompt {
   /** Joined text of every ordered chunk, separated by `\n\n`. */
   text: string;
   orderedChunks: ComposedChunk[];
+  /** OP-192: `lazy: true` modules, partitioned out of `text`. Empty when no
+   *  composed module is lazy. */
+  lazySkills: LazySkill[];
   /**
    * For every user var that was *referenced* anywhere in any composed chunk,
    * the resolved value + the precedence layer that supplied it. Vars never
@@ -403,6 +423,7 @@ export function composeWorkflow(args: ComposeArgs): ComposedPrompt {
     };
     return finaliseComposed({
       orderedChunks: [chunk],
+      lazySkills: [],
       perVarSourceMap: {},
       diagnostics,
       maxChars: ctx.maxWorkflowChars ?? DEFAULT_MAX_WORKFLOW_CHARS,
@@ -433,6 +454,7 @@ export function composeWorkflow(args: ComposeArgs): ComposedPrompt {
   if (orderedModules.length === 0) {
     return finaliseComposed({
       orderedChunks: [],
+      lazySkills: [],
       perVarSourceMap: {},
       diagnostics,
       maxChars: ctx.maxWorkflowChars ?? DEFAULT_MAX_WORKFLOW_CHARS,
@@ -473,6 +495,7 @@ export function composeWorkflow(args: ComposeArgs): ComposedPrompt {
   }
 
   const orderedChunks: ComposedChunk[] = [];
+  const lazySkills: LazySkill[] = [];
   for (const lm of orderedModules) {
     const r = renderModule({
       module: lm.module,
@@ -482,6 +505,31 @@ export function composeWorkflow(args: ComposeArgs): ComposedPrompt {
       ctx,
     });
     diagnostics.push(...r.diagnostics);
+    if (lm.module.lazy) {
+      let description = lm.module.description;
+      if (description === undefined) {
+        description = lm.module.title;
+        diagnostics.push({
+          code: "lazy-skill",
+          severity: "warning",
+          message: `Module ${lm.module.id} is lazy but has no \`description:\` — using its title as the skill activation hint, which may reduce activation accuracy.`,
+          moduleId: lm.module.id,
+        });
+      }
+      diagnostics.push({
+        code: "lazy-skill",
+        severity: "info",
+        message: `Module ${lm.module.id} emitted as on-demand skill op-module-${lm.module.id}, not inlined. Run op-emit-lazy-skills to materialize it.`,
+        moduleId: lm.module.id,
+      });
+      lazySkills.push({
+        id: lm.module.id,
+        name: slugifySkillName(lm.module.id),
+        description,
+        body: r.text,
+      });
+      continue;
+    }
     orderedChunks.push({
       moduleId: lm.module.id,
       scope: lm.module.scope,
@@ -492,6 +540,7 @@ export function composeWorkflow(args: ComposeArgs): ComposedPrompt {
 
   return finaliseComposed({
     orderedChunks,
+    lazySkills,
     perVarSourceMap,
     diagnostics,
     maxChars: ctx.maxWorkflowChars ?? DEFAULT_MAX_WORKFLOW_CHARS,
@@ -504,6 +553,7 @@ export function composeWorkflow(args: ComposeArgs): ComposedPrompt {
 
 interface FinaliseArgs {
   orderedChunks: ComposedChunk[];
+  lazySkills: LazySkill[];
   perVarSourceMap: Record<string, UserVarSource>;
   diagnostics: WorkflowDiagnostic[];
   maxChars: number;
@@ -527,6 +577,7 @@ function finaliseComposed(args: FinaliseArgs): ComposedPrompt {
   return {
     text,
     orderedChunks: args.orderedChunks,
+    lazySkills: args.lazySkills,
     perVarSourceMap: args.perVarSourceMap,
     sizeChars,
     diagnostics,
@@ -537,6 +588,7 @@ function emptyComposed(diagnostics: WorkflowDiagnostic[]): ComposedPrompt {
   return {
     text: "",
     orderedChunks: [],
+    lazySkills: [],
     perVarSourceMap: {},
     sizeChars: 0,
     diagnostics,

--- a/plugins/op-obsidian/src/docLinks.ts
+++ b/plugins/op-obsidian/src/docLinks.ts
@@ -35,7 +35,8 @@ export type DocLinkDiagnosticCode =
   | "import-collision"
   | "intra-scope-collision"
   | "malformed-frontmatter"
-  | "size-budget";
+  | "size-budget"
+  | "lazy-skill";
 
 /**
  * Vault-relative paths to the docs we link to. Single point of update if
@@ -93,6 +94,7 @@ const DIAGNOSTIC_LINKS: Readonly<Record<DocLinkDiagnosticCode, DocAnchor>> =
       anchor: "malformed-frontmatter",
     },
     "size-budget": { file: DOC_PATHS.troubleshooting, anchor: "size-budget" },
+    "lazy-skill": { file: DOC_PATHS.troubleshooting, anchor: "lazy-skill" },
   });
 
 export function sectionDocAnchor(id: DocLinkSectionId): DocAnchor {

--- a/plugins/op-obsidian/src/emitLazySkills.test.ts
+++ b/plugins/op-obsidian/src/emitLazySkills.test.ts
@@ -1,8 +1,11 @@
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { promises as fs } from "fs";
+import * as os from "os";
+import * as path from "path";
 
 // Stub obsidian and the IO-layer imports that pull in Obsidian runtime classes.
-// This test only exercises the pure `planSkillEmission` function; the IO half
-// (`emitLazySkills`) is not invoked here, but vitest loads the whole module.
+// This test only exercises the pure `planSkillEmission` function and, via mocks,
+// the IO `emitLazySkills` function against a real tmpdir.
 vi.mock("obsidian", () => ({
   App: class {},
   TFile: class { path = ""; basename = ""; name = ""; },
@@ -25,7 +28,25 @@ vi.mock("obsidian", () => ({
   prepareFuzzySearch: () => () => null,
 }));
 
-import { planSkillEmission } from "./emitLazySkills";
+// Mock composeWorkflow so loadAndComposeWorkflow is controllable in IO tests.
+vi.mock("./composeWorkflow", () => ({
+  loadAndComposeWorkflow: vi.fn(),
+}));
+
+// Mock explainWorkflow so buildIssueRenderContext, readProjectVars, and
+// resolveProfileById don't need a real Obsidian App instance.
+vi.mock("./explainWorkflow", () => ({
+  buildIssueRenderContext: vi.fn(),
+  readProjectVars: vi.fn(),
+  resolveProfileById: vi.fn(),
+}));
+
+import { planSkillEmission, emitLazySkills } from "./emitLazySkills";
+import { loadAndComposeWorkflow } from "./composeWorkflow";
+import { buildIssueRenderContext, readProjectVars } from "./explainWorkflow";
+import { renderSkillMd } from "./lazySkillPure";
+import type { IssueEntry } from "./types";
+import type { OpSettings } from "./settings";
 
 describe("planSkillEmission (OP-192)", () => {
   const lazy = [
@@ -58,5 +79,210 @@ describe("planSkillEmission (OP-192)", () => {
     });
     expect(plan.writes).toEqual([]);
     expect(plan.prunes).toEqual(["/wt/.claude/skills/op-module-tmux"]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// IO tests — emitLazySkills against a real tmpdir
+// ---------------------------------------------------------------------------
+
+const fakeApp = {} as any;
+const fakeSettings: Partial<OpSettings> = {
+  defaultAgent: "claude",
+  workflowVars: {},
+  injection: { maxWorkflowChars: 50000 } as any,
+};
+const fakeEntry: IssueEntry = {
+  path: "Projects/testing/OP-1.md",
+  type: "issue",
+  id: "OP-1",
+  project: "testing",
+  status: "open",
+  title: "Test issue",
+  resolvedFolder: false,
+};
+
+function makeDeps(tmpdir: string) {
+  const mockBuildIssueRenderContext = buildIssueRenderContext as ReturnType<typeof vi.fn>;
+  const mockReadProjectVars = readProjectVars as ReturnType<typeof vi.fn>;
+  mockBuildIssueRenderContext.mockReturnValue({
+    id: "OP-1",
+    title: "Test issue",
+    project: "testing",
+    status: "open",
+    parent: null,
+    vault_path: "/vault",
+    vault_name: "OP-Test",
+    today: "2026-05-15",
+    agent: "claude",
+    mode: "kickoff",
+    repo_path: tmpdir,
+  });
+  mockReadProjectVars.mockReturnValue({});
+}
+
+async function mkTmp(prefix: string): Promise<string> {
+  return fs.mkdtemp(path.join(os.tmpdir(), prefix));
+}
+
+describe("emitLazySkills IO (OP-192)", () => {
+  let tmpdir: string;
+
+  beforeEach(async () => {
+    tmpdir = await mkTmp("op-emit-lazy-skills-test-");
+    vi.clearAllMocks();
+  });
+
+  afterEach(async () => {
+    await fs.rm(tmpdir, { recursive: true, force: true });
+  });
+
+  it("writes SKILL.md + .gitignore for each lazy skill and returns correct result", async () => {
+    makeDeps(tmpdir);
+    const mockLoadAndCompose = loadAndComposeWorkflow as ReturnType<typeof vi.fn>;
+    const skills = [
+      { id: "module-a", name: "op-module-a", description: "Module A description", body: "# Module A\nContent here" },
+      { id: "module-b", name: "op-module-b", description: "Module B description", body: "# Module B\nContent there" },
+    ];
+    mockLoadAndCompose.mockResolvedValue({
+      composed: {
+        lazySkills: skills,
+        text: "",
+        orderedChunks: [],
+        perVarSourceMap: {},
+        sizeChars: 0,
+        diagnostics: [],
+      },
+    });
+
+    const result = await emitLazySkills(
+      fakeApp,
+      { settings: fakeSettings as OpSettings, resolveIssue: () => fakeEntry },
+      { issueId: "OP-1", destDir: tmpdir },
+    );
+
+    // SKILL.md for module-a
+    const skillAPath = path.join(tmpdir, ".claude", "skills", "op-module-a", "SKILL.md");
+    const gitignoreAPath = path.join(tmpdir, ".claude", "skills", "op-module-a", ".gitignore");
+    const skillBPath = path.join(tmpdir, ".claude", "skills", "op-module-b", "SKILL.md");
+    const gitignoreBPath = path.join(tmpdir, ".claude", "skills", "op-module-b", ".gitignore");
+
+    const skillAContent = await fs.readFile(skillAPath, "utf8");
+    expect(skillAContent).toBe(renderSkillMd({ name: "op-module-a", description: "Module A description", body: "# Module A\nContent here" }));
+
+    const gitignoreAContent = await fs.readFile(gitignoreAPath, "utf8");
+    expect(gitignoreAContent).toBe("*\n");
+
+    const skillBContent = await fs.readFile(skillBPath, "utf8");
+    expect(skillBContent).toBe(renderSkillMd({ name: "op-module-b", description: "Module B description", body: "# Module B\nContent there" }));
+
+    const gitignoreBContent = await fs.readFile(gitignoreBPath, "utf8");
+    expect(gitignoreBContent).toBe("*\n");
+
+    // result metadata
+    expect(result.written.sort()).toEqual([skillAPath, gitignoreAPath, skillBPath, gitignoreBPath].sort());
+    expect(result.empty).toBe(false);
+    expect(result.pruned).toEqual([]);
+    expect(result.skillNames).toEqual(["op-module-a", "op-module-b"]);
+    expect(result.emptyBodySkills).toEqual([]);
+  });
+
+  it("prunes stale op-module-* dirs not in the current lazy skill set", async () => {
+    makeDeps(tmpdir);
+    const mockLoadAndCompose = loadAndComposeWorkflow as ReturnType<typeof vi.fn>;
+    mockLoadAndCompose.mockResolvedValue({
+      composed: {
+        lazySkills: [{ id: "module-a", name: "op-module-a", description: "d", body: "body" }],
+        text: "",
+        orderedChunks: [],
+        perVarSourceMap: {},
+        sizeChars: 0,
+        diagnostics: [],
+      },
+    });
+
+    // Pre-create stale dir
+    const staleDir = path.join(tmpdir, ".claude", "skills", "op-module-stale");
+    await fs.mkdir(staleDir, { recursive: true });
+    await fs.writeFile(path.join(staleDir, "SKILL.md"), "stale content", "utf8");
+
+    const result = await emitLazySkills(
+      fakeApp,
+      { settings: fakeSettings as OpSettings, resolveIssue: () => fakeEntry },
+      { issueId: "OP-1", destDir: tmpdir },
+    );
+
+    // Stale dir should be gone
+    await expect(fs.stat(staleDir)).rejects.toThrow();
+    expect(result.pruned).toContain(staleDir);
+    // The new skill is still written
+    const skillAPath = path.join(tmpdir, ".claude", "skills", "op-module-a", "SKILL.md");
+    expect(await fs.readFile(skillAPath, "utf8")).toBeTruthy();
+  });
+
+  it("still writes SKILL.md for whitespace-body skills and reports them in emptyBodySkills", async () => {
+    makeDeps(tmpdir);
+    const mockLoadAndCompose = loadAndComposeWorkflow as ReturnType<typeof vi.fn>;
+    mockLoadAndCompose.mockResolvedValue({
+      composed: {
+        lazySkills: [{ id: "empty-skill", name: "op-module-empty-skill", description: "d", body: "  " }],
+        text: "",
+        orderedChunks: [],
+        perVarSourceMap: {},
+        sizeChars: 0,
+        diagnostics: [],
+      },
+    });
+
+    const result = await emitLazySkills(
+      fakeApp,
+      { settings: fakeSettings as OpSettings, resolveIssue: () => fakeEntry },
+      { issueId: "OP-1", destDir: tmpdir },
+    );
+
+    const skillPath = path.join(tmpdir, ".claude", "skills", "op-module-empty-skill", "SKILL.md");
+    // SKILL.md is still written even though body is whitespace
+    expect(await fs.readFile(skillPath, "utf8")).toBeTruthy();
+    // emptyBodySkills contains the skill's name
+    expect(result.emptyBodySkills).toContain("op-module-empty-skill");
+  });
+
+  it("throws 'no destination' when destDir is absent and repo_path is undefined", async () => {
+    const mockBuildIssueRenderContext = buildIssueRenderContext as ReturnType<typeof vi.fn>;
+    const mockReadProjectVars = readProjectVars as ReturnType<typeof vi.fn>;
+    // Return a context with no repo_path
+    mockBuildIssueRenderContext.mockReturnValue({
+      id: "OP-1",
+      title: "Test issue",
+      project: "testing",
+      status: "open",
+      parent: null,
+      vault_path: "/vault",
+      vault_name: "OP-Test",
+      today: "2026-05-15",
+      agent: "claude",
+      mode: "kickoff",
+      // repo_path intentionally absent
+    });
+    mockReadProjectVars.mockReturnValue({});
+    const mockLoadAndCompose = loadAndComposeWorkflow as ReturnType<typeof vi.fn>;
+    mockLoadAndCompose.mockResolvedValue({
+      composed: {
+        lazySkills: [],
+        text: "",
+        orderedChunks: [],
+        perVarSourceMap: {},
+        sizeChars: 0,
+        diagnostics: [],
+      },
+    });
+
+    await expect(
+      emitLazySkills(
+        fakeApp,
+        { settings: fakeSettings as OpSettings, resolveIssue: () => fakeEntry },
+        { issueId: "OP-1" /* no destDir */ },
+      ),
+    ).rejects.toThrow(/no destination/);
   });
 });

--- a/plugins/op-obsidian/src/emitLazySkills.test.ts
+++ b/plugins/op-obsidian/src/emitLazySkills.test.ts
@@ -285,4 +285,43 @@ describe("emitLazySkills IO (OP-192)", () => {
       ),
     ).rejects.toThrow(/no destination/);
   });
+
+  it("throws 'absolute path' when an explicit relative destDir is passed (URI route defense)", async () => {
+    const mockBuildIssueRenderContext = buildIssueRenderContext as ReturnType<typeof vi.fn>;
+    const mockReadProjectVars = readProjectVars as ReturnType<typeof vi.fn>;
+    // repo_path is undefined so the explicit destDir is the only source
+    mockBuildIssueRenderContext.mockReturnValue({
+      id: "OP-1",
+      title: "Test issue",
+      project: "testing",
+      status: "open",
+      parent: null,
+      vault_path: "/vault",
+      vault_name: "OP-Test",
+      today: "2026-05-15",
+      agent: "claude",
+      mode: "kickoff",
+      // repo_path intentionally absent
+    });
+    mockReadProjectVars.mockReturnValue({});
+    const mockLoadAndCompose = loadAndComposeWorkflow as ReturnType<typeof vi.fn>;
+    mockLoadAndCompose.mockResolvedValue({
+      composed: {
+        lazySkills: [],
+        text: "",
+        orderedChunks: [],
+        perVarSourceMap: {},
+        sizeChars: 0,
+        diagnostics: [],
+      },
+    });
+
+    await expect(
+      emitLazySkills(
+        fakeApp,
+        { settings: fakeSettings as OpSettings, resolveIssue: () => fakeEntry },
+        { issueId: "OP-1", destDir: "relative/path" },
+      ),
+    ).rejects.toThrow(/absolute path/);
+  });
 });

--- a/plugins/op-obsidian/src/emitLazySkills.test.ts
+++ b/plugins/op-obsidian/src/emitLazySkills.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect, vi } from "vitest";
+
+// Stub obsidian and the IO-layer imports that pull in Obsidian runtime classes.
+// This test only exercises the pure `planSkillEmission` function; the IO half
+// (`emitLazySkills`) is not invoked here, but vitest loads the whole module.
+vi.mock("obsidian", () => ({
+  App: class {},
+  TFile: class { path = ""; basename = ""; name = ""; },
+  TFolder: class {},
+  Modal: class {},
+  FuzzySuggestModal: class {},
+  SuggestModal: class {},
+  Notice: class {},
+  Setting: class {},
+  ItemView: class {},
+  WorkspaceLeaf: class {},
+  MarkdownView: class {},
+  Component: class {},
+  Menu: class {},
+  Platform: { isDesktop: true },
+  normalizePath: (p: string) => p,
+  parseYaml: (s: string) => s,
+  setIcon: () => {},
+  setTooltip: () => {},
+  prepareFuzzySearch: () => () => null,
+}));
+
+import { planSkillEmission } from "./emitLazySkills";
+
+describe("planSkillEmission (OP-192)", () => {
+  const lazy = [
+    { id: "tmux", name: "op-module-tmux", description: "d", body: "B1" },
+    { id: "git", name: "op-module-git", description: "d", body: "B2" },
+  ];
+
+  it("plans a SKILL.md + self-ignoring .gitignore per lazy skill", () => {
+    const plan = planSkillEmission({ destDir: "/wt", lazySkills: lazy, existingOpModuleDirs: [] });
+    expect(plan.writes).toEqual([
+      { path: "/wt/.claude/skills/op-module-tmux/SKILL.md", kind: "skill", skill: lazy[0] },
+      { path: "/wt/.claude/skills/op-module-tmux/.gitignore", kind: "gitignore" },
+      { path: "/wt/.claude/skills/op-module-git/SKILL.md", kind: "skill", skill: lazy[1] },
+      { path: "/wt/.claude/skills/op-module-git/.gitignore", kind: "gitignore" },
+    ]);
+    expect(plan.prunes).toEqual([]);
+  });
+
+  it("prunes orphaned op-module-* dirs not in the current set", () => {
+    const plan = planSkillEmission({
+      destDir: "/wt", lazySkills: [lazy[0]],
+      existingOpModuleDirs: ["op-module-tmux", "op-module-stale"],
+    });
+    expect(plan.prunes).toEqual(["/wt/.claude/skills/op-module-stale"]);
+  });
+
+  it("prunes ALL op-module-* dirs when there are no lazy skills", () => {
+    const plan = planSkillEmission({
+      destDir: "/wt", lazySkills: [], existingOpModuleDirs: ["op-module-tmux"],
+    });
+    expect(plan.writes).toEqual([]);
+    expect(plan.prunes).toEqual(["/wt/.claude/skills/op-module-tmux"]);
+  });
+});

--- a/plugins/op-obsidian/src/emitLazySkills.ts
+++ b/plugins/op-obsidian/src/emitLazySkills.ts
@@ -87,6 +87,11 @@ export async function emitLazySkills(
       `op-emit-lazy-skills: no destination — issue ${args.issueId}'s project has no repo path; pass dir="$(pwd)" from inside your working directory.`,
     );
   }
+  if (!path.isAbsolute(destDir)) {
+    throw new Error(
+      `op-emit-lazy-skills: destination must be an absolute path (got ${JSON.stringify(destDir)}); pass dir="$(pwd)" from inside your working directory.`,
+    );
+  }
 
   const skillsRoot = path.join(destDir, ".claude", "skills");
   let existing: string[] = [];

--- a/plugins/op-obsidian/src/emitLazySkills.ts
+++ b/plugins/op-obsidian/src/emitLazySkills.ts
@@ -3,18 +3,14 @@ import path from "path";
 import { App } from "obsidian";
 import type { IssueEntry } from "./types";
 import type { OpSettings } from "./settings";
-import { resolveProfile } from "./openAgent";
-import { AGENT_IDS, type AgentId } from "./agentProfiles";
 import { loadAndComposeWorkflow } from "./composeWorkflow";
-import { buildIssueRenderContext, readProjectVars } from "./explainWorkflow";
+import { buildIssueRenderContext, readProjectVars, resolveProfileById } from "./explainWorkflow";
 import { renderSkillMd } from "./lazySkillPure";
 import type { LazySkill } from "./composeWorkflowPure";
 
-export interface SkillWrite {
-  path: string;
-  kind: "skill" | "gitignore";
-  skill?: LazySkill;
-}
+export type SkillWrite =
+  | { path: string; kind: "skill"; skill: LazySkill }
+  | { path: string; kind: "gitignore" };
 export interface EmissionPlan {
   writes: SkillWrite[];
   prunes: string[];
@@ -67,11 +63,7 @@ export async function emitLazySkills(
   if (!project) {
     throw new Error(`op-emit-lazy-skills: issue ${args.issueId} has no project`);
   }
-  const agentRaw = entry.agent ?? deps.settings.defaultAgent;
-  const agentId = (AGENT_IDS as readonly string[]).includes(agentRaw)
-    ? (agentRaw as AgentId)
-    : deps.settings.defaultAgent;
-  const profile = resolveProfile(deps.settings, agentId);
+  const profile = resolveProfileById(deps.settings, entry.agent ?? deps.settings.defaultAgent);
   const renderContext = buildIssueRenderContext(app, deps.settings, entry, profile, "kickoff");
   const projectVars = readProjectVars(app, project);
 
@@ -118,7 +110,7 @@ export async function emitLazySkills(
     } else {
       await fs.writeFile(
         w.path,
-        renderSkillMd({ name: w.skill!.name, description: w.skill!.description, body: w.skill!.body }),
+        renderSkillMd({ name: w.skill.name, description: w.skill.description, body: w.skill.body }),
         "utf8",
       );
     }

--- a/plugins/op-obsidian/src/emitLazySkills.ts
+++ b/plugins/op-obsidian/src/emitLazySkills.ts
@@ -1,5 +1,5 @@
 import { promises as fs } from "fs";
-import path from "path";
+import * as path from "path";
 import { App } from "obsidian";
 import type { IssueEntry } from "./types";
 import type { OpSettings } from "./settings";

--- a/plugins/op-obsidian/src/emitLazySkills.ts
+++ b/plugins/op-obsidian/src/emitLazySkills.ts
@@ -1,0 +1,142 @@
+import { promises as fs } from "fs";
+import path from "path";
+import { App } from "obsidian";
+import type { IssueEntry } from "./types";
+import type { OpSettings } from "./settings";
+import { resolveProfile } from "./openAgent";
+import { AGENT_IDS, type AgentId } from "./agentProfiles";
+import { loadAndComposeWorkflow } from "./composeWorkflow";
+import { buildIssueRenderContext, readProjectVars } from "./explainWorkflow";
+import { renderSkillMd } from "./lazySkillPure";
+import type { LazySkill } from "./composeWorkflowPure";
+
+export interface SkillWrite {
+  path: string;
+  kind: "skill" | "gitignore";
+  skill?: LazySkill;
+}
+export interface EmissionPlan {
+  writes: SkillWrite[];
+  prunes: string[];
+}
+
+/** Pure: decide which files to write and which `op-module-*` dirs to prune. */
+export function planSkillEmission(args: {
+  destDir: string;
+  lazySkills: LazySkill[];
+  existingOpModuleDirs: string[];
+}): EmissionPlan {
+  const skillsRoot = path.join(args.destDir, ".claude", "skills");
+  const keep = new Set(args.lazySkills.map((s) => s.name));
+  const writes: SkillWrite[] = [];
+  for (const s of args.lazySkills) {
+    const dir = path.join(skillsRoot, s.name);
+    writes.push({ path: path.join(dir, "SKILL.md"), kind: "skill", skill: s });
+    writes.push({ path: path.join(dir, ".gitignore"), kind: "gitignore" });
+  }
+  const prunes = args.existingOpModuleDirs
+    .filter((d) => d.startsWith("op-module-") && !keep.has(d))
+    .map((d) => path.join(skillsRoot, d));
+  return { writes, prunes };
+}
+
+export interface EmitLazySkillsDeps {
+  settings: OpSettings;
+  resolveIssue: (id: string) => IssueEntry;
+}
+export interface EmitLazySkillsResult {
+  issueId: string;
+  project: string;
+  destDir: string;
+  written: string[];
+  pruned: string[];
+  skillNames: string[];
+  empty: boolean;
+  /** OP-192 review M1: lazy modules whose rendered body was empty/whitespace —
+   *  emitted anyway but surfaced so the caller can warn. */
+  emptyBodySkills: string[];
+}
+
+export async function emitLazySkills(
+  app: App,
+  deps: EmitLazySkillsDeps,
+  args: { issueId: string; destDir?: string },
+): Promise<EmitLazySkillsResult> {
+  const entry = deps.resolveIssue(args.issueId);
+  const project = entry.project;
+  if (!project) {
+    throw new Error(`op-emit-lazy-skills: issue ${args.issueId} has no project`);
+  }
+  const agentRaw = entry.agent ?? deps.settings.defaultAgent;
+  const agentId = (AGENT_IDS as readonly string[]).includes(agentRaw)
+    ? (agentRaw as AgentId)
+    : deps.settings.defaultAgent;
+  const profile = resolveProfile(deps.settings, agentId);
+  const renderContext = buildIssueRenderContext(app, deps.settings, entry, profile, "kickoff");
+  const projectVars = readProjectVars(app, project);
+
+  const { composed } = await loadAndComposeWorkflow(app, {
+    project,
+    step: "kickoff",
+    ctx: {
+      render: renderContext,
+      globalVars: deps.settings.workflowVars ?? {},
+      projectVars,
+      launchVars: {},
+      maxWorkflowChars: deps.settings.injection.maxWorkflowChars,
+    },
+  });
+
+  const lazySkills: LazySkill[] = composed?.lazySkills ?? [];
+  const destDir =
+    (args.destDir && args.destDir.trim()) || renderContext.repo_path || "";
+  if (!destDir) {
+    throw new Error(
+      `op-emit-lazy-skills: no destination — issue ${args.issueId}'s project has no repo path; pass dir="$(pwd)" from inside your working directory.`,
+    );
+  }
+
+  const skillsRoot = path.join(destDir, ".claude", "skills");
+  let existing: string[] = [];
+  try {
+    existing = (await fs.readdir(skillsRoot, { withFileTypes: true }))
+      .filter((e) => e.isDirectory())
+      .map((e) => e.name);
+  } catch {
+    existing = [];
+  }
+
+  const plan = planSkillEmission({ destDir, lazySkills, existingOpModuleDirs: existing });
+  for (const p of plan.prunes) {
+    await fs.rm(p, { recursive: true, force: true });
+  }
+  const written: string[] = [];
+  for (const w of plan.writes) {
+    await fs.mkdir(path.dirname(w.path), { recursive: true });
+    if (w.kind === "gitignore") {
+      await fs.writeFile(w.path, "*\n", "utf8");
+    } else {
+      await fs.writeFile(
+        w.path,
+        renderSkillMd({ name: w.skill!.name, description: w.skill!.description, body: w.skill!.body }),
+        "utf8",
+      );
+    }
+    written.push(w.path);
+  }
+
+  const emptyBodySkills = lazySkills
+    .filter((s) => s.body.trim().length === 0)
+    .map((s) => s.name);
+
+  return {
+    issueId: args.issueId,
+    project,
+    destDir,
+    written,
+    pruned: plan.prunes,
+    skillNames: lazySkills.map((s) => s.name),
+    empty: lazySkills.length === 0,
+    emptyBodySkills,
+  };
+}

--- a/plugins/op-obsidian/src/explainWorkflow.ts
+++ b/plugins/op-obsidian/src/explainWorkflow.ts
@@ -141,7 +141,7 @@ export async function listVars(
   return buildListVarsPayload(renderContext);
 }
 
-function resolveProfileById(settings: OpSettings, raw: string): AgentProfile {
+export function resolveProfileById(settings: OpSettings, raw: string): AgentProfile {
   const id = (AGENT_IDS as readonly string[]).includes(raw)
     ? (raw as AgentId)
     : settings.defaultAgent;

--- a/plugins/op-obsidian/src/explainWorkflow.ts
+++ b/plugins/op-obsidian/src/explainWorkflow.ts
@@ -91,6 +91,7 @@ export async function explainWorkflow(
       composed: {
         text: "",
         orderedChunks: [],
+        lazySkills: [],
         perVarSourceMap: {},
         sizeChars: 0,
         diagnostics: [...agentDiags, ...bundle.diagnostics],

--- a/plugins/op-obsidian/src/lazySkillPure.test.ts
+++ b/plugins/op-obsidian/src/lazySkillPure.test.ts
@@ -16,6 +16,12 @@ describe("slugifySkillName (OP-192)", () => {
     expect(/^[a-z0-9-]+$/.test(out)).toBe(true);
     expect(out.endsWith("-")).toBe(false);
   });
+  it("doesn't end in a dash when truncation cuts at a replaced char", () => {
+    const out = slugifySkillName("a".repeat(53) + "!!!more");
+    expect(out.length).toBeLessThanOrEqual(64);
+    expect(out.endsWith("-")).toBe(false);
+    expect(/^[a-z0-9-]+$/.test(out)).toBe(true);
+  });
 });
 
 describe("renderSkillMd (OP-192)", () => {

--- a/plugins/op-obsidian/src/lazySkillPure.test.ts
+++ b/plugins/op-obsidian/src/lazySkillPure.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect } from "vitest";
+import { slugifySkillName, renderSkillMd } from "./lazySkillPure";
+
+describe("slugifySkillName (OP-192)", () => {
+  it("prefixes op-module- and lowercases", () => {
+    expect(slugifySkillName("Tmux-Gotchas")).toBe("op-module-tmux-gotchas");
+  });
+  it("replaces invalid chars and collapses dashes", () => {
+    expect(slugifySkillName("a b/c__d")).toBe("op-module-a-b-c-d");
+  });
+  it("trims leading/trailing dashes and caps at 64 chars", () => {
+    const long = "x".repeat(100);
+    const out = slugifySkillName(long);
+    expect(out.length).toBeLessThanOrEqual(64);
+    expect(out.startsWith("op-module-")).toBe(true);
+    expect(/^[a-z0-9-]+$/.test(out)).toBe(true);
+    expect(out.endsWith("-")).toBe(false);
+  });
+});
+
+describe("renderSkillMd (OP-192)", () => {
+  it("emits valid YAML frontmatter + body", () => {
+    const md = renderSkillMd({ name: "op-module-tmux", description: "tmux gotchas", body: "Body here" });
+    expect(md).toBe(
+      "---\nname: op-module-tmux\ndescription: \"tmux gotchas\"\n---\n\nBody here\n",
+    );
+  });
+  it("YAML-escapes a description containing quotes, colons, and newlines", () => {
+    const md = renderSkillMd({
+      name: "op-module-x",
+      description: 'has: a "quote" and\nnewline',
+      body: "B",
+    });
+    const fm = md.split("---")[1];
+    expect(fm).toContain('description: "has: a \\"quote\\" and\\nnewline"');
+    expect(md.endsWith("B\n")).toBe(true);
+  });
+});

--- a/plugins/op-obsidian/src/lazySkillPure.ts
+++ b/plugins/op-obsidian/src/lazySkillPure.ts
@@ -1,0 +1,38 @@
+// OP-192: pure helpers for emitting `lazy: true` workflow modules as Claude
+// Code skills. No I/O — `emitLazySkills.ts` owns filesystem writes.
+
+/**
+ * Derive a Claude-Code-valid skill name from a module id. Claude Code skill
+ * names: lowercase letters, digits, hyphens only; max 64 chars. The
+ * `op-module-` prefix namespaces emitted skills away from the canonical `op`
+ * skill so the agent's skill list is unambiguous.
+ */
+export function slugifySkillName(id: string): string {
+  const slug = `op-module-${id}`
+    .toLowerCase()
+    .replace(/[^a-z0-9-]+/g, "-")
+    .replace(/-+/g, "-")
+    .replace(/^-+|-+$/g, "");
+  return slug.slice(0, 64).replace(/-+$/g, "");
+}
+
+export interface RenderSkillMdArgs {
+  name: string;
+  description: string;
+  body: string;
+}
+
+/**
+ * Render a SKILL.md document. `description` is emitted as a YAML double-quoted
+ * scalar with `\`, `"`, and newlines escaped so an arbitrary one-liner can
+ * never corrupt the frontmatter. Body is appended verbatim with a single
+ * trailing newline.
+ */
+export function renderSkillMd(args: RenderSkillMdArgs): string {
+  const desc = args.description
+    .replace(/\\/g, "\\\\")
+    .replace(/"/g, '\\"')
+    .replace(/\n/g, "\\n");
+  const body = args.body.replace(/\n+$/, "");
+  return `---\nname: ${args.name}\ndescription: "${desc}"\n---\n\n${body}\n`;
+}

--- a/plugins/op-obsidian/src/lazySkillPure.ts
+++ b/plugins/op-obsidian/src/lazySkillPure.ts
@@ -23,16 +23,14 @@ export interface RenderSkillMdArgs {
 }
 
 /**
- * Render a SKILL.md document. `description` is emitted as a YAML double-quoted
- * scalar with `\`, `"`, and newlines escaped so an arbitrary one-liner can
- * never corrupt the frontmatter. Body is appended verbatim with a single
- * trailing newline.
+ * Render a SKILL.md document. `description` is emitted as a JSON/YAML
+ * double-quoted scalar via `JSON.stringify` so any control character
+ * (newlines, CR, tabs, NUL, and others) is safely escaped and the frontmatter
+ * can never be corrupted. Body is appended verbatim with a single trailing
+ * newline.
  */
 export function renderSkillMd(args: RenderSkillMdArgs): string {
-  const desc = args.description
-    .replace(/\\/g, "\\\\")
-    .replace(/"/g, '\\"')
-    .replace(/\n/g, "\\n");
+  const desc = JSON.stringify(args.description).slice(1, -1);
   const body = args.body.replace(/\n+$/, "");
   return `---\nname: ${args.name}\ndescription: "${desc}"\n---\n\n${body}\n`;
 }

--- a/plugins/op-obsidian/src/main.ts
+++ b/plugins/op-obsidian/src/main.ts
@@ -109,6 +109,7 @@ import {
   handleOpGetSkillUri as handleOpGetSkillUriPure,
   handleOpExplainWorkflowUri as handleOpExplainWorkflowUriPure,
   handleOpListVarsUri as handleOpListVarsUriPure,
+  handleOpEmitLazySkillsUri as handleOpEmitLazySkillsUriPure,
   handleOpWorkflowUri as handleOpWorkflowUriPure,
   type UriHandlerDeps,
 } from "./uriHandlers";
@@ -141,8 +142,10 @@ import {
   parseDocEditParams,
   parseFlushVaultHistoryParams,
   parseWorkflowParams,
+  parseEmitLazySkillsParams,
 } from "./cliHandlers";
 import { explainWorkflow, getProjectWorkflow, listVars } from "./explainWorkflow";
+import { emitLazySkills } from "./emitLazySkills";
 import {
   summarizeExplainPayload,
 } from "./explainWorkflowPure";
@@ -1184,6 +1187,12 @@ export default class OpPlugin extends Plugin {
       );
     });
 
+    this.registerObsidianProtocolHandler("op-emit-lazy-skills", (params) => {
+      this.runUri("op-emit-lazy-skills", normalizeUriParams(params), (p) =>
+        handleOpEmitLazySkillsUriPure(this.uriDeps(), p),
+      );
+    });
+
     this.registerObsidianProtocolHandler("op-edit-module", (params) => {
       this.runUri("op-edit-module", normalizeUriParams(params), (p) =>
         this.handleOpEditModuleUri(p),
@@ -1525,6 +1534,19 @@ export default class OpPlugin extends Plugin {
         },
       },
       (params) => this.handleOpListVarsCli(params),
+    );
+
+    this.registerCliHandler(
+      "op-emit-lazy-skills",
+      "Materialize this issue's lazy: true workflow modules as on-demand Claude Code skills under <dir>/.claude/skills/. Run from inside your working directory.",
+      {
+        issue: { value: "<id>", description: "Issue id (e.g. OP-34)" },
+        dir: {
+          value: "<abs-path>",
+          description: 'Absolute path of your working directory. Pass dir="$(pwd)" from inside your worktree. Defaults to the project repo path.',
+        },
+      },
+      (params) => this.handleOpEmitLazySkillsCli(params),
     );
 
     this.registerCliHandler(
@@ -2626,6 +2648,12 @@ export default class OpPlugin extends Plugin {
         ),
       listVars: (args) =>
         listVars(
+          this.app,
+          { settings: this.settings, resolveIssue: (id) => this.resolveByIdOrThrow(id) },
+          args,
+        ),
+      emitLazySkills: (args) =>
+        emitLazySkills(
           this.app,
           { settings: this.settings, resolveIssue: (id) => this.resolveByIdOrThrow(id) },
           args,
@@ -4063,6 +4091,33 @@ export default class OpPlugin extends Plugin {
       );
       await writeUriResponse(this.app, { ok: true, command, ...payload });
       return summarizeListVarsPayload(payload);
+    } catch (err: any) {
+      const msg = err?.message ?? String(err);
+      console.error("[op-obsidian]", command, err);
+      await writeUriResponse(this.app, { ok: false, command, error: msg });
+      return `${command} failed: ${msg}`;
+    }
+  }
+
+  private async handleOpEmitLazySkillsCli(params: Record<string, string>): Promise<string> {
+    const command = "op-emit-lazy-skills";
+    try {
+      const parsed = parseEmitLazySkillsParams(params);
+      if (!parsed.ok) return parsed.error;
+      const args: { issueId: string; destDir?: string } = { issueId: parsed.value.issueId };
+      if (parsed.value.destDir !== undefined) args.destDir = parsed.value.destDir;
+      const payload = await emitLazySkills(
+        this.app,
+        { settings: this.settings, resolveIssue: (i) => this.resolveByIdOrThrow(i) },
+        args,
+      );
+      await writeUriResponse(this.app, { ok: true, command, ...payload });
+      const warn = payload.emptyBodySkills.length > 0
+        ? ` (warning: ${payload.emptyBodySkills.length} skill(s) had an empty rendered body: ${payload.emptyBodySkills.join(", ")})`
+        : "";
+      return payload.empty
+        ? `${command}: ${payload.issueId} — no lazy modules; nothing to emit`
+        : `${command}: ${payload.issueId} → wrote ${payload.skillNames.length} skill(s) to ${payload.destDir}/.claude/skills/ (pruned ${payload.pruned.length})${warn}`;
     } catch (err: any) {
       const msg = err?.message ?? String(err);
       console.error("[op-obsidian]", command, err);

--- a/plugins/op-obsidian/src/main.ts
+++ b/plugins/op-obsidian/src/main.ts
@@ -1538,7 +1538,7 @@ export default class OpPlugin extends Plugin {
 
     this.registerCliHandler(
       "op-emit-lazy-skills",
-      "Materialize this issue's lazy: true workflow modules as on-demand Claude Code skills under <dir>/.claude/skills/. Run from inside your working directory.",
+      "Materialize this issue's lazy: true workflow modules as on-demand Claude Code skills under <dir>/.claude/skills/. <dir> defaults to the project's configured repo path; pass dir=\"$(pwd)\" to target your current worktree.",
       {
         issue: { value: "<id>", description: "Issue id (e.g. OP-34)" },
         dir: {
@@ -4115,9 +4115,10 @@ export default class OpPlugin extends Plugin {
       const warn = payload.emptyBodySkills.length > 0
         ? ` (warning: ${payload.emptyBodySkills.length} skill(s) had an empty rendered body: ${payload.emptyBodySkills.join(", ")})`
         : "";
+      const prunedClause = payload.pruned.length > 0 ? ` (pruned ${payload.pruned.length})` : "";
       return payload.empty
-        ? `${command}: ${payload.issueId} — no lazy modules; nothing to emit`
-        : `${command}: ${payload.issueId} → wrote ${payload.skillNames.length} skill(s) to ${payload.destDir}/.claude/skills/ (pruned ${payload.pruned.length})${warn}`;
+        ? `${command}: ${payload.issueId} — no lazy modules; nothing to emit${warn}`
+        : `${command}: ${payload.issueId} → wrote ${payload.skillNames.length} skill(s) to ${payload.destDir}/.claude/skills/${prunedClause}${warn}`;
     } catch (err: any) {
       const msg = err?.message ?? String(err);
       console.error("[op-obsidian]", command, err);

--- a/plugins/op-obsidian/src/openAgent.ts
+++ b/plugins/op-obsidian/src/openAgent.ts
@@ -24,10 +24,7 @@ import { renderTemplate } from "./renderTemplate";
 import { currentProjectsRoot, statusPathFor } from "./projectPaths";
 import { resolveWorkingDir } from "./workingDir";
 import { launchInTerminal } from "./terminalLaunch";
-import { buildRenderContext } from "./pluginVarRegistry";
-import { renderTemplate } from "./renderTemplate";
 import { colorRegistry } from "./colorRegistry";
-import { dispatchPostLaunch } from "./postLaunchDispatch";
 import {
   refreshAgentDetection,
   type AgentDetector,

--- a/plugins/op-obsidian/src/previewWorkflowModal.ts
+++ b/plugins/op-obsidian/src/previewWorkflowModal.ts
@@ -225,6 +225,7 @@ export class PreviewWorkflowModal extends Modal {
         : {
             text: "",
             orderedChunks: [],
+            lazySkills: [],
             perVarSourceMap: {},
             sizeChars: 0,
             diagnostics: bundle.diagnostics,

--- a/plugins/op-obsidian/src/promptBuild.test.ts
+++ b/plugins/op-obsidian/src/promptBuild.test.ts
@@ -936,6 +936,93 @@ describe("composeWorkflowSection — OP-199 (2b)", () => {
   });
 });
 
+describe("composeWorkflowSection lazy skills (OP-192)", () => {
+  // Shared workflow + module fixture: one inline module ("Inline") and one lazy
+  // module ("tmux"). The lazy module has `lazy: true` and a `description`.
+  function lazyFiles(): FakeFile[] {
+    return [
+      {
+        path: "Projects/demo/WORKFLOW.md",
+        frontmatter: {
+          type: "workflow",
+          schema: 1,
+          project: "demo",
+          default_agent: "claude",
+          default_model: "opus",
+          steps: [{ step: "kickoff", modules: ["inline-mod", "tmux"] }],
+        },
+        raw: "---\n# yaml omitted\n---\n",
+      },
+      {
+        path: "Projects/_op-modules/inline-mod.md",
+        frontmatter: {
+          id: "inline-mod",
+          title: "Inline",
+          type: "workflow-module",
+          scope: "kickoff",
+          vars: [],
+        },
+        raw: "---\n# yaml omitted\n---\nInline\n",
+      },
+      {
+        path: "Projects/_op-modules/tmux.md",
+        frontmatter: {
+          id: "tmux",
+          title: "op-module-tmux",
+          type: "workflow-module",
+          scope: "kickoff",
+          lazy: true,
+          description: "d",
+          vars: [],
+        },
+        raw: "---\n# yaml omitted\n---\nLAZY BODY\n",
+      },
+    ];
+  }
+
+  it("Case A: repoPath set → pointer block emitted; lazy body NOT inlined", async () => {
+    const app = fakeApp(lazyFiles());
+    const section = await composeWorkflowSection(app, {
+      entry: entry(),
+      profile: profile(),
+      injection: injection(),
+      vaultBasePath: "/Users/me/vault",
+      workflowMode: "modules",
+      workflowStep: "kickoff",
+      repoPath: "/wt",
+    });
+    // Inline module content must be present.
+    expect(section).toContain("Inline");
+    // Lazy body must NOT be inlined.
+    expect(section).not.toContain("LAZY BODY");
+    // Pointer block must reference the CLI command.
+    expect(section).toContain("op-emit-lazy-skills");
+    // Pointer block must include the dir=$(pwd) snippet.
+    expect(section).toContain('dir="$(pwd)"');
+    // Pointer block must include the issue id.
+    expect(section).toContain("issue=OP-1");
+  });
+
+  it("Case B: repoPath undefined → lazy body inlined with no-working-directory note", async () => {
+    const app = fakeApp(lazyFiles());
+    const section = await composeWorkflowSection(app, {
+      entry: entry(),
+      profile: profile(),
+      injection: injection(),
+      vaultBasePath: "/Users/me/vault",
+      workflowMode: "modules",
+      workflowStep: "kickoff",
+      // repoPath deliberately omitted (meta-only)
+    });
+    // Lazy body must be present (inlined fallback).
+    expect(section).toContain("LAZY BODY");
+    // Heading for the inlined-because-no-working-dir block.
+    expect(section).toContain("## Optional reference");
+    // Inline module content must still be present.
+    expect(section).toContain("Inline");
+  });
+});
+
 describe("composeWorkflowSection — OP-199 (2b) repoPath undefined (#10)", () => {
   it.each([
     ["evaluate"],

--- a/plugins/op-obsidian/src/promptBuild.test.ts
+++ b/plugins/op-obsidian/src/promptBuild.test.ts
@@ -999,8 +999,12 @@ describe("composeWorkflowSection lazy skills (OP-192)", () => {
     expect(section).toContain("op-emit-lazy-skills");
     // Pointer block must include the dir=$(pwd) snippet.
     expect(section).toContain('dir="$(pwd)"');
-    // Pointer block must include the issue id.
-    expect(section).toContain("issue=OP-1");
+    // Pointer block must include the quoted issue id (M4).
+    expect(section).toContain('issue="OP-1"');
+    // Pointer block must use the canonical heading (M2 consistency).
+    expect(section).toContain("## Optional reference skills");
+    // Pointer block must use the softened wording (M1).
+    expect(section).toContain("typically reference-only");
   });
 
   it("Case B: repoPath undefined → lazy body inlined with no-working-directory note", async () => {
@@ -1016,10 +1020,167 @@ describe("composeWorkflowSection lazy skills (OP-192)", () => {
     });
     // Lazy body must be present (inlined fallback).
     expect(section).toContain("LAZY BODY");
-    // Heading for the inlined-because-no-working-dir block.
-    expect(section).toContain("## Optional reference");
+    // Heading for the inlined-because-no-working-dir block (M2 exact heading).
+    expect(section).toContain("## Optional reference skills (inlined — no working directory)");
     // Inline module content must still be present.
     expect(section).toContain("Inline");
+  });
+
+  it("Case C — multiple lazy skills, meta-only, joined with blank line between bodies", async () => {
+    // Two lazy skills — verify both bodies appear and are separated by \n\n.
+    const files: FakeFile[] = [
+      {
+        path: "Projects/demo/WORKFLOW.md",
+        frontmatter: {
+          type: "workflow",
+          schema: 1,
+          project: "demo",
+          default_agent: "claude",
+          default_model: "opus",
+          steps: [{ step: "kickoff", modules: ["mod-a", "mod-b"] }],
+        },
+        raw: "---\n# yaml omitted\n---\n",
+      },
+      {
+        path: "Projects/_op-modules/mod-a.md",
+        frontmatter: {
+          id: "mod-a",
+          title: "op-module-a",
+          type: "workflow-module",
+          scope: "kickoff",
+          lazy: true,
+          description: "d",
+          vars: [],
+        },
+        raw: "---\n# yaml omitted\n---\nBODY A\n",
+      },
+      {
+        path: "Projects/_op-modules/mod-b.md",
+        frontmatter: {
+          id: "mod-b",
+          title: "op-module-b",
+          type: "workflow-module",
+          scope: "kickoff",
+          lazy: true,
+          description: "d",
+          vars: [],
+        },
+        raw: "---\n# yaml omitted\n---\nBODY B\n",
+      },
+    ];
+    const app = fakeApp(files);
+    const section = await composeWorkflowSection(app, {
+      entry: entry(),
+      profile: profile(),
+      injection: injection(),
+      vaultBasePath: "/Users/me/vault",
+      workflowMode: "modules",
+      workflowStep: "kickoff",
+      // repoPath omitted — meta-only, so inline fallback is used
+    });
+    // Both headings and bodies present.
+    // name = slugifySkillName(id) = op-module-<id>, so "mod-a" → "op-module-mod-a".
+    expect(section).toContain("### op-module-mod-a");
+    expect(section).toContain("BODY A");
+    expect(section).toContain("### op-module-mod-b");
+    expect(section).toContain("BODY B");
+    // Blank-line join between the two skill sections (guards against .join("\n") regression).
+    expect(section).toContain("BODY A\n\n### op-module-mod-b");
+  });
+
+  it("Case D — empty-body lazy skill omitted from inline (I2)", async () => {
+    // Lazy skill with whitespace-only body must be filtered out.
+    const files: FakeFile[] = [
+      {
+        path: "Projects/demo/WORKFLOW.md",
+        frontmatter: {
+          type: "workflow",
+          schema: 1,
+          project: "demo",
+          default_agent: "claude",
+          default_model: "opus",
+          steps: [{ step: "kickoff", modules: ["mod-e"] }],
+        },
+        raw: "---\n# yaml omitted\n---\n",
+      },
+      {
+        path: "Projects/_op-modules/mod-e.md",
+        frontmatter: {
+          id: "mod-e",
+          title: "op-module-e",
+          type: "workflow-module",
+          scope: "kickoff",
+          lazy: true,
+          description: "d",
+          vars: [],
+        },
+        // Body is whitespace-only — after trimEnd/filter it is dropped.
+        raw: "---\n# yaml omitted\n---\n   \n",
+      },
+    ];
+    const app = fakeApp(files);
+    const section = await composeWorkflowSection(app, {
+      entry: entry(),
+      profile: profile(),
+      injection: injection(),
+      vaultBasePath: "/Users/me/vault",
+      workflowMode: "modules",
+      workflowStep: "kickoff",
+      // repoPath omitted — meta-only
+    });
+    // Empty-body skill must not produce a heading.
+    // name = slugifySkillName("mod-e") = "op-module-mod-e".
+    expect(section).not.toContain("### op-module-mod-e");
+    // With no usable lazy body and no workflow text, the section is empty.
+    expect(section).toBe("");
+  });
+
+  it("Case E — text empty + one usable lazy skill returns lazy section alone (no Project workflow heading)", async () => {
+    // Workflow step produces no text (empty step), but there is a lazy skill
+    // with repoPath set → pointer block should be returned without the
+    // "## Project workflow" heading.
+    const files: FakeFile[] = [
+      {
+        path: "Projects/demo/WORKFLOW.md",
+        frontmatter: {
+          type: "workflow",
+          schema: 1,
+          project: "demo",
+          default_agent: "claude",
+          default_model: "opus",
+          steps: [{ step: "kickoff", modules: ["mod-lazy-only"] }],
+        },
+        raw: "---\n# yaml omitted\n---\n",
+      },
+      {
+        path: "Projects/_op-modules/mod-lazy-only.md",
+        frontmatter: {
+          id: "mod-lazy-only",
+          title: "op-module-lazy-only",
+          type: "workflow-module",
+          scope: "kickoff",
+          lazy: true,
+          description: "d",
+          vars: [],
+        },
+        raw: "---\n# yaml omitted\n---\nLAZY ONLY BODY\n",
+      },
+    ];
+    const app = fakeApp(files);
+    const section = await composeWorkflowSection(app, {
+      entry: entry(),
+      profile: profile(),
+      injection: injection(),
+      vaultBasePath: "/Users/me/vault",
+      workflowMode: "modules",
+      workflowStep: "kickoff",
+      repoPath: "/wt",
+    });
+    // Must NOT contain the main workflow heading (text was empty).
+    expect(section).not.toContain("## Project workflow");
+    // Must contain the pointer block heading and CLI command.
+    expect(section).toContain("## Optional reference skills");
+    expect(section).toContain("op-emit-lazy-skills");
   });
 });
 

--- a/plugins/op-obsidian/src/promptBuild.ts
+++ b/plugins/op-obsidian/src/promptBuild.ts
@@ -231,11 +231,41 @@ export async function composeWorkflowSection(
   }
 
   const text = composed.text.trim();
+  const lazy = composed.lazySkills ?? [];
+
+  // OP-192: build the lazy-skills section.
+  let lazySection = "";
+  if (lazy.length > 0) {
+    if (args.repoPath) {
+      // Issue has a working directory — emit a pointer block so the agent can
+      // materialise the skills on demand without bloating the launch prompt.
+      const names = lazy.map((s) => s.name).join(", ");
+      lazySection =
+        `## Optional reference skills\n\n` +
+        `This issue has ${lazy.length} optional reference module(s) (${names}) available as on-demand skills. ` +
+        `From inside your working directory (after creating your worktree) run:\n\n` +
+        "```bash\n" +
+        `obsidian op-emit-lazy-skills issue=${entry.id} dir="$(pwd)"\n` +
+        "```\n\n" +
+        `Then activate the relevant one via the Skill tool when needed. Skipping this is safe — they are reference-only.`;
+    } else {
+      // Meta-only project (no repo path) — inline the lazy bodies so the
+      // content is never lost (there is no working directory to run the CLI in).
+      lazySection =
+        `## Optional reference (no working directory — inlined)\n\n` +
+        lazy.map((s) => `### ${s.name}\n\n${s.body}`).join("\n\n");
+    }
+  }
+
   // Non-null but empty: WORKFLOW.md exists, requested step exists, but the
-  // step produced nothing (e.g. `modules: []`). Return "" so the caller
-  // suppresses the section without injecting legacy content.
-  if (!text) return "";
-  return `## Project workflow\n\n${text}`;
+  // step produced nothing (e.g. `modules: []`). Return "" (or lazySection if
+  // there is one) so the caller suppresses the main section without injecting
+  // legacy content.
+  if (!text) {
+    return lazySection ? lazySection : "";
+  }
+  const section = `## Project workflow\n\n${text}`;
+  return lazySection ? `${section}\n\n${lazySection}` : section;
 }
 
 function buildLaunchRenderContext(

--- a/plugins/op-obsidian/src/promptBuild.ts
+++ b/plugins/op-obsidian/src/promptBuild.ts
@@ -245,15 +245,20 @@ export async function composeWorkflowSection(
         `This issue has ${lazy.length} optional reference module(s) (${names}) available as on-demand skills. ` +
         `From inside your working directory (after creating your worktree) run:\n\n` +
         "```bash\n" +
-        `obsidian op-emit-lazy-skills issue=${entry.id} dir="$(pwd)"\n` +
+        `obsidian op-emit-lazy-skills issue="${entry.id}" dir="$(pwd)"\n` +
         "```\n\n" +
-        `Then activate the relevant one via the Skill tool when needed. Skipping this is safe — they are reference-only.`;
+        `Then activate the relevant one via the Skill tool when needed. These are typically reference-only modules; skim each skill's description and skip emission only if none are relevant.`;
     } else {
       // Meta-only project (no repo path) — inline the lazy bodies so the
       // content is never lost (there is no working directory to run the CLI in).
-      lazySection =
-        `## Optional reference (no working directory — inlined)\n\n` +
-        lazy.map((s) => `### ${s.name}\n\n${s.body}`).join("\n\n");
+      // Skip skills whose body is empty (I2) and trim trailing whitespace (I1).
+      const inlined = lazy
+        .filter((s) => s.body.trim().length > 0)
+        .map((s) => `### ${s.name}\n\n${s.body.trimEnd()}`)
+        .join("\n\n");
+      lazySection = inlined
+        ? `## Optional reference skills (inlined — no working directory)\n\n${inlined}`
+        : "";
     }
   }
 

--- a/plugins/op-obsidian/src/uriHandlers.ts
+++ b/plugins/op-obsidian/src/uriHandlers.ts
@@ -20,6 +20,7 @@ import type { GetProjectWorkflowResult } from "./explainWorkflow";
 import { getSkill } from "./skill";
 import type { ExplainWorkflowPayload } from "./explainWorkflowPure";
 import type { ListVarsPayload } from "./listVarsPure";
+import type { EmitLazySkillsResult } from "./emitLazySkills";
 
 export interface UriHandlerDeps {
   store: { issues(): IssueEntry[] };
@@ -62,6 +63,7 @@ export interface UriHandlerDeps {
     agent?: string;
   }) => Promise<ExplainWorkflowPayload>;
   listVars?: (args: { project?: string; issue?: string }) => Promise<ListVarsPayload>;
+  emitLazySkills?: (args: { issueId: string; destDir?: string }) => Promise<EmitLazySkillsResult>;
 }
 
 export function findIssueById(store: { issues(): IssueEntry[] }, id: string): IssueEntry {
@@ -422,6 +424,24 @@ export async function handleOpListVarsUri(
   return {
     ok: true,
     command: "op-list-vars",
+    ...payload,
+  };
+}
+
+export async function handleOpEmitLazySkillsUri(
+  deps: UriHandlerDeps,
+  params: Record<string, string>,
+): Promise<UriResponsePayload> {
+  if (!deps.emitLazySkills) throw new Error("op-emit-lazy-skills not wired");
+  const id = trimOrUndef(params.issue ?? params.id);
+  if (!id) throw new Error("op-emit-lazy-skills URI: issue is required");
+  const dir = trimOrUndef(params.dir);
+  const args: { issueId: string; destDir?: string } = { issueId: id };
+  if (dir !== undefined) args.destDir = dir;
+  const payload = await deps.emitLazySkills(args);
+  return {
+    ok: true,
+    command: "op-emit-lazy-skills",
     ...payload,
   };
 }

--- a/plugins/op-obsidian/src/varSuggest.test.ts
+++ b/plugins/op-obsidian/src/varSuggest.test.ts
@@ -18,6 +18,7 @@ const FAKE_GLOBAL_MOD: WorkflowModule = {
   title: "Orient",
   scope: "kickoff",
   order: 0,
+  lazy: false,
   vars: [
     { kind: "object", name: "tone", default: "concise", description: "Voice for the agent." },
     { kind: "default", name: "lang", value: "en" },
@@ -30,6 +31,7 @@ const FAKE_PROJECT_MOD: WorkflowModule = {
   title: "House style",
   scope: "kickoff",
   order: 0,
+  lazy: false,
   vars: [{ kind: "object", name: "tone", default: "warm", description: "Per-project tone override." }],
   source: { kind: "project", path: "Projects/demo/MODULES/house-style.md", projectSlug: "demo" },
 };
@@ -39,6 +41,7 @@ const FAKE_CURRENT_MOD: WorkflowModule = {
   title: "Review",
   scope: "review",
   order: 0,
+  lazy: false,
   vars: [
     { kind: "bare", name: "reviewer" },
     { kind: "object", name: "checklist", default: "default-checklist" },

--- a/plugins/op-obsidian/src/workflowDiagnostic.ts
+++ b/plugins/op-obsidian/src/workflowDiagnostic.ts
@@ -19,7 +19,11 @@ export type WorkflowDiagnosticCode =
   // `maxWorkflowChars`. Modern models tolerate the size comfortably; the cap
   // is a guardrail that surfaces "this got bigger than you might have
   // expected" rather than a constraint that blocks the launch.
-  | "size-budget";
+  | "size-budget"
+  // OP-192: emitted when a `lazy: true` module is partitioned out of the
+  // inlined prompt into a skill (`info`), or when such a module lacks a
+  // `description:` and falls back to its title (`warning`).
+  | "lazy-skill";
 
 export type WorkflowDiagnosticSeverity = "error" | "warning" | "info";
 

--- a/plugins/op-obsidian/src/workflowDiagnosticFormat.test.ts
+++ b/plugins/op-obsidian/src/workflowDiagnosticFormat.test.ts
@@ -23,6 +23,7 @@ const ALL_CODES: WorkflowDiagnosticCode[] = [
   "intra-scope-collision",
   "malformed-frontmatter",
   "size-budget",
+  "lazy-skill",
 ];
 
 const ALL_SCOPES: PrecedenceScope[] = ["module", "global", "project", "launch"];
@@ -97,6 +98,7 @@ describe("codeLabel", () => {
     expect(codeLabel("intra-scope-collision")).toBe("Intra-scope collision");
     expect(codeLabel("malformed-frontmatter")).toBe("Malformed frontmatter");
     expect(codeLabel("size-budget")).toBe("Workflow size notice");
+    expect(codeLabel("lazy-skill")).toBe("Lazy skill");
   });
 
   it("never returns the raw kebab-case code (verifies humanization happened)", () => {
@@ -124,6 +126,37 @@ describe("formatDiagnostic — every code", () => {
       expect(f.hint!.length).toBeGreaterThan(0);
     });
   }
+});
+
+// ─── lazy-skill code (OP-192) ────────────────────────────────────────────
+
+describe("lazy-skill code (OP-192)", () => {
+  const d: WorkflowDiagnostic = {
+    code: "lazy-skill",
+    severity: "info",
+    message: "Module tmux-safety emitted as a skill.",
+    moduleId: "tmux-safety",
+  };
+
+  it("formats without throwing and carries the correct label", () => {
+    const f = formatDiagnostic(d);
+    expect(f.code).toBe("lazy-skill");
+    expect(f.codeLabel).toBe("Lazy skill");
+    expect(f.severity).toBe("info");
+    expect(f.severityBadge).toBe("I");
+    expect(f.message).toBe("Module tmux-safety emitted as a skill.");
+  });
+
+  it("populates a non-empty hint", () => {
+    const f = formatDiagnostic(d);
+    expect(typeof f.hint).toBe("string");
+    expect(f.hint!.length).toBeGreaterThan(0);
+  });
+
+  it("diagnosticToLine renders the canonical shape", () => {
+    const line = diagnosticToLine(d);
+    expect(line).toMatch(/^\[I\] Lazy skill — /);
+  });
 });
 
 describe("formatDiagnostic — passthrough fields", () => {

--- a/plugins/op-obsidian/src/workflowDiagnosticFormat.ts
+++ b/plugins/op-obsidian/src/workflowDiagnosticFormat.ts
@@ -163,6 +163,7 @@ const CODE_LABELS: Readonly<Record<WorkflowDiagnosticCode, string>> = Object.fre
   "intra-scope-collision": "Intra-scope collision",
   "malformed-frontmatter": "Malformed frontmatter",
   "size-budget": "Workflow size notice",
+  "lazy-skill": "Lazy skill",
 });
 
 export function codeLabel(code: WorkflowDiagnosticCode): string {
@@ -186,6 +187,8 @@ const HINTS: Readonly<Record<WorkflowDiagnosticCode, string>> = Object.freeze({
     "Open the module file and fix the highlighted field — the existing value is the wrong type.",
   "size-budget":
     "The composed workflow exceeds the recommended character budget. Modern models handle this well — consider splitting the workflow into smaller modules if latency increases.",
+  "lazy-skill":
+    "This module is emitted as an on-demand Claude Code skill instead of being inlined. Run op-emit-lazy-skills to materialize it.",
 });
 
 /**
@@ -207,6 +210,7 @@ export function formatDiagnostic(d: WorkflowDiagnostic): FormattedDiagnostic {
     case "intra-scope-collision":
     case "malformed-frontmatter":
     case "size-budget":
+    case "lazy-skill":
       return buildFormatted(d);
     default:
       return assertNeverCode(code);

--- a/plugins/op-obsidian/src/workflowDiagnosticFormat.ts
+++ b/plugins/op-obsidian/src/workflowDiagnosticFormat.ts
@@ -188,7 +188,7 @@ const HINTS: Readonly<Record<WorkflowDiagnosticCode, string>> = Object.freeze({
   "size-budget":
     "The composed workflow exceeds the recommended character budget. Modern models handle this well — consider splitting the workflow into smaller modules if latency increases.",
   "lazy-skill":
-    "This module is emitted as an on-demand Claude Code skill instead of being inlined. Run op-emit-lazy-skills to materialize it.",
+    "This module is lazy: emitted as an on-demand Claude Code skill when a working directory is available, otherwise inlined as optional reference. Not part of the always-inlined prompt body.",
 });
 
 /**

--- a/plugins/op-obsidian/src/workflowModulePure.test.ts
+++ b/plugins/op-obsidian/src/workflowModulePure.test.ts
@@ -331,6 +331,7 @@ describe("parseModule", () => {
       project: undefined,
       agent: undefined,
       order: 0,
+      lazy: false,
       vars: [],
       source: GLOBAL_SOURCE,
     });
@@ -492,6 +493,40 @@ describe("parseModule", () => {
   });
 });
 
+describe("parseModule lazy + description (OP-192)", () => {
+  const baseFm = { id: "m", title: "M", type: "workflow-module", scope: "kickoff" };
+  const src = { kind: "global" as const, path: "Projects/_op-modules/m.md" };
+
+  it("defaults lazy to false and description to undefined", () => {
+    const r = parseModule({ id: "m", frontmatter: { ...baseFm }, source: src });
+    expect(r.module).not.toBeNull();
+    expect(r.module!.lazy).toBe(false);
+    expect(r.module!.description).toBeUndefined();
+  });
+
+  it("accepts lazy: true and a string description", () => {
+    const r = parseModule({
+      id: "m",
+      frontmatter: { ...baseFm, lazy: true, description: "tmux gotchas catalog" },
+      source: src,
+    });
+    expect(r.module!.lazy).toBe(true);
+    expect(r.module!.description).toBe("tmux gotchas catalog");
+  });
+
+  it("rejects non-boolean lazy without coercion (still loadable)", () => {
+    const r = parseModule({ id: "m", frontmatter: { ...baseFm, lazy: "true" }, source: src });
+    expect(r.module).toBeNull();
+    expect(r.diagnostics.some(d => d.code === "malformed-frontmatter" && /lazy/.test(d.message))).toBe(true);
+  });
+
+  it("rejects non-string description", () => {
+    const r = parseModule({ id: "m", frontmatter: { ...baseFm, description: 42 }, source: src });
+    expect(r.module).toBeNull();
+    expect(r.diagnostics.some(d => d.code === "malformed-frontmatter" && /description/.test(d.message))).toBe(true);
+  });
+});
+
 describe("validateIntraScopeCollisions", () => {
   function module(
     id: string,
@@ -506,6 +541,7 @@ describe("validateIntraScopeCollisions", () => {
       project: undefined,
       agent: undefined,
       order: 0,
+      lazy: false,
       vars: varNames.map((n) => ({ kind: "bare", name: n })),
       source,
     };

--- a/plugins/op-obsidian/src/workflowModulePure.test.ts
+++ b/plugins/op-obsidian/src/workflowModulePure.test.ts
@@ -514,7 +514,7 @@ describe("parseModule lazy + description (OP-192)", () => {
     expect(r.module!.description).toBe("tmux gotchas catalog");
   });
 
-  it("rejects non-boolean lazy without coercion (still loadable)", () => {
+  it("rejects non-boolean lazy (hard fail — module: null)", () => {
     const r = parseModule({ id: "m", frontmatter: { ...baseFm, lazy: "true" }, source: src });
     expect(r.module).toBeNull();
     expect(r.diagnostics.some(d => d.code === "malformed-frontmatter" && /lazy/.test(d.message))).toBe(true);

--- a/plugins/op-obsidian/src/workflowModulePure.ts
+++ b/plugins/op-obsidian/src/workflowModulePure.ts
@@ -64,6 +64,12 @@ export interface WorkflowModule {
   agent?: string;
   /** Integer sort key within a scope. Default 0 when frontmatter omits it. */
   order: number;
+  /** OP-192: when true, this module is emitted as an on-demand skill instead
+   *  of being inlined into the composed prompt. Default false. */
+  lazy: boolean;
+  /** OP-192: one-line activation hint used as the emitted skill's
+   *  `description:`. Optional; lazy modules without it fall back to `title`. */
+  description?: string;
   vars: VarDecl[];
   source: ModuleSource;
 }
@@ -387,6 +393,30 @@ export function parseModule(args: ParseModuleArgs): ParseModuleResult {
     }
   }
 
+  let lazy = false;
+  if (Object.prototype.hasOwnProperty.call(frontmatter, "lazy")) {
+    const v = frontmatter.lazy;
+    if (v !== undefined && v !== null) {
+      if (typeof v !== "boolean") {
+        diagnostics.push(invalidFieldDiag(path, id, "lazy", v, "boolean"));
+      } else {
+        lazy = v;
+      }
+    }
+  }
+
+  let description: string | undefined;
+  if (Object.prototype.hasOwnProperty.call(frontmatter, "description")) {
+    const v = frontmatter.description;
+    if (v !== undefined && v !== null) {
+      if (typeof v !== "string") {
+        diagnostics.push(invalidFieldDiag(path, id, "description", v, "string"));
+      } else if (v.trim().length > 0) {
+        description = v;
+      }
+    }
+  }
+
   const varsResult = parseVarDecls(frontmatter.vars);
   for (const d of varsResult.diagnostics) {
     diagnostics.push({ ...d, moduleId: id, extra: { ...(d.extra ?? {}), path } });
@@ -410,6 +440,8 @@ export function parseModule(args: ParseModuleArgs): ParseModuleResult {
     project,
     agent,
     order,
+    lazy,
+    ...(description !== undefined ? { description } : {}),
     vars: varsResult.decls,
     source,
   };

--- a/plugins/op/.claude-plugin/plugin.json
+++ b/plugins/op/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "op",
   "description": "Obsidian Projects workflow — schema, slash commands, and agent skill for running a Jira-lite issue tracker inside an Obsidian vault.",
-  "version": "0.96.1",
+  "version": "0.97.0",
   "author": {
     "name": "Eugene Archibald"
   },

--- a/scripts/build-seeds.mjs
+++ b/scripts/build-seeds.mjs
@@ -179,6 +179,32 @@ build("seed/workflow-modules", () => {
     ].join("\n"),
   );
 
+  // Per-project lazy module — kickoff scope, lazy: true so it is emitted as a
+  // Claude Code skill rather than inlined. The smoke harness asserts the
+  // lazy-skill info diagnostic appears and the body text is absent from
+  // composed.text. OP-192.
+  writeVaultFile(
+    "Projects/testing/MODULES/tmux-gotchas.md",
+    [
+      "---",
+      "id: tmux-gotchas",
+      "title: Tmux gotchas",
+      "type: workflow-module",
+      "scope: kickoff",
+      "project: testing",
+      "lazy: true",
+      'description: "Tmux pane/window gotchas — activate when wrangling tmux"',
+      "order: 20",
+      "---",
+      "",
+      "Known tmux gotchas:",
+      "",
+      "- detached panes survive reload",
+      "- window indices are not stable",
+      "",
+    ].join("\n"),
+  );
+
   // Per-project workflow file — references both modules across kickoff + plan
   // steps. Uses the canonical schema=1 frontmatter shape (OP-196).
   writeVaultFile(
@@ -192,13 +218,14 @@ build("seed/workflow-modules", () => {
       "default_model: sonnet",
       "steps:",
       "  - step: kickoff",
-      "    modules: [branching]",
+      "    modules: [branching, tmux-gotchas]",
       "  - step: plan",
       "    modules: [plan-rules]",
       "---",
       "",
       "Workflow file for the testing project. Composes the global `branching` module at",
-      "kickoff and the per-project `plan-rules` module during plan mode.",
+      "kickoff, the per-project `tmux-gotchas` lazy module (op-emit-lazy-skills target),",
+      "and the per-project `plan-rules` module during plan mode.",
       "",
     ].join("\n"),
   );

--- a/scripts/smoke-workflow-modules.mjs
+++ b/scripts/smoke-workflow-modules.mjs
@@ -35,7 +35,9 @@
 // PR-check shell script.
 
 import { existsSync, readFileSync } from "node:fs";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
 import { join } from "node:path";
+import { tmpdir } from "node:os";
 
 import { OP_TEST_VAULT, assertOpTestVaultOpen, fail, runObsidian } from "./lib/op-test.mjs";
 
@@ -114,6 +116,100 @@ expect(
   kickoff.diagnostics,
 );
 
+// OP-192: lazy-skill assertions for the tmux-gotchas module -------------------
+const LAZY_MODULE_ID = "tmux-gotchas";
+const LAZY_SKILL_NAME = "op-module-tmux-gotchas";
+const LAZY_BODY_SNIPPET = "Known tmux gotchas";
+
+// 1. diagnostics must include an info-severity lazy-skill entry for tmux-gotchas
+expect(
+  "kickoff: diagnostics include lazy-skill info for tmux-gotchas",
+  Array.isArray(kickoff.diagnostics) &&
+    kickoff.diagnostics.some(
+      (d) => d.code === "lazy-skill" && d.severity === "info" && d.moduleId === LAZY_MODULE_ID,
+    ),
+  kickoff.diagnostics,
+);
+
+// 2. tmux-gotchas body text must NOT be inlined in composed.text
+expect(
+  "kickoff: lazy tmux-gotchas body NOT inlined in composed.text",
+  !kickoff.composed?.text?.includes(LAZY_BODY_SNIPPET),
+  { textSnippet: kickoff.composed?.text?.slice(0, 400) },
+);
+
+// OP-192: op-emit-lazy-skills assertions --------------------------------------
+const EMIT_TMP = mkdtempSync(join(tmpdir(), "op-192-smoke-"));
+
+// 5. Prune: plant a stale op-module-* dir before first emit so pruning is exercised
+const STALE_DIR = join(EMIT_TMP, ".claude", "skills", "op-module-zzz-stale");
+mkdirSync(STALE_DIR, { recursive: true });
+writeFileSync(join(STALE_DIR, "SKILL.md"), "stale content\n", "utf8");
+
+// 3. First emit: write skills into EMIT_TMP
+const emit1 = emitLazySkills(ISSUE, EMIT_TMP);
+expect("emit: ok === true", emit1.ok === true, emit1);
+
+const SKILL_MD_PATH = join(EMIT_TMP, ".claude", "skills", LAZY_SKILL_NAME, "SKILL.md");
+const GITIGNORE_PATH = join(EMIT_TMP, ".claude", "skills", LAZY_SKILL_NAME, ".gitignore");
+
+expect(
+  `emit: SKILL.md exists at ${SKILL_MD_PATH}`,
+  existsSync(SKILL_MD_PATH),
+  { checked: SKILL_MD_PATH },
+);
+if (existsSync(SKILL_MD_PATH)) {
+  const skillMdContent = readFileSync(SKILL_MD_PATH, "utf8");
+  expect(
+    "emit: SKILL.md contains name: op-module-tmux-gotchas",
+    skillMdContent.includes(`name: ${LAZY_SKILL_NAME}`),
+    { skillMdContent },
+  );
+}
+expect(
+  `emit: .gitignore exists at ${GITIGNORE_PATH}`,
+  existsSync(GITIGNORE_PATH),
+  { checked: GITIGNORE_PATH },
+);
+if (existsSync(GITIGNORE_PATH)) {
+  const gitignoreContent = readFileSync(GITIGNORE_PATH, "utf8");
+  expect(
+    'emit: .gitignore content is exactly "*\\n"',
+    gitignoreContent === "*\n",
+    { gitignoreContent },
+  );
+}
+expect(
+  "emit: response payload lists the written SKILL.md path",
+  Array.isArray(emit1.written) && emit1.written.some((p) => p.endsWith("SKILL.md")),
+  { written: emit1.written },
+);
+
+// 5 (continued). stale dir must have been pruned
+expect(
+  "emit: stale op-module-zzz-stale dir was pruned",
+  !existsSync(STALE_DIR),
+  { checked: STALE_DIR },
+);
+expect(
+  "emit: response payload lists the pruned stale dir",
+  Array.isArray(emit1.pruned) && emit1.pruned.some((p) => p.includes("op-module-zzz-stale")),
+  { pruned: emit1.pruned },
+);
+
+// 4. Idempotency: second emit succeeds and SKILL.md still present
+const emit2 = emitLazySkills(ISSUE, EMIT_TMP);
+expect("emit idempotency: ok === true on second run", emit2.ok === true, emit2);
+expect(
+  "emit idempotency: SKILL.md still present after second emit",
+  existsSync(SKILL_MD_PATH),
+  { checked: SKILL_MD_PATH },
+);
+
+// 6. Clean up
+rmSync(EMIT_TMP, { recursive: true, force: true });
+console.log(`  (cleaned up temp dir ${EMIT_TMP})`);
+
 // ---- 2. op-explain-workflow id=<ISSUE> mode=plan --------------------------
 const plan = explainWorkflow(ISSUE, "plan", AGENT);
 expect("plan: payload.mode === plan", plan.mode === "plan", plan);
@@ -182,6 +278,11 @@ function explainWorkflow(issue, mode, agent) {
 
 function listVarsForIssue(project, issue) {
   runObsidian(["op-list-vars", `project=${project}`, `issue=${issue}`]);
+  return readScratchPayload();
+}
+
+function emitLazySkills(issue, dir) {
+  runObsidian(["op-emit-lazy-skills", `issue=${issue}`, `dir=${dir}`]);
   return readScratchPayload();
 }
 


### PR DESCRIPTION
## Summary

Implements OP-192 (final child of OP-181): a workflow module flagged `lazy: true` is partitioned out of the always-inlined kickoff prompt and instead surfaced as an on-demand Claude Code skill the agent pulls into its worktree — saving kickoff context for rarely-needed reference modules.

- **Schema** (`workflowModulePure.ts`): optional `lazy: boolean` + `description?: string`, strictly type-checked (no truthy coercion). Per-module `lazy: true` is the sole opt-in (fails safe via unknown-key tolerance on older builds — no global setting, by design).
- **Pure composer** (`composeWorkflowPure.ts`): lazy modules excluded from `text`/`orderedChunks` into `ComposedPrompt.lazySkills[]` (bodies still fully var-resolved); `lazy-skill` `info` diagnostic per emitted module, `warning` + `title` fallback when `description` missing (never hard-fails a launch).
- **Delivery** (`emitLazySkills.ts` + new `op-emit-lazy-skills` CLI/URI): agent runs `obsidian op-emit-lazy-skills issue=<id> dir="$(pwd)"` from inside its worktree → writes `<dir>/.claude/skills/op-module-<id>/SKILL.md` + self-ignoring `.gitignore`, prunes stale `op-module-*`, idempotent. Agent-pull chosen because skill discovery cannot escape a git-worktree root (plugin-push is broken by op's worktree-per-issue flow — see spec).
- **Launch wiring** (`promptBuild.ts`): kickoff pointer block when a working dir exists; inline fallback (content never lost) for meta-only projects.
- YAML-safe SKILL.md rendering, absolute-`dir` validation (CLI parser + IO defense-in-depth), `lazy-skill` threaded through the exhaustive diagnostic-format/doc-link maps + troubleshooting stub.

Design spec: `docs/superpowers/specs/2026-05-15-lazy-skill-emission-design.md`. Version bumped 0.96.1 → 0.97.0 (minor — additive verb + optional fields).

## Test Plan

- [x] 1910 unit/integration tests pass (only pre-existing `iTermPrefs.test.ts` baseline failure, unrelated). Real-fs IO tests for emit/prune; pure tests for parser/composer/renderer; promptBuild pointer/inline boundary cases.
- [x] OP-192-touched files tsc-clean; `npm run build` green.
- [ ] **Live in-Obsidian smoke not run from CI shell** (OP-Test vault filesystem unreachable here). Run on the Obsidian host: `node scripts/dev-sync.mjs && node scripts/build-seeds.mjs && node scripts/reset-test-vault.mjs workflow-modules && node scripts/smoke-workflow-modules.mjs`

🤖 Generated with [Claude Code](https://claude.com/claude-code)