### PR TITLE
OP-280: self-healing plugin overlay on seed reset

### DIFF
--- a/scripts/build-seeds.mjs
+++ b/scripts/build-seeds.mjs
@@ -41,6 +41,7 @@ import {
   fail,
   runGit,
   runObsidian,
+  syncBuiltPlugin,
 } from "./lib/op-test.mjs";
 
 const FIXTURE_REPO_NAME = "op-test-fixture";
@@ -51,6 +52,15 @@ const FIXTURE_DESCRIPTION =
 assertOpTestVaultOpen();
 assertCleanTree();
 ensureBaselineTag();
+
+// ensureBaselineTag() just did `git reset --hard seed/empty`, which reverted
+// the git-tracked plugin to whatever the baseline pinned. Overlay the
+// freshly-built artifact so the rebuilt ladder bakes the *current* plugin into
+// every seed commit below — keeps the committed seeds in sync with the plugin
+// code (the docstring promise) and matches what reset-test-vault.mjs restores.
+for (const c of syncBuiltPlugin()) {
+  console.log(`overlaid current ${c.file} (${c.bytes} bytes) into baseline`);
+}
 
 build("seed/empty", () => {
   // Baseline; nothing to mutate. Tagging is unconditional below.

--- a/scripts/dev-sync.mjs
+++ b/scripts/dev-sync.mjs
@@ -15,44 +15,20 @@
 // `vault=OP-Test` routing on every CLI call (OP-175) jointly enforce this;
 // no Obsidian window needs to be focused on OP-Test.
 
-import { copyFileSync, existsSync, mkdirSync, statSync } from "node:fs";
-import { dirname, join, relative } from "node:path";
-import { fileURLToPath } from "node:url";
-
 import {
-  OP_TEST_PLUGIN_DEST,
-  assertNotAgentVault,
   assertOpTestVaultOpen,
   fail,
   runObsidian,
+  syncBuiltPlugin,
 } from "./lib/op-test.mjs";
 
-const here = dirname(fileURLToPath(import.meta.url));
-const root = join(here, "..");
-const pluginSrc = join(root, "plugins/op-obsidian");
-const filesToCopy = ["main.js", "manifest.json"];
-
 assertOpTestVaultOpen();
-assertNotAgentVault(OP_TEST_PLUGIN_DEST);
 
-for (const f of filesToCopy) {
-  const src = join(pluginSrc, f);
-  if (!existsSync(src)) {
-    fail(
-      `Source artifact missing: ${relative(root, src)}\n` +
-        `Run \`node scripts/bump-version.mjs <patch|minor|major>\` first to build.`,
-    );
-  }
-}
-
-mkdirSync(OP_TEST_PLUGIN_DEST, { recursive: true });
-
-for (const f of filesToCopy) {
-  const src = join(pluginSrc, f);
-  const dest = join(OP_TEST_PLUGIN_DEST, f);
-  copyFileSync(src, dest);
-  const { size } = statSync(dest);
-  console.log(`copied ${f} (${size} bytes) → ${dest}`);
+// syncBuiltPlugin() owns the Agent-Vault guard, the unbuilt-artifact check,
+// and the copy itself (single source of truth, shared with reset-test-vault.mjs
+// and build-seeds.mjs).
+for (const c of syncBuiltPlugin()) {
+  console.log(`copied ${c.file} (${c.bytes} bytes) → ${c.dest}`);
 }
 
 // Try the fast path first; fall back to load-manifests + enable for the

--- a/scripts/lib/op-test.mjs
+++ b/scripts/lib/op-test.mjs
@@ -14,10 +14,11 @@
 // focused — it will always hit OP-Test. Callers that need a different vault
 // should use spawnSync directly.
 
-import { existsSync, realpathSync } from "node:fs";
+import { copyFileSync, existsSync, mkdirSync, realpathSync, statSync } from "node:fs";
 import { spawnSync } from "node:child_process";
 import { homedir } from "node:os";
-import { join, sep } from "node:path";
+import { dirname, join, relative, sep } from "node:path";
+import { fileURLToPath } from "node:url";
 
 export const OP_TEST_VAULT_NAME = "OP-Test";
 
@@ -166,6 +167,49 @@ export function assertNotAgentVault(targetPath) {
         `Agent-Vault is a BRAT customer of op-obsidian. Dev syncs target OP-Test only.`,
     );
   }
+}
+
+// Repo root, derived from this file's location (scripts/lib/op-test.mjs →
+// ../../). The locally-built plugin artifact lives at
+// plugins/op-obsidian/{main.js,manifest.json}.
+const REPO_ROOT = join(dirname(fileURLToPath(import.meta.url)), "..", "..");
+const PLUGIN_SRC_DIR = join(REPO_ROOT, "plugins/op-obsidian");
+const PLUGIN_ARTIFACTS = ["main.js", "manifest.json"];
+
+// Copy the locally-built op-obsidian artifact into OP_TEST_PLUGIN_DEST.
+//
+// Why this exists: the OP-Test git repo *tracks* the plugin's main.js and
+// manifest.json, and the seed/* tags pin them at whatever version was current
+// when the ladder was last built. `git reset --hard seed/<name>` (run by
+// reset-test-vault.mjs and build-seeds.mjs) therefore reverts the plugin to a
+// possibly-stale version. Calling this *after* the reset re-overlays the
+// freshly-built plugin so smoke tests always exercise the current code,
+// regardless of what the seed tag pinned. Single source of truth for the copy
+// — dev-sync.mjs delegates here too.
+//
+// Does NOT reload the plugin; callers own the reload (they each do it
+// differently — reset-test-vault via plugin:reload, dev-sync with a
+// first-install fallback).
+export function syncBuiltPlugin() {
+  assertNotAgentVault(OP_TEST_PLUGIN_DEST);
+  for (const f of PLUGIN_ARTIFACTS) {
+    const src = join(PLUGIN_SRC_DIR, f);
+    if (!existsSync(src)) {
+      fail(
+        `Source artifact missing: ${relative(REPO_ROOT, src)}\n` +
+          `Run \`node scripts/bump-version.mjs <patch|minor|major>\` (or ` +
+          `\`npm --prefix plugins/op-obsidian run build\`) first to build the plugin.`,
+      );
+    }
+  }
+  mkdirSync(OP_TEST_PLUGIN_DEST, { recursive: true });
+  const copied = [];
+  for (const f of PLUGIN_ARTIFACTS) {
+    const dest = join(OP_TEST_PLUGIN_DEST, f);
+    copyFileSync(join(PLUGIN_SRC_DIR, f), dest);
+    copied.push({ file: f, bytes: statSync(dest).size, dest });
+  }
+  return copied;
 }
 
 // Run the `obsidian` CLI with `vault=OP-Test` prepended so the call is

--- a/scripts/reset-test-vault.mjs
+++ b/scripts/reset-test-vault.mjs
@@ -15,6 +15,7 @@ import {
   fail,
   runGit,
   runObsidian,
+  syncBuiltPlugin,
 } from "./lib/op-test.mjs";
 
 const VALID_SEEDS = new Set([
@@ -59,6 +60,16 @@ if (tagCheck.status !== 0) {
 console.log(`resetting ${OP_TEST_VAULT} to ${tag} …`);
 runGit(["reset", "--hard", tag]);
 runGit(["clean", "-fd"]);
+
+// The seed tags git-track the plugin's main.js/manifest.json at whatever
+// version was current when the ladder was last built. The reset above just
+// reverted the plugin to that pinned (possibly-stale) version, so re-overlay
+// the freshly-built artifact — otherwise `reset && smoke` would exercise an
+// out-of-date plugin and fail on any feature added since the seeds were built.
+const synced = syncBuiltPlugin();
+for (const c of synced) {
+  console.log(`overlaid current ${c.file} (${c.bytes} bytes) → ${c.dest}`);
+}
 
 console.log("reloading op-obsidian so Obsidian picks up vault state …");
 const reload = runObsidian(["plugin:reload", "id=op-obsidian"], { allowFail: true });


### PR DESCRIPTION
## Summary
- The OP-Test git repo tracks `op-obsidian` `main.js`/`manifest.json`; the `seed/*` tags pinned them at a pre-OP-192 plugin (0.96.1). `reset-test-vault.mjs` does `git reset --hard seed/<name>`, reverting any synced current plugin back to the stale pinned version — so `reset && smoke` ran the OP-192 lazy-skill smoke against a plugin with no `op-emit-lazy-skills` command, causing 8 spurious FAILs. The OP-192 plugin code itself was correct all along.
- Added `syncBuiltPlugin()` to `scripts/lib/op-test.mjs` — single source of truth for the artifact copy (Agent-Vault guard + actionable unbuilt error).
- `reset-test-vault.mjs` and `build-seeds.mjs` now overlay the freshly-built plugin right after their `git reset --hard`, making the seed-reset path self-healing across all future plugin changes.
- `dev-sync.mjs` refactored to delegate to the shared helper (fast-path + first-install fallback unchanged).
- Scripts-only change; built `main.js` is gitignored → no semver bump.

## Test plan
- [x] `node scripts/reset-test-vault.mjs workflow-modules && node scripts/smoke-workflow-modules.mjs` → 28/28 PASS, 0 failed (no manual dev-sync)
- [x] `node scripts/dev-sync.mjs` still copies + reloads via the shared helper
- [x] `node --check` clean on all four modified scripts

🤖 Generated with [Claude Code](https://claude.com/claude-code)