### PR TITLE
OP-237: daemon self-heals user.op_issue on iTerm-restart reattach

### DIFF
--- a/plugins/op-obsidian/dashboard/README.md
+++ b/plugins/op-obsidian/dashboard/README.md
@@ -107,14 +107,19 @@ notification.
   `user.op_issue` user-var — the OP-233 OSC 1337 emit lives inside the
   inner agent script, and tmux's `select-window` reattach does not
   re-run that script. The tmux side of the correlation union still
-  matches the window by name, so the live row continues to appear in
-  the dashboard. iTerm-targeted ops (`close_pane`, future "focus this
-  session" commands) degrade for that row until a *fresh* launch creates
-  a new tmux window and reruns the inner script to retag the iTerm
-  session; plain reattach flows that hit `select-window` do not retag.
-  Workaround is to let the surviving tmux-backed agent exit (or quit it)
-  and then relaunch the issue from op-obsidian. Tracked as a deferred
-  follow-up under OP-217; not fixed in v1.
+  matches the window by name, so the live row keeps appearing.
+  **Self-heal:** every `reconcile()` pass calls
+  `ITermBridge.heal_untagged()`, which maps each iTerm tab's
+  `tmux_window_id` (exposed by the iTerm API regardless of the lost
+  user-var) back to its issue via `tmux list-windows -F
+  '#{window_id}\t#S\t#W'`, then re-sets `user.op_issue` (plain id, the
+  raw form `scan()` already honors) through `async_set_variable`. The
+  healed session-id folds into the same cycle's `iterm_map`, so
+  `close_pane` / reveal recover within one ~1 s poll — no fresh launch
+  needed. Idempotent (already-tagged sessions are skipped) and a no-op
+  in tmux-only mode. If the iTerm API is unavailable the row still
+  works via the tmux-only path, with iTerm-targeted ops degraded as
+  before.
 
 ## Testing
 

--- a/plugins/op-obsidian/dashboard/op-dashboard.py
+++ b/plugins/op-obsidian/dashboard/op-dashboard.py
@@ -310,6 +310,38 @@ async def list_op_agent_windows() -> List[Tuple[str, str]]:
     return filter_op_agent_windows(parse_list_windows(out))
 
 
+def parse_list_windows_ids(stdout: str) -> List[Tuple[str, str, str]]:
+    """Parse tab-separated `#{window_id}\\t#S\\t#W` → [(window_id, session,
+    window)]. Used by the OP-237 reattach self-heal to map a tmux window-id
+    (which iTerm exposes via `tab.tmux_window_id` regardless of `user.op_issue`)
+    back to its issue id."""
+    out: List[Tuple[str, str, str]] = []
+    for line in stdout.splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        parts = line.split("\t")
+        if len(parts) != 3 or not all(parts):
+            continue
+        out.append((parts[0], parts[1], parts[2]))
+    return out
+
+
+def filter_op_agent_window_ids(
+    rows: List[Tuple[str, str, str]]
+) -> List[Tuple[str, str, str]]:
+    return [(wid, s, w) for wid, s, w in rows if TMUX_SESSION_RE.match(s)]
+
+
+async def list_op_agent_window_ids() -> List[Tuple[str, str, str]]:
+    rc, out, _ = await tmux_run(
+        "list-windows", "-a", "-F", "#{window_id}\t#S\t#W", check=False
+    )
+    if rc != 0:
+        return []
+    return filter_op_agent_window_ids(parse_list_windows_ids(out))
+
+
 async def capture_pane(target: str, lines: int = CAPTURE_TAIL_LINES) -> str:
     """Capture the last `lines` rows of the named tmux window's active pane."""
     rc, out, _ = await tmux_run(
@@ -383,6 +415,61 @@ class ITermBridge:
             log.warning("iterm scan failed: %s", e)
         self._uuid_by_issue = dict(result)
         return result
+
+    async def heal_untagged(
+        self, windowid_to_issue: Dict[str, str]
+    ) -> Dict[str, str]:
+        """OP-237: re-tag iTerm sessions that lost `user.op_issue` on an
+        iTerm-restart-while-tmux-survives reattach.
+
+        `tab.tmux_window_id` ties an iTerm tab to its tmux window-id even when
+        the session is untagged (the OSC 1337 from OP-233 only fires on the
+        *initial* inner-script run, not on tmux `select-window` reattach). We
+        cross-reference that against the tmux window-id→issue map and set the
+        plain issue id back via the iTerm Python API — the raw form that
+        `decode_user_op_issue` and `scan()` already honor (OP-230). Idempotent:
+        a session already carrying the right id is skipped.
+
+        Returns {issue_id: session_id} for sessions it (re)tagged, and folds
+        them into `_uuid_by_issue` so the same poll cycle's reveal/close-pane
+        recover without waiting for the next `scan()`.
+        """
+        if not self.available or self.app is None or not windowid_to_issue:
+            return {}
+        healed: Dict[str, str] = {}
+        try:
+            for window in self.app.terminal_windows:
+                for tab in window.tabs:
+                    wid = getattr(tab, "tmux_window_id", None)
+                    if not wid:
+                        continue
+                    issue_id = windowid_to_issue.get(wid)
+                    if not issue_id:
+                        continue
+                    for sess in tab.sessions:
+                        try:
+                            raw = await sess.async_get_variable("user.op_issue")
+                        except Exception:
+                            raw = None
+                        current = decode_user_op_issue(str(raw)) if raw else None
+                        if current == issue_id:
+                            continue
+                        try:
+                            await sess.async_set_variable(
+                                "user.op_issue", issue_id
+                            )
+                        except Exception as e:
+                            log.warning(
+                                "heal_untagged(%s) set failed: %s", issue_id, e
+                            )
+                            continue
+                        healed[issue_id] = sess.session_id
+                        self._uuid_by_issue[issue_id] = sess.session_id
+        except Exception as e:
+            log.warning("heal_untagged scan failed: %s", e)
+        if healed:
+            log.info("reattach self-heal re-tagged: %s", sorted(healed))
+        return healed
 
     async def close_pane(self, issue_id: str) -> bool:
         if not self.available or self.app is None:
@@ -831,6 +918,14 @@ async def reconcile(state: AppState) -> Tuple[List[AgentSession], List[AgentSess
     """Build the in-memory session map from tmux + iTerm + data.json."""
     tmux_rows = await list_op_agent_windows()
     iterm_map = await state.iterm.scan()
+    # OP-237: re-tag iTerm sessions that lost `user.op_issue` on an
+    # iTerm-restart-while-tmux-survives reattach. The window-id→issue map comes
+    # from tmux (authoritative even when the iTerm tag is gone); folding the
+    # healed sessions into iterm_map recovers reveal/close-pane this same cycle.
+    windowid_to_issue = {
+        wid: window for wid, _sess, window in await list_op_agent_window_ids()
+    }
+    iterm_map.update(await state.iterm.heal_untagged(windowid_to_issue))
     data_json_map: Dict[str, dict] = {}
     for path in find_data_json_paths():
         for issue_id, ref in read_orchestrator_state(path).items():

--- a/plugins/op-obsidian/dashboard/test_op_dashboard.py
+++ b/plugins/op-obsidian/dashboard/test_op_dashboard.py
@@ -430,6 +430,123 @@ class TmuxSessionRegexTests(unittest.TestCase):
             self.assertIsNone(opd.TMUX_SESSION_RE.match(s))
 
 
+class WindowIdParseTests(unittest.TestCase):
+    """OP-237: reattach self-heal needs tmux window-id → issue, parsed from
+    `tmux list-windows -a -F '#{window_id}\\t#S\\t#W'`."""
+
+    def test_parse_list_windows_ids(self):
+        out = "@1\top-agents\tOP-217\n@4\top-agents-1\tOP-218\n@9\tmain\tscratch\n"
+        rows = opd.parse_list_windows_ids(out)
+        self.assertEqual(rows, [
+            ("@1", "op-agents", "OP-217"),
+            ("@4", "op-agents-1", "OP-218"),
+            ("@9", "main", "scratch"),
+        ])
+
+    def test_parse_skips_blank_and_malformed(self):
+        out = "\n  \nfoo\t bar\n@2\top-agents\tOP-3\n@x\tonly-two\n"
+        rows = opd.parse_list_windows_ids(out)
+        self.assertEqual(rows, [("@2", "op-agents", "OP-3")])
+
+    def test_filter_op_agent_window_ids(self):
+        rows = [
+            ("@1", "op-agents", "OP-1"),
+            ("@2", "op-agents-2", "OP-2"),
+            ("@3", "main", "x"),
+            ("@4", "op-agents-x", "y"),
+        ]
+        self.assertEqual(opd.filter_op_agent_window_ids(rows), [
+            ("@1", "op-agents", "OP-1"),
+            ("@2", "op-agents-2", "OP-2"),
+        ])
+
+
+class _FakeSession:
+    def __init__(self, session_id, op_issue=None):
+        self.session_id = session_id
+        self._vars = {}
+        if op_issue is not None:
+            self._vars["user.op_issue"] = op_issue
+        self.set_calls = []
+
+    async def async_get_variable(self, name):
+        return self._vars.get(name)
+
+    async def async_set_variable(self, name, value):
+        self._vars[name] = value
+        self.set_calls.append((name, value))
+
+
+class _FakeTab:
+    def __init__(self, tmux_window_id, sessions):
+        self.tmux_window_id = tmux_window_id
+        self.sessions = sessions
+
+
+class _FakeWindow:
+    def __init__(self, tabs):
+        self.tabs = tabs
+
+
+class _FakeApp:
+    def __init__(self, windows):
+        self.terminal_windows = windows
+
+
+class ReattachSelfHealTests(unittest.TestCase):
+    """OP-237: when iTerm restarts while tmux survives, the reattached iTerm
+    session loses `user.op_issue`. The daemon re-tags it via the iTerm Python
+    API on reconcile so Reveal/Close-pane recover."""
+
+    def _bridge(self, app):
+        b = opd.ITermBridge()
+        b.available = True
+        b.app = app
+        return b
+
+    def test_heals_untagged_session(self):
+        sess = _FakeSession("UUID-A", op_issue=None)
+        app = _FakeApp([_FakeWindow([_FakeTab("@1", [sess])])])
+        bridge = self._bridge(app)
+        healed = asyncio.run(bridge.heal_untagged({"@1": "OP-237"}))
+        self.assertEqual(healed, {"OP-237": "UUID-A"})
+        self.assertEqual(sess.set_calls, [("user.op_issue", "OP-237")])
+        # _uuid_by_issue is updated so close_pane works the same cycle.
+        self.assertEqual(bridge._uuid_by_issue.get("OP-237"), "UUID-A")
+
+    def test_idempotent_when_already_tagged(self):
+        # iTerm stores the OSC-set value already decoded to the plain id.
+        sess = _FakeSession("UUID-B", op_issue="OP-237")
+        app = _FakeApp([_FakeWindow([_FakeTab("@1", [sess])])])
+        healed = asyncio.run(self._bridge(app).heal_untagged({"@1": "OP-237"}))
+        self.assertEqual(healed, {})
+        self.assertEqual(sess.set_calls, [])
+
+    def test_corrects_stale_wrong_tag(self):
+        sess = _FakeSession("UUID-C", op_issue="OP-999")
+        app = _FakeApp([_FakeWindow([_FakeTab("@7", [sess])])])
+        healed = asyncio.run(self._bridge(app).heal_untagged({"@7": "OP-237"}))
+        self.assertEqual(healed, {"OP-237": "UUID-C"})
+        self.assertEqual(sess.set_calls, [("user.op_issue", "OP-237")])
+
+    def test_ignores_non_tmux_and_unmapped_tabs(self):
+        s1 = _FakeSession("U1")  # non-tmux tab
+        s2 = _FakeSession("U2")  # tmux tab but not an op-agents window
+        app = _FakeApp([_FakeWindow([
+            _FakeTab(None, [s1]),
+            _FakeTab("@99", [s2]),
+        ])])
+        healed = asyncio.run(self._bridge(app).heal_untagged({"@1": "OP-237"}))
+        self.assertEqual(healed, {})
+        self.assertEqual(s1.set_calls, [])
+        self.assertEqual(s2.set_calls, [])
+
+    def test_noop_when_iterm_unavailable(self):
+        bridge = opd.ITermBridge()  # available=False, app=None
+        healed = asyncio.run(bridge.heal_untagged({"@1": "OP-237"}))
+        self.assertEqual(healed, {})
+
+
 try:
     from aiohttp import web as _aiohttp_web  # noqa: F401
     from aiohttp.test_utils import TestClient, TestServer

--- a/plugins/op-obsidian/manifest.json
+++ b/plugins/op-obsidian/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "op-obsidian",
   "name": "Obsidian Projects (op)",
-  "version": "0.97.1",
+  "version": "0.97.2",
   "minAppVersion": "1.5.0",
   "description": "Jira-lite issue tracker for Obsidian vaults — deterministic commands backing the op workflow.",
   "author": "Eugene Archibald",

--- a/plugins/op-obsidian/package.json
+++ b/plugins/op-obsidian/package.json
@@ -1,6 +1,6 @@
 {
   "name": "op-obsidian",
-  "version": "0.97.1",
+  "version": "0.97.2",
   "description": "Obsidian plugin that owns the deterministic half of the op workflow.",
   "main": "main.js",
   "scripts": {

--- a/plugins/op/.claude-plugin/plugin.json
+++ b/plugins/op/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "op",
   "description": "Obsidian Projects workflow — schema, slash commands, and agent skill for running a Jira-lite issue tracker inside an Obsidian vault.",
-  "version": "0.97.1",
+  "version": "0.97.2",
   "author": {
     "name": "Eugene Archibald"
   },


### PR DESCRIPTION
## What

When iTerm restarts while the tmux server survives, the reattached pane has no `user.op_issue` user-var — OP-233's OSC 1337 emit lives in the *initial* inner agent script and tmux `select-window` reattach never re-runs it. The OP-230 daemon's tmux-only correlation still tracks the row by window name, but iTerm-targeted ops (`close_pane`, reveal) degraded for that row until a *fresh* launch.

## Decision

The daemon's tmux-only fallback genuinely covers session tracking/state/capture/send/quit on reattach — only iTerm-native actions degrade. Per the issue's scope question, the chosen fix is the daemon-side self-heal (issue option #2); the `.zshrc`/`.bashrc` option is non-viable because the inner script `exec`s the agent (no interactive shell hook ever fires).

## Change

`ITermBridge.heal_untagged()`: every `reconcile()` pass maps each iTerm tab's `tmux_window_id` (exposed by the iTerm API regardless of the lost user-var) back to its issue via `tmux list-windows -F '#{window_id}\t#S\t#W'`, then re-sets `user.op_issue` (plain id — the raw form `scan()` already honors per OP-230) through `async_set_variable`. Healed session-ids fold into the same cycle's `iterm_map`, so `close_pane`/reveal recover within one ~1 s poll — no fresh launch needed. Idempotent (already-tagged sessions skipped); no-op in tmux-only mode.

- `op-dashboard.py` — `parse_list_windows_ids` + `filter_op_agent_window_ids` + `list_op_agent_window_ids` (pure), `ITermBridge.heal_untagged`, one `reconcile()` call site.
- `test_op_dashboard.py` — 8 new stdlib tests (parser + heal: untagged/idempotent/wrong-tag/non-op-tab/api-unavailable).
- `README.md` — fallback-modes section updated to document the self-heal.
- Patch bump 0.97.1 → 0.97.2 (daemon-only static asset; no TS runtime change).

## Test

- `python3 -m unittest test_op_dashboard` → 57 pass, 5 skipped (aiohttp absent in dev Python — pre-existing gate).
- `bump-version.mjs` build green; `dev-sync.mjs` into OP-Test, plugin reloads at 0.97.2 with a clean `dev:console`.

Closes #309.

🤖 Generated with [Claude Code](https://claude.com/claude-code)