### PR TITLE
OP-279: disk-fallback project resolver so op-new survives stale metadataCache

### DIFF
--- a/plugins/op-obsidian/manifest.json
+++ b/plugins/op-obsidian/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "op-obsidian",
   "name": "Obsidian Projects (op)",
-  "version": "0.97.0",
+  "version": "0.97.1",
   "minAppVersion": "1.5.0",
   "description": "Jira-lite issue tracker for Obsidian vaults — deterministic commands backing the op workflow.",
   "author": "Eugene Archibald",

--- a/plugins/op-obsidian/package.json
+++ b/plugins/op-obsidian/package.json
@@ -1,6 +1,6 @@
 {
   "name": "op-obsidian",
-  "version": "0.97.0",
+  "version": "0.97.1",
   "description": "Obsidian plugin that owns the deterministic half of the op workflow.",
   "main": "main.js",
   "scripts": {

--- a/plugins/op-obsidian/src/createIssue.test.ts
+++ b/plugins/op-obsidian/src/createIssue.test.ts
@@ -228,3 +228,79 @@ describe("createIssue", () => {
     expect(result.entry.title).toBe(fullTitle);
   });
 });
+
+// OP-279: build-seeds' `setProjectVars` rewrites a project's STATUS.md via
+// processFrontMatter, then immediately dispatches `op-new` in a separate CLI
+// process. The metadataCache entry for STATUS.md is transiently stale during
+// that window, so the cache-only resolver (`findProjectBySlug`) misses the
+// project and createIssue threw "Unknown project slug" — even though STATUS.md
+// is well-formed on disk. createIssue must fall back to a deterministic disk
+// read before declaring the slug unknown.
+function fakeAppStaleCache(slug: string, prefix: string) {
+  const statusPath = `Projects/${slug}/STATUS.md`;
+  const statusFile = Object.assign(new TFile(), {
+    path: statusPath,
+    basename: "STATUS",
+    name: "STATUS.md",
+  });
+  // What's actually on disk — correct, just not yet reflected in metadataCache.
+  const onDisk =
+    `---\nproject: ${slug}\nprefix: ${prefix}\ntype: project-status\n` +
+    `vars:\n  reviewer_handle: "@x"\n---\n\n![[${slug}.base#Open Issues]]\n`;
+  const folders = new Set<string>();
+  const created: Array<{ path: string; content: string; file: TFile }> = [];
+
+  const app = {
+    vault: {
+      getMarkdownFiles: () => [statusFile],
+      getAbstractFileByPath: (p: string) => {
+        if (p === statusPath) return statusFile;
+        if (folders.has(p)) return { children: [] };
+        const hit = created.find((c) => c.path === p);
+        return hit ? hit.file : null;
+      },
+      read: async (f: TFile) => (f === statusFile ? onDisk : ""),
+      createFolder: async (p: string) => {
+        folders.add(p);
+      },
+      create: async (path: string, content: string) => {
+        const basename = path.split("/").pop()!.replace(/\.md$/, "");
+        const file = Object.assign(new TFile(), {
+          path,
+          basename,
+          name: `${basename}.md`,
+        });
+        created.push({ path, content, file });
+        return file;
+      },
+    },
+    // Stale: STATUS.md is in the vault but its cached frontmatter is missing.
+    metadataCache: {
+      getFileCache: (_f: TFile) => ({ frontmatter: undefined }),
+    },
+  };
+
+  return { app: app as any, store: { issues: () => [] } as any, created };
+}
+
+describe("createIssue — stale metadataCache disk fallback (OP-279)", () => {
+  it("resolves the project from disk when the STATUS.md cache entry is stale", async () => {
+    const { app, store } = fakeAppStaleCache("testing", "TST");
+    const result = await createIssue(app, store, {
+      slug: "testing",
+      title: "Workflow modules smoke target",
+      priority: "med",
+    });
+    expect(result.id).toMatch(/^TST-\d+$/);
+    expect(result.project.slug).toBe("testing");
+    expect(result.project.prefix).toBe("TST");
+    expect(result.path).toContain("Projects/testing/ISSUES/");
+  });
+
+  it("still throws Unknown project slug when no STATUS.md exists on disk either", async () => {
+    const { app, store } = fakeAppStaleCache("testing", "TST");
+    await expect(
+      createIssue(app, store, { slug: "ghost", title: "x" }),
+    ).rejects.toThrow(/Unknown project slug: ghost/);
+  });
+});

--- a/plugins/op-obsidian/src/createIssue.ts
+++ b/plugins/op-obsidian/src/createIssue.ts
@@ -1,6 +1,6 @@
 import { App, TFile, normalizePath } from "obsidian";
 import type { IssueStore } from "./issueStore";
-import { findProjectBySlug, type ProjectInfo } from "./projects";
+import { resolveProjectBySlug, type ProjectInfo } from "./projects";
 import { nextIssueNumberFromVault } from "./findIssue";
 import { joinVaultPath } from "./projectPaths";
 import { issueFilename } from "./sanitize";
@@ -40,7 +40,7 @@ export async function createIssue(
   store: IssueStore,
   input: CreateIssueInput,
 ): Promise<CreateIssueResult> {
-  const project = findProjectBySlug(app, input.slug);
+  const project = await resolveProjectBySlug(app, input.slug);
   if (!project) throw new Error(`Unknown project slug: ${input.slug}`);
   if (!project.prefix) {
     throw new Error(

--- a/plugins/op-obsidian/src/projects.ts
+++ b/plugins/op-obsidian/src/projects.ts
@@ -1,8 +1,9 @@
-import { App, TFile } from "obsidian";
+import type { App, TFile } from "obsidian";
 import {
   currentProjectsRoot,
   isWithinProjectsRoot,
   projectFolderFromStatusPath,
+  statusPathFor,
 } from "./projectPaths";
 
 export interface ProjectInfo {
@@ -59,4 +60,72 @@ export function findProjectByPrefix(app: App, prefix: string): ProjectInfo | und
 
 export function findProjectBySlug(app: App, slug: string): ProjectInfo | undefined {
   return listProjects(app).find((p) => p.slug === slug);
+}
+
+// OP-279: resolve a project slug with a deterministic disk fallback.
+//
+// `listProjects()` (and thus `findProjectBySlug`) reads project membership
+// purely from `app.metadataCache`. An external `processFrontMatter` /
+// `vault.modify` that rewrites a project's STATUS.md (e.g. build-seeds'
+// `setProjectVars` in the workflow-modules seed) invalidates that cache
+// entry; Obsidian's reindex is async/debounced. A separate `op-new` CLI
+// process dispatched microseconds later then misses the project and threw
+// "Unknown project slug" even though STATUS.md is well-formed on disk.
+//
+// On a cache miss, re-read the conventional STATUS.md path from disk and
+// parse its frontmatter directly before declaring the slug unknown. O(1) on
+// miss, deterministic (no polling — strictly better than the
+// `retryCreateSeed` workaround in scaffoldProject.ts), and benefits every
+// caller routing through it (op-new CLI, op-new URI, build-seeds, and real
+// users editing STATUS.md then immediately creating an issue).
+export async function resolveProjectBySlug(
+  app: App,
+  slug: string,
+): Promise<ProjectInfo | undefined> {
+  const cached = findProjectBySlug(app, slug);
+  if (cached) return cached;
+
+  const statusPath = statusPathFor(slug, currentProjectsRoot(app));
+  // Duck-typed file check: a TFolder exposes `children`, a TFile does not.
+  // Avoids a runtime `instanceof TFile` so this module stays free of a
+  // runtime "obsidian" import (pure tests import the resolver chain without
+  // mocking Obsidian — see findIssue.test.ts / projects.test.ts).
+  const file = app.vault.getAbstractFileByPath(statusPath) as TFile | null;
+  if (!file || (file as { children?: unknown }).children !== undefined) {
+    return undefined;
+  }
+
+  let raw: string;
+  try {
+    raw = await app.vault.read(file);
+  } catch {
+    return undefined;
+  }
+
+  const fm = parseStatusFrontmatter(raw);
+  if (fm.type !== "project-status") return undefined;
+
+  const folderPath = projectFolderFromStatusPath(statusPath);
+  const resolvedSlug = folderPath?.split("/").pop();
+  if (!folderPath || !resolvedSlug) return undefined;
+  return { slug: resolvedSlug, prefix: fm.prefix, statusPath, folderPath };
+}
+
+// Extract just the top-level scalar keys we need (`type`, `prefix`) from a
+// STATUS.md frontmatter block. STATUS.md always emits these as simple
+// unindented scalars (see renderStatus in scaffoldProject.ts); nested keys
+// (`tags:`, `vars:`) are indented and intentionally ignored. Deliberately
+// avoids `parseYaml` so projects.ts needs no runtime "obsidian" import.
+function parseStatusFrontmatter(raw: string): {
+  type?: string;
+  prefix?: string;
+} {
+  const match = raw.match(/^---\r?\n([\s\S]*?)\r?\n---(?:\r?\n|$)/);
+  if (!match) return {};
+  const out: { type?: string; prefix?: string } = {};
+  for (const line of match[1].split("\n")) {
+    const m = line.match(/^(type|prefix):[ \t]+(.+?)[ \t]*$/);
+    if (m) out[m[1] as "type" | "prefix"] = m[2].replace(/^["'](.*)["']$/, "$1");
+  }
+  return out;
 }

--- a/plugins/op/.claude-plugin/plugin.json
+++ b/plugins/op/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "op",
   "description": "Obsidian Projects workflow — schema, slash commands, and agent skill for running a Jira-lite issue tracker inside an Obsidian vault.",
-  "version": "0.97.0",
+  "version": "0.97.1",
   "author": {
     "name": "Eugene Archibald"
   },


### PR DESCRIPTION
## Problem

`build-seeds.mjs` `seed/workflow-modules` rewrites `Projects/testing/STATUS.md` via `processFrontMatter` (the `setProjectVars` step), then immediately dispatches a separate `obsidian op-new project=testing` process. `processFrontMatter` invalidates the `metadataCache` entry; reindex is async, so the cache-only resolver (`listProjects` → `findProjectBySlug`) missed the project and threw `Unknown project slug: testing` — even though STATUS.md was well-formed on disk. Only `seed/workflow-modules` does processFrontMatter-on-existing-STATUS-then-op-new, so only it failed (the sole blocker for the OP-192 live workflow-modules smoke).

## Fix

New async `resolveProjectBySlug(app, slug)` in `projects.ts`: cache fast-path (`findProjectBySlug`, unchanged hot path), then on miss a **deterministic disk read** of the conventional STATUS.md path via `app.vault.read`, parsing only the top-level `type`/`prefix` scalars. Deliberately avoids `parseYaml`/`instanceof TFile` so `projects.ts` stays free of a runtime `obsidian` import — pure tests (`findIssue.test.ts`, `projects.test.ts`) still import the resolver chain unmocked. `createIssue` (the op-new path) uses it. O(1) on miss, no polling — strictly better than the existing `retryCreateSeed` workaround (left in place; now a no-op fast-path). Benefits every op-new caller (CLI, URI, build-seeds, real users editing STATUS.md then creating an issue).

## Verification

- **TDD**: failing unit test in `createIssue.test.ts` (stale `metadataCache` + on-disk STATUS via `vault.read`) reproduced `Unknown project slug: testing`; green after fix.
- Full vitest: **1874 pass**; only the pre-existing `iTermPrefs.test.ts` baseline-noise failure remains (documented, unrelated). `tsc` clean on changed files.
- Live (OP-Test, plugin 0.97.1 dev-synced): `node scripts/build-seeds.mjs` builds **all 6 seeds incl. seed/workflow-modules green** — the exact `op-new project=testing` that failed now succeeds. `reset-test-vault workflow-modules` + `smoke-workflow-modules`: every OP-279-relevant assertion passes.

## Out of scope

`smoke-workflow-modules.mjs` still reports 8 FAILs, all in OP-192's lazy-skill **SKILL.md emission** (`op-module-tmux-gotchas`, stale-dir prune) — a separate subsystem this 3-file change doesn't touch, surfaced only because OP-279 unblocked the smoke from ever running. Tracked separately as **OP-280**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)