### PR TITLE
OP-227: drop stale default_branch from pr-required README row

### DIFF
--- a/docs/examples/workflow-library/README.md
+++ b/docs/examples/workflow-library/README.md
@@ -38,7 +38,7 @@ docs/examples/workflow-library/   ← vault root
 | `branching.md` | `kickoff` | `default_branch=main`, `branch_strategy=worktree` | Always isolate from the default branch — worktree or feature branch. |
 | `tmux-safety.md` | `kickoff` | `protected_session_prefixes=op-agents-,view-`, `experiment_session_pattern=op-experiment-$$` | Don't kill shared tmux sessions; experiment in a disposable one. |
 | `commit-mapping.md` | `implement` | `commit_command=op-append-commit`, `commit_field=commits` | Append every commit to the issue note's commits list, per-commit not batched. |
-| `pr-required.md` | `review` | `default_branch=main`, `pr_title_pattern="<ID>: <subject>"`, `merge_command=gh pr merge --squash --delete-branch` | PRs gate merges; PR title carries the issue id. |
+| `pr-required.md` | `review` | `pr_title_pattern="<ID>: <subject>"`, `merge_command=gh pr merge --squash --delete-branch` | PRs gate merges; PR title carries the issue id. Uses `{{vars.default_branch}}` but does not declare it — `branching.md` owns that var. |
 | `adversarial-review.md` | `review` | `copilot_cmd=copilot --autopilot --allow-all -p`, `bypass_criteria=all` | Invoke the local `copilot` CLI synchronously with concrete pressure-test prompts; expect pushed fix commits plus a `## Adversarial review (local copilot)` summary comment on the PR; bypass only when *all* criteria apply. |
 | `version-cadence.md` | `finalize` | `package_name=op-obsidian`, `bump_command=node scripts/bump-version.mjs` | Bump version files in lockstep at resolve time. |
 | `gh-issue-close.md` | `finalize` | `auto_close_setting_path=closeGithubIssueOnResolve` | Don't close the linked GH issue manually — let `op-resolve` handle it; read the JSON response. |


### PR DESCRIPTION
## Summary

The `default_branch` var collision between the `branching` and `pr-required` workflow modules (OP-227) was **already resolved in the module files** by a prior change in the OP-181/OP-218 module series:

- `branching.md` (scope `kickoff`) owns `default_branch=main` — the natural home per the issue.
- `pr-required.md` (scope `review`) only *references* `{{vars.default_branch}}`; it declares only `pr_title_pattern` + `merge_command`.

`op-explain-workflow mode=kickoff/plan/review` reports **0 `intra-scope-collision`** (kickoff: 0E/0W/1I — only the `size-budget` info notice), and `docsExamples.test.ts` passes 6/6.

The one lingering defect was documentation: `docs/examples/workflow-library/README.md` still listed `default_branch=main` among `pr-required.md`'s *declared* vars (the "Vars (with inline defaults)" column), contradicting the shipped frontmatter. This PR corrects that row and names `branching.md` as the owner.

**No behavior change:** `{{vars.default_branch}}` still resolves to `main` from `branching` for every consumer including `pr-required`. No troubleshooting-doc regression note required (scope item 4 is conditional on a behavior change; none introduced). Docs-only — no `plugins/op-obsidian/` source touched, no semver bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)