### PR TITLE
OP-278: make OP-Test vault path configurable

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,7 +23,7 @@ Always, in order:
    ```bash
    node scripts/dev-sync.mjs
    ```
-   The script hardcodes `~/Documents/OP-Test/OP-Test/.obsidian/plugins/op-obsidian/` as the target. It asserts OP-Test is **open** in Obsidian (any window — focus is not required since OP-175 routes every internal CLI call via `vault=OP-Test`) and rejects any path containing `Agent-Vault` (belt-and-suspenders against muscle-memory mistakes — Agent-Vault is BRAT-only, see below). Never `rm -rf` the dest — `data.json` (user settings) lives there; `dev-sync.mjs` only overwrites `main.js` and `manifest.json`.
+   The script targets `<OP-Test-vault>/.obsidian/plugins/op-obsidian/`, where the vault path is resolved by `scripts/lib/op-test.mjs` (see the override precedence in "OP-Test vault: the sole dev sync target" below — canonical location is `~/Vault/OP-Test`). It asserts OP-Test is **open** in Obsidian (any window — focus is not required since OP-175 routes every internal CLI call via `vault=OP-Test`) and rejects any path containing `Agent-Vault` (belt-and-suspenders against muscle-memory mistakes — Agent-Vault is BRAT-only, see below). Never `rm -rf` the dest — `data.json` (user settings) lives there; `dev-sync.mjs` only overwrites `main.js` and `manifest.json`.
 
 3. **Reload the plugin.** `dev-sync.mjs` handles this: it tries `obsidian plugin:reload id=op-obsidian` first and falls back to the `loadManifests + enablePluginAndSave` recipe on first-install (when Obsidian hasn't scanned the new folder yet). No separate manual step needed.
 
@@ -68,7 +68,15 @@ Never skip these steps, even for "trivial" changes — untested plugin builds sh
 
 ## OP-Test vault: the sole dev sync target
 
-The **OP-Test** vault at `~/Documents/OP-Test/OP-Test/` is a clean-room test vault — separate from your day-to-day Agent-Vault — used to verify the plugin's behavior in a vault that has no project state, no settings carry-over, and no other plugins. **OP-Test is the only vault that receives dev syncs from this repo.** `node scripts/dev-sync.mjs` enforces this: it asserts the OP-Test vault is open in Obsidian before mutating, routes every internal CLI call via `vault=OP-Test` (OP-175 — focus is not required), and refuses any target path containing `Agent-Vault`.
+The **OP-Test** vault — canonically at `~/Vault/OP-Test/` (matches the `~/Vault/` domain in the global AGENTS.md) — is a clean-room test vault, separate from your day-to-day Agent-Vault, used to verify the plugin's behavior in a vault that has no project state, no settings carry-over, and no other plugins. **OP-Test is the only vault that receives dev syncs from this repo.** `node scripts/dev-sync.mjs` enforces this: it asserts the OP-Test vault is open in Obsidian before mutating, routes every internal CLI call via `vault=OP-Test` (OP-175 — focus is not required), and refuses any target path containing `Agent-Vault`.
+
+**Vault-path resolution (OP-278).** `scripts/lib/op-test.mjs` resolves the OP-Test vault path once at module load, with this precedence:
+
+1. **`OP_TEST_VAULT` env var** — explicit override, highest precedence. Use it when the vault lives somewhere non-standard: `OP_TEST_VAULT=/abs/path node scripts/dev-sync.mjs`.
+2. **Obsidian-reported `app.vault.adapter.basePath`** — auto-derived from the running app (probed via `obsidian vault=OP-Test eval`). Since these scripts already require OP-Test to be open, this tracks vault moves (e.g. the `~/Documents/OP-Test` → `~/Vault/OP-Test` relocation) with zero config.
+3. **Legacy `~/Documents/OP-Test/OP-Test`** — final fallback, used only when Obsidian is unreachable so the open-vault assertion still surfaces a clear error rather than crashing at import.
+
+Everything downstream (`OP_TEST_PLUGIN_DEST`, the smoke/seed scratch paths) derives from the resolved value, so no script hardcodes a vault location.
 
 **Do not install op-obsidian into OP-Test via BRAT.** We're the plugin's authors and the dev build is on disk; BRAT adds GitHub-release latency and doesn't carry uncommitted work. Use `dev-sync.mjs` instead — it handles the file copy, the first-install enable recipe, and subsequent reloads.
 

--- a/scripts/dev-sync.mjs
+++ b/scripts/dev-sync.mjs
@@ -7,11 +7,13 @@
 //   node scripts/bump-version.mjs <bump>   # build first
 //   node scripts/dev-sync.mjs              # then sync into OP-Test
 //
-// Hardcoded target: ~/Documents/OP-Test/OP-Test/.obsidian/plugins/op-obsidian/
-// No env-var override — Agent-Vault is BRAT-only and must never receive a
-// dev sync. The OP-Test-open assertion + the Agent-Vault path-segment guard
-// + explicit `vault=OP-Test` routing on every CLI call (OP-175) jointly
-// enforce this; no Obsidian window needs to be focused on OP-Test.
+// Target: <OP-Test-vault>/.obsidian/plugins/op-obsidian/, where the vault
+// path is resolved by scripts/lib/op-test.mjs (OP_TEST_VAULT env override >
+// Obsidian-reported basePath > legacy ~/Documents/OP-Test default — OP-278).
+// Agent-Vault is BRAT-only and must never receive a dev sync. The
+// OP-Test-open assertion + the Agent-Vault path-segment guard + explicit
+// `vault=OP-Test` routing on every CLI call (OP-175) jointly enforce this;
+// no Obsidian window needs to be focused on OP-Test.
 
 import { copyFileSync, existsSync, mkdirSync, statSync } from "node:fs";
 import { dirname, join, relative } from "node:path";

--- a/scripts/lib/op-test.mjs
+++ b/scripts/lib/op-test.mjs
@@ -1,7 +1,9 @@
-// Shared helpers for OP-Test test-vault scripts (OP-147, OP-175).
+// Shared helpers for OP-Test test-vault scripts (OP-147, OP-175, OP-278).
 //
 // Single source of truth for:
-//   - the OP-Test vault path (no env-var override)
+//   - the OP-Test vault path (resolved once at module load — see
+//     `resolveOpTestVault`: OP_TEST_VAULT env override > Obsidian-reported
+//     basePath > legacy ~/Documents/OP-Test/OP-Test default)
 //   - the OP-Test-open assertion (vault registered + reachable, not necessarily focused)
 //   - thin wrappers around `obsidian` CLI and `git` so error reporting stays
 //     consistent across dev-sync / build-seeds / reset-test-vault.
@@ -17,8 +19,66 @@ import { spawnSync } from "node:child_process";
 import { homedir } from "node:os";
 import { join, sep } from "node:path";
 
-export const OP_TEST_VAULT = join(homedir(), "Documents/OP-Test/OP-Test");
 export const OP_TEST_VAULT_NAME = "OP-Test";
+
+// Historical hardcoded location, kept as the final fallback so behavior is
+// unchanged when Obsidian is unreachable (the assertion below then surfaces
+// the proper "open OP-Test" error rather than crashing at import).
+const LEGACY_OP_TEST_VAULT = join(homedir(), "Documents/OP-Test/OP-Test");
+
+// Strip the obsidian-cli `=> ` reply prefix and any wrapping quotes.
+function parseEvalString(stdout) {
+  let s = (stdout || "").trim();
+  if (s.startsWith("=>")) s = s.slice(2).trim();
+  if (
+    (s.startsWith('"') && s.endsWith('"')) ||
+    (s.startsWith("'") && s.endsWith("'"))
+  ) {
+    s = s.slice(1, -1);
+  }
+  return s;
+}
+
+// Resolve the OP-Test vault path once at module load. Consumers import
+// OP_TEST_VAULT as a const and read it at import time (e.g.
+// `const SCRATCH = join(OP_TEST_VAULT, …)`), so resolution must be eager and
+// synchronous. Precedence (OP-278):
+//   1. OP_TEST_VAULT env var          — explicit override, highest precedence
+//   2. Obsidian-reported basePath     — auto-tracks vault moves; the scripts
+//                                        require OP-Test open anyway, so the
+//                                        probe is free
+//   3. legacy ~/Documents/OP-Test/…   — final fallback (Obsidian unreachable)
+function resolveOpTestVault() {
+  const env = process.env.OP_TEST_VAULT?.trim();
+  if (env) return env;
+
+  try {
+    const r = spawnSync(
+      "obsidian",
+      [
+        `vault=${OP_TEST_VAULT_NAME}`,
+        "eval",
+        "code=app.vault.adapter.basePath",
+      ],
+      { encoding: "utf8" },
+    );
+    const stdout = (r.stdout || "").trim();
+    if (
+      !r.error &&
+      r.status === 0 &&
+      !/vault not found/i.test(stdout)
+    ) {
+      const p = parseEvalString(stdout);
+      if (p && p.startsWith("/")) return p;
+    }
+  } catch {
+    /* fall through to the legacy default */
+  }
+
+  return LEGACY_OP_TEST_VAULT;
+}
+
+export const OP_TEST_VAULT = resolveOpTestVault();
 export const OP_TEST_PLUGIN_DEST = join(
   OP_TEST_VAULT,
   ".obsidian/plugins/op-obsidian",
@@ -42,7 +102,8 @@ export function assertOpTestVaultOpen() {
   if (!existsSync(OP_TEST_VAULT)) {
     fail(
       `OP-Test vault is missing at ${OP_TEST_VAULT}.\n` +
-        `Create the directory and run \`git init\` inside it before re-running.`,
+        `Create the directory and run \`git init\` inside it, or point at the\n` +
+        `real location with \`OP_TEST_VAULT=/abs/path …\` before re-running.`,
     );
   }
   const r = spawnSync(


### PR DESCRIPTION
## What

Recovers and lands the OP-278 fix. `scripts/lib/op-test.mjs` hardcoded `OP_TEST_VAULT = ~/Documents/OP-Test/OP-Test` with no override. The live OP-Test vault relocated to `~/Vault/OP-Test`, so every consumer (`dev-sync`/`build-seeds`/`reset-test-vault`/`smoke-*`) aborted at the `existsSync` guard.

Replaces the const with `resolveOpTestVault()`, evaluated once at module load, precedence:

1. **`OP_TEST_VAULT` env var** — explicit override, highest precedence
2. **Obsidian-reported `app.vault.adapter.basePath`** — auto-derived; tracks vault moves with zero config
3. **legacy `~/Documents/OP-Test/OP-Test`** — final fallback when Obsidian is unreachable

`OP_TEST_PLUGIN_DEST` and all downstream consumers derive from the resolved value. Stale "no env-var override" header comments refreshed in `op-test.mjs` + `dev-sync.mjs`; override precedence + canonical `~/Vault/OP-Test` location documented in `CLAUDE.md`.

No plugin source touched — scripts + docs only, so no op-obsidian semver bump.

## Provenance

The OP-278 issue was marked resolved with commit `208615b` "left to the integrator," but the worktree was discarded before merge and the fix never landed in `main` (`op-test.mjs:20` still hardcoded the legacy path). This PR recovers the intact dangling commit `208615b` (cherry-picked clean, no conflicts) and lands it properly.

## Verification

All three precedence tiers exercised on this branch:
- Tier 1 env override → `/tmp/custom-optest` (`OP_TEST_PLUGIN_DEST` follows)
- Tier 2 Obsidian auto-derive → `/Users/earchibald/Vault/OP-Test`
- Tier 3 legacy fallback (node present, obsidian off PATH) → `/Users/earchibald/Documents/OP-Test/OP-Test`

`node --check` clean on both modified scripts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)